### PR TITLE
fix(runner): strip ANTHROPIC_API_KEY from child spawn env to prevent API billing

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -111,6 +111,11 @@ const COMPACT_TIMEOUT_ENABLED = true;
  * - `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST`: tells the CLI "the host process
  *   manages provider auth — don't read local credentials." In a detached
  *   daemon there is no host to consult; the CLI errors with `Not logged in`.
+ * - `ANTHROPIC_API_KEY`: a raw API key in the daemon's environment (e.g. from
+ *   a .env file that also serves other tools like MCP servers). Claude Code
+ *   treats `ANTHROPIC_API_KEY` with higher priority than the credential store,
+ *   so if left in the child env it bypasses OAuth entirely and bills against
+ *   API credits rather than the user's Claude subscription.
  *
  * Cross-platform note: the helper just deletes keys from the inherited env
  * object — no shell, no OS-specific calls. The `claude` CLI it spawns then
@@ -121,6 +126,7 @@ function cleanSpawnEnv(): Record<string, string> {
     "CLAUDECODE",
     "CLAUDE_CODE_OAUTH_TOKEN",
     "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+    "ANTHROPIC_API_KEY",  // see comment above — prevents accidental API-key billing
   ]);
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -57,7 +57,7 @@ export async function getSession(
   agentName?: string
 ): Promise<{ sessionId: string; turnCount: number; compactWarned: boolean } | null> {
   const existing = await loadSession(agentName);
-  if (existing) {
+  if (existing && existing.sessionId) {
     // Backfill missing fields from older session.json files
     if (typeof existing.turnCount !== "number") existing.turnCount = 0;
     if (typeof existing.compactWarned !== "boolean") existing.compactWarned = false;


### PR DESCRIPTION
## Problem

If the daemon's process environment contains `ANTHROPIC_API_KEY` (e.g. from a shared `.env` file that also serves MCP servers, Graphiti, etc.), spawned `claude` child processes inherit it. Claude Code treats `ANTHROPIC_API_KEY` with **higher priority than the credential store**, so when it's present in the env the CLI silently bypasses OAuth and bills against API credits rather than the user's Claude subscription.

Discovered on the Hetzner deployment: `ANTHROPIC_API_KEY` was set in `~/.claudeclaw-env` for other tools, resulting in `Error (exit 1): Credit balance is too low` when Claude API credits were exhausted — even though a valid OAuth session (`~/.claude/.credentials.json`) was present and should have been used.

## Fix

Add `ANTHROPIC_API_KEY` to `cleanSpawnEnv`'s strip set. Spawned `claude` processes will then fall back to platform-native credential resolution (Keychain on macOS, `~/.claude/.credentials.json` on Linux) as intended.

## Impact

**None** for users who only set `ANTHROPIC_API_KEY` in ClaudeClaw's `apiToken` settings field — that path already goes through `buildChildEnv` as `ANTHROPIC_AUTH_TOKEN`, which is not stripped.

**Fixes** the regression for any deployment where `ANTHROPIC_API_KEY` leaks in via the process environment (Docker env, `.env` file, system env).