### PR TITLE
feat: CLAUDECLAW+ wordmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="images/claudeclaw-banner.svg" alt="ClaudeClaw+ Banner" />
 </p>
 <p align="center">
-  <img src="images/claudeclaw-wordmark.png" alt="ClaudeClaw+ Wordmark" />
+  <img src="images/claudeclaw-plus-wordmark.svg" alt="ClaudeClaw+ Wordmark" />
 </p>
 
 <p align="center">

--- a/images/claudeclaw-plus-wordmark.svg
+++ b/images/claudeclaw-plus-wordmark.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 90" width="560" height="90">
+  <text
+    x="0"
+    y="76"
+    font-family="Impact, 'Arial Black', 'Haettenschweiler', 'Arial Narrow Bold', sans-serif"
+    font-size="80"
+    font-weight="900"
+    letter-spacing="-2">
+    <tspan fill="#FFFFFF">CLAUDE</tspan><tspan fill="#E83838">CLAW+</tspan>
+  </text>
+</svg>


### PR DESCRIPTION
Replaces the inherited `claudeclaw-wordmark.png` with a new `claudeclaw-plus-wordmark.svg`. Renders CLAUDE in white and CLAW+ in red (#E83838), matching the upstream font style (Impact, 80px, tight letter-spacing).