### PR TITLE
fix(ui): resolve conflict markers in script/styles/template — second production outage

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.11",
+      "version": "2.0.12",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -988,17 +988,12 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     // ── Chat ──
     const tabDashboardBtn = $("tab-dashboard");
     const tabChatBtn = $("tab-chat");
-<<<<<<< HEAD
     const tabKanbanBtn = $("tab-kanban");
-    const dashboardPanel = $("dashboard-panel");
-    const chatPanel = $("chat-panel");
-    const kanbanPanel = $("kanban-panel");
-=======
     const tabUsageBtn = $("tab-usage");
     const dashboardPanel = $("dashboard-panel");
     const chatPanel = $("chat-panel");
+    const kanbanPanel = $("kanban-panel");
     const usagePanel = $("usage-panel");
->>>>>>> upstream/master
     const chatMessages = $("chat-messages");
     const chatForm = $("chat-form");
     const chatInput = $("chat-input");
@@ -1117,13 +1112,8 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     })();
 
     function setActiveTab(tab) {
-<<<<<<< HEAD
-      const allBtns = [tabDashboardBtn, tabChatBtn, tabKanbanBtn];
-      const allPanels = [dashboardPanel, chatPanel, kanbanPanel];
-=======
-      const allBtns = [tabDashboardBtn, tabChatBtn, tabUsageBtn];
-      const allPanels = [dashboardPanel, chatPanel, usagePanel];
->>>>>>> upstream/master
+      const allBtns = [tabDashboardBtn, tabChatBtn, tabKanbanBtn, tabUsageBtn];
+      const allPanels = [dashboardPanel, chatPanel, kanbanPanel, usagePanel];
       allBtns.forEach(b => { if (b) { b.classList.remove("tab-btn-active"); b.setAttribute("aria-selected", "false"); } });
       allPanels.forEach(p => { if (p) p.hidden = true; });
 
@@ -1131,19 +1121,16 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
         tabDashboardBtn && tabDashboardBtn.classList.add("tab-btn-active");
         tabDashboardBtn && tabDashboardBtn.setAttribute("aria-selected", "true");
         if (dashboardPanel) dashboardPanel.hidden = false;
-<<<<<<< HEAD
       } else if (tab === "kanban") {
         tabKanbanBtn && tabKanbanBtn.classList.add("tab-btn-active");
         tabKanbanBtn && tabKanbanBtn.setAttribute("aria-selected", "true");
         if (kanbanPanel) kanbanPanel.hidden = false;
         loadKanban();
-=======
       } else if (tab === "usage") {
         tabUsageBtn && tabUsageBtn.classList.add("tab-btn-active");
         tabUsageBtn && tabUsageBtn.setAttribute("aria-selected", "true");
         if (usagePanel) usagePanel.hidden = false;
         fetchUsage();
->>>>>>> upstream/master
       } else {
         tabChatBtn && tabChatBtn.classList.add("tab-btn-active");
         tabChatBtn && tabChatBtn.setAttribute("aria-selected", "true");
@@ -1154,11 +1141,8 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
 
     if (tabDashboardBtn) tabDashboardBtn.addEventListener("click", () => setActiveTab("dashboard"));
     if (tabChatBtn) tabChatBtn.addEventListener("click", function() { setActiveTab("chat"); loadSessions(); });
-<<<<<<< HEAD
     if (tabKanbanBtn) tabKanbanBtn.addEventListener("click", () => setActiveTab("kanban"));
-=======
     if (tabUsageBtn) tabUsageBtn.addEventListener("click", function() { setActiveTab("usage"); });
->>>>>>> upstream/master
 
     // --- Session browser ---
 
@@ -1603,7 +1587,6 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
       }
     }, 1000);
 
-<<<<<<< HEAD
 // ── Kanban ───────────────────────────────────────────────────────────────────
 var kanbanData = { columns: { todo: [], in_progress: [], done: [] } };
 
@@ -1717,8 +1700,8 @@ if ($("kanban-input-title")) {
 }
 
 loadKanban();
-setInterval(loadKanban, 10000);`;
-=======
+setInterval(loadKanban, 10000);
+
     // --- Usage monitoring ---
     var usageWrap = $("usage-table-wrap");
 
@@ -1799,4 +1782,3 @@ setInterval(loadKanban, 10000);`;
 
     fetchUsage();
     setInterval(fetchUsage, 60_000);`;
->>>>>>> upstream/master

--- a/src/ui/page/styles.ts
+++ b/src/ui/page/styles.ts
@@ -1550,7 +1550,6 @@ export const pageStyles = String.raw`    :root {
   .chat-sidebar { width: 100%; min-width: 100%; max-height: 180px; border-right: none; border-bottom: 1px solid var(--border); }
 }
 
-<<<<<<< HEAD
 /* ── Tab nav ── */
 [hidden] { display: none !important; }
 .tab-nav {
@@ -1770,8 +1769,8 @@ export const pageStyles = String.raw`    :root {
   font-size: 13px;
   padding: 7px 16px;
 }
-.kanban-btn-secondary:hover { color: rgba(255,255,255,0.7); }`;
-=======
+.kanban-btn-secondary:hover { color: rgba(255,255,255,0.7); }
+
     /* ── File attachment UI ── */
     .chat-attach {
       flex-shrink: 0;
@@ -1916,4 +1915,3 @@ export const pageStyles = String.raw`    :root {
   .usage-td-cost { min-width: 80px; }
 }
 `;
->>>>>>> upstream/master

--- a/src/ui/page/template.ts
+++ b/src/ui/page/template.ts
@@ -115,11 +115,8 @@ ${pageStyles}
     <nav class="tab-nav" role="tablist" aria-label="Main navigation">
       <button class="tab-btn tab-btn-active" id="tab-dashboard" type="button" role="tab" aria-selected="true" aria-controls="dashboard-panel">Dashboard</button>
       <button class="tab-btn" id="tab-chat" type="button" role="tab" aria-selected="false" aria-controls="chat-panel">Chat</button>
-<<<<<<< HEAD
       <button class="tab-btn" id="tab-kanban" type="button" role="tab" aria-selected="false" aria-controls="kanban-panel">Kanban</button>
-=======
       <button class="tab-btn" id="tab-usage" type="button" role="tab" aria-selected="false" aria-controls="usage-panel">Usage</button>
->>>>>>> upstream/master
     </nav>
     <div id="dashboard-panel">
     <section class="hero">


### PR DESCRIPTION
## Summary

PR #32 merged with raw git conflict markers committed in three UI files. Bun's parser treated them as syntax errors, crashing the daemon on startup. Second production outage (20h gap on Discord, 502 on Web UI).

Resolved by keeping ALL features from both sides:

| File | HEAD (Plus) | Upstream | Resolution |
|---|---|---|---|
| `template.ts` | Kanban tab button | Usage tab button | Both |
| `script.ts` (5 conflicts) | Kanban tab vars, feature block | Usage tab vars, feature block | Both coexist |
| `styles.ts` | Tab nav + Kanban CSS | File-attach + Usage CSS | All four |

## Why both?

Kanban is a Plus feature. Usage monitoring and file-attachment CSS landed from upstream PR #206/#205. These are independent features that don't conflict — the conflict markers were a git merge artifact, not a real incompatibility.

## Test plan

- [ ] `bun build src/index.ts --outdir /tmp --target bun` exits 0 (smoke test passes)
- [ ] Web UI shows: Dashboard / Chat / **Kanban** / **Usage** tabs
- [ ] Kanban board loads and accepts new cards
- [ ] Usage tab shows session table