### PR TITLE
feat: rebrand TUI, web UI, and README to ClaudeClaw+

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.github/workflows/marketplace-version-guard.yml
+++ b/.github/workflows/marketplace-version-guard.yml
@@ -50,10 +50,10 @@ jobs:
 
           base_version="$(
             git show "$BASE_SHA:.claude-plugin/marketplace.json" | \
-            python3 -c 'import json,sys; data=json.load(sys.stdin); plugin=next((p for p in data.get("plugins", []) if p.get("name")=="claudeclaw"), (data.get("plugins") or [{}])[0]); print(plugin["version"])'
+            python3 -c 'import json,sys; data=json.load(sys.stdin); plugin=next((p for p in data.get("plugins", []) if p.get("name")=="claudeclaw-plus"), (data.get("plugins") or [{}])[0]); print(plugin["version"])'
           )"
           head_version="$(
-            python3 -c 'import json; data=json.load(open(".claude-plugin/marketplace.json")); plugin=next((p for p in data.get("plugins", []) if p.get("name")=="claudeclaw"), (data.get("plugins") or [{}])[0]); print(plugin["version"])'
+            python3 -c 'import json; data=json.load(open(".claude-plugin/marketplace.json")); plugin=next((p for p in data.get("plugins", []) if p.get("name")=="claudeclaw-plus"), (data.get("plugins") or [{}])[0]); print(plugin["version"])'
           )"
 
           if [ "$base_version" = "$head_version" ]; then

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ The setup wizard covers model, heartbeat, Telegram, Discord, and security. Your 
 
 ## What's in Plus that isn't in claudeclaw
 
-These features originated as PRs to `moazbuilds/claudeclaw`. The upstream maintainer has given his blessing for them to live here instead. Links below point to the originating PRs so you can read the full rationale.
+These features originated as PRs to `moazbuilds/claudeclaw` and have been closed upstream — they're out of scope for the lightweight core and live here permanently. Links below point to the originating PRs so you can read the full rationale.
 
 ### Policy Engine — fine-grained tool governance
 
-**[PR #71 — open upstream](https://github.com/moazbuilds/claudeclaw/pull/71)**
+**[PR #71 — closed upstream — lives here](https://github.com/moazbuilds/claudeclaw/pull/71)**
 
 Every tool call (Bash, Read, Edit, etc.) is evaluated against deterministic rules before execution. Rules can allow, deny, or gate behind operator approval — scoped by channel, user, skill, and source. Includes an audit log and a bounded LRU approval cache.
 
@@ -98,7 +98,7 @@ Every tool call (Bash, Read, Edit, etc.) is evaluated against deterministic rule
 
 ### Governance Layer — model routing, budgets, watchdog
 
-**[PR #72 — open upstream](https://github.com/moazbuilds/claudeclaw/pull/72)**
+**[PR #72 — closed upstream — lives here](https://github.com/moazbuilds/claudeclaw/pull/72)**
 
 Sits between the daemon and Claude CLI. Automatically routes planning tasks to Opus and implementation tasks to Sonnet. Tracks token and cost spend per session and globally, with configurable warn/throttle/block states. Watchdog kills runaway sessions before they drain your credits.
 
@@ -108,7 +108,7 @@ Sits between the daemon and Claude CLI. Automatically routes planning tasks to O
 
 ### Gateway, Events & Escalation — unified ingestion and replayable event log
 
-**[PR #73 — open upstream](https://github.com/moazbuilds/claudeclaw/pull/73)**
+**[PR #73 — closed upstream — lives here](https://github.com/moazbuilds/claudeclaw/pull/73)**
 
 Unified message ingestion pipeline normalises Discord/Telegram messages to a common format. Crash-safe append-only event log, retry queue with exponential backoff, dead-letter queue, full event replay, and an escalation framework (pause session, hand off to a human, notify across channels).
 
@@ -118,7 +118,7 @@ Unified message ingestion pipeline normalises Discord/Telegram messages to a com
 
 ### Orchestrator — DAG task graph and resumable jobs
 
-**[PR #74 — open upstream](https://github.com/moazbuilds/claudeclaw/pull/74)**
+**[PR #74 — closed upstream — lives here](https://github.com/moazbuilds/claudeclaw/pull/74)**
 
 Multi-step task execution via dependency graph with topological sort. Durable workflow state with atomic writes. Jobs survive daemon restarts mid-execution. Governance-integrated executor with configurable parallelism.
 
@@ -128,7 +128,7 @@ Multi-step task execution via dependency graph with topological sort. Durable wo
 
 ### CSRF Protection for Web UI
 
-**[PR #75 — open upstream](https://github.com/moazbuilds/claudeclaw/pull/75)**
+**[PR #75 — closed upstream — lives here](https://github.com/moazbuilds/claudeclaw/pull/75)**
 
 Cryptographically random single-use UUID tokens per session, timing-safe comparison, conditional `Secure` cookie flag, and a client-side `mutatingFetch()` wrapper that auto-retries on 403.
 
@@ -138,7 +138,7 @@ Cryptographically random single-use UUID tokens per session, timing-safe compari
 
 ### Persistent Memory — cross-session `MEMORY.md`
 
-**[PR #77 — open upstream](https://github.com/moazbuilds/claudeclaw/pull/77)**
+**[PR #77 — closed upstream — lives here](https://github.com/moazbuilds/claudeclaw/pull/77)**
 
 `MEMORY.md` loaded into `--append-system-prompt` on every invocation. Dual-layer write guarantee: Claude is instructed to write after each task, and a daemon-side fallback appends a log entry if `MEMORY.md` is unchanged after a run. Pre-compact and pre-shutdown saves, 200-line cap with auto-trim, per-agent memory paths.
 
@@ -156,7 +156,7 @@ See [docs/MULTI_SESSION.md](docs/MULTI_SESSION.md) for technical details.
 
 ### Daemon Plugin API
 
-**[PR #144 — open upstream](https://github.com/moazbuilds/claudeclaw/pull/144)**
+**[PR #144 — closed upstream — lives here](https://github.com/moazbuilds/claudeclaw/pull/144)**
 
 OpenClaw-compatible lifecycle events at the daemon level — `gateway_start`, `before_agent_start`, `before_prompt_build`, `tool_result_persist`, `agent_end`, and more. Plugins hook in via `api.on()`, `api.registerService()`, and `api.registerCommand()`. Includes path traversal prevention, SSRF-safe health checks, and fire-and-forget async emission.
 
@@ -206,7 +206,7 @@ Watch the [Issues](https://github.com/TerrysPOV/ClaudeClaw-Plus/issues) tab for 
 <details open>
   <summary><strong>Will features here go back upstream?</strong></summary>
   <p>
-    Sometimes. All the Plus features were proposed to upstream first.
+    Unlikely for the Plus-exclusive features — they've been closed upstream as out-of-scope for the lightweight core.
     <a href="https://github.com/moazbuilds">@moazbuilds</a> decides what fits the lightweight core.
     Whether they get merged upstream or not, they're available here today.
   </p>

--- a/scripts/bump-marketplace-version.ts
+++ b/scripts/bump-marketplace-version.ts
@@ -48,7 +48,7 @@ async function main(): Promise<void> {
     throw new Error(`${MARKETPLACE_JSON} does not contain any plugins.`);
   }
 
-  const plugin = marketplace.plugins.find((entry) => entry.name === "claudeclaw") ?? marketplace.plugins[0];
+  const plugin = marketplace.plugins.find((entry) => entry.name === "claudeclaw-plus") ?? marketplace.plugins[0];
   if (!plugin || typeof plugin.version !== "string" || plugin.version.trim() === "") {
     throw new Error(`${MARKETPLACE_JSON} is missing a valid plugin version string.`);
   }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -67,7 +67,7 @@ function alive() {
 }
 
 var B = DIM + "\\u2502" + R;
-var TITLE = " \\ud83e\\udd9e ClaudeClaw \\ud83e\\udd9e ";
+var TITLE = " \\ud83e\\udd9e ClaudeClaw+ \\ud83e\\udd9e ";
 var PAD = 6;
 var INNER_W = PAD + visibleLen(TITLE) + PAD;
 
@@ -379,7 +379,7 @@ export async function start(args: string[] = []) {
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
 
-  console.log("ClaudeClaw daemon started");
+  console.log("ClaudeClaw+ daemon started");
   console.log(`  PID: ${process.pid}`);
   console.log(`  Security: ${settings.security.level}`);
   if (settings.security.allowedTools.length > 0)

--- a/src/ui/page/template.ts
+++ b/src/ui/page/template.ts
@@ -19,7 +19,7 @@ export function htmlPage(): string {
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>ClaudeClaw</title>
+  <title>ClaudeClaw+</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300;9..144,500&family=Space+Grotesk:wght@400;500;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
@@ -31,12 +31,12 @@ ${pageStyles}
   <div class="grain" aria-hidden="true"></div>
   <a
     class="repo-cta"
-    href="https://github.com/moazbuilds/claudeclaw"
+    href="https://github.com/TerrysPOV/ClaudeClaw-Plus"
     target="_blank"
     rel="noopener noreferrer"
-    aria-label="Star claudeclaw on GitHub"
+    aria-label="Star ClaudeClaw+ on GitHub"
   >
-    <span class="repo-text">Like ClaudeClaw? Star it on GitHub</span>
+    <span class="repo-text">Like ClaudeClaw+? Star it on GitHub</span>
     <span class="repo-star">★</span>
   </a>
   <button class="settings-btn" id="settings-btn" type="button">Settings</button>


### PR DESCRIPTION
## Summary

- **TUI status bar**: `ClaudeClaw` → `ClaudeClaw+` (the box title in Claude Code's status bar)
- **Daemon startup log**: `ClaudeClaw daemon started` → `ClaudeClaw+ daemon started`
- **Web UI title**: `ClaudeClaw` → `ClaudeClaw+`
- **Web UI GitHub link**: points to `TerrysPOV/ClaudeClaw-Plus` (was `moazbuilds/claudeclaw`)
- **Web UI banner**: `Like ClaudeClaw? Star it on GitHub` → `Like ClaudeClaw+? Star it on GitHub`
- **README**: all `open upstream` → `closed upstream — lives here`; intro paragraph updated to reflect that upstream PRs are now closed and these features are permanently in ClaudeClaw+

## Test plan

- [ ] Start daemon, confirm status bar shows `ClaudeClaw+` in title box
- [ ] Open web dashboard, confirm page title and GitHub star banner show `ClaudeClaw+`
- [ ] Confirm GitHub link in web UI goes to `TerrysPOV/ClaudeClaw-Plus`