### PR TITLE
feat(telegram): opt-in live tool-call streaming progress

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.42",
+      "version": "2.2.43",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.42",
+  "version": "2.2.43",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -475,6 +475,52 @@ async function sendTyping(token: string, chatId: number, threadId?: number): Pro
   }).catch(() => {});
 }
 
+async function sendMessageAndGetId(
+  token: string,
+  chatId: number,
+  text: string,
+  threadId?: number,
+): Promise<number | null> {
+  try {
+    const resp = await callApi<{ ok: boolean; result: { message_id: number } }>(
+      token,
+      "sendMessage",
+      {
+        chat_id: chatId,
+        text,
+        ...(threadId ? { message_thread_id: threadId } : {}),
+      },
+    );
+    return resp.result?.message_id ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function editProgressMessage(
+  token: string,
+  chatId: number,
+  messageId: number,
+  text: string,
+): Promise<void> {
+  await callApi(token, "editMessageText", {
+    chat_id: chatId,
+    message_id: messageId,
+    text,
+  }).catch(() => {});
+}
+
+async function deleteProgressMessage(
+  token: string,
+  chatId: number,
+  messageId: number,
+): Promise<void> {
+  await callApi(token, "deleteMessage", {
+    chat_id: chatId,
+    message_id: messageId,
+  }).catch(() => {});
+}
+
 async function sendDocumentToChat(
   token: string,
   chatId: number,
@@ -1717,16 +1763,42 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
       );
       return;
     } else {
+      let progressMsgId: number | null = null;
+      let progressOp: Promise<void> = Promise.resolve();
+      const onToolCall = config.streamToolCalls
+        ? (toolName: string) => {
+            const txt = `⚙️ ${toolName}…`;
+            progressOp = progressOp
+              .then(async () => {
+                if (progressMsgId === null) {
+                  progressMsgId = await sendMessageAndGetId(config.token, chatId, txt, threadId);
+                } else {
+                  await editProgressMessage(config.token, chatId, progressMsgId, txt);
+                }
+              })
+              .catch(() => {});
+          }
+        : undefined;
+
       const stream = makeStreamCallback(config.token, chatId, threadId, { verbose });
-      result = await runUserMessage(
-        "telegram",
-        prefixedPrompt,
-        sessionKey,
-        undefined,
-        stream.onChunk,
-        stream.onToolEvent,
-        modelOverride,
-      );
+      try {
+        result = await runUserMessage(
+          "telegram",
+          prefixedPrompt,
+          sessionKey,
+          undefined,
+          stream.onChunk,
+          stream.onToolEvent,
+          modelOverride,
+          onToolCall,
+        );
+      } finally {
+        await progressOp;
+        if (progressMsgId !== null) {
+          await deleteProgressMessage(config.token, chatId, progressMsgId);
+          progressMsgId = null;
+        }
+      }
       const streamResult = await stream.waitForStreamMsg();
       streamMsgId = streamResult.msgId;
       hadToolLines = streamResult.hadToolLines;

--- a/src/config.ts
+++ b/src/config.ts
@@ -131,6 +131,7 @@ const DEFAULT_SETTINGS: Settings = {
     listenChats: [],
     receiveEnabled: true,
     dmIsolation: "shared",
+    streamToolCalls: false,
   },
   discord: {
     token: "",
@@ -216,6 +217,8 @@ export interface TelegramConfig {
    * - "perUser": each DM user gets their own isolated session.
    */
   dmIsolation: "shared" | "perUser";
+  /** When true, stream live tool-call progress indicator to Telegram while Claude processes. Default: false */
+  streamToolCalls?: boolean;
   /** Local whisper.cpp model for voice transcription. Default: "base.en".
    *  Supported values: tiny, base, small, medium, large-v3, large-v3-turbo (with or without .en suffix).
    *  Ignored when stt.baseUrl is configured. */
@@ -588,6 +591,7 @@ function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Set
         : [],
       receiveEnabled: raw.telegram?.receiveEnabled !== false,
       dmIsolation: raw.telegram?.dmIsolation === "perUser" ? "perUser" : "shared",
+      streamToolCalls: raw.telegram?.streamToolCalls === true,
       ...(typeof raw.telegram?.whisperModel === "string" && raw.telegram.whisperModel.trim()
         ? { whisperModel: raw.telegram.whisperModel.trim() }
         : {}),

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -825,6 +825,7 @@ async function runClaudeStream(
   cwd?: string,
   onChunk?: (text: string) => void,
   onToolEvent?: (line: string) => void,
+  onToolCall?: (toolName: string) => void,
 ): Promise<{ rawStdout: string; stderr: string; exitCode: number; sessionId?: string }> {
   const args = [...baseArgs];
   const normalizedModel = model.trim().toLowerCase();
@@ -873,7 +874,7 @@ async function runClaudeStream(
           }
           // Emit streaming callbacks if provided
           if (
-            (onChunk || onToolEvent) &&
+            (onChunk || onToolEvent || onToolCall) &&
             event.type === "assistant" &&
             (event.message as any)?.content
           ) {
@@ -888,9 +889,12 @@ async function runClaudeStream(
             for (const block of msg.content) {
               if (block.type === "text" && typeof block.text === "string") {
                 full += block.text;
-              } else if (block.type === "tool_use" && onToolEvent) {
-                streamPendingToolCalls.set(block.id, block.name);
-                onToolEvent(`● ${formatToolCallSummary(block.name, block.input ?? {})}`);
+              } else if (block.type === "tool_use") {
+                if (onToolEvent) {
+                  streamPendingToolCalls.set(block.id, block.name);
+                  onToolEvent(`● ${formatToolCallSummary(block.name, block.input ?? {})}`);
+                }
+                if (onToolCall && block.name) onToolCall(block.name);
               }
             }
             if (onChunk && full.length > streamDelivered.length) {
@@ -1549,6 +1553,7 @@ async function execClaude(
   timeoutCategory?: string,
   onChunk?: (text: string) => void,
   onToolEvent?: (line: string) => void,
+  onToolCall?: (toolName: string) => void,
 ): Promise<RunResult> {
   mainRunCount++;
   persistRunCount();
@@ -1803,6 +1808,7 @@ async function execClaude(
         spawnCwd,
         onChunk,
         onToolEvent,
+        onToolCall,
       );
     } else {
       const sessionKey = threadId
@@ -2328,6 +2334,7 @@ export async function run(
   timeoutCategory?: string,
   onChunk?: (text: string) => void,
   onToolEvent?: (line: string) => void,
+  onToolCall?: (toolName: string) => void,
 ): Promise<RunResult> {
   return enqueue(
     () =>
@@ -2341,6 +2348,7 @@ export async function run(
         timeoutCategory,
         onChunk,
         onToolEvent,
+        onToolCall,
       ),
     threadId,
   );
@@ -2614,6 +2622,7 @@ export async function runUserMessage(
   onChunk?: (text: string) => void,
   onToolEvent?: (line: string) => void,
   modelOverride?: string,
+  onToolCall?: (toolName: string) => void,
 ): Promise<RunResult> {
   return run(
     name,
@@ -2625,6 +2634,7 @@ export async function runUserMessage(
     undefined,
     onChunk,
     onToolEvent,
+    onToolCall,
   );
 }
 


### PR DESCRIPTION
## Summary

Implements #13 — opt-in live tool-call progress indicator in Telegram.

When `telegram.streamToolCalls: true` is set in `settings.json`, each tool call Claude makes is surfaced as a live Telegram message that updates in-place:

1. First tool call → sends `⚙️ ToolName…` as a new message
2. Subsequent tool calls → edits that message to show the current tool
3. Claude finishes → deletes the progress message, sends the final response

### Changes

**`src/runner.ts`**
- `runClaudeStream`: add optional `onToolCall?: (toolName: string) => void` parameter; fires for each `tool_use` block in `assistant` stream events
- Thread `onToolCall` through `execClaude` → `run` → `runUserMessage` (all optional, fully backward-compatible)
- Only the primary `runClaudeStream` call receives `onToolCall`; fallback/stale-recovery retries do not (no duplicate notifications)

**`src/config.ts`**
- `TelegramConfig`: add `streamToolCalls?: boolean` (default `false`, strict opt-in via `=== true`)
- `DEFAULT_SETTINGS` and `parseSettings` updated accordingly

**`src/commands/telegram.ts`**
- New helpers: `sendMessageAndGetId`, `editProgressMessage`, `deleteProgressMessage`
- `handleMessage`: when `streamToolCalls` is enabled, build an `onToolCall` callback that chains Telegram API calls via a serial `Promise` to avoid race conditions between rapid tool calls

### Configuration

```json
{
  "telegram": {
    "token": "...",
    "streamToolCalls": true
  }
}
```

### Design notes

- **Opt-in, off by default** — existing deployments are unaffected
- **Serial Promise chain** — `progressOp = progressOp.then(...)` prevents races if two tool calls fire in quick succession
- **Always cleaned up** — `await progressOp` + delete runs on both success and error paths
- **Non-blocking** — the `onToolCall` callback fires synchronously in the stdout reader loop but Telegram API calls are fire-and-forget from Claude's perspective

Closes #13