### PR TITLE
feat: built-in Kanban board in web UI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,13 +25,13 @@ jobs:
       id-token: write
 
     steps:
-      - name: Check API key configured
+      - name: Check token configured
         id: token-check
         env:
-          API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
         run: |
-          if [ -z "$API_KEY" ]; then
-            echo "::warning::ANTHROPIC_API_KEY secret is not configured — skipping auto-review."
+          if [ -z "$TOKEN" ]; then
+            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN secret is not configured — skipping auto-review."
             echo "configured=false" >> "$GITHUB_OUTPUT"
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
@@ -51,7 +51,7 @@ jobs:
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa
         with:
           github_token: ${{ github.token }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           allowed_non_write_users: '*'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,13 +25,13 @@ jobs:
       id-token: write
 
     steps:
-      - name: Check token configured
+      - name: Check API key configured
         id: token-check
         env:
-          TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: |
-          if [ -z "$TOKEN" ]; then
-            echo "::warning::CLAUDE_CODE_OAUTH_TOKEN secret is not configured — skipping auto-review. Add the secret to enable it."
+          if [ -z "$API_KEY" ]; then
+            echo "::warning::ANTHROPIC_API_KEY secret is not configured — skipping auto-review."
             echo "configured=false" >> "$GITHUB_OUTPUT"
           else
             echo "configured=true" >> "$GITHUB_OUTPUT"
@@ -51,7 +51,7 @@ jobs:
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa
         with:
           github_token: ${{ github.token }}
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_non_write_users: '*'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,6 +52,7 @@ jobs:
         with:
           github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_non_write_users: '*'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -52,7 +52,6 @@ jobs:
         with:
           github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_non_write_users: '*'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -988,8 +988,10 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     // ── Chat ──
     const tabDashboardBtn = $("tab-dashboard");
     const tabChatBtn = $("tab-chat");
+    const tabKanbanBtn = $("tab-kanban");
     const dashboardPanel = $("dashboard-panel");
     const chatPanel = $("chat-panel");
+    const kanbanPanel = $("kanban-panel");
     const chatMessages = $("chat-messages");
     const chatForm = $("chat-form");
     const chatInput = $("chat-input");
@@ -1008,8 +1010,8 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     })();
 
     function setActiveTab(tab) {
-      const allBtns = [tabDashboardBtn, tabChatBtn];
-      const allPanels = [dashboardPanel, chatPanel];
+      const allBtns = [tabDashboardBtn, tabChatBtn, tabKanbanBtn];
+      const allPanels = [dashboardPanel, chatPanel, kanbanPanel];
       allBtns.forEach(b => { if (b) { b.classList.remove("tab-btn-active"); b.setAttribute("aria-selected", "false"); } });
       allPanels.forEach(p => { if (p) p.hidden = true; });
 
@@ -1017,6 +1019,11 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
         tabDashboardBtn && tabDashboardBtn.classList.add("tab-btn-active");
         tabDashboardBtn && tabDashboardBtn.setAttribute("aria-selected", "true");
         if (dashboardPanel) dashboardPanel.hidden = false;
+      } else if (tab === "kanban") {
+        tabKanbanBtn && tabKanbanBtn.classList.add("tab-btn-active");
+        tabKanbanBtn && tabKanbanBtn.setAttribute("aria-selected", "true");
+        if (kanbanPanel) kanbanPanel.hidden = false;
+        loadKanban();
       } else {
         tabChatBtn && tabChatBtn.classList.add("tab-btn-active");
         tabChatBtn && tabChatBtn.setAttribute("aria-selected", "true");
@@ -1027,6 +1034,7 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
 
     if (tabDashboardBtn) tabDashboardBtn.addEventListener("click", () => setActiveTab("dashboard"));
     if (tabChatBtn) tabChatBtn.addEventListener("click", function() { setActiveTab("chat"); loadSessions(); });
+    if (tabKanbanBtn) tabKanbanBtn.addEventListener("click", () => setActiveTab("kanban"));
 
     // --- Session browser ---
 
@@ -1461,4 +1469,119 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
         var elapsedEl = chatMessages.querySelector(".chat-msg-elapsed");
         if (elapsedEl) elapsedEl.textContent = fmtElapsed(Date.now() - chatStartedAt);
       }
-    }, 1000);`;
+    }, 1000);
+
+// ── Kanban ───────────────────────────────────────────────────────────────────
+var kanbanData = { columns: { todo: [], in_progress: [], done: [] } };
+
+function timeAgoKanban(isoString) {
+  if (!isoString) return "";
+  var diff = Date.now() - new Date(isoString).getTime();
+  var s = Math.floor(diff / 1000);
+  if (s < 60) return s + "s ago";
+  var m = Math.floor(s / 60);
+  if (m < 60) return m + "m ago";
+  var h = Math.floor(m / 60);
+  if (h < 24) return h + "h ago";
+  return Math.floor(h / 24) + "d ago";
+}
+
+function escKanban(str) {
+  if (!str) return "";
+  return String(str).replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function renderKanbanCard(card, isDone) {
+  return '<div class="kanban-card" data-id="' + escKanban(card.id) + '">' +
+    '<div class="kanban-card-title">' + escKanban(card.title) + "</div>" +
+    (card.description ? '<div class="kanban-card-desc">' + escKanban(card.description) + "</div>" : "") +
+    '<div class="kanban-card-meta">' +
+      (card.started_at ? '<span>' + timeAgoKanban(isDone ? card.completed_at : card.started_at) + "</span>" : "") +
+    "</div>" +
+  "</div>";
+}
+
+function renderKanban() {
+  var todo = kanbanData.columns.todo || [];
+  var ip = kanbanData.columns.in_progress || [];
+  var done = kanbanData.columns.done || [];
+
+  var countTodo = $("kanban-count-todo");
+  var countIp = $("kanban-count-inprogress");
+  var countDone = $("kanban-count-done");
+  var cardsTodo = $("kanban-cards-todo");
+  var cardsIp = $("kanban-cards-inprogress");
+  var cardsDone = $("kanban-cards-done");
+
+  if (countTodo) countTodo.textContent = todo.length;
+  if (countIp) countIp.textContent = ip.length;
+  if (countDone) countDone.textContent = done.length;
+
+  if (cardsTodo) cardsTodo.innerHTML = todo.length
+    ? todo.map(function(c) { return renderKanbanCard(c, false); }).join("")
+    : '<div class="kanban-empty">No tasks queued</div>';
+  if (cardsIp) cardsIp.innerHTML = ip.length
+    ? ip.map(function(c) { return renderKanbanCard(c, false); }).join("")
+    : '<div class="kanban-empty">No active tasks</div>';
+  if (cardsDone) cardsDone.innerHTML = done.length
+    ? done.map(function(c) { return renderKanbanCard(c, true); }).join("")
+    : '<div class="kanban-empty">Nothing completed yet</div>';
+}
+
+async function loadKanban() {
+  try {
+    var res = await fetch("/api/kanban");
+    if (res.ok) { kanbanData = await res.json(); renderKanban(); }
+  } catch (_) {}
+}
+
+async function saveKanban() {
+  try {
+    await fetch("/api/kanban", { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify(kanbanData) });
+  } catch (_) {}
+}
+
+function clearKanbanDone() {
+  kanbanData.columns.done = [];
+  renderKanban();
+  saveKanban();
+}
+
+var kanbanModal = $("kanban-modal-overlay");
+var kanbanAddBtn = $("kanban-add-btn");
+var kanbanCancelBtn = $("kanban-cancel-btn");
+var kanbanSaveBtn = $("kanban-save-btn");
+var kanbanModalClose = $("kanban-modal-close");
+
+function openKanbanModal() { if (kanbanModal) kanbanModal.hidden = false; }
+function closeKanbanModal() {
+  if (kanbanModal) kanbanModal.hidden = true;
+  var t = $("kanban-input-title"); var d = $("kanban-input-desc");
+  if (t) t.value = ""; if (d) d.value = "";
+}
+
+function addKanbanTask() {
+  var titleEl = $("kanban-input-title");
+  var descEl = $("kanban-input-desc");
+  var title = titleEl ? titleEl.value.trim() : "";
+  if (!title) { if (titleEl) titleEl.focus(); return; }
+  var card = { id: "task-" + Date.now(), title: title, description: descEl ? descEl.value.trim() : "", started_at: new Date().toISOString() };
+  if (!Array.isArray(kanbanData.columns.todo)) kanbanData.columns.todo = [];
+  kanbanData.columns.todo.unshift(card);
+  closeKanbanModal();
+  renderKanban();
+  saveKanban();
+}
+
+if (kanbanAddBtn) kanbanAddBtn.addEventListener("click", openKanbanModal);
+if (kanbanCancelBtn) kanbanCancelBtn.addEventListener("click", closeKanbanModal);
+if (kanbanModalClose) kanbanModalClose.addEventListener("click", closeKanbanModal);
+if (kanbanSaveBtn) kanbanSaveBtn.addEventListener("click", addKanbanTask);
+if ($("kanban-input-title")) {
+  $("kanban-input-title").addEventListener("keydown", function(e) {
+    if (e.key === "Enter") { e.preventDefault(); addKanbanTask(); }
+  });
+}
+
+loadKanban();
+setInterval(loadKanban, 10000);`;

--- a/src/ui/page/styles.ts
+++ b/src/ui/page/styles.ts
@@ -1548,4 +1548,224 @@ export const pageStyles = String.raw`    :root {
   .chat-layout { flex-direction: column; }
   .chat-sidebar { width: 100%; min-width: 100%; max-height: 180px; border-right: none; border-bottom: 1px solid var(--border); }
 }
-`;
+
+/* ── Tab nav ── */
+[hidden] { display: none !important; }
+.tab-nav {
+  display: flex;
+  gap: 4px;
+  padding: 12px 24px 0;
+  border-bottom: 1px solid var(--glass-border, rgba(255,255,255,0.08));
+  margin-bottom: 0;
+}
+.tab-btn {
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--fg-3, #888);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  padding: 6px 14px 10px;
+  transition: color 0.15s, border-color 0.15s;
+}
+.tab-btn:hover { color: var(--fg-1, #eee); }
+.tab-btn-active {
+  border-bottom-color: var(--accent, #4a9eff);
+  color: var(--fg-1, #eee);
+}
+
+/* ── Kanban board ── */
+.kanban-board {
+  display: flex;
+  gap: 0;
+  height: calc(100vh - 200px);
+  overflow: hidden;
+}
+.kanban-col {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid rgba(255,255,255,0.06);
+  overflow: hidden;
+}
+.kanban-col:last-child { border-right: none; }
+.kanban-col-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 18px 10px;
+  flex-shrink: 0;
+}
+.kanban-col-title-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.kanban-col-indicator {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+}
+.kanban-indicator-todo { background: #a855f7; }
+.kanban-indicator-inprogress { background: #f59e0b; box-shadow: 0 0 6px #f59e0b; }
+.kanban-indicator-done { background: #22c55e; }
+.kanban-col-title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(255,255,255,0.5);
+}
+.kanban-col-count {
+  font-size: 11px;
+  font-weight: 600;
+  background: rgba(255,255,255,0.08);
+  border-radius: 10px;
+  padding: 1px 7px;
+  color: rgba(255,255,255,0.4);
+}
+.kanban-clear-btn {
+  background: none;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 5px;
+  color: rgba(255,255,255,0.35);
+  cursor: pointer;
+  font-size: 11px;
+  padding: 2px 8px;
+}
+.kanban-clear-btn:hover { color: rgba(255,255,255,0.7); border-color: rgba(255,255,255,0.25); }
+.kanban-cards {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.kanban-card {
+  background: rgba(255,255,255,0.04);
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 8px;
+  padding: 10px 12px;
+  cursor: default;
+  transition: background 0.15s;
+}
+.kanban-card:hover { background: rgba(255,255,255,0.07); }
+.kanban-card-title {
+  font-size: 13px;
+  font-weight: 500;
+  color: rgba(255,255,255,0.85);
+  margin-bottom: 3px;
+}
+.kanban-card-desc {
+  font-size: 12px;
+  color: rgba(255,255,255,0.4);
+  margin-bottom: 5px;
+  line-height: 1.4;
+}
+.kanban-card-meta {
+  font-size: 11px;
+  color: rgba(255,255,255,0.3);
+  font-family: "JetBrains Mono", monospace;
+}
+.kanban-empty {
+  color: rgba(255,255,255,0.2);
+  font-size: 12px;
+  text-align: center;
+  padding: 24px 0;
+}
+.kanban-toolbar {
+  padding: 10px 18px;
+  border-top: 1px solid rgba(255,255,255,0.06);
+}
+.kanban-add-btn {
+  background: rgba(74,158,255,0.1);
+  border: 1px solid rgba(74,158,255,0.25);
+  border-radius: 7px;
+  color: rgba(74,158,255,0.9);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 7px 16px;
+  transition: background 0.15s;
+}
+.kanban-add-btn:hover { background: rgba(74,158,255,0.18); }
+.kanban-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 200;
+}
+.kanban-modal {
+  background: #1a1a1f;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 12px;
+  min-width: 360px;
+  max-width: 480px;
+  width: 100%;
+}
+.kanban-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px 12px;
+  font-weight: 600;
+  font-size: 14px;
+  border-bottom: 1px solid rgba(255,255,255,0.07);
+}
+.kanban-modal-close {
+  background: none;
+  border: none;
+  color: rgba(255,255,255,0.4);
+  cursor: pointer;
+  font-size: 20px;
+  line-height: 1;
+}
+.kanban-modal-body { padding: 16px 20px; display: flex; flex-direction: column; gap: 10px; }
+.kanban-input {
+  background: rgba(255,255,255,0.05);
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 7px;
+  color: rgba(255,255,255,0.85);
+  font-family: inherit;
+  font-size: 13px;
+  padding: 9px 12px;
+  width: 100%;
+  resize: none;
+}
+.kanban-input:focus { outline: none; border-color: rgba(74,158,255,0.4); }
+.kanban-textarea { min-height: 70px; }
+.kanban-modal-footer {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  padding: 12px 20px 16px;
+  border-top: 1px solid rgba(255,255,255,0.07);
+}
+.kanban-btn-primary {
+  background: rgba(74,158,255,0.15);
+  border: 1px solid rgba(74,158,255,0.3);
+  border-radius: 7px;
+  color: rgba(74,158,255,0.95);
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 7px 16px;
+}
+.kanban-btn-primary:hover { background: rgba(74,158,255,0.25); }
+.kanban-btn-secondary {
+  background: none;
+  border: 1px solid rgba(255,255,255,0.1);
+  border-radius: 7px;
+  color: rgba(255,255,255,0.4);
+  cursor: pointer;
+  font-size: 13px;
+  padding: 7px 16px;
+}
+.kanban-btn-secondary:hover { color: rgba(255,255,255,0.7); }`;

--- a/src/ui/page/template.ts
+++ b/src/ui/page/template.ts
@@ -115,6 +115,7 @@ ${pageStyles}
     <nav class="tab-nav" role="tablist" aria-label="Main navigation">
       <button class="tab-btn tab-btn-active" id="tab-dashboard" type="button" role="tab" aria-selected="true" aria-controls="dashboard-panel">Dashboard</button>
       <button class="tab-btn" id="tab-chat" type="button" role="tab" aria-selected="false" aria-controls="chat-panel">Chat</button>
+      <button class="tab-btn" id="tab-kanban" type="button" role="tab" aria-selected="false" aria-controls="kanban-panel">Kanban</button>
     </nav>
     <div id="dashboard-panel">
     <section class="hero">
@@ -218,6 +219,60 @@ ${pageStyles}
           </div>
         </div><!-- chat-main -->
       </div><!-- chat-layout -->
+    </div>
+    <div id="kanban-panel" hidden>
+      <div class="kanban-board">
+        <div class="kanban-col" id="kanban-col-todo">
+          <div class="kanban-col-header">
+            <div class="kanban-col-title-group">
+              <div class="kanban-col-indicator kanban-indicator-todo"></div>
+              <span class="kanban-col-title">To Do</span>
+              <span class="kanban-col-count" id="kanban-count-todo">0</span>
+            </div>
+          </div>
+          <div class="kanban-cards" id="kanban-cards-todo"></div>
+        </div>
+        <div class="kanban-col" id="kanban-col-inprogress">
+          <div class="kanban-col-header">
+            <div class="kanban-col-title-group">
+              <div class="kanban-col-indicator kanban-indicator-inprogress"></div>
+              <span class="kanban-col-title">In Progress</span>
+              <span class="kanban-col-count" id="kanban-count-inprogress">0</span>
+            </div>
+          </div>
+          <div class="kanban-cards" id="kanban-cards-inprogress"></div>
+        </div>
+        <div class="kanban-col" id="kanban-col-done">
+          <div class="kanban-col-header">
+            <div class="kanban-col-title-group">
+              <div class="kanban-col-indicator kanban-indicator-done"></div>
+              <span class="kanban-col-title">Done</span>
+              <span class="kanban-col-count" id="kanban-count-done">0</span>
+            </div>
+            <button class="kanban-clear-btn" onclick="clearKanbanDone()" type="button">Clear</button>
+          </div>
+          <div class="kanban-cards" id="kanban-cards-done"></div>
+        </div>
+      </div>
+      <div class="kanban-toolbar">
+        <button class="kanban-add-btn" id="kanban-add-btn" type="button">+ Add task</button>
+      </div>
+      <div class="kanban-modal-overlay" id="kanban-modal-overlay" hidden>
+        <div class="kanban-modal">
+          <div class="kanban-modal-header">
+            <span>Add task</span>
+            <button class="kanban-modal-close" id="kanban-modal-close" type="button">×</button>
+          </div>
+          <div class="kanban-modal-body">
+            <input class="kanban-input" id="kanban-input-title" placeholder="Task title" type="text" />
+            <textarea class="kanban-input kanban-textarea" id="kanban-input-desc" placeholder="Description (optional)" rows="3"></textarea>
+          </div>
+          <div class="kanban-modal-footer">
+            <button class="kanban-btn-secondary" id="kanban-cancel-btn" type="button">Cancel</button>
+            <button class="kanban-btn-primary" id="kanban-save-btn" type="button">Add to To Do</button>
+          </div>
+        </div>
+      </div>
     </div>
   </main>
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -408,6 +408,8 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
       }
 
       if (url.pathname === "/api/kanban" && req.method === "POST") {
+        const csrfError = requireCsrf(req);
+        if (csrfError) return csrfError;
         try {
           const body = await req.json() as KanbanBoard;
           await writeKanban(body);

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -10,6 +10,7 @@ import { fireJob } from "../commands/fire";
 import { readLogs } from "./services/logs";
 import { listSessions, readSessionMessages, listAgents } from "./services/sessions";
 import { runUserMessage } from "../runner";
+import { readKanban, writeKanban, type KanbanBoard } from "./services/kanban";
 
 // --- Security: CSRF Protection ---
 // NOTE: The Web UI has no built-in authentication. CSRF protection prevents
@@ -399,6 +400,20 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
         } catch (err) {
           console.error("Chat request failed:", err);
           return json({ ok: false, error: "Chat request failed" });
+        }
+      }
+
+      if (url.pathname === "/api/kanban" && req.method === "GET") {
+        return json(await readKanban());
+      }
+
+      if (url.pathname === "/api/kanban" && req.method === "POST") {
+        try {
+          const body = await req.json() as KanbanBoard;
+          await writeKanban(body);
+          return json({ ok: true });
+        } catch (err) {
+          return json({ ok: false, error: String(err) });
         }
       }
 

--- a/src/ui/services/kanban.ts
+++ b/src/ui/services/kanban.ts
@@ -1,0 +1,77 @@
+import { join } from "path";
+import { existsSync } from "fs";
+import { mkdir } from "fs/promises";
+
+const KANBAN_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const KANBAN_FILE = join(KANBAN_DIR, "kanban.json");
+
+export interface KanbanCard {
+  id: string;
+  title: string;
+  description?: string;
+  started_at?: string;
+  completed_at?: string;
+  agent_type?: string;
+}
+
+export interface KanbanBoard {
+  columns: {
+    todo: KanbanCard[];
+    in_progress: KanbanCard[];
+    done: KanbanCard[];
+  };
+}
+
+const DEFAULT_BOARD: KanbanBoard = {
+  columns: { todo: [], in_progress: [], done: [] },
+};
+
+export async function readKanban(): Promise<KanbanBoard> {
+  try {
+    if (!existsSync(KANBAN_FILE)) return structuredClone(DEFAULT_BOARD);
+    const text = await Bun.file(KANBAN_FILE).text();
+    const parsed = JSON.parse(text) as KanbanBoard;
+    if (!parsed.columns) parsed.columns = { todo: [], in_progress: [], done: [] };
+    if (!Array.isArray(parsed.columns.todo)) parsed.columns.todo = [];
+    if (!Array.isArray(parsed.columns.in_progress)) parsed.columns.in_progress = [];
+    if (!Array.isArray(parsed.columns.done)) parsed.columns.done = [];
+    return parsed;
+  } catch {
+    return structuredClone(DEFAULT_BOARD);
+  }
+}
+
+export async function writeKanban(board: KanbanBoard): Promise<void> {
+  await mkdir(KANBAN_DIR, { recursive: true });
+  await Bun.write(KANBAN_FILE, JSON.stringify(board, null, 2));
+}
+
+export async function addCardToColumn(
+  column: keyof KanbanBoard["columns"],
+  card: KanbanCard
+): Promise<void> {
+  const board = await readKanban();
+  board.columns[column].unshift(card);
+  await writeKanban(board);
+}
+
+export async function moveCard(
+  id: string,
+  toColumn: keyof KanbanBoard["columns"],
+  patch?: Partial<KanbanCard>
+): Promise<void> {
+  const board = await readKanban();
+  let card: KanbanCard | undefined;
+  for (const col of Object.keys(board.columns) as Array<keyof KanbanBoard["columns"]>) {
+    const idx = board.columns[col].findIndex((c) => c.id === id);
+    if (idx !== -1) {
+      card = board.columns[col].splice(idx, 1)[0];
+      break;
+    }
+  }
+  if (card) {
+    Object.assign(card, patch ?? {});
+    board.columns[toColumn].unshift(card);
+    await writeKanban(board);
+  }
+}


### PR DESCRIPTION
## What

Adds a Kanban board as a native tab in the ClaudeClaw+ web UI — no external server, no iframe, no configuration.

**Three columns:** To Do → In Progress → Done

- Add tasks via a modal (`+ Add task`)
- Clear the Done column in one click
- Auto-refreshes every 10 seconds
- State persists to `.claude/claudeclaw/kanban.json`
- Integrates with the existing Dashboard/Chat tab system

## Why it lives in Plus (not upstream)

This pairs naturally with the agent lifecycle events tab (already in ClaudeClaw+) — `addCardToColumn` / `moveCard` helpers are ready for sub-agent auto-tracking. The scope (509 lines across 5 UI files, project-management feature) doesn't fit upstream's lightweight brief.

## Architecture

**New:** `src/ui/services/kanban.ts` — `readKanban`, `writeKanban`, `addCardToColumn`, `moveCard`

**New endpoints:** `GET /api/kanban`, `POST /api/kanban`

**Card schema:**
```typescript
{ id: string; title: string; description?: string;
  started_at?: string; completed_at?: string; agent_type?: string; }
```

## Test plan

- [ ] Open web UI, click Kanban tab
- [ ] Add task via modal → appears in To Do
- [ ] Reload → board state restored from `kanban.json`
- [ ] Clear Done column → cards removed
- [ ] Dashboard and Chat tabs still work normally

## Attribution

Originally submitted by [@chetan-guevara](https://github.com/chetan-guevara) in [moazbuilds/claudeclaw#42](https://github.com/moazbuilds/claudeclaw/pull/42). Ported to ClaudeClaw+ and adapted to fit the existing Dashboard/Chat tab structure. Thank you Chetan.