### PR TITLE
ci: skip version guards for sync/* branches

### DIFF
--- a/.github/workflows/marketplace-version-guard.yml
+++ b/.github/workflows/marketplace-version-guard.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   marketplace-version-guard:
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'sync/') }}
     permissions:
       contents: read
 

--- a/.github/workflows/plugin-version-guard.yml
+++ b/.github/workflows/plugin-version-guard.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   plugin-version-guard:
     runs-on: ubuntu-latest
+    if: ${{ !startsWith(github.head_ref, 'sync/') }}
     permissions:
       contents: read
 


### PR DESCRIPTION
Sync PRs always contain raw conflict markers in `plugin.json` and `marketplace.json` (the sync workflow commits them unresolved so a human can review). The version guard's `python3 json.load()` crashes on those files, causing a misleading failure on every sync PR.

Sync PRs require manual review before merge — the version bump is enforced as part of that human step. Skipping the guard for `sync/*` branches removes the noise without weakening enforcement for contributor PRs.

Fixes the recurring failures on #26, #27, #29 and future sync PRs.