### PR TITLE
feat(memory): wire reindexEveryNTurns periodic re-index in runner (#19 follow-up)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.7",
+      "version": "2.0.8",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -111,9 +111,9 @@ export interface MemorySearchSettings {
   /** Hybrid blend, 1.0=semantic only, 0.0=FTS5 only. Default: 0.5. */
   alpha?: number;
   /**
-   * NYI — wired in a follow-up PR. Currently parsed but not enforced.
-   *
-   * Re-index after every N runner turns. Default: 10. 0 disables.
+   * Re-index session DB after every N runner turns. Default: 10. 0 disables.
+   * Wired in src/runner.ts after each successful turn; fire-and-forget so
+   * the runner never blocks on indexing.
    */
   reindexEveryNTurns?: number;
   /** Max seconds a search subprocess is allowed to run. Default: 60. */

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -30,7 +30,7 @@ import { recordInvocationStart, recordInvocationCompletion, recordInvocationFail
 import { recordExecutionMetric, checkLimits, handleTrigger as watchdogHandleTrigger } from "./governance/watchdog";
 import { startSession as watchdogStart, recordResult as watchdogRecord, abortReason as watchdogAbortReason, clearSession as watchdogClear } from "./watchdog";
 import { getGovernanceClient, type GovernanceClient } from "./governance/client";
-import { loadMemory, loadMemoryInstructions, ensureMemoryFile, getMemoryPath } from "./memory";
+import { loadMemory, loadMemoryInstructions, ensureMemoryFile, getMemoryPath, indexSessionsBackground } from "./memory";
 import { loadAgent } from "./agents";
 import { selectModel } from "./model-router";
 import { recordResult, abortReason, clearSession, startSession } from "./watchdog";
@@ -1435,6 +1435,15 @@ async function execClaude(
         await markCompactWarned(agentName);
       }
       emitCompactEvent({ type: "warn", turnCount });
+    }
+
+    // memory-search: periodic re-index every N turns (issue #19 follow-up).
+    // Default 10 turns; 0 disables. Fire-and-forget — never blocks the runner.
+    const memSettings = getSettings().memorySearch;
+    const reindexEvery = memSettings?.reindexEveryNTurns ?? 10;
+    if (reindexEvery > 0 && turnCount > 0 && turnCount % reindexEvery === 0) {
+      console.log(`[${new Date().toLocaleTimeString()}] memory-search: periodic re-index (turn ${turnCount})`);
+      indexSessionsBackground(memSettings);
     }
   }
 


### PR DESCRIPTION
The MemorySearchSettings.reindexEveryNTurns option was parsed and exposed
in the public interface but marked NYI. This wires it into the runner so
the session DB stays current as conversations grow.

Changes:
- src/runner.ts: after each successful turn (in the existing turn-tracking
  block, post-incrementTurn), if turnCount % reindexEveryNTurns === 0,
  fire indexSessionsBackground(memSettings). Fire-and-forget — never
  blocks the runner. Logs the trigger at the same point as the existing
  Turn count log line.
- src/memory.ts: drop the 'NYI - wired in a follow-up PR' marker from
  reindexEveryNTurns JSDoc; document where it is wired and the
  fire-and-forget semantic.

Behavior:
- Default 10 turns (per Terry's spec in #19).
- 0 disables.
- Single getSettings() call per turn-end (no double-read).
- Re-uses the existing indexSessionsBackground() async variant; the Python
  indexer is mtime-aware so repeated calls are cheap (skips unchanged
  session files).

Tested via tsc --noEmit: no new errors in runner.ts or memory.ts.
