### PR TITLE
fix(statusline): reject 0/NaN/non-positive PIDs in alive()

### DIFF
--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -61,7 +61,11 @@ function fmt(ms) {
 function alive() {
   try {
     var pid = readFileSync(PID_FILE, "utf-8").trim();
-    process.kill(Number(pid), 0);
+    var parsedPid = Number(pid);
+    if (!Number.isFinite(parsedPid) || !Number.isInteger(parsedPid) || parsedPid <= 0) {
+      return false;
+    }
+    process.kill(parsedPid, 0);
     return true;
   } catch { return false; }
 }


### PR DESCRIPTION
## What

Guard `alive()` against empty or corrupt pidfile contents that cause `process.kill(0, 0)` to silently report the daemon as live.

`process.kill(0, signal)` is special in Node — it operates on the *calling process group*, not a specific PID, and always succeeds. So an empty pidfile (daemon crashed mid-write, lifecycle race) was returning `true` forever, leaving the statusline stuck on `● live` and blocking daemon restarts without a manual `rm daemon.pid`.

The fix validates the parsed PID is a finite, positive integer before passing it to `process.kill`. Any other value returns `false` immediately.

## Why

Hit naturally in the wild: daemon crash left an empty pidfile, statusline reported live, `claudeclaw start` skipped the restart and required manual intervention.

## Test plan

- [ ] Empty pidfile → `alive()` returns `false`
- [ ] Pidfile contains `"0"` → `false`
- [ ] Pidfile contains a valid running PID → `true` (unchanged)
- [ ] Pidfile contains a stale PID → `false` (unchanged)

## Attribution

Ported from [moazbuilds/claudeclaw#127](https://github.com/moazbuilds/claudeclaw/pull/127) by [@prashantsolanki3](https://github.com/prashantsolanki3). Thank you Prashant for the clean diagnosis and fix.