### PR TITLE
feat(memory): session-history search via FTS5 + sentence-transformers (#19)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.4",
+      "version": "2.0.5",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/skills/session-recall.md
+++ b/skills/session-recall.md
@@ -1,0 +1,75 @@
+---
+name: session-recall
+description: Hybrid keyword + semantic search over past Claude Code session history. Use when the user asks "what did we do about X", "you remember when", "was there a fix for Y", "earlier we talked about Z", or any callback to a prior conversation that isn't in the current session.
+trigger:
+  - "qu'est-ce qu'on avait fait"
+  - "tu te souviens"
+  - "c'était quoi le fix"
+  - "on en avait parlé"
+  - "retrouve-moi"
+  - "what did we do about"
+  - "was there a discussion"
+  - "earlier we"
+  - "remember when"
+---
+
+# session-recall
+
+Hybrid FTS5 + sentence-transformer search over the JSONL session history that
+Claude Code persists under `~/.claude/projects/`. Surfaces past sessions
+relevant to the current question without loading their full text into context.
+
+## When to use
+
+- The user references something they remember discussing but you don't have
+  it in the current context window.
+- You need to check whether a problem was already solved in a prior session.
+- The user asks for a status summary that spans multiple past sessions.
+
+## How to use
+
+```bash
+memory-search recall "<query>" --top 5
+```
+
+Add `--no-summary` for a faster keyword/vector match without the LLM
+summarization step.
+
+For programmatic use inside skills:
+
+```python
+from memory_search import recall
+result = recall("yfinance crumb fix", top_k=5)
+for hit in result["hits"]:
+    print(hit["score"], hit["timestamp"], hit["excerpt"])
+print(result["summary"])
+```
+
+## Examples
+
+```bash
+memory-search recall "BREAKOUT_52W backtest results"
+memory-search recall "fix yfinance crumb"
+memory-search recall "Asterisk SRTP codec negotiation"
+memory-search recall "IBKR Gateway zombie session"
+```
+
+## Reindex (when needed)
+
+The indexer is idempotent (skips files whose mtime is unchanged) so it's safe
+to run on every daemon start or on a cron.
+
+```bash
+memory-search index           # incremental
+memory-search index --force   # full reindex (e.g. after model change)
+memory-search stats           # quick health check
+```
+
+## Notes
+
+- The first invocation downloads the sentence-transformer model (~80 MB).
+- Vector search alone returns up to 50 candidates; FTS5 is layered on top
+  for keyword anchoring and the two are blended with `alpha` (default 0.5).
+- Search results are deduplicated per session: the top chunk wins.
+- The `--summary` step uses `claude --print`, so it works without an
+  Anthropic API key (relies on Claude Code's existing OAuth session).

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -17,7 +17,7 @@ import { initializeJobSystem } from "../orchestrator/resumable-jobs";
 import type { Job } from "../jobs";
 import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
 import { PluginManager, setPluginManager } from "../plugins";
-import { indexSessions } from "../memory";
+import { indexSessionsBackground } from "../memory";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
@@ -340,20 +340,6 @@ export async function start(args: string[] = []) {
   // dev. Idempotent and non-destructive.
   try {
     const links = await ensureUserSymlinks();
-  // memory-search: incremental session re-index on boot (issue #19).
-  // Idempotent (skips files whose mtime is unchanged), so it is cheap to
-  // run every time. Runs synchronously to keep the deterministic R/W
-  // contract; failures are logged but never block daemon startup.
-  try {
-    const memSettings = (await loadSettings()) as { memorySearch?: any };
-    const idx = indexSessions(memSettings.memorySearch);
-    if (idx.indexed > 0) {
-      console.log(`[memory-search] indexed ${idx.indexed} new session(s) (${idx.skipped} up-to-date)`);
-    }
-  } catch (e) {
-    console.log(`[memory-search] index skipped on boot: ${(e as Error).message}`);
-  }
-
     const now = new Date().toLocaleTimeString();
     if (links.created.length > 0) {
       console.log(`[${now}] Installed ${links.created.length} user symlink(s): ${links.created.join(", ")}`);
@@ -365,6 +351,18 @@ export async function start(args: string[] = []) {
     }
   } catch (err) {
     console.error(`[${new Date().toLocaleTimeString()}] ensureUserSymlinks failed:`, err);
+  }
+
+  // memory-search: incremental session re-index on boot (issue #19).
+  // Async fire-and-forget — must NOT block the Bun event loop on first boot
+  // (model download + indexing of N sessions could otherwise freeze Telegram /
+  // Discord polling for tens of seconds). Top-level try so failures here are
+  // never confused with symlink-installation failures.
+  try {
+    const memSettings = (await loadSettings()) as { memorySearch?: any };
+    indexSessionsBackground(memSettings.memorySearch);
+  } catch (e) {
+    console.log(`[memory-search] background index could not be scheduled: ${(e as Error).message}`);
   }
 
   // Phase 17: migrate any Phase 16 single-job agents from flat dir into agents/<name>/jobs/default.md

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -17,6 +17,7 @@ import { initializeJobSystem } from "../orchestrator/resumable-jobs";
 import type { Job } from "../jobs";
 import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
 import { PluginManager, setPluginManager } from "../plugins";
+import { indexSessions } from "../memory";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
@@ -339,6 +340,20 @@ export async function start(args: string[] = []) {
   // dev. Idempotent and non-destructive.
   try {
     const links = await ensureUserSymlinks();
+  // memory-search: incremental session re-index on boot (issue #19).
+  // Idempotent (skips files whose mtime is unchanged), so it is cheap to
+  // run every time. Runs synchronously to keep the deterministic R/W
+  // contract; failures are logged but never block daemon startup.
+  try {
+    const memSettings = (await loadSettings()) as { memorySearch?: any };
+    const idx = indexSessions(memSettings.memorySearch);
+    if (idx.indexed > 0) {
+      console.log(`[memory-search] indexed ${idx.indexed} new session(s) (${idx.skipped} up-to-date)`);
+    }
+  } catch (e) {
+    console.log(`[memory-search] index skipped on boot: ${(e as Error).message}`);
+  }
+
     const now = new Date().toLocaleTimeString();
     if (links.created.length > 0) {
       console.log(`[${now}] Installed ${links.created.length} user symlink(s): ${links.created.join(", ")}`);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -359,7 +359,7 @@ export async function start(args: string[] = []) {
   // Discord polling for tens of seconds). Top-level try so failures here are
   // never confused with symlink-installation failures.
   try {
-    const memSettings = (await loadSettings()) as { memorySearch?: any };
+    const memSettings = await loadSettings();
     indexSessionsBackground(memSettings.memorySearch);
   } catch (e) {
     console.log(`[memory-search] background index could not be scheduled: ${(e as Error).message}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { existsSync } from "fs";
 import { normalizeTimezoneName, resolveTimezoneOffsetMinutes } from "./timezone";
 import { parseWatchdogConfig, type WatchdogConfig } from "./watchdog";
 import { parsePlugins, type PluginEntry } from "./plugins";
+import { parseMemorySearchSettings, type MemorySearchSettings } from "./memory";
 
 /** Re-exported under the name used in the Settings interface. */
 export type WatchdogSettings = WatchdogConfig;
@@ -90,6 +91,7 @@ const DEFAULT_SETTINGS: Settings = {
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
   session: { autoRotate: false, maxMessages: 50, maxAgeHours: 24, summaryPath: "" },
   plugins: {},
+  memorySearch: {},
 };
 
 export interface HeartbeatExcludeWindow {
@@ -174,6 +176,7 @@ export interface Settings {
   watchdog: WatchdogSettings;
   plugins: Record<string, PluginEntry>;
   session: SessionConfig;
+  memorySearch: MemorySearchSettings;
   jobsDir?: string;
 }
 
@@ -391,6 +394,7 @@ function parseSettings(
     },
     watchdog: parseWatchdogConfig(raw.watchdog),
     plugins: parsePlugins(raw.plugins),
+    memorySearch: parseMemorySearchSettings(raw.memorySearch),
     session: {
       autoRotate: raw.session?.autoRotate ?? false,
       maxMessages: Number.isFinite(raw.session?.maxMessages) ? Number(raw.session.maxMessages) : 50,

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -297,9 +297,10 @@ export function indexSessionsBackground(opts?: MemorySearchSettings): void {
  *
  * @param query  free-text query
  * @param topK   max distinct sessions to return (default 5)
- * @param withSummary  if true, the Python CLI also runs `claude --print` to
- *                     summarize the hits (default false from this entry point —
- *                     callers like skills can opt in). Costs ~1-3s extra.
+ * @param withSummary  if false, skip the `claude --print` summarization step
+ *                     for ~1-3s less latency. Default true, matching the
+ *                     `memory-search recall` CLI default and the
+ *                     session-recall skill documentation.
  */
 export function searchSessions(
   query: string,
@@ -318,7 +319,7 @@ export function searchSessions(
   if (opts?.alpha !== undefined) {
     args.push("--alpha", String(opts.alpha));
   }
-  if (!opts?.withSummary) {
+  if (opts?.withSummary === false) {
     args.push("--no-summary");
   }
 

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -7,6 +7,7 @@
 
 import { join } from "path";
 import { existsSync } from "fs";
+import { spawnSync } from "child_process";
 import { readFile, writeFile, mkdir } from "fs/promises";
 
 const PROJECT_DIR = process.cwd();
@@ -71,5 +72,165 @@ export async function loadMemoryInstructions(agentName?: string): Promise<string
     return content.trim().replace(/<MEMORY_PATH>/g, getMemoryPath(agentName));
   } catch {
     return "";
+  }
+}
+// ---------------------------------------------------------------------------
+// Session-history search (added 2026-05-03 for issue #19)
+//
+// Wraps the Python `tools/memory-search/` indexer + searcher. We keep the
+// heavy lifting (SQLite + FTS5 + sentence-transformer embeddings) in Python
+// where the libraries are mature, and expose deterministic read/write entry
+// points to the rest of the daemon from here.
+//
+// Determinism notes:
+//   - No in-process cache: every searchSessions() call shells out to a
+//     fresh Python subprocess that reads from the on-disk SQLite database.
+//     If you write a memory or index a new session, the very next read
+//     reflects it.
+//   - indexSessions() is idempotent (the Python indexer skips files whose
+//     mtime has not changed) so calling it on every boot is cheap.
+// ---------------------------------------------------------------------------
+
+const MEMORY_SEARCH_DIR = join(import.meta.dir, "..", "tools", "memory-search");
+const MEMORY_SEARCH_BIN = join(MEMORY_SEARCH_DIR, ".venv", "bin", "memory-search");
+
+export interface MemorySearchSettings {
+  /** Disable the whole subsystem at runtime. Default: true. */
+  enabled?: boolean;
+  /** Path to the `memory-search` CLI. Falls back to project venv then PATH. */
+  binPath?: string;
+  /** Path to the SQLite DB. Falls back to ~/.claude/claudeclaw/memory-search.db. */
+  dbPath?: string;
+  /** Colon-separated session JSONL directories. Falls back to all of ~/.claude/projects/*. */
+  sessionsDir?: string;
+  /** sentence-transformer model name. Default: all-MiniLM-L6-v2. */
+  model?: string;
+  /** Hybrid blend, 1.0=semantic only, 0.0=FTS5 only. Default: 0.5. */
+  alpha?: number;
+  /** Re-index after every N runner turns. Default: 10. 0 disables. */
+  reindexEveryNTurns?: number;
+  /** Max seconds a search subprocess is allowed to run. Default: 60. */
+  searchTimeoutSec?: number;
+  /** Max seconds an index subprocess is allowed to run. Default: 600. */
+  indexTimeoutSec?: number;
+}
+
+export interface SessionSearchHit {
+  score: number;
+  session_id: string;
+  timestamp: string;
+  turn_count: number;
+  excerpt: string;
+}
+
+export interface SessionSearchResult {
+  query: string;
+  hits: SessionSearchHit[];
+  summary: string | null;
+}
+
+export interface IndexResult {
+  found: number;
+  indexed: number;
+  skipped: number;
+}
+
+function resolveBin(opts?: MemorySearchSettings): string {
+  if (opts?.binPath) return opts.binPath;
+  if (existsSync(MEMORY_SEARCH_BIN)) return MEMORY_SEARCH_BIN;
+  return "memory-search"; // rely on PATH
+}
+
+function buildEnv(opts?: MemorySearchSettings): NodeJS.ProcessEnv {
+  const env = { ...process.env };
+  if (opts?.dbPath) env.MEMORY_SEARCH_DB = opts.dbPath;
+  if (opts?.sessionsDir) env.MEMORY_SEARCH_SESSIONS_DIR = opts.sessionsDir;
+  if (opts?.model) env.MEMORY_SEARCH_MODEL = opts.model;
+  return env;
+}
+
+/**
+ * Re-index every configured session JSONL into the search DB.
+ * Idempotent — skips files whose mtime is unchanged.
+ *
+ * Returns counts. Throws on subprocess failure (caller decides whether
+ * a failed boot-time index should be fatal).
+ */
+export function indexSessions(opts?: MemorySearchSettings): IndexResult {
+  if (opts?.enabled === false) {
+    return { found: 0, indexed: 0, skipped: 0 };
+  }
+  const result = spawnSync(resolveBin(opts), ["index"], {
+    env: buildEnv(opts),
+    encoding: "utf8",
+    timeout: (opts?.indexTimeoutSec ?? 600) * 1000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  if (result.status !== 0) {
+    const stderr = (result.stderr || "").trim();
+    throw new Error(`memory-search index failed (exit ${result.status}): ${stderr}`);
+  }
+
+  // Parse the human-readable output: "📂 found: N  ✅ indexed: N  ⏭️  skipped: N"
+  const stdout = result.stdout || "";
+  const found = parseInt(stdout.match(/found:\s*(\d+)/)?.[1] ?? "0", 10);
+  const indexed = parseInt(stdout.match(/indexed:\s*(\d+)/)?.[1] ?? "0", 10);
+  const skipped = parseInt(stdout.match(/skipped[^:]*:\s*(\d+)/)?.[1] ?? "0", 10);
+  return { found, indexed, skipped };
+}
+
+/**
+ * Search past sessions for a query.
+ * Always reads the on-disk DB fresh (no cache), so writes from a concurrent
+ * indexSessions() are visible immediately.
+ *
+ * @param query  free-text query
+ * @param topK   max distinct sessions to return (default 5)
+ * @param withSummary  if true, the Python CLI also runs `claude --print` to
+ *                     summarize the hits (default false from this entry point —
+ *                     callers like skills can opt in). Costs ~1-3s extra.
+ */
+export function searchSessions(
+  query: string,
+  opts?: MemorySearchSettings & { topK?: number; withSummary?: boolean }
+): SessionSearchResult {
+  if (opts?.enabled === false) {
+    return { query, hits: [], summary: null };
+  }
+  const args = [
+    "recall",
+    query,
+    "--top",
+    String(opts?.topK ?? 5),
+    "--json",
+  ];
+  if (opts?.alpha !== undefined) {
+    args.push("--alpha", String(opts.alpha));
+  }
+  if (!opts?.withSummary) {
+    args.push("--no-summary");
+  }
+
+  const result = spawnSync(resolveBin(opts), args, {
+    env: buildEnv(opts),
+    encoding: "utf8",
+    timeout: (opts?.searchTimeoutSec ?? 60) * 1000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  // exit code 1 just means "no hits" (caller can still parse JSON for empty array)
+  if (result.status !== 0 && result.status !== 1) {
+    const stderr = (result.stderr || "").trim();
+    throw new Error(`memory-search recall failed (exit ${result.status}): ${stderr}`);
+  }
+
+  const stdout = (result.stdout || "").trim();
+  if (!stdout) return { query, hits: [], summary: null };
+
+  try {
+    return JSON.parse(stdout) as SessionSearchResult;
+  } catch (e) {
+    throw new Error(`memory-search returned invalid JSON: ${(e as Error).message}`);
   }
 }

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -119,6 +119,38 @@ export interface MemorySearchSettings {
   indexTimeoutSec?: number;
 }
 
+/**
+ * Parse a raw settings.memorySearch object into a strict MemorySearchSettings.
+ * Unknown / wrong-type fields are dropped. Returns `{}` (all defaults) when
+ * the input is missing or not an object.
+ */
+export function parseMemorySearchSettings(raw: unknown): MemorySearchSettings {
+  if (!raw || typeof raw !== "object") return {};
+  const r = raw as Record<string, unknown>;
+  const out: MemorySearchSettings = {};
+
+  if (typeof r.enabled === "boolean") out.enabled = r.enabled;
+  if (typeof r.binPath === "string" && r.binPath.trim()) out.binPath = r.binPath.trim();
+  if (typeof r.dbPath === "string" && r.dbPath.trim()) out.dbPath = r.dbPath.trim();
+  if (typeof r.sessionsDir === "string" && r.sessionsDir.trim()) out.sessionsDir = r.sessionsDir.trim();
+  if (typeof r.model === "string" && r.model.trim()) out.model = r.model.trim();
+
+  if (typeof r.alpha === "number" && Number.isFinite(r.alpha) && r.alpha >= 0 && r.alpha <= 1) {
+    out.alpha = r.alpha;
+  }
+  if (typeof r.reindexEveryNTurns === "number" && Number.isInteger(r.reindexEveryNTurns) && r.reindexEveryNTurns >= 0) {
+    out.reindexEveryNTurns = r.reindexEveryNTurns;
+  }
+  if (typeof r.searchTimeoutSec === "number" && Number.isFinite(r.searchTimeoutSec) && r.searchTimeoutSec > 0) {
+    out.searchTimeoutSec = r.searchTimeoutSec;
+  }
+  if (typeof r.indexTimeoutSec === "number" && Number.isFinite(r.indexTimeoutSec) && r.indexTimeoutSec > 0) {
+    out.indexTimeoutSec = r.indexTimeoutSec;
+  }
+
+  return out;
+}
+
 export interface SessionSearchHit {
   score: number;
   session_id: string;

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -171,10 +171,37 @@ export interface IndexResult {
   skipped: number;
 }
 
-function resolveBin(opts?: MemorySearchSettings): string {
-  if (opts?.binPath) return opts.binPath;
-  if (existsSync(MEMORY_SEARCH_BIN)) return MEMORY_SEARCH_BIN;
-  return "memory-search"; // rely on PATH
+const SETUP_HINT =
+  "Run: cd tools/memory-search && uv pip install -e .";
+
+type BinCheck =
+  | { ok: true; bin: string }
+  | { ok: false; reason: string };
+
+/**
+ * Locate the memory-search binary, with a clear setup hint when missing.
+ * Order: explicit `opts.binPath` → project venv → `which memory-search` on PATH.
+ */
+function checkMemorySearchBin(opts?: MemorySearchSettings): BinCheck {
+  if (opts?.binPath) {
+    if (existsSync(opts.binPath)) return { ok: true, bin: opts.binPath };
+    return {
+      ok: false,
+      reason: `binary not found at configured binPath '${opts.binPath}'. ${SETUP_HINT}`,
+    };
+  }
+  if (existsSync(MEMORY_SEARCH_BIN)) return { ok: true, bin: MEMORY_SEARCH_BIN };
+
+  // Fall back to PATH lookup so users with a system-wide install still work.
+  const which = spawnSync("which", ["memory-search"], { encoding: "utf8" });
+  if (which.status === 0 && which.stdout.trim()) {
+    return { ok: true, bin: which.stdout.trim() };
+  }
+
+  return {
+    ok: false,
+    reason: `binary not installed (looked at ${MEMORY_SEARCH_BIN} and PATH). ${SETUP_HINT}`,
+  };
 }
 
 function buildEnv(opts?: MemorySearchSettings): NodeJS.ProcessEnv {
@@ -196,7 +223,11 @@ export function indexSessions(opts?: MemorySearchSettings): IndexResult {
   if (opts?.enabled === false) {
     return { found: 0, indexed: 0, skipped: 0 };
   }
-  const result = spawnSync(resolveBin(opts), ["index"], {
+  const check = checkMemorySearchBin(opts);
+  if (!check.ok) {
+    throw new Error(`memory-search ${check.reason}`);
+  }
+  const result = spawnSync(check.bin, ["index"], {
     env: buildEnv(opts),
     encoding: "utf8",
     timeout: (opts?.indexTimeoutSec ?? 600) * 1000,
@@ -228,8 +259,13 @@ export function indexSessions(opts?: MemorySearchSettings): IndexResult {
  */
 export function indexSessionsBackground(opts?: MemorySearchSettings): void {
   if (opts?.enabled === false) return;
+  const check = checkMemorySearchBin(opts);
+  if (!check.ok) {
+    console.log(`[memory-search] ${check.reason}`);
+    return;
+  }
   const { spawn } = require("child_process") as typeof import("child_process");
-  const proc = spawn(resolveBin(opts), ["index"], {
+  const proc = spawn(check.bin, ["index"], {
     env: buildEnv(opts),
     stdio: ["ignore", "pipe", "pipe"],
   });
@@ -286,7 +322,12 @@ export function searchSessions(
     args.push("--no-summary");
   }
 
-  const result = spawnSync(resolveBin(opts), args, {
+  const check = checkMemorySearchBin(opts);
+  if (!check.ok) {
+    throw new Error(`memory-search ${check.reason}`);
+  }
+
+  const result = spawnSync(check.bin, args, {
     env: buildEnv(opts),
     encoding: "utf8",
     timeout: (opts?.searchTimeoutSec ?? 60) * 1000,

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -107,7 +107,11 @@ export interface MemorySearchSettings {
   model?: string;
   /** Hybrid blend, 1.0=semantic only, 0.0=FTS5 only. Default: 0.5. */
   alpha?: number;
-  /** Re-index after every N runner turns. Default: 10. 0 disables. */
+  /**
+   * NYI — wired in a follow-up PR. Currently parsed but not enforced.
+   *
+   * Re-index after every N runner turns. Default: 10. 0 disables.
+   */
   reindexEveryNTurns?: number;
   /** Max seconds a search subprocess is allowed to run. Default: 60. */
   searchTimeoutSec?: number;
@@ -178,6 +182,44 @@ export function indexSessions(opts?: MemorySearchSettings): IndexResult {
   const indexed = parseInt(stdout.match(/indexed:\s*(\d+)/)?.[1] ?? "0", 10);
   const skipped = parseInt(stdout.match(/skipped[^:]*:\s*(\d+)/)?.[1] ?? "0", 10);
   return { found, indexed, skipped };
+}
+
+/**
+ * Async fire-and-forget variant of indexSessions, suitable for the daemon
+ * boot trigger where blocking the event loop is not acceptable.
+ *
+ * The first run downloads ~80MB of model weights and may walk hundreds of
+ * sessions; with spawnSync that froze the entire daemon (no Telegram /
+ * Discord during boot). Switching to spawn keeps the event loop responsive.
+ *
+ * Returns immediately. Logs completion / failure asynchronously.
+ */
+export function indexSessionsBackground(opts?: MemorySearchSettings): void {
+  if (opts?.enabled === false) return;
+  const { spawn } = require("child_process") as typeof import("child_process");
+  const proc = spawn(resolveBin(opts), ["index"], {
+    env: buildEnv(opts),
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  let stdout = "";
+  let stderr = "";
+  proc.stdout?.on("data", (chunk: Buffer) => { stdout += chunk.toString(); });
+  proc.stderr?.on("data", (chunk: Buffer) => { stderr += chunk.toString(); });
+  proc.on("close", (code: number | null) => {
+    if (code === 0) {
+      const indexed = parseInt(stdout.match(/indexed:\s*(\d+)/)?.[1] ?? "0", 10);
+      const skipped = parseInt(stdout.match(/skipped[^:]*:\s*(\d+)/)?.[1] ?? "0", 10);
+      if (indexed > 0) {
+        console.log(`[memory-search] background index done: ${indexed} new, ${skipped} up-to-date`);
+      }
+    } else {
+      const detail = (stderr || stdout || "").trim().slice(0, 200);
+      console.log(`[memory-search] background index failed (exit ${code}): ${detail}`);
+    }
+  });
+  proc.on("error", (e: Error) => {
+    console.log(`[memory-search] background index could not start: ${e.message}`);
+  });
 }
 
 /**

--- a/tools/memory-search/.gitignore
+++ b/tools/memory-search/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+*.db
+.venv/

--- a/tools/memory-search/README.md
+++ b/tools/memory-search/README.md
@@ -24,7 +24,7 @@ episodic memory next to the existing semantic memory.
 
 ```bash
 cd tools/memory-search
-pip install -e .
+uv pip install -e .
 ```
 
 This installs a `memory-search` console script. The first run will download
@@ -121,7 +121,7 @@ print(result["summary"])
 ## Development
 
 ```bash
-pip install -e ".[dev]"
+uv pip install -e ".[dev]"
 pytest
 ```
 

--- a/tools/memory-search/README.md
+++ b/tools/memory-search/README.md
@@ -1,0 +1,130 @@
+# memory-search
+
+Hybrid keyword + semantic recall over Claude Code session history.
+
+Indexes the JSONL session files Claude Code writes under `~/.claude/projects/`
+into a local SQLite database (FTS5 + sentence-transformer vectors), then lets
+you query that history by meaning, not just exact words.
+
+Optional: pipe the top hits through `claude --print` to get a short narrative
+answer to your query — works without an Anthropic API key, since it reuses
+Claude Code's own OAuth session.
+
+## Why
+
+ClaudeClaw's curated `MEMORY.md` is great for facts the agent should always
+remember. But everything you've ever discussed in a Claude Code session is
+already on disk as JSONL — and most of it is too verbose to pin in `MEMORY.md`.
+
+`memory-search` gives Claude (and you) a way to recall past sessions on demand,
+without paying the context cost of loading them. Think of it as long-term
+episodic memory next to the existing semantic memory.
+
+## Install
+
+```bash
+cd tools/memory-search
+pip install -e .
+```
+
+This installs a `memory-search` console script. The first run will download
+the sentence-transformer model (`all-MiniLM-L6-v2`, ~80 MB).
+
+## Usage
+
+```bash
+# Index every Claude Code session JSONL on disk
+memory-search index
+
+# Re-index everything (e.g. after model change)
+memory-search index --force
+
+# Search past sessions
+memory-search recall "BREAKOUT_52W swing trader pattern"
+
+# Search without the summary (faster, no claude CLI required)
+memory-search recall "yfinance crumb fix" --no-summary
+
+# Programmatic / scripting use
+memory-search recall "voice pipeline asterisk" --json --top 3
+```
+
+Sample output:
+
+```
+🔍 Recherche : "voice pipeline asterisk"
+
+✅ 3 session(s) trouvée(s) :
+
+  📅 2026-05-02T22:54 | Score: 0.5 | 119 tours
+     Asterisk installé, extension 100 → AGI Python pipeline STT/Claude/TTS...
+
+  📅 2026-04-28T04:23 | Score: 0.42 | 33 tours
+     Whisper local actif, messages vocaux Telegram...
+
+💬 Résumé :
+----------------------------------------
+- Pipeline vocal 2-way Asterisk + AGI Python opérationnel sur ext 100
+- Voix québécoise Antoine via Edge TTS, STT via Groq Whisper large-v3
+- Forward Telegram natif via /api/inject
+```
+
+## Configuration
+
+All paths and tunables are env-overridable:
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `MEMORY_SEARCH_DB` | `~/.claude/claudeclaw/memory-search.db` | SQLite DB path |
+| `MEMORY_SEARCH_SESSIONS_DIR` | All subdirs of `~/.claude/projects/` | Where to find session JSONLs (colon-separated) |
+| `MEMORY_SEARCH_MODEL` | `all-MiniLM-L6-v2` | sentence-transformer model |
+| `MEMORY_SEARCH_DIM` | `384` | Embedding dimensionality |
+| `MEMORY_SEARCH_ALPHA` | `0.5` | Hybrid blend (1.0=semantic, 0.0=FTS5) |
+| `MEMORY_SEARCH_CHUNK_SIZE` | `5` | Messages per chunk |
+| `MEMORY_SEARCH_MSG_MAX` | `2000` | Max chars per message before truncation |
+| `MEMORY_SEARCH_CHUNK_EXCERPT` | `400` | Max chars per message inside a chunk |
+| `MEMORY_SEARCH_SUMMARY_MODEL` | `claude-haiku-4-5` | Model for the summary step |
+| `MEMORY_SEARCH_SUMMARY_TIMEOUT` | `30` | Summary subprocess timeout (seconds) |
+| `CLAUDECLAW_CLAUDE_BIN` | `which claude` | Path to the `claude` CLI used for summaries |
+
+## How it works
+
+```
+session JSONL → parse user/assistant text turns → chunk(5 turns) → embed → store
+                                                                         ↓
+                                                                  SQLite + FTS5
+                                                                         ↓
+query → vectorize → cosine via dot                                       │
+        FTS5 keyword match                                               │
+        weighted blend → top-K → optional claude --print summary  ───────┘
+```
+
+- **Idempotent indexing**: `index_session()` skips files whose `mtime`
+  hasn't changed since the last indexing pass.
+- **Hybrid scoring**: `alpha * semantic + (1 - alpha) * fts5` after
+  per-pool min-max normalization.
+- **Per-session deduplication**: search returns at most one chunk per
+  session (the highest-scoring one), so your top-K is K distinct sessions.
+
+## Library use
+
+```python
+from memory_search import index_all, recall
+
+index_all()                    # one-shot reindex
+result = recall("yfinance fix")
+for hit in result["hits"]:
+    print(hit["score"], hit["timestamp"], hit["excerpt"])
+print(result["summary"])
+```
+
+## Development
+
+```bash
+pip install -e ".[dev]"
+pytest
+```
+
+## License
+
+MIT — same as ClaudeClaw-Plus.

--- a/tools/memory-search/memory_search/__init__.py
+++ b/tools/memory-search/memory_search/__init__.py
@@ -1,0 +1,20 @@
+"""
+memory-search — hybrid FTS5 + sentence-transformer recall over Claude Code sessions.
+"""
+
+from .db import index_all, index_session, search, stats
+from .recall import recall, summarize, format_for_humans, format_as_json
+
+__version__ = "0.1.0"
+
+__all__ = [
+    "index_all",
+    "index_session",
+    "search",
+    "stats",
+    "recall",
+    "summarize",
+    "format_for_humans",
+    "format_as_json",
+    "__version__",
+]

--- a/tools/memory-search/memory_search/cli.py
+++ b/tools/memory-search/memory_search/cli.py
@@ -1,0 +1,90 @@
+"""
+Command-line entry point for memory-search.
+
+Usage:
+    memory-search index [--force]
+    memory-search recall "query" [--top 5] [--alpha 0.5] [--no-summary] [--json]
+    memory-search stats
+    memory-search --help
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+
+from . import db
+from .recall import recall as do_recall, format_for_humans, format_as_json
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="memory-search",
+        description="Hybrid keyword + semantic search over Claude Code session history.",
+    )
+    p.add_argument("-v", "--verbose", action="store_true", help="Verbose logging")
+    sub = p.add_subparsers(dest="cmd", required=True, metavar="COMMAND")
+
+    p_index = sub.add_parser("index", help="(Re)index session JSONL files into the DB")
+    p_index.add_argument("--force", action="store_true",
+                         help="Re-index every file even if mtime unchanged")
+
+    p_recall = sub.add_parser("recall", help="Search past sessions for a query")
+    p_recall.add_argument("query", help="Free-text query")
+    p_recall.add_argument("--top", type=int, default=5,
+                          help="Max number of sessions to return (default: 5)")
+    p_recall.add_argument("--alpha", type=float, default=None,
+                          help="Hybrid blend (1.0=semantic only, 0.0=FTS5 only, default: 0.5)")
+    p_recall.add_argument("--no-summary", action="store_true",
+                          help="Skip the claude --print summary step")
+    p_recall.add_argument("--json", action="store_true",
+                          help="Emit JSON instead of human-readable output")
+
+    sub.add_parser("stats", help="Print DB stats (sessions/chunks/vectorized)")
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.WARNING,
+        format="%(levelname)s %(name)s: %(message)s",
+    )
+
+    if args.cmd == "index":
+        result = db.index_all(force=args.force)
+        print(f"📂 found: {result['found']}")
+        print(f"✅ indexed: {result['indexed']}")
+        print(f"⏭️  skipped (up-to-date): {result['skipped']}")
+        return 0
+
+    if args.cmd == "recall":
+        result = do_recall(
+            args.query,
+            top_k=args.top,
+            alpha=args.alpha,
+            do_summary=not args.no_summary,
+        )
+        if args.json:
+            print(format_as_json(result))
+        else:
+            print(format_for_humans(result))
+        return 0 if result["hits"] else 1
+
+    if args.cmd == "stats":
+        s = db.stats()
+        print(f"📊 sessions: {s['sessions']}")
+        print(f"📦 chunks: {s['chunks']} ({s['vectorized']} with vectors)")
+        return 0
+
+    parser.print_help()
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/memory-search/memory_search/config.py
+++ b/tools/memory-search/memory_search/config.py
@@ -1,0 +1,118 @@
+"""
+Configuration for memory-search.
+
+All paths and tunables are env-overridable so the tool works in any project,
+not just the original author's `~/agent/` setup.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+from typing import Optional
+
+
+# --- Paths ---
+
+def _default_claudeclaw_root() -> Path:
+    """Resolve the ClaudeClaw root directory."""
+    env = os.environ.get("CLAUDECLAW_ROOT")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".claude" / "claudeclaw"
+
+
+def db_path() -> Path:
+    """Path to the SQLite memory-search database."""
+    env = os.environ.get("MEMORY_SEARCH_DB")
+    if env:
+        return Path(env).expanduser()
+    return _default_claudeclaw_root() / "memory-search.db"
+
+
+def sessions_dirs() -> list[Path]:
+    """
+    Directories to scan for session JSONL files.
+
+    Default: scan all subdirs under ~/.claude/projects/ (Claude Code's
+    default location). Override via MEMORY_SEARCH_SESSIONS_DIR (colon-separated).
+    """
+    env = os.environ.get("MEMORY_SEARCH_SESSIONS_DIR")
+    if env:
+        return [Path(p).expanduser() for p in env.split(":") if p.strip()]
+
+    default = Path.home() / ".claude" / "projects"
+    if default.exists():
+        # Each project gets its own subdir under ~/.claude/projects/
+        return [d for d in default.iterdir() if d.is_dir()]
+    return []
+
+
+# --- Embedding model ---
+
+def embedding_model_name() -> str:
+    """Sentence-transformer model name. Override with MEMORY_SEARCH_MODEL."""
+    return os.environ.get("MEMORY_SEARCH_MODEL", "all-MiniLM-L6-v2")
+
+
+def embedding_dim() -> int:
+    """Embedding dimensionality. Used for sanity-checking persisted vectors."""
+    return int(os.environ.get("MEMORY_SEARCH_DIM", "384"))
+
+
+# --- Search defaults ---
+
+def default_alpha() -> float:
+    """
+    Alpha blend for hybrid search.
+    1.0 = pure semantic, 0.0 = pure FTS5, 0.5 = equal weight.
+    """
+    return float(os.environ.get("MEMORY_SEARCH_ALPHA", "0.5"))
+
+
+def chunk_size() -> int:
+    """Number of message turns per chunk. Bigger = more context per vector."""
+    return int(os.environ.get("MEMORY_SEARCH_CHUNK_SIZE", "5"))
+
+
+def message_max_chars() -> int:
+    """Truncate individual messages at N chars before chunking."""
+    return int(os.environ.get("MEMORY_SEARCH_MSG_MAX", "2000"))
+
+
+def chunk_msg_excerpt_chars() -> int:
+    """When concatenating messages into a chunk, truncate each at N chars."""
+    return int(os.environ.get("MEMORY_SEARCH_CHUNK_EXCERPT", "400"))
+
+
+# --- Summarizer ---
+
+def claude_cli_path() -> Optional[str]:
+    """
+    Resolve the `claude` CLI binary.
+
+    Priority:
+      1. CLAUDECLAW_CLAUDE_BIN env var
+      2. shutil.which('claude')
+      3. None (caller should fall back to no-summary)
+    """
+    env = os.environ.get("CLAUDECLAW_CLAUDE_BIN")
+    if env and Path(env).exists():
+        return env
+    return shutil.which("claude")
+
+
+def summarizer_model() -> str:
+    """Claude model used by the `claude --print` summarizer."""
+    return os.environ.get("MEMORY_SEARCH_SUMMARY_MODEL", "claude-haiku-4-5")
+
+
+def summarizer_timeout_sec() -> int:
+    return int(os.environ.get("MEMORY_SEARCH_SUMMARY_TIMEOUT", "30"))
+
+
+def summarizer_cwd() -> Optional[Path]:
+    """Working dir for the summarizer subprocess (defaults to None = current cwd)."""
+    env = os.environ.get("MEMORY_SEARCH_SUMMARY_CWD")
+    return Path(env).expanduser() if env else None

--- a/tools/memory-search/memory_search/db.py
+++ b/tools/memory-search/memory_search/db.py
@@ -1,0 +1,364 @@
+"""
+Session memory DB: SQLite + FTS5 + sentence-transformer vectors.
+
+Indexes Claude Code session JSONL files (`~/.claude/projects/*/...jsonl`)
+for hybrid keyword + semantic recall. The same DB is used by `recall.py`
+to surface past sessions that are relevant to a query.
+
+Refactored from the original `session-db.py` PoC (Nibbler1250, April 2026).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+import numpy as np
+
+from . import config
+
+log = logging.getLogger(__name__)
+
+_model = None  # lazy-loaded sentence-transformer
+
+
+# --- Model ---
+
+def get_model():
+    """Lazy-load the sentence-transformer (heavy, ~80MB on first use)."""
+    global _model
+    if _model is None:
+        from sentence_transformers import SentenceTransformer
+        _model = SentenceTransformer(config.embedding_model_name())
+    return _model
+
+
+def vectorize(texts: list[str]) -> np.ndarray:
+    """Embed a batch of strings; vectors are L2-normalized for cosine via dot product."""
+    return get_model().encode(texts, normalize_embeddings=True, show_progress_bar=False)
+
+
+# --- DB lifecycle ---
+
+SCHEMA = """
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id    TEXT PRIMARY KEY,
+    first_message TEXT,
+    last_message  TEXT,
+    turn_count    INTEGER DEFAULT 0,
+    indexed_at    REAL,
+    file_path     TEXT
+);
+
+CREATE TABLE IF NOT EXISTS chunks (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id    TEXT NOT NULL REFERENCES sessions(session_id),
+    chunk_index   INTEGER NOT NULL,
+    role          TEXT NOT NULL,
+    content       TEXT NOT NULL,
+    timestamp     TEXT,
+    vector        BLOB
+);
+
+CREATE VIRTUAL TABLE IF NOT EXISTS chunks_fts USING fts5(
+    content,
+    content='chunks',
+    content_rowid='id',
+    tokenize='unicode61'
+);
+
+CREATE TRIGGER IF NOT EXISTS chunks_ai AFTER INSERT ON chunks BEGIN
+    INSERT INTO chunks_fts(rowid, content) VALUES (new.id, new.content);
+END;
+
+CREATE TRIGGER IF NOT EXISTS chunks_ad AFTER DELETE ON chunks BEGIN
+    INSERT INTO chunks_fts(chunks_fts, rowid, content) VALUES ('delete', old.id, old.content);
+END;
+"""
+
+
+def get_db(path: Optional[Path] = None) -> sqlite3.Connection:
+    """Open the DB, create the file's parent dir if needed, apply schema."""
+    db_file = path or config.db_path()
+    db_file.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_file))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.executescript(SCHEMA)
+    conn.commit()
+    return conn
+
+
+# --- Parsing ---
+
+def parse_session_file(jsonl_path: Path) -> list[dict]:
+    """Extract user/assistant text messages from a Claude Code session JSONL file."""
+    messages: list[dict] = []
+    msg_max = config.message_max_chars()
+    try:
+        with open(jsonl_path) as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+
+                if entry.get("type") not in ("user", "assistant"):
+                    continue
+
+                msg = entry.get("message", {})
+                role = msg.get("role", entry.get("type", ""))
+                content = msg.get("content", "")
+
+                # `content` can be a list of blocks (Claude API format) or a string
+                if isinstance(content, list):
+                    parts = [
+                        block.get("text", "")
+                        for block in content
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    ]
+                    content = " ".join(parts)
+
+                if not content or not isinstance(content, str):
+                    continue
+
+                content = content.strip()
+                # Skip noise (very short turns)
+                if len(content) < 20:
+                    continue
+
+                messages.append({
+                    "role": role,
+                    "content": content[:msg_max],
+                    "timestamp": entry.get("timestamp", ""),
+                    "session_id": entry.get("sessionId", ""),
+                })
+    except OSError as e:
+        log.warning("could not read %s: %s", jsonl_path, e)
+    return messages
+
+
+def chunk_messages(messages: list[dict]) -> list[dict]:
+    """Group consecutive messages into chunks for better embedding context."""
+    size = config.chunk_size()
+    excerpt_chars = config.chunk_msg_excerpt_chars()
+    chunks: list[dict] = []
+    for i in range(0, len(messages), size):
+        group = messages[i:i + size]
+        combined = " | ".join(
+            f"[{m['role']}] {m['content'][:excerpt_chars]}" for m in group
+        )
+        chunks.append({
+            "content": combined,
+            "role": "mixed",
+            "timestamp": group[0]["timestamp"] if group else "",
+            "chunk_index": i // size,
+        })
+    return chunks
+
+
+# --- Indexing ---
+
+def index_session(
+    conn: sqlite3.Connection,
+    jsonl_path: Path,
+    *,
+    force: bool = False,
+) -> bool:
+    """
+    Index one session file. Idempotent (skips if mtime unchanged unless `force`).
+    Returns True if (re)indexed, False if skipped.
+    """
+    session_id = jsonl_path.stem
+
+    if not force:
+        row = conn.execute(
+            "SELECT indexed_at FROM sessions WHERE session_id = ?", (session_id,)
+        ).fetchone()
+        if row and row[0] and jsonl_path.stat().st_mtime <= row[0]:
+            return False
+
+    messages = parse_session_file(jsonl_path)
+    if not messages:
+        return False
+
+    # Wipe previous data for this session (clean re-index)
+    conn.execute("DELETE FROM chunks WHERE session_id = ?", (session_id,))
+    conn.execute("DELETE FROM sessions WHERE session_id = ?", (session_id,))
+
+    chunks = chunk_messages(messages)
+    if not chunks:
+        return False
+
+    vectors = vectorize([c["content"] for c in chunks])
+
+    first_ts = messages[0]["timestamp"]
+    last_ts = messages[-1]["timestamp"]
+    conn.execute(
+        "INSERT INTO sessions VALUES (?, ?, ?, ?, ?, ?)",
+        (session_id, first_ts, last_ts, len(messages),
+         jsonl_path.stat().st_mtime, str(jsonl_path)),
+    )
+
+    for chunk, vec in zip(chunks, vectors):
+        conn.execute(
+            "INSERT INTO chunks (session_id, chunk_index, role, content, timestamp, vector) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (session_id, chunk["chunk_index"], chunk["role"],
+             chunk["content"], chunk["timestamp"], vec.tobytes()),
+        )
+
+    conn.commit()
+    return True
+
+
+def index_all(
+    *,
+    force: bool = False,
+    sessions_dirs: Optional[Iterable[Path]] = None,
+) -> dict:
+    """
+    Walk every configured sessions directory, index every JSONL.
+    Returns counts.
+    """
+    dirs = list(sessions_dirs) if sessions_dirs is not None else config.sessions_dirs()
+    if not dirs:
+        log.warning("no sessions directories configured (set MEMORY_SEARCH_SESSIONS_DIR)")
+        return {"indexed": 0, "skipped": 0, "found": 0}
+
+    conn = get_db()
+    indexed = 0
+    skipped = 0
+    found = 0
+    for d in dirs:
+        for jsonl in sorted(Path(d).rglob("*.jsonl")):
+            found += 1
+            if index_session(conn, jsonl, force=force):
+                indexed += 1
+            else:
+                skipped += 1
+    conn.close()
+    return {"indexed": indexed, "skipped": skipped, "found": found}
+
+
+# --- Search ---
+
+def search(
+    query: str,
+    *,
+    top_k: int = 5,
+    alpha: Optional[float] = None,
+) -> list[dict]:
+    """
+    Hybrid search: alpha * semantic_score + (1 - alpha) * fts5_score.
+    Returns up to top_k unique sessions, best chunk per session.
+    """
+    if alpha is None:
+        alpha = config.default_alpha()
+
+    conn = get_db()
+
+    # FTS5 phase
+    fts_scores: dict[int, float] = {}
+    try:
+        rows = conn.execute(
+            "SELECT rowid, rank FROM chunks_fts WHERE content MATCH ? ORDER BY rank LIMIT 50",
+            (query,),
+        ).fetchall()
+        if rows:
+            ranks = [r[1] for r in rows]
+            lo, hi = min(ranks), max(ranks)
+            span = (hi - lo) or 1
+            for rowid, rank in rows:
+                fts_scores[rowid] = (rank - lo) / span
+    except sqlite3.OperationalError:
+        # FTS5 throws on some queries (e.g. only stop-words); fall back to vector only.
+        pass
+
+    # Vector phase
+    query_vec = vectorize([query])[0]
+    rows = conn.execute(
+        "SELECT id, session_id, content, timestamp, vector FROM chunks WHERE vector IS NOT NULL"
+    ).fetchall()
+
+    vec_scores: dict[int, tuple[float, str, str, str]] = {}
+    for chunk_id, session_id, content, ts, vec_bytes in rows:
+        if not vec_bytes:
+            continue
+        vec = np.frombuffer(vec_bytes, dtype=np.float32)
+        score = float(np.dot(query_vec, vec))
+        vec_scores[chunk_id] = (score, session_id, content, ts)
+
+    # Normalize vector scores into [0, 1]
+    if vec_scores:
+        scores = [v[0] for v in vec_scores.values()]
+        lo, hi = min(scores), max(scores)
+        span = (hi - lo) or 1
+        vec_norm = {
+            k: ((v[0] - lo) / span, v[1], v[2], v[3])
+            for k, v in vec_scores.items()
+        }
+    else:
+        vec_norm = {}
+
+    # Blend
+    candidates: list[tuple[float, int, str, str, str]] = []
+    for chunk_id in set(fts_scores) | set(vec_norm):
+        fts = fts_scores.get(chunk_id, 0.0)
+        if chunk_id in vec_norm:
+            v_score, session_id, content, ts = vec_norm[chunk_id]
+        else:
+            v_score = 0.0
+            row = conn.execute(
+                "SELECT session_id, content, timestamp FROM chunks WHERE id = ?",
+                (chunk_id,),
+            ).fetchone()
+            if not row:
+                continue
+            session_id, content, ts = row
+        combined = alpha * v_score + (1 - alpha) * fts
+        candidates.append((combined, chunk_id, session_id, content, ts))
+
+    candidates.sort(reverse=True)
+
+    results = []
+    seen_sessions: set[str] = set()
+    for score, _chunk_id, session_id, content, ts in candidates:
+        if session_id in seen_sessions:
+            continue
+        seen_sessions.add(session_id)
+        sess = conn.execute(
+            "SELECT first_message, turn_count FROM sessions WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        results.append({
+            "score": round(score, 4),
+            "session_id": session_id,
+            "timestamp": ts or (sess[0] if sess else ""),
+            "turn_count": sess[1] if sess else 0,
+            "excerpt": content[:500],
+        })
+        if len(results) >= top_k:
+            break
+
+    conn.close()
+    return results
+
+
+def stats() -> dict:
+    """Return counts for inspection / health-check."""
+    conn = get_db()
+    sessions = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    chunks = conn.execute("SELECT COUNT(*) FROM chunks").fetchone()[0]
+    with_vec = conn.execute(
+        "SELECT COUNT(*) FROM chunks WHERE vector IS NOT NULL"
+    ).fetchone()[0]
+    conn.close()
+    return {"sessions": sessions, "chunks": chunks, "vectorized": with_vec}

--- a/tools/memory-search/memory_search/recall.py
+++ b/tools/memory-search/memory_search/recall.py
@@ -1,0 +1,127 @@
+"""
+High-level recall: search the session DB and optionally summarize the hits.
+
+Two modes:
+  1. Plain: print the top-N session excerpts.
+  2. With summary: pipe the excerpts through `claude --print` to get a
+     short narrative answer to the user's query.
+
+The `claude --print` path uses Claude Code's existing OAuth session, so it
+works without an Anthropic API key (handy for Claude Max users).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from typing import Optional
+
+from . import config, db
+
+log = logging.getLogger(__name__)
+
+
+def summarize(query: str, hits: list[dict]) -> Optional[str]:
+    """
+    Produce a short summary of the search hits using `claude --print`.
+    Returns None if the CLI is unavailable or the call fails.
+    """
+    cli = config.claude_cli_path()
+    if not cli:
+        log.info("claude CLI not found; skipping summary")
+        return None
+
+    if not hits:
+        return None
+
+    excerpts = []
+    for h in hits:
+        ts = (h.get("timestamp") or "?")[:16]
+        sid = h.get("session_id", "")[:8]
+        excerpts.append(f"--- Session {sid} ({ts}) ---\n{h.get('excerpt', '')}")
+
+    prompt = (
+        f'Voici des extraits de sessions passées pertinentes pour la requête : "{query}"\n\n'
+        + "\n\n".join(excerpts)
+        + "\n\nRésume en 3-5 points concis ce qui a été fait ou discuté en lien avec cette requête. "
+          "Sois direct et factuel."
+    )
+
+    try:
+        result = subprocess.run(
+            [cli, "--print", "--model", config.summarizer_model()],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=config.summarizer_timeout_sec(),
+            cwd=config.summarizer_cwd(),
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        log.warning("claude --print failed: %s", e)
+        return None
+
+    if result.returncode != 0:
+        log.warning("claude --print exit=%s stderr=%s",
+                    result.returncode, result.stderr[:200])
+        return None
+
+    out = (result.stdout or "").strip()
+    return out or None
+
+
+def recall(
+    query: str,
+    *,
+    top_k: int = 5,
+    alpha: Optional[float] = None,
+    do_summary: bool = True,
+) -> dict:
+    """
+    Run a hybrid search and return a structured response with optional summary.
+
+    Returns:
+        {
+            "query": str,
+            "hits": [ {score, session_id, timestamp, turn_count, excerpt}, ... ],
+            "summary": str | None,
+        }
+    """
+    hits = db.search(query, top_k=top_k, alpha=alpha)
+    summary = summarize(query, hits) if do_summary else None
+    return {"query": query, "hits": hits, "summary": summary}
+
+
+def format_for_humans(result: dict) -> str:
+    """Render the recall response for terminal output."""
+    lines: list[str] = []
+    lines.append(f'🔍 Recherche : "{result["query"]}"')
+    if not result["hits"]:
+        lines.append("❌ Aucun résultat dans l'historique des sessions.")
+        return "\n".join(lines)
+
+    lines.append("")
+    lines.append(f"✅ {len(result['hits'])} session(s) trouvée(s) :")
+    lines.append("")
+    for h in result["hits"]:
+        ts = (h.get("timestamp") or "?")[:16]
+        lines.append(
+            f"  📅 {ts} | Score: {h['score']} | {h['turn_count']} tours"
+        )
+        excerpt = h.get("excerpt", "")
+        lines.append(f"     {excerpt[:200]}{'...' if len(excerpt) > 200 else ''}")
+        lines.append("")
+
+    if result.get("summary"):
+        lines.append("💬 Résumé :")
+        lines.append("-" * 40)
+        lines.append(result["summary"])
+    elif result["hits"]:
+        # Be explicit so the user knows why there's no summary
+        if not config.claude_cli_path():
+            lines.append("(claude CLI introuvable — résumé désactivé)")
+    return "\n".join(lines)
+
+
+def format_as_json(result: dict) -> str:
+    return json.dumps(result, ensure_ascii=False, indent=2)

--- a/tools/memory-search/memory_search/recall.py
+++ b/tools/memory-search/memory_search/recall.py
@@ -42,10 +42,10 @@ def summarize(query: str, hits: list[dict]) -> Optional[str]:
         excerpts.append(f"--- Session {sid} ({ts}) ---\n{h.get('excerpt', '')}")
 
     prompt = (
-        f'Voici des extraits de sessions passées pertinentes pour la requête : "{query}"\n\n'
+        f'Here are excerpts from past Claude Code sessions relevant to the query: "{query}"\n\n'
         + "\n\n".join(excerpts)
-        + "\n\nRésume en 3-5 points concis ce qui a été fait ou discuté en lien avec cette requête. "
-          "Sois direct et factuel."
+        + "\n\nSummarize in 3-5 concise bullet points what was done or discussed "
+          "in relation to this query. Be direct and factual."
     )
 
     try:
@@ -95,31 +95,31 @@ def recall(
 def format_for_humans(result: dict) -> str:
     """Render the recall response for terminal output."""
     lines: list[str] = []
-    lines.append(f'🔍 Recherche : "{result["query"]}"')
+    lines.append(f'🔍 Search: "{result["query"]}"')
     if not result["hits"]:
-        lines.append("❌ Aucun résultat dans l'historique des sessions.")
+        lines.append("❌ No results in session history.")
         return "\n".join(lines)
 
     lines.append("")
-    lines.append(f"✅ {len(result['hits'])} session(s) trouvée(s) :")
+    lines.append(f"✅ {len(result['hits'])} session(s) found:")
     lines.append("")
     for h in result["hits"]:
         ts = (h.get("timestamp") or "?")[:16]
         lines.append(
-            f"  📅 {ts} | Score: {h['score']} | {h['turn_count']} tours"
+            f"  📅 {ts} | Score: {h['score']} | {h['turn_count']} turns"
         )
         excerpt = h.get("excerpt", "")
         lines.append(f"     {excerpt[:200]}{'...' if len(excerpt) > 200 else ''}")
         lines.append("")
 
     if result.get("summary"):
-        lines.append("💬 Résumé :")
+        lines.append("💬 Summary:")
         lines.append("-" * 40)
         lines.append(result["summary"])
     elif result["hits"]:
         # Be explicit so the user knows why there's no summary
         if not config.claude_cli_path():
-            lines.append("(claude CLI introuvable — résumé désactivé)")
+            lines.append("(claude CLI not found — summary disabled)")
     return "\n".join(lines)
 
 

--- a/tools/memory-search/pyproject.toml
+++ b/tools/memory-search/pyproject.toml
@@ -1,0 +1,29 @@
+[project]
+name = "memory-search"
+version = "0.1.0"
+description = "Hybrid FTS5 + sentence-transformer recall over Claude Code session history."
+readme = "README.md"
+license = { text = "MIT" }
+requires-python = ">=3.10"
+authors = [
+    { name = "Nibbler1250" },
+]
+dependencies = [
+    "numpy>=1.26",
+    "sentence-transformers>=2.2",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4",
+]
+
+[project.scripts]
+memory-search = "memory_search.cli:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["memory_search*"]

--- a/tools/memory-search/tests/test_db.py
+++ b/tools/memory-search/tests/test_db.py
@@ -1,0 +1,138 @@
+"""
+Smoke tests for memory_search.db.
+
+These don't load the real sentence-transformer model; instead they patch
+`memory_search.db.vectorize` to emit a deterministic 384-dim vector.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from memory_search import db
+
+
+# --- Fixtures ---
+
+@pytest.fixture(autouse=True)
+def isolated_paths(tmp_path, monkeypatch):
+    """Point the DB and sessions dir at a tmpdir for every test."""
+    db_file = tmp_path / "memory.db"
+    sessions = tmp_path / "sessions"
+    sessions.mkdir()
+    monkeypatch.setenv("MEMORY_SEARCH_DB", str(db_file))
+    monkeypatch.setenv("MEMORY_SEARCH_SESSIONS_DIR", str(sessions))
+    yield tmp_path
+
+
+@pytest.fixture
+def fake_vectorize(monkeypatch):
+    """Replace the real model with a hash-based deterministic vector."""
+    def _v(texts):
+        # Normalized 384-dim vector seeded from hash of each text
+        out = []
+        for t in texts:
+            seed = abs(hash(t)) % (2**31)
+            rng = np.random.default_rng(seed)
+            v = rng.normal(size=384).astype(np.float32)
+            v /= np.linalg.norm(v) + 1e-9
+            out.append(v)
+        return np.stack(out)
+    monkeypatch.setattr(db, "vectorize", _v)
+
+
+def write_session(sessions_dir: Path, session_id: str, turns: list[tuple[str, str]]) -> Path:
+    """Create a minimal JSONL file mimicking Claude Code's session format."""
+    path = sessions_dir / f"{session_id}.jsonl"
+    with open(path, "w") as f:
+        for i, (role, text) in enumerate(turns):
+            entry = {
+                "type": role,  # "user" or "assistant"
+                "sessionId": session_id,
+                "timestamp": f"2026-05-03T10:00:{i:02d}Z",
+                "message": {"role": role, "content": text},
+            }
+            f.write(json.dumps(entry) + "\n")
+    return path
+
+
+# --- Tests ---
+
+def test_get_db_creates_schema(tmp_path):
+    conn = db.get_db(tmp_path / "fresh.db")
+    tables = {row[0] for row in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )}
+    assert {"sessions", "chunks"}.issubset(tables)
+    conn.close()
+
+
+def test_index_session_writes_chunks(isolated_paths, fake_vectorize):
+    sess_dir = isolated_paths / "sessions"
+    path = write_session(sess_dir, "abc123", [
+        ("user", "How do I configure Asterisk for a SIP trunk to Twilio?"),
+        ("assistant", "You configure pjsip.conf with a transport-udp section..."),
+        ("user", "Can I use the same trunk for outbound only?"),
+        ("assistant", "Yes, leave the origination block empty."),
+    ])
+
+    conn = db.get_db()
+    indexed = db.index_session(conn, path)
+    conn.close()
+    assert indexed is True
+
+    s = db.stats()
+    assert s["sessions"] == 1
+    assert s["chunks"] >= 1
+    assert s["vectorized"] == s["chunks"]
+
+
+def test_index_skips_when_unchanged(isolated_paths, fake_vectorize):
+    sess_dir = isolated_paths / "sessions"
+    path = write_session(sess_dir, "abc123", [
+        ("user", "Hello world this is a long enough message to get past the 20-char filter."),
+        ("assistant", "Hi there, this is also a sufficiently long reply for indexing."),
+    ])
+
+    conn = db.get_db()
+    assert db.index_session(conn, path) is True
+    # Second call without --force: should skip
+    assert db.index_session(conn, path) is False
+    conn.close()
+
+
+def test_search_finds_relevant_session(isolated_paths, fake_vectorize):
+    sess_dir = isolated_paths / "sessions"
+    write_session(sess_dir, "asterisk-help", [
+        ("user", "How do I configure Asterisk pjsip endpoints for SRTP?"),
+        ("assistant", "Use media_encryption=sdes with optimistic mode for fallback."),
+        ("user", "What about codec negotiation problems with Linphone?"),
+        ("assistant", "Make sure ulaw and opus are both allowed in the endpoint."),
+    ])
+    write_session(sess_dir, "trading-hello", [
+        ("user", "What's a swing trading pattern that uses 52-week breakouts?"),
+        ("assistant", "Look at BREAKOUT_52W with confirmation on volume."),
+        ("user", "How does it compare to a flat base breakout?"),
+        ("assistant", "The 52W breakout requires a longer consolidation period."),
+    ])
+
+    db.index_all()
+
+    # FTS5 should match exact "Asterisk" keyword strongly
+    hits = db.search("Asterisk pjsip", top_k=5, alpha=0.0)
+    assert any(h["session_id"] == "asterisk-help" for h in hits)
+
+
+def test_search_returns_empty_on_empty_db(isolated_paths, fake_vectorize):
+    hits = db.search("anything", top_k=5)
+    assert hits == []
+
+
+def test_stats_on_empty_db(isolated_paths):
+    s = db.stats()
+    assert s == {"sessions": 0, "chunks": 0, "vectorized": 0}


### PR DESCRIPTION
Resolves #19. Adds hybrid keyword + semantic search over Claude Code session JSONL history, exposed as deterministic read/write entry points on `src/memory.ts` (per your option **(c)** preference in #19).

## Architecture (option C from #19)

```
src/memory.ts          ← TS extension, deterministic R/W entry points
  ├─ indexSessions()   ← spawn Python indexer, return counts
  └─ searchSessions()  ← spawn Python search CLI, return parsed JSON

tools/memory-search/   ← Python core (heavy lifting kept here)
  ├─ memory_search/db.py     SQLite + FTS5 + sentence-transformers
  ├─ memory_search/recall.py search + claude --print summarizer
  ├─ memory_search/cli.py    argparse CLI used by the TS layer
  ├─ memory_search/config.py env-var-driven configuration
  └─ tests/test_db.py        pytest smoke tests (6/6 passing)

skills/session-recall.md     ← skill markdown, plug-and-play
```

## Determinism

Every `searchSessions()` call shells out to a fresh Python subprocess that reads from the on-disk SQLite DB. No in-process cache — a write from a concurrent `indexSessions()` is visible immediately on the next read.

`indexSessions()` is idempotent: the indexer skips JSONL files whose mtime hasn't changed since the last index pass. Cheap to call on every boot.

## Wired to your asks from #19

| Your answer | This PR |
|---|---|
| Option (c) — extension to `src/memory.ts` | ✅ |
| Boot trigger | ✅ `src/commands/start.ts` calls `indexSessions()` after `ensureUserSymlinks()`. Wrapped in try/catch — never blocks startup. |
| Periodic re-index every N turns | ⏳ Saved for follow-up PR (touches `runner.ts` / `agents.ts`, kept out of this PR per your scope guidance) |
| Configurable embedding model | ✅ `MEMORY_SEARCH_MODEL` env var, defaults to `all-MiniLM-L6-v2` |
| First PR scope: indexer + skill | ✅ |

## Configuration

All knobs are env-var driven so the tool works on any project layout. Defaults match Claude Code's default `~/.claude/projects/` location:

| Env var | Default |
|---|---|
| `MEMORY_SEARCH_DB` | `~/.claude/claudeclaw/memory-search.db` |
| `MEMORY_SEARCH_SESSIONS_DIR` | All subdirs of `~/.claude/projects/` |
| `MEMORY_SEARCH_MODEL` | `all-MiniLM-L6-v2` |
| `MEMORY_SEARCH_ALPHA` | `0.5` (hybrid blend) |
| `MEMORY_SEARCH_CHUNK_SIZE` | `5` |
| `MEMORY_SEARCH_SUMMARY_MODEL` | `claude-haiku-4-5` |
| `CLAUDECLAW_CLAUDE_BIN` | `which claude` |

The `Settings` interface accepts an optional `memorySearch` block that maps to the same knobs (intentionally typed loosely in this PR — happy to add a strict TS type to `config.ts` in a follow-up if you want it baked in).

## Install

```bash
cd tools/memory-search
pip install -e .
```

That installs the `memory-search` console script and registers the package. The TS layer in `src/memory.ts` uses `spawnSync` and falls back from `tools/memory-search/.venv/bin/memory-search` → PATH → graceful no-op.

## Tested locally

- 41 sessions / 427 chunks indexed against my own `~/.claude/projects/` history
- Hybrid search returns relevant sessions (e.g. `"voice pipeline asterisk"` correctly surfaces the May 2 setup session as #1 hit)
- 6/6 pytest tests green (mocked vectorize so tests don't load the real model)
- `bunx tsc --noEmit` is clean for both `src/memory.ts` and the new lines in `src/commands/start.ts`. Two pre-existing TS errors in `start.ts` (lines 499, 504) are unrelated to this PR — they're present on `main` (their line numbers just shift by +15 due to the boot-trigger insertion).

## Out of scope (intentionally — for follow-ups)

- N-turn periodic re-index trigger (touches `runner.ts`)
- Strict TS type for `memorySearch` settings in `config.ts`
- Agent-system-prompt integration so Claude proactively recalls
- Multi-file MEMORY.md index pattern (separate issue you said you'd assign)

Marked as draft so you can shape it before final review. Happy to slice differently if any of the above should land in this PR instead.
