### PR TITLE
feat(skills-tuner): core engine — TunableSubject framework + security + storage + git_ops (1/3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/bun.lock
+++ b/bun.lock
@@ -3,40 +3,67 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "claude-heartbeat",
+      "name": "claudeclaw",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.40.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "js-yaml": "^4.1.0",
         "ogg-opus-decoder": "^1.7.3",
+        "simple-git": "^3.27.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.9",
+        "@types/js-yaml": "^4.0.9",
       },
     },
   },
   "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.40.1", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w=="],
+
     "@eshaz/web-worker": ["@eshaz/web-worker@1.2.2", "", {}, "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
+    "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
+
+    "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+    "@simple-git/args-pathspec": ["@simple-git/args-pathspec@1.0.3", "", {}, "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="],
 
-    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+    "@simple-git/argv-parser": ["@simple-git/argv-parser@1.1.1", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.3" } }, "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
+
+    "@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
     "@wasm-audio-decoders/common": ["@wasm-audio-decoders/common@9.0.7", "", { "dependencies": { "@eshaz/web-worker": "1.2.2", "simple-yenc": "^1.0.4" } }, "sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag=="],
 
     "@wasm-audio-decoders/opus-ml": ["@wasm-audio-decoders/opus-ml@0.0.2", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-58rWEqDGg+CKCyEeKm2KoxxSwTWtHh/NLTW9ObR4K8CGF6VwuuGudEI1CtniS/oSRmL1nJq/eh8MKARiluw4DQ=="],
 
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
-    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -45,6 +72,8 @@
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "codec-parser": ["codec-parser@2.5.0", "", {}, "sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -60,6 +89,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
@@ -74,9 +105,13 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
@@ -92,6 +127,12 @@
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
+
+    "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
+
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
@@ -106,11 +147,15 @@
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -125,6 +170,8 @@
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -143,6 +190,10 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -196,19 +247,29 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "simple-git": ["simple-git@3.36.0", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "@simple-git/args-pathspec": "^1.0.3", "@simple-git/argv-parser": "^1.1.0", "debug": "^4.4.0" } }, "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q=="],
+
     "simple-yenc": ["simple-yenc@1.0.4", "", {}, "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -217,5 +278,9 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "claude-heartbeat",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "ogg-opus-decoder": "^1.7.3",
       },
       "devDependencies": {
@@ -15,6 +16,10 @@
   "packages": {
     "@eshaz/web-worker": ["@eshaz/web-worker@1.2.2", "", {}, "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
@@ -23,16 +28,194 @@
 
     "@wasm-audio-decoders/opus-ml": ["@wasm-audio-decoders/opus-ml@0.0.2", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-58rWEqDGg+CKCyEeKm2KoxxSwTWtHh/NLTW9ObR4K8CGF6VwuuGudEI1CtniS/oSRmL1nJq/eh8MKARiluw4DQ=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "codec-parser": ["codec-parser@2.5.0", "", {}, "sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.1", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "ogg-opus-decoder": ["ogg-opus-decoder@1.7.3", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7", "@wasm-audio-decoders/opus-ml": "0.0.2", "codec-parser": "2.5.0", "opus-decoder": "0.7.11" } }, "sha512-w47tiZpkLgdkpa+34VzYD8mHUj8I9kfWVZa82mBbNwDvB1byfLXSSzW/HxA4fI3e9kVlICSpXGFwMLV1LPdjwg=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "opus-decoder": ["opus-decoder@0.7.11", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
     "simple-yenc": ["simple-yenc@1.0.4", "", {}, "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw=="],
 
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
   }
 }

--- a/docs/plugin-integration.md
+++ b/docs/plugin-integration.md
@@ -1,0 +1,201 @@
+# Plugin Tool Integration Guide
+
+ClaudeClaw-Plus exposes a `PluginMcpBridge` that lets daemon plugins register tools and expose them to the MCP ecosystem. All registered tools are served via a stdio MCP server that any MCP client (Claude Desktop, etc.) can connect to.
+
+---
+
+## Architecture Overview
+
+```
+Plus daemon
+├── PluginManager (src/plugins.ts)
+│   └── lifecycle events (gateway_start, session_start, agent_end, …)
+└── PluginMcpBridge (src/plugins/mcp-bridge.ts)
+    ├── registerPluginTool(pluginId, tool)  ← plugin registration API
+    ├── McpServer (src/plugins/mcp-server.ts, stdio)
+    ├── HMAC-SHA256 signed inter-plugin calls
+    └── Append-only audit log (~/.config/plus/plugin-audit.jsonl)
+```
+
+---
+
+## Registering Tools from a Plugin
+
+Plugins receive a `PluginApi` object at init time. Call `api.registerTool(tool)` to register an MCP-compatible tool:
+
+```typescript
+import type { PluginInitFn } from "claudeclaw-plus/src/plugins.js";
+import { z } from "zod";
+
+const init: PluginInitFn = (api) => {
+  api.registerTool({
+    name: "pending",
+    description: "List pending tuner proposals",
+    schema: z.object({
+      subject: z.string().optional(),
+    }),
+    handler: async (args) => {
+      return engine.listPending(args.subject);
+    },
+  });
+
+  api.registerTool({
+    name: "apply",
+    description: "Apply a tuner proposal by ID",
+    schema: z.object({ id: z.string() }),
+    handler: async (args) => engine.apply(args.id),
+  });
+};
+
+export default init;
+```
+
+The tool is registered under the FQN `{pluginId}__{toolName}` (e.g. `skills-tuner__pending`).
+
+---
+
+## Pattern: Archiviste Plugin
+
+```typescript
+const init: PluginInitFn = (api) => {
+  api.registerTool({
+    name: "search_docs",
+    description: "Full-text search across archived documents",
+    schema: z.object({
+      query: z.string(),
+      trusted_only: z.boolean().optional(),
+      limit: z.number().optional(),
+    }),
+    handler: async (args) => archiviste.search(args),
+  });
+
+  api.registerTool({
+    name: "index_doc",
+    description: "Index a new document into the archive",
+    schema: z.object({
+      path: z.string(),
+      tags: z.array(z.string()).optional(),
+    }),
+    handler: async (args) => archiviste.index(args.path, args.tags),
+  });
+};
+```
+
+---
+
+## Pattern: Voice Plugin (Greg)
+
+```typescript
+const init: PluginInitFn = (api) => {
+  api.registerTool({
+    name: "play_tts",
+    description: "Synthesize and play text-to-speech audio",
+    schema: z.object({
+      text: z.string(),
+      voice: z.string().optional(),
+    }),
+    handler: async (args) => voice.playTts(args.text, args.voice),
+  });
+
+  api.registerTool({
+    name: "transcribe_audio",
+    description: "Transcribe an audio file to text using Whisper",
+    schema: z.object({ path: z.string() }),
+    handler: async (args) => voice.transcribe(args.path),
+  });
+};
+```
+
+---
+
+## Security
+
+### Per-Plugin Secret
+
+Each plugin gets a 32-byte random secret stored at:
+```
+~/.config/plus/plugins/<pluginId>/.secret   (mode 0600)
+```
+
+The secret is auto-created on first use and hex-encoded on disk. It never leaves the local machine.
+
+### HMAC-SHA256 Signing
+
+Every `invokeTool` call is signed before reaching the handler:
+
+```typescript
+const sig = bridge.signCall(pluginId, args, Date.now());
+const ok  = bridge.verifyCall(pluginId, args, ts, sig);
+```
+
+Verification uses `timingSafeEqual` to prevent timing attacks.
+
+### Zod Validation
+
+All tool arguments are validated against the plugin-provided `schema` before the handler is called. Invalid args throw immediately and are logged to the audit log.
+
+### Audit Log
+
+Every `register`, `invoke`, `error` event is appended to:
+```
+~/.config/plus/plugin-audit.jsonl
+```
+
+Each line is a JSON object with `{ event, ts, fqn, pluginId, … }`. The file is append-only; never truncate it — it is an audit trail.
+
+---
+
+## Starting the MCP Server
+
+### Standalone
+
+```bash
+bun run src/plugins/mcp-server.ts
+```
+
+The server listens on stdio and exposes all registered tools to any MCP client.
+
+### Claude Desktop Configuration
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or equivalent:
+
+```json
+{
+  "mcpServers": {
+    "claudeclaw-plus": {
+      "command": "bun",
+      "args": ["run", "/home/simon/Projects/ClaudeClaw-Plus/src/plugins/mcp-server.ts"]
+    }
+  }
+}
+```
+
+---
+
+## Direct Bridge Access (Advanced)
+
+If you need to register tools outside of the Plugin lifecycle, import the singleton directly:
+
+```typescript
+import { getMcpBridge } from "claudeclaw-plus/src/plugins/mcp-bridge.js";
+import { z } from "zod";
+
+const bridge = getMcpBridge();
+
+bridge.registerPluginTool("my-service", {
+  name: "status",
+  description: "Get service status",
+  schema: z.object({}),
+  handler: async () => ({ ok: true }),
+});
+```
+
+---
+
+## Running Tests
+
+```bash
+bun test src/__tests__/plugins/mcp-bridge.test.ts
+```
+
+All 8+ assertions cover: registration, duplicates, zod validation, HMAC round-trips, audit log entries, and secret management.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/bun": "^1.3.9"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "ogg-opus-decoder": "^1.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,15 @@
     "bump:marketplace-version": "bun run scripts/bump-marketplace-version.ts"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.9"
+    "@types/bun": "^1.3.9",
+    "@types/js-yaml": "^4.0.9"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "ogg-opus-decoder": "^1.7.3"
+    "@anthropic-ai/sdk": "^0.40.0",
+    "js-yaml": "^4.1.0",
+    "ogg-opus-decoder": "^1.7.3",
+    "simple-git": "^3.27.0",
+    "zod": "^4.4.3"
   }
 }

--- a/src/__tests__/plugins/mcp-bridge.test.ts
+++ b/src/__tests__/plugins/mcp-bridge.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { z } from "zod";
+import { PluginMcpBridge, _resetMcpBridge, getMcpBridge } from "../../plugins/mcp-bridge.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeBridge(): { bridge: PluginMcpBridge; auditPath: string; tmpDir: string } {
+  const tmpDir = mkdtempSync(join(tmpdir(), "mcp-bridge-test-"));
+  const auditPath = join(tmpDir, "audit.jsonl");
+  const bridge = new PluginMcpBridge(auditPath);
+  return { bridge, auditPath, tmpDir };
+}
+
+function readAuditLines(auditPath: string): Array<Record<string, unknown>> {
+  try {
+    return readFileSync(auditPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+  } catch {
+    return [];
+  }
+}
+
+const echoTool = {
+  name: "echo",
+  description: "Echo input back",
+  schema: z.object({ message: z.string() }),
+  handler: async (args: { message: string }) => args.message,
+};
+
+const addTool = {
+  name: "add",
+  description: "Add two numbers",
+  schema: z.object({ a: z.number(), b: z.number() }),
+  handler: async (args: { a: number; b: number }) => args.a + args.b,
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PluginMcpBridge", () => {
+  describe("registerPluginTool + listTools", () => {
+    it("registers a tool and returns it in listTools with correct FQN", () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("my-plugin", echoTool);
+      const tools = bridge.listTools();
+
+      expect(tools).toHaveLength(1);
+      expect(tools[0].fqn).toBe("my-plugin__echo");
+      expect(tools[0].description).toBe("Echo input back");
+      expect(tools[0].inputSchema).toMatchObject({ type: "object" });
+    });
+
+    it("registers multiple tools from different plugins", () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("plugin-a", echoTool);
+      bridge.registerPluginTool("plugin-b", addTool);
+      const tools = bridge.listTools();
+
+      expect(tools).toHaveLength(2);
+      const fqns = tools.map((t) => t.fqn);
+      expect(fqns).toContain("plugin-a__echo");
+      expect(fqns).toContain("plugin-b__add");
+    });
+  });
+
+  describe("duplicate registration", () => {
+    it("throws on duplicate tool FQN", () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("my-plugin", echoTool);
+      expect(() => bridge.registerPluginTool("my-plugin", echoTool)).toThrow(
+        /Duplicate tool registration/,
+      );
+    });
+
+    it("allows same tool name for different plugins", () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("plugin-a", echoTool);
+      expect(() => bridge.registerPluginTool("plugin-b", echoTool)).not.toThrow();
+    });
+  });
+
+  describe("invokeTool", () => {
+    it("calls handler with valid args and returns result", async () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("calc", addTool);
+      const result = await bridge.invokeTool("calc__add", { a: 3, b: 4 });
+      expect(result).toBe(7);
+    });
+
+    it("throws on invalid args (zod validation failure)", async () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("my-plugin", echoTool);
+      await expect(bridge.invokeTool("my-plugin__echo", { message: 42 })).rejects.toThrow(
+        /Invalid args/,
+      );
+    });
+
+    it("throws on unknown tool name", async () => {
+      const { bridge } = makeBridge();
+
+      await expect(bridge.invokeTool("nonexistent__tool", {})).rejects.toThrow(/Unknown tool/);
+    });
+
+    it("propagates handler errors", async () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("failing", {
+        name: "fail",
+        description: "Always fails",
+        schema: z.object({}),
+        handler: async () => {
+          throw new Error("handler exploded");
+        },
+      });
+      await expect(bridge.invokeTool("failing__fail", {})).rejects.toThrow("handler exploded");
+    });
+  });
+
+  describe("HMAC signing", () => {
+    it("signCall + verifyCall round-trip returns true", () => {
+      const { bridge } = makeBridge();
+
+      const body = { foo: "bar", count: 42 };
+      const ts = Date.now();
+      const sig = bridge.signCall("test-plugin", body, ts);
+      expect(bridge.verifyCall("test-plugin", body, ts, sig)).toBe(true);
+    });
+
+    it("verifyCall rejects tampered signature", () => {
+      const { bridge } = makeBridge();
+
+      const body = { foo: "bar" };
+      const ts = Date.now();
+      const sig = bridge.signCall("test-plugin", body, ts);
+      const tampered = sig.slice(0, -2) + "00";
+      expect(bridge.verifyCall("test-plugin", body, ts, tampered)).toBe(false);
+    });
+
+    it("verifyCall rejects tampered body", () => {
+      const { bridge } = makeBridge();
+
+      const ts = Date.now();
+      const sig = bridge.signCall("test-plugin", { foo: "bar" }, ts);
+      expect(bridge.verifyCall("test-plugin", { foo: "TAMPERED" }, ts, sig)).toBe(false);
+    });
+
+    it("verifyCall rejects tampered ts", () => {
+      const { bridge } = makeBridge();
+
+      const ts = Date.now();
+      const body = { x: 1 };
+      const sig = bridge.signCall("test-plugin", body, ts);
+      expect(bridge.verifyCall("test-plugin", body, ts + 1, sig)).toBe(false);
+    });
+  });
+
+  describe("audit log", () => {
+    it("writes a register entry when a tool is registered", () => {
+      const { bridge, auditPath } = makeBridge();
+
+      bridge.registerPluginTool("audit-test", echoTool);
+      const lines = readAuditLines(auditPath);
+
+      expect(lines).toHaveLength(1);
+      expect(lines[0].event).toBe("register");
+      expect(lines[0].fqn).toBe("audit-test__echo");
+    });
+
+    it("writes invoke + success entries when tool is called", async () => {
+      const { bridge, auditPath } = makeBridge();
+
+      bridge.registerPluginTool("audit-test", echoTool);
+      await bridge.invokeTool("audit-test__echo", { message: "hello" });
+      const lines = readAuditLines(auditPath);
+
+      const invokeEntry = lines.find((l) => l.event === "invoke");
+      expect(invokeEntry).toBeDefined();
+      expect(invokeEntry?.success).toBe(true);
+    });
+
+    it("writes error entry on validation failure", async () => {
+      const { bridge, auditPath } = makeBridge();
+
+      bridge.registerPluginTool("audit-test", echoTool);
+      try {
+        await bridge.invokeTool("audit-test__echo", { message: 999 });
+      } catch {
+        // expected
+      }
+
+      const lines = readAuditLines(auditPath);
+      const errorEntry = lines.find((l) => l.event === "error");
+      expect(errorEntry).toBeDefined();
+      expect(errorEntry?.phase).toBe("validation");
+    });
+  });
+
+  describe("per-plugin secret", () => {
+    it("auto-creates a 32-byte secret for a plugin", () => {
+      const { bridge } = makeBridge();
+
+      const secret = bridge.loadOrCreateSecret("new-plugin");
+      expect(secret).toBeInstanceOf(Buffer);
+      expect(secret.length).toBe(32);
+    });
+
+    it("returns the same secret on subsequent calls (cached)", () => {
+      const { bridge } = makeBridge();
+
+      const a = bridge.loadOrCreateSecret("plugin-x");
+      const b = bridge.loadOrCreateSecret("plugin-x");
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it("different plugins get different secrets", () => {
+      const { bridge } = makeBridge();
+
+      const a = bridge.loadOrCreateSecret("plugin-alpha");
+      const b = bridge.loadOrCreateSecret("plugin-beta");
+      expect(a.equals(b)).toBe(false);
+    });
+  });
+
+  describe("getMcpBridge singleton", () => {
+    it("returns the same instance on multiple calls", () => {
+      _resetMcpBridge();
+      const a = getMcpBridge();
+      const b = getMcpBridge();
+      expect(a).toBe(b);
+      _resetMcpBridge();
+    });
+  });
+});

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -17,6 +17,7 @@
 
 import { join, isAbsolute, resolve } from "path";
 import { existsSync } from "fs";
+import { getMcpBridge, type PluginTool } from "./plugins/mcp-bridge.js";
 
 // ── Event types ──────────────────────────────────────────────────────────────
 
@@ -60,6 +61,7 @@ export interface PluginApi {
   on(event: string, handler: EventHandler): void;
   registerService(service: PluginService): void;
   registerCommand(cmd: PluginCommand): void;
+  registerTool(tool: PluginTool): void;
   runtime: {
     channel: Record<string, Record<string, (...args: unknown[]) => unknown>>;
   };
@@ -201,6 +203,9 @@ export class PluginManager {
       },
       registerCommand(cmd: PluginCommand) {
         self.commands.set(cmd.name, cmd);
+      },
+      registerTool(tool: PluginTool) {
+        getMcpBridge().registerPluginTool(pluginId, tool);
       },
       runtime: {
         channel: self.channelRuntime,

--- a/src/plugins/mcp-bridge.ts
+++ b/src/plugins/mcp-bridge.ts
@@ -1,0 +1,222 @@
+import { z } from "zod";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { appendFileSync, mkdirSync, writeFileSync, existsSync, readFileSync, chmodSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface PluginTool<T extends z.ZodType = z.ZodType<any, any>> {
+  name: string;
+  description: string;
+  schema: T;
+  handler: (args: z.infer<T>) => Promise<unknown> | unknown;
+}
+
+export interface PluginToolContext {
+  pluginId: string;
+  callerToken?: string;
+  signature: string;
+  ts: number;
+}
+
+export interface RegisteredTool {
+  plugin: string;
+  tool: PluginTool;
+}
+
+export interface ListedTool {
+  fqn: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+// ── PluginMcpBridge ───────────────────────────────────────────────────────────
+
+export class PluginMcpBridge {
+  private tools = new Map<string, RegisteredTool>();
+  private secrets = new Map<string, Buffer>();
+  private auditPath: string;
+
+  constructor(auditPath?: string) {
+    this.auditPath = auditPath
+      ? resolve(auditPath)
+      : resolve(homedir(), ".config", "plus", "plugin-audit.jsonl");
+
+    // Ensure audit directory exists
+    const auditDir = this.auditPath.substring(0, this.auditPath.lastIndexOf("/"));
+    mkdirSync(auditDir, { recursive: true });
+  }
+
+  // ── Tool registration ──────────────────────────────────────────────────
+
+  registerPluginTool(pluginId: string, tool: PluginTool): void {
+    const fqn = `${pluginId}__${tool.name}`;
+
+    if (this.tools.has(fqn)) {
+      throw new Error(`Duplicate tool registration: "${fqn}" is already registered`);
+    }
+
+    this.tools.set(fqn, { plugin: pluginId, tool });
+    this.audit("register", { fqn, pluginId, toolName: tool.name, description: tool.description });
+  }
+
+  // ── Secret management ──────────────────────────────────────────────────
+
+  loadOrCreateSecret(pluginId: string): Buffer {
+    const cached = this.secrets.get(pluginId);
+    if (cached) return cached;
+
+    const secretDir = resolve(homedir(), ".config", "plus", "plugins", pluginId);
+    const secretPath = join(secretDir, ".secret");
+
+    mkdirSync(secretDir, { recursive: true });
+
+    let secret: Buffer;
+    if (existsSync(secretPath)) {
+      const raw = readFileSync(secretPath);
+      // hex-encoded 32 bytes = 64 chars
+      secret = Buffer.from(raw.toString().trim(), "hex");
+    } else {
+      secret = randomBytes(32);
+      writeFileSync(secretPath, secret.toString("hex"), { encoding: "utf8" });
+      chmodSync(secretPath, 0o600);
+    }
+
+    this.secrets.set(pluginId, secret);
+    return secret;
+  }
+
+  // ── HMAC signing ──────────────────────────────────────────────────────
+
+  signCall(pluginId: string, body: unknown, ts: number): string {
+    const secret = this.loadOrCreateSecret(pluginId);
+    const canonical = JSON.stringify({ body, ts });
+    return createHmac("sha256", secret).update(canonical).digest("hex");
+  }
+
+  verifyCall(pluginId: string, body: unknown, ts: number, signature: string): boolean {
+    const expected = this.signCall(pluginId, body, ts);
+    try {
+      const expectedBuf = Buffer.from(expected, "hex");
+      const signatureBuf = Buffer.from(signature, "hex");
+      if (expectedBuf.length !== signatureBuf.length) return false;
+      return timingSafeEqual(expectedBuf, signatureBuf);
+    } catch {
+      return false;
+    }
+  }
+
+  // ── Tool invocation ───────────────────────────────────────────────────
+
+  async invokeTool(fqn: string, args: unknown): Promise<unknown> {
+    const registered = this.tools.get(fqn);
+    if (!registered) {
+      throw new Error(`Unknown tool: "${fqn}"`);
+    }
+
+    const { plugin: pluginId, tool } = registered;
+
+    // Validate args via Zod schema
+    const parsed = tool.schema.safeParse(args);
+    if (!parsed.success) {
+      const err = new Error(`Invalid args for "${fqn}": ${parsed.error.message}`);
+      this.audit("error", { fqn, pluginId, error: parsed.error.message, phase: "validation" });
+      throw err;
+    }
+
+    // Sign the call
+    const ts = Date.now();
+    const signature = this.signCall(pluginId, parsed.data, ts);
+
+    try {
+      const result = await tool.handler(parsed.data);
+      this.audit("invoke", { fqn, pluginId, ts, signature, success: true });
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.audit("error", { fqn, pluginId, ts, signature, error: message, phase: "handler" });
+      throw err;
+    }
+  }
+
+  // ── Tool listing ──────────────────────────────────────────────────────
+
+  listTools(): ListedTool[] {
+    return Array.from(this.tools.entries()).map(([fqn, { tool }]) => ({
+      fqn,
+      description: tool.description,
+      inputSchema: this.zodToJson(tool.schema),
+    }));
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+
+  private zodToJson(schema: z.ZodType): Record<string, unknown> {
+    // MVP minimal converter — returns a basic JSON Schema object
+    if (schema instanceof z.ZodObject) {
+      const shape = schema.shape as Record<string, z.ZodType>;
+      const properties: Record<string, unknown> = {};
+      const required: string[] = [];
+
+      for (const [key, field] of Object.entries(shape)) {
+        properties[key] = this.zodFieldToJson(field as z.ZodType);
+        // If not optional, mark as required
+        if (!(field instanceof z.ZodOptional) && !(field instanceof z.ZodDefault)) {
+          required.push(key);
+        }
+      }
+
+      return {
+        type: "object",
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+        additionalProperties: false,
+      };
+    }
+
+    // Fallback for non-object schemas
+    return { type: "object", additionalProperties: true };
+  }
+
+  private zodFieldToJson(field: z.ZodType): Record<string, unknown> {
+    if (field instanceof z.ZodOptional) {
+      return this.zodFieldToJson(field.unwrap() as z.ZodType);
+    }
+    if (field instanceof z.ZodDefault) {
+      return this.zodFieldToJson(field._def.innerType as z.ZodType);
+    }
+    if (field instanceof z.ZodString) return { type: "string" };
+    if (field instanceof z.ZodNumber) return { type: "number" };
+    if (field instanceof z.ZodBoolean) return { type: "boolean" };
+    if (field instanceof z.ZodArray) return { type: "array", items: this.zodFieldToJson(field.element as z.ZodType) };
+    if (field instanceof z.ZodEnum) return { type: "string", enum: field.options as string[] };
+    return { type: "object", additionalProperties: true };
+  }
+
+  private audit(event: string, payload: Record<string, unknown>): void {
+    try {
+      const entry = JSON.stringify({ event, ts: new Date().toISOString(), ...payload }) + "\n";
+      appendFileSync(this.auditPath, entry, { encoding: "utf8" });
+    } catch {
+      // Audit failures must not break the bridge
+    }
+  }
+}
+
+// ── Singleton ─────────────────────────────────────────────────────────────────
+
+let _bridge: PluginMcpBridge | null = null;
+
+export function getMcpBridge(): PluginMcpBridge {
+  if (!_bridge) {
+    _bridge = new PluginMcpBridge();
+  }
+  return _bridge;
+}
+
+/** Reset singleton — only for testing */
+export function _resetMcpBridge(): void {
+  _bridge = null;
+}

--- a/src/plugins/mcp-server.ts
+++ b/src/plugins/mcp-server.ts
@@ -1,0 +1,71 @@
+/**
+ * ClaudeClaw-Plus MCP stdio server
+ *
+ * Exposes all plugin-registered tools via the Model Context Protocol.
+ * Run standalone: bun run src/plugins/mcp-server.ts
+ *
+ * Or configure in claude_desktop_config.json:
+ *   { "mcpServers": { "claudeclaw-plus": { "command": "bun", "args": ["run", "/path/to/mcp-server.ts"] } } }
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { getMcpBridge } from "./mcp-bridge.js";
+
+export async function startMcpServer(): Promise<void> {
+  const bridge = getMcpBridge();
+
+  const server = new Server(
+    { name: "claudeclaw-plus", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  // List all registered plugin tools
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const tools = bridge.listTools();
+    return {
+      tools: tools.map((t) => ({
+        name: t.fqn,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
+    };
+  });
+
+  // Invoke a tool by FQN
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    try {
+      const result = await bridge.invokeTool(name, args ?? {});
+      return {
+        content: [
+          {
+            type: "text",
+            text: typeof result === "string" ? result : JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text", text: `Error: ${message}` }],
+        isError: true,
+      };
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+// Run standalone when executed directly
+if (import.meta.main) {
+  startMcpServer().catch((err) => {
+    console.error("[mcp-server] Fatal:", err);
+    process.exit(1);
+  });
+}

--- a/src/skills-tuner/README.md
+++ b/src/skills-tuner/README.md
@@ -1,0 +1,210 @@
+# skills-tuner-ts
+
+**Continuous, human-in-the-loop improvement platform for Claude Code skills — TypeScript port.**
+
+---
+
+## Status
+
+![tests](https://img.shields.io/badge/tests-99%2B%20passing-brightgreen)
+![typescript](https://img.shields.io/badge/TypeScript-strict-blue)
+![license](https://img.shields.io/badge/license-MIT-lightgrey)
+
+Phase 1–8 complete. All 99+ unit and integration tests pass.
+
+---
+
+## What is this
+
+Skills Tuner watches your Claude Code session logs, detects patterns where your skills
+could be improved, and proposes targeted patches — one at a time, with your approval.
+It runs on a cron schedule, signs every proposal with HMAC-SHA256, and keeps a full
+JSONL audit trail. External ML optimizers (Optuna, custom Python) plug in via a
+stdio JSON-RPC adapter without touching the TypeScript core.
+
+---
+
+## Architecture
+
+```
+[ Cron 03:00 ]
+       │
+       ▼
+[ TS Engine ] ── HMAC sign ──> [ JSONL audit + proposals ]
+       │
+       ├── [ Native subjects: SkillsSubject, VoiceSubject, ... ] ── LLM
+       │
+       └── [ ExternalProcessSubject ] ──stdio JSON-RPC──> [ Python ML / Optuna / ... ]
+
+[ Adapters ]
+   ├── CLI (stdout)
+   ├── Telegram (inline keyboard, allowedUserIds gate)
+   └── PlusEventAdapter (stub for #31)
+```
+
+**Core modules**
+
+| Module | Purpose |
+|---|---|
+| `src/core/engine.ts` | Orchestration: collect → detect → propose → sign → apply |
+| `src/core/security.ts` | HMAC-SHA256 signing + audit log |
+| `src/storage/proposals.ts` | Append-only JSONL proposal ledger |
+| `src/storage/refused.ts` | TTL-gated refusal store |
+| `src/git_ops/branches.ts` | Per-proposal git branches + commits |
+| `src/subjects/` | SkillsSubject, ExternalProcessSubject |
+| `src/adapters/` | CLI, Telegram, Plus event stub |
+| `src/cli/index.ts` | Commander CLI (9 commands) |
+
+---
+
+## Install
+
+```bash
+# From npm (once published)
+npm install -g @skills-tuner/core
+
+# Or run locally with bun
+bun add https://github.com/Nibbler1250/skills-tuner-ts
+```
+
+---
+
+## Quick start
+
+```bash
+# 1. First-run setup — copies tuner skill + creates default config
+tuner setup
+
+# 2. Sanity check — verify config, secret, git repo, JSONL files
+tuner doctor
+
+# 3. Dry-run — see what would be proposed without writing anything
+tuner cron-run --dry --since 24h
+
+# 4. Real run
+tuner cron-run --since 7d
+
+# 5. Review pending proposals
+tuner pending
+
+# 6. Apply or skip
+tuner apply 1 A
+tuner skip 2
+```
+
+---
+
+## CLI commands
+
+| Command | Arguments | Description |
+|---|---|---|
+| `doctor` | — | Check config, secret, git repo, session files |
+| `cron-run` | `--since <duration>` `--dry` `--subject <name>` | Run full detect+propose cycle |
+| `pending` | — | List pending proposal signatures |
+| `apply` | `<id> <alt>` | Apply an alternative (creates git branch + commit) |
+| `skip` | `<id>` | Refuse a proposal (TTL-gated, won't re-appear for 30 days) |
+| `revert` | `<id>` | Revert an applied proposal via `git revert` |
+| `feedback` | `<id> <yes\|yes-but\|no>` | Record preference feedback |
+| `stats` | — | Show created / applied / refused counts |
+| `setup` | — | First-run wizard: copy skill template + generate config |
+
+Duration format: `30s`, `10m`, `24h`, `7d`.
+
+---
+
+## Subjects
+
+| Subject | Description |
+|---|---|
+| `skills` | Parses `.md` skill files, detects stale triggers, missing examples, weak descriptions |
+| `voice` | Detects repeated phrasing patterns in voice transcripts |
+| `external_process` | Spawns any Python/binary over stdio JSON-RPC — plug in Optuna, custom ML, etc. |
+
+---
+
+## Claude Code / Plus integration
+
+Skills Tuner ships a `/tuner` skill (copied by `tuner setup`) that hooks into Claude
+Code sessions. The `PlusEventAdapter` (see `src/adapters/plus_event.ts`) emits
+structured events to the Plus event bus — enabling real-time proposal notifications
+inside your Claude Code UI without polling.
+
+---
+
+## Companion skill
+
+The `/tuner` skill installed by `tuner setup` gives you inline commands inside
+Claude Code:
+
+```
+/tuner pending      — list proposals
+/tuner apply 3 B   — apply alternative B for proposal #3
+/tuner stats        — quick stats summary
+```
+
+---
+
+## Security model
+
+- Every proposal is signed with **HMAC-SHA256** before being persisted.
+  `applyProposal` re-verifies the signature — any tamper is detected and rejected.
+- The 32-byte secret lives at `~/.config/tuner/.secret` with `0600` permissions.
+  `tuner doctor` verifies this on every run.
+- The audit log at `~/.config/tuner/audit.jsonl` records every operation:
+  `proposal_created`, `apply_attempted`, `apply_success`, `signature_mismatch`,
+  `refused`, `reverted`.
+- Refused proposals are TTL-gated (default 30 days) and won't resurface unless
+  the underlying skill file is edited after the refusal.
+
+---
+
+## Compliance angle
+
+The JSONL audit trail + HMAC signatures provide a lightweight evidence chain
+suitable for regulated environments that require change management records for
+AI-generated modifications. Every applied change links back to a git commit SHA
+and a signed proposal record.
+
+---
+
+## Migrating from the Python implementation
+
+If you have an existing `~/.config/tuner/proposals.jsonl` from the Python `skills-tuner` package, run the one-shot migration script:
+
+1. Stop the Python cron job (`crontab -e`, remove tuner entry)
+2. Uninstall the Python package: `pip uninstall skills-tuner`
+3. Run the migration (dry-run first):
+   ```bash
+   bun run migrate -- --dry-run   # preview changes
+   bun run migrate                # apply migration
+   ```
+4. Verify: `tuner doctor` and `tuner stats`
+
+The script backs up the original file to `proposals.jsonl.python-backup-<timestamp>` before writing. All proposals are re-signed with the current HMAC secret.
+
+---
+
+## Development
+
+```bash
+# Install dependencies
+bun install
+
+# Run all tests (unit + integration)
+bun test
+
+# Type-check without emitting
+bun run typecheck
+
+# Build to dist/
+bun run build
+```
+
+The `src/` tree is pure TypeScript ESM. Tests live in `tests/unit/` and
+`tests/integration/`. No test requires a live LLM — all subjects are mocked.
+
+---
+
+## License
+
+MIT

--- a/src/skills-tuner/core/config.ts
+++ b/src/skills-tuner/core/config.ts
@@ -1,0 +1,129 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import yaml from 'js-yaml';
+import { z } from 'zod';
+
+export const DEFAULT_CONFIG_PATH = join(homedir(), '.config', 'tuner', 'config.yaml');
+
+const ModelConfigSchema = z.object({
+  intent_classifier: z.string().default('claude-haiku-4-5-20251001'),
+  detector: z.string().default('claude-opus-4-7'),
+  proposer_default: z.string().default('claude-sonnet-4-6'),
+  proposer_high_stakes: z.string().default('claude-opus-4-7'),
+  judge: z.string().default('claude-opus-4-7'),
+});
+
+const SubjectConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  auto_merge: z.union([z.boolean(), z.array(z.string())]).default(false),
+  proposer: z.string().optional(),
+  proposer_for_create: z.string().optional(),
+  scan_dirs: z.array(z.string()).default([]),
+});
+export type SubjectConfig = z.infer<typeof SubjectConfigSchema>;
+
+const DetectionConfigSchema = z.object({
+  improvement_keywords_extra: z.array(z.string()).default([]),
+  confidence_floor: z.number().min(0).max(1).default(0.65),
+  max_proposals_per_run: z.number().int().positive().default(5),
+});
+
+const ProposerConfigSchema = z.object({
+  alternatives_count: z.number().int().positive().default(3),
+  language_preference: z.string().default('en'),
+});
+
+const UiConfigSchema = z.object({
+  primary_adapter: z.string().default('cli'),
+  follow_up_survey: z.boolean().default(true),
+  follow_up_after_seconds: z.number().int().positive().default(30),
+});
+
+const StorageConfigSchema = z.object({
+  proposals_jsonl: z.string().default(join(homedir(), '.config', 'tuner', 'proposals.jsonl')),
+  refused_jsonl: z.string().default(join(homedir(), '.config', 'tuner', 'refused.jsonl')),
+  schema_version: z.number().int().default(1),
+  backup_keep: z.number().int().default(7),
+  git_repo: z.string().optional(),
+});
+
+const LLMConfigSchema = z.object({
+  backend: z.enum(['anthropic_api', 'claude_cli']).default('anthropic_api'),
+  api_key: z.string().optional(),
+});
+
+const TunerConfigSchema = z.object({
+  models: ModelConfigSchema.default({}),
+  llm: LLMConfigSchema.default({}),
+  detection: DetectionConfigSchema.default({}),
+  proposer: ProposerConfigSchema.default({}),
+  subjects: z.record(SubjectConfigSchema).default({}),
+  ui: UiConfigSchema.default({}),
+  storage: StorageConfigSchema.default({}),
+});
+export type TunerConfig = z.infer<typeof TunerConfigSchema>;
+
+export function subjectConfig(config: TunerConfig, name: string): SubjectConfig {
+  return config.subjects[name] ?? SubjectConfigSchema.parse({});
+}
+
+export function loadConfig(path = DEFAULT_CONFIG_PATH): TunerConfig {
+  if (!existsSync(path)) {
+    return TunerConfigSchema.parse({});
+  }
+  const raw = yaml.load(readFileSync(path, 'utf8')) as Record<string, unknown> ?? {};
+  // Expand ~ in storage paths
+  if (raw['storage'] && typeof raw['storage'] === 'object') {
+    const storage = raw['storage'] as Record<string, unknown>;
+    for (const key of ['proposals_jsonl', 'refused_jsonl', 'git_repo']) {
+      if (typeof storage[key] === 'string') {
+        storage[key] = (storage[key] as string).replace(/^~/, homedir());
+      }
+    }
+  }
+  return TunerConfigSchema.parse(raw);
+}
+
+const DEFAULT_YAML = `# Skills Tuner TS configuration
+
+llm:
+  backend: anthropic_api
+  # api_key: sk-ant-...   # or set ANTHROPIC_API_KEY env var
+
+detection:
+  confidence_floor: 0.65
+  max_proposals_per_run: 5
+
+models:
+  intent_classifier: claude-haiku-4-5-20251001
+  detector: claude-opus-4-7
+  proposer_default: claude-sonnet-4-6
+  proposer_high_stakes: claude-opus-4-7
+  judge: claude-opus-4-7
+
+proposer:
+  alternatives_count: 3
+  language_preference: en
+
+subjects:
+  skills:
+    enabled: true
+    auto_merge: [patch, frontmatter]
+    proposer: claude-sonnet-4-6
+    proposer_for_create: claude-opus-4-7
+
+ui:
+  primary_adapter: cli
+  follow_up_survey: true
+  follow_up_after_seconds: 30
+
+storage:
+  backup_keep: 7
+`;
+
+export function writeDefaultConfig(path = DEFAULT_CONFIG_PATH): void {
+  mkdirSync(join(path, '..'), { recursive: true });
+  if (existsSync(path)) throw new Error(`Config already exists at ${path}`);
+  writeFileSync(path, DEFAULT_YAML, 'utf8');
+}

--- a/src/skills-tuner/core/engine.ts
+++ b/src/skills-tuner/core/engine.ts
@@ -1,0 +1,195 @@
+import { computeProposalSignature, verifyProposalSignature, loadSecret, auditLog } from './security.js';
+import { subjectConfig } from './config.js';
+import type { TunerConfig } from './config.js';
+import type { Proposal, UnsignedProposal } from './types.js';
+import type { TunableSubject } from './interfaces.js';
+import type { Registry } from './registry.js';
+import type { ProposalsStore } from '../storage/proposals.js';
+import type { RefusedStore } from '../storage/refused.js';
+import type { BranchManager } from '../git_ops/branches.js';
+
+export class SecurityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SecurityError';
+  }
+}
+
+export class Engine {
+  private secret: Buffer;
+  private readonly _applying = new Set<number>(); // in-memory lock: prevents concurrent double-apply
+
+  constructor(
+    public readonly config: TunerConfig,
+    public readonly registry: Registry,
+    public readonly proposals: ProposalsStore,
+    public readonly refused: RefusedStore,
+    public readonly branches: BranchManager,
+  ) {
+    this.secret = loadSecret();
+  }
+
+  async runCycle(opts: { since?: Date; subjectName?: string; dryRun?: boolean } = {}): Promise<{ proposed: number; autoApplied: number }> {
+    const windowDays = (this.config.detection as unknown as Record<string, unknown>)['window_days'] as number | undefined ?? 7;
+    const since = opts.since ?? new Date(Date.now() - windowDays * 86_400_000);
+    const totals = { proposed: 0, autoApplied: 0 };
+
+    const subjects: TunableSubject[] = opts.subjectName
+      ? [this.registry.getSubject(opts.subjectName)].filter((s): s is TunableSubject => s != null)
+      : this.registry.enabledSubjects(this.config);
+
+    for (const subject of subjects) {
+      try {
+        const r = await this._runSubject(subject.name, since, opts.dryRun ?? false);
+        totals.proposed += r.proposed;
+        totals.autoApplied += r.autoApplied;
+      } catch (err) {
+        console.error(`Error running subject ${subject.name}:`, err);
+      }
+    }
+    return totals;
+  }
+
+  private async _runSubject(subjectName: string, since: Date, dryRun: boolean): Promise<{ proposed: number; autoApplied: number }> {
+    const subject = this.registry.getSubject(subjectName);
+    if (!subject) return { proposed: 0, autoApplied: 0 };
+
+    const maxPerRun = this.config.detection.max_proposals_per_run;
+    const refusedSigs = this.refused.activeSignatures();
+    const appliedSigs = this.proposals.appliedSignatures({ withinDays: 30 });
+    const pendingSigs = this.proposals.pendingSignatures({ subject: subjectName });
+
+    const observations = await subject.collectObservations(since);
+    const clusters = await subject.detectProblems(observations);
+
+    let proposed = 0;
+    let autoApplied = 0;
+
+    for (const cluster of clusters) {
+      if (proposed >= maxPerRun) break;
+
+      const rawProposal: UnsignedProposal = await subject.proposeChange(cluster);
+
+      // Dedup checks (anti-spam — bug fix 2351440)
+      if (refusedSigs.has(rawProposal.pattern_signature)) continue;
+      if (appliedSigs.has(rawProposal.pattern_signature)) continue;
+      if (pendingSigs.has(rawProposal.pattern_signature)) continue;
+
+      if (dryRun) { proposed++; continue; }
+
+      // Assign ID and sign
+      const existingRecords = this.proposals.readAll();
+      // Use reduce instead of Math.max(...spread) to avoid stack overflow at ~10k+ records
+      const nextId = existingRecords.reduce((max, r) => Math.max(max, r?.proposal?.id ?? 0), 0) + 1;
+      const unsignedProposal: UnsignedProposal = { ...rawProposal, id: nextId };
+      const sig = computeProposalSignature(unsignedProposal, this.secret);
+      const signedProposal: Proposal = { ...unsignedProposal, signature: sig };
+
+      this.proposals.append({ proposal: signedProposal, event: 'created', ts: new Date().toISOString() });
+      auditLog('proposal_created', { proposal_id: signedProposal.id, subject: signedProposal.subject, pattern_signature: signedProposal.pattern_signature });
+      proposed++;
+
+      // Auto-merge check — high/critical risk_tier subjects never auto-merge
+      const subjectCfg = subjectConfig(this.config, subjectName);
+      const autoMerge = subjectCfg.auto_merge;
+      const shouldAutoMerge = autoMerge === true || (Array.isArray(autoMerge) && autoMerge.includes(signedProposal.kind));
+      if (subject.risk_tier === 'high' || subject.risk_tier === 'critical') {
+        if (shouldAutoMerge) {
+          console.warn(`[Engine] Auto-merge blocked: subject ${subjectName} has risk_tier=${subject.risk_tier}`);
+          auditLog('auto_merge_blocked', { proposal_id: signedProposal.id, subject: subjectName, risk_tier: subject.risk_tier });
+        }
+      } else if (shouldAutoMerge && signedProposal.alternatives.length > 0) {
+        try {
+          await this.applyProposal(signedProposal.id, signedProposal.alternatives[0]!.id);
+          autoApplied++;
+        } catch (err) {
+          console.error(`Auto-merge failed for proposal ${signedProposal.id}:`, err);
+        }
+      }
+    }
+    return { proposed, autoApplied };
+  }
+
+  async applyProposal(proposalId: number, alternativeId: string): Promise<void> {
+    // In-memory lock prevents concurrent double-apply from two simultaneous calls
+    if (this._applying.has(proposalId)) {
+      throw new Error(`Proposal #${proposalId} is already being applied — concurrent apply rejected`);
+    }
+    this._applying.add(proposalId);
+    try {
+      return await this._applyProposalInner(proposalId, alternativeId);
+    } finally {
+      this._applying.delete(proposalId);
+    }
+  }
+
+  private async _applyProposalInner(proposalId: number, alternativeId: string): Promise<void> {
+    const all = this.proposals.readAll();
+    const alreadyApplied = all.find(r => r?.proposal?.id === proposalId && r.event === 'applied');
+    if (alreadyApplied) throw new Error(`Proposal #${proposalId} already applied — cannot re-apply`);
+    const alreadyRefused = all.find(r => r?.proposal?.id === proposalId && r.event === 'refused');
+    if (alreadyRefused) throw new Error(`Proposal #${proposalId} already refused — cannot apply`);
+    const record = all.find(r => r?.proposal?.id === proposalId && r.event === 'created');
+    if (!record) throw new Error(`Proposal #${proposalId} not found or not pending`);
+    const proposal = record.proposal;
+
+    const subject = this.registry.getSubject(proposal.subject);
+    if (!subject) throw new Error(`Subject ${proposal.subject} not registered`);
+
+    auditLog('apply_attempted', { proposal_id: proposalId, alternative_id: alternativeId });
+
+    if (!verifyProposalSignature(proposal, this.secret)) {
+      auditLog('signature_mismatch', { proposal_id: proposalId });
+      throw new SecurityError(`Proposal #${proposalId} signature mismatch — tamper detected`);
+    }
+
+    const patch = await subject.apply(proposal, alternativeId);
+    const validation = await subject.validate(patch);
+
+    if (!validation.valid) {
+      auditLog('apply_invalid', { proposal_id: proposalId, reason: validation.reason });
+      throw new Error(`Validation failed: ${validation.reason ?? 'unknown'}`);
+    }
+
+    await this.branches.createProposalBranch(proposalId);
+    const commitSha = await this.branches.commitPatch(patch, proposal, alternativeId);
+
+    this.proposals.append({
+      proposal,
+      event: 'applied',
+      ts: new Date().toISOString(),
+      alternative_id: alternativeId,
+      commit_sha: commitSha,
+      applied_target_path: patch.target_path,
+    });
+    auditLog('apply_success', { proposal_id: proposalId, alternative_id: alternativeId, commit_sha: commitSha });
+  }
+
+  async refuseProposal(proposalId: number, reason = 'refuse'): Promise<void> {
+    const record = this.proposals.readAll().find(r => r?.proposal?.id === proposalId);
+    if (!record) throw new Error(`Proposal #${proposalId} not found`);
+    const proposal = record.proposal;
+
+    this.refused.add(proposal.pattern_signature, proposal.subject, reason);
+    this.proposals.append({ proposal, event: 'refused', ts: new Date().toISOString() });
+    auditLog('refused', { proposal_id: proposalId, pattern_signature: proposal.pattern_signature });
+  }
+
+  async revertProposal(proposalId: number): Promise<void> {
+    const appliedRecord = this.proposals.readAll().find(r => r?.proposal?.id === proposalId && r.event === 'applied');
+    if (!appliedRecord) throw new Error(`No applied record found for proposal #${proposalId}`);
+
+    const commitSha = (appliedRecord as typeof appliedRecord & { commit_sha?: string }).commit_sha;
+    if (!commitSha) throw new Error(`No commit SHA recorded for proposal #${proposalId}`);
+
+    try {
+      // Checkout the proposal branch so revert applies in the right context
+      await this.branches.checkoutProposalBranch(proposalId);
+      await this.branches.revertPatch(commitSha);
+      auditLog('reverted', { proposal_id: proposalId, commit_sha: commitSha });
+    } catch (err) {
+      auditLog('revert_failed', { proposal_id: proposalId, commit_sha: commitSha, error: String(err) });
+      throw err;
+    }
+  }
+}

--- a/src/skills-tuner/core/interfaces.ts
+++ b/src/skills-tuner/core/interfaces.ts
@@ -1,0 +1,34 @@
+import type { Cluster, Observation, Patch, Proposal, UnsignedProposal, ValidationResult } from './types.js';
+import { ORPHAN_SUBJECT } from './types.js';
+
+export type RiskTier = 'low' | 'medium' | 'high' | 'critical';
+
+export abstract class TunableSubject {
+  abstract readonly name: string;
+  readonly risk_tier: RiskTier = 'low';
+  readonly auto_merge_default: boolean = false;
+  readonly supports_creation: boolean = false;
+  readonly orphan_min_observations: number = 2;
+
+  abstract collectObservations(since: Date): Promise<Observation[]>;
+  abstract detectProblems(observations: Observation[]): Promise<Cluster[]>;
+  abstract proposeChange(cluster: Cluster): Promise<UnsignedProposal>;
+  abstract apply(proposal: Proposal, alternativeId: string): Promise<Patch>;
+  abstract validate(patch: Patch): Promise<ValidationResult>;
+
+  scoreSignal(_verbatim: string, _attributedTo: string, _knownEntities: Record<string, unknown>): number {
+    return 0;
+  }
+
+  reclassifySignal(_verbatim: string, _knownEntities: Record<string, unknown>): string {
+    return ORPHAN_SUBJECT;
+  }
+}
+
+export abstract class Adapter {
+  abstract renderProposal(proposal: Proposal): Promise<void>;
+  abstract renderApplyConfirmation(proposal: Proposal, alternativeId: string): Promise<void>;
+}
+
+export { ORPHAN_SUBJECT, CREATE_KINDS } from './types.js';
+export type { UnsignedProposal } from './types.js';

--- a/src/skills-tuner/core/llm.ts
+++ b/src/skills-tuner/core/llm.ts
@@ -1,0 +1,106 @@
+import { spawn } from 'node:child_process';
+import type { TunerConfig } from './config.js';
+
+export type Role = 'intent_classifier' | 'detector' | 'proposer' | 'proposer_high_stakes' | 'judge';
+
+export interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface LLMClient {
+  call(role: Role, system: string, messages: Message[], maxTokens?: number): Promise<string>;
+  modelFor(role: Role): string;
+}
+
+function buildPrompt(system: string, messages: Message[]): string {
+  const lines: string[] = ['[system]', system, '[/system]'];
+  for (const m of messages) {
+    lines.push('[' + m.role + ']', m.content, '[/' + m.role + ']');
+  }
+  return lines.join('\n');
+}
+
+export class ClaudeCliBackend implements LLMClient {
+  private readonly models: TunerConfig['models'];
+
+  constructor(config: TunerConfig) {
+    this.models = config.models;
+  }
+
+  modelFor(role: Role): string {
+    const m = this.models;
+    return ({
+      intent_classifier: m.intent_classifier,
+      detector: m.detector,
+      proposer: m.proposer_default,
+      proposer_high_stakes: m.proposer_high_stakes,
+      judge: m.judge,
+    } as Record<Role, string>)[role];
+  }
+
+  async call(role: Role, system: string, messages: Message[], maxTokens = 4096): Promise<string> {
+    const prompt = buildPrompt(system, messages);
+    return new Promise((resolve, reject) => {
+      const child = spawn('claude', ['-p', prompt, '--max-tokens', String(maxTokens)], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let out = '';
+      let err = '';
+      child.stdout.on('data', (d: Buffer) => { out += d.toString(); });
+      child.stderr.on('data', (d: Buffer) => { err += d.toString(); });
+      child.on('close', (code) => {
+        if (code !== 0) reject(new Error('claude CLI exited ' + code + ': ' + err.slice(0, 200)));
+        else resolve(out.trim());
+      });
+      child.on('error', reject);
+    });
+  }
+}
+
+export class AnthropicApiBackend implements LLMClient {
+  private readonly models: TunerConfig['models'];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private client: any;
+
+  private readonly apiKey: string;
+
+  constructor(config: TunerConfig) {
+    this.models = config.models;
+    const apiKey = config.llm.api_key ?? process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) throw new Error('anthropic_api backend requires api_key in config or ANTHROPIC_API_KEY env var');
+    this.apiKey = apiKey;
+  }
+
+  modelFor(role: Role): string {
+    const m = this.models;
+    return ({
+      intent_classifier: m.intent_classifier,
+      detector: m.detector,
+      proposer: m.proposer_default,
+      proposer_high_stakes: m.proposer_high_stakes,
+      judge: m.judge,
+    } as Record<Role, string>)[role];
+  }
+
+  async call(role: Role, system: string, messages: Message[], maxTokens = 4096): Promise<string> {
+    if (!this.client) {
+      const { default: Anthropic } = await import('@anthropic-ai/sdk');
+      this.client = new Anthropic({ apiKey: this.apiKey, maxRetries: 4 });
+    }
+    const model = this.modelFor(role);
+    const response = await this.client.messages.create({
+      model,
+      system,
+      messages: messages.map((m: Message) => ({ role: m.role, content: m.content })),
+      max_tokens: maxTokens,
+    });
+    const block = response.content[0];
+    return block && 'text' in block ? block.text : '';
+  }
+}
+
+export function makeLLMClient(config: TunerConfig): LLMClient {
+  if (config.llm.backend === 'anthropic_api') return new AnthropicApiBackend(config);
+  return new ClaudeCliBackend(config);
+}

--- a/src/skills-tuner/core/registry.ts
+++ b/src/skills-tuner/core/registry.ts
@@ -1,0 +1,31 @@
+import type { TunableSubject, Adapter } from './interfaces.js';
+import type { TunerConfig } from './config.js';
+
+export class Registry {
+  private subjects = new Map<string, TunableSubject>();
+  private adapters = new Map<string, Adapter>();
+
+  registerSubject(subject: TunableSubject): void {
+    this.subjects.set(subject.name, subject);
+  }
+
+  registerAdapter(name: string, adapter: Adapter): void {
+    this.adapters.set(name, adapter);
+  }
+
+  getSubject(name: string): TunableSubject | undefined {
+    return this.subjects.get(name);
+  }
+
+  getAdapter(name: string): Adapter | undefined {
+    return this.adapters.get(name);
+  }
+
+  allSubjects(): TunableSubject[] {
+    return [...this.subjects.values()];
+  }
+
+  enabledSubjects(config: Pick<TunerConfig, 'subjects'>): TunableSubject[] {
+    return [...this.subjects.values()].filter(s => config.subjects?.[s.name]?.enabled !== false);
+  }
+}

--- a/src/skills-tuner/core/security.ts
+++ b/src/skills-tuner/core/security.ts
@@ -1,0 +1,73 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, appendFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import type { Proposal, UnsignedProposal } from './types.js';
+
+export const SECRET_PATH = join(homedir(), '.config', 'tuner', '.secret');
+export const AUDIT_PATH = join(homedir(), '.config', 'tuner', 'audit.jsonl');
+
+export function initSecret(): void {
+  mkdirSync(dirname(SECRET_PATH), { recursive: true });
+  if (existsSync(SECRET_PATH)) return;
+  writeFileSync(SECRET_PATH, randomBytes(32));
+  chmodSync(SECRET_PATH, 0o600);
+}
+
+export function loadSecret(): Buffer {
+  if (!existsSync(SECRET_PATH)) initSecret();
+  return readFileSync(SECRET_PATH);
+}
+
+function proposalCanonical(proposal: UnsignedProposal | Proposal): Buffer {
+  const data = {
+    alternatives: proposal.alternatives.map(a => ({
+      diff_or_content: a.diff_or_content,
+      id: a.id,
+      label: a.label,
+      tradeoff: a.tradeoff,
+    })),
+    cluster_id: proposal.cluster_id,
+    created_at: proposal.created_at.toISOString(),
+    id: proposal.id,
+    kind: proposal.kind,
+    pattern_signature: proposal.pattern_signature,
+    subject: proposal.subject,
+    target_path: proposal.target_path,
+  };
+  return Buffer.from(JSON.stringify(data), 'utf8');
+}
+
+export function computeProposalSignature(proposal: UnsignedProposal | Proposal, secret: Buffer): string {
+  return createHmac('sha256', secret).update(proposalCanonical(proposal)).digest('hex');
+}
+
+export function verifyProposalSignature(proposal: Proposal, secret: Buffer): boolean {
+  const expected = computeProposalSignature(proposal, secret);
+  const got = proposal.signature ?? '';
+  if (expected.length !== got.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(got, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+// Zero-width chars + prompt injection markers
+const INJECTION_RE = /[​-‏‪-‮⁠﻿]/g;
+const MARKER_RE = /<(\/?)(system|human|assistant|instruction|prompt|ignore|INST|SYS)[^>]*>/gi;
+// Bracket-style markers (used by claude_cli buildPrompt format) — also neutralize
+const BRACKET_MARKER_RE = /\[(\/?)(system|human|user|assistant|instruction|prompt|ignore|INST|SYS)\]/gi;
+
+export function sanitizeObservationContent(text: string, maxLength = 10_000): string {
+  let cleaned = text.replace(INJECTION_RE, '');
+  cleaned = cleaned.replace(MARKER_RE, '<$1$2-neutralized>');
+  cleaned = cleaned.replace(BRACKET_MARKER_RE, '($1$2-neutralized)');
+  return cleaned.slice(0, maxLength);
+}
+
+export function auditLog(event: string, payload: Record<string, unknown>): void {
+  mkdirSync(dirname(AUDIT_PATH), { recursive: true });
+  const entry = { ts: new Date().toISOString(), event, ...payload };
+  appendFileSync(AUDIT_PATH, JSON.stringify(entry) + '\n');
+}

--- a/src/skills-tuner/core/types.ts
+++ b/src/skills-tuner/core/types.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+
+export const ORPHAN_SUBJECT = '__new_entity__' as const;
+
+export const CREATE_KINDS = new Set([
+  'new_skill', 'new_intent', 'new_source', 'new_mcp', 'new_tool',
+] as const);
+export type CreateKind = 'new_skill' | 'new_intent' | 'new_source' | 'new_mcp' | 'new_tool';
+
+export const ObservationSchema = z.object({
+  session_id: z.string(),
+  observed_at: z.coerce.date(),
+  signal_type: z.enum(['correction', 'positive_feedback', 'repeated_trigger', 'orphan']),
+  verbatim: z.string().max(500),
+  metadata: z.record(z.unknown()).default({}),
+});
+export type Observation = z.infer<typeof ObservationSchema>;
+
+export const AlternativeSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  diff_or_content: z.string(),
+  tradeoff: z.string().default(''),
+});
+export type Alternative = z.infer<typeof AlternativeSchema>;
+
+export const UnsignedProposalSchema = z.object({
+  id: z.number().int(),
+  cluster_id: z.string(),
+  subject: z.string(),
+  kind: z.string(),
+  target_path: z.string(),
+  alternatives: z.array(AlternativeSchema).min(1).max(3),
+  pattern_signature: z.string(),
+  created_at: z.coerce.date(),
+});
+export type UnsignedProposal = z.infer<typeof UnsignedProposalSchema>;
+
+export const ProposalSchema = UnsignedProposalSchema.extend({
+  signature: z.string().min(1),
+});
+export type Proposal = z.infer<typeof ProposalSchema>;
+
+export const ClusterSchema = z.object({
+  id: z.string(),
+  subject: z.string(),
+  observations: z.array(ObservationSchema),
+  frequency: z.number().int().min(1),
+  success_rate: z.number().min(0).max(1),
+  sentiment: z.enum(['positive', 'negative', 'neutral']),
+  subjects_touched: z.array(z.string()).default([]),
+});
+export type Cluster = z.infer<typeof ClusterSchema>;
+
+export const PatchSchema = z.object({
+  target_path: z.string(),
+  kind: z.string(),
+  applied_content: z.string(),
+});
+export type Patch = z.infer<typeof PatchSchema>;
+
+export const ValidationResultSchema = z.object({
+  valid: z.boolean(),
+  reason: z.string().optional(),
+});
+export type ValidationResult = z.infer<typeof ValidationResultSchema>;

--- a/src/skills-tuner/git_ops/branches.ts
+++ b/src/skills-tuner/git_ops/branches.ts
@@ -1,0 +1,90 @@
+import { simpleGit, type SimpleGit } from 'simple-git';
+import { writeFileSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
+import { dirname, resolve, sep } from 'node:path';
+import { homedir } from 'node:os';
+import type { Patch, Proposal } from '../core/types.js';
+
+export class BranchManager {
+  private git: SimpleGit;
+
+  constructor(public readonly repoPath: string) {
+    this.git = simpleGit(repoPath);
+  }
+
+  async ensureRepo(): Promise<void> {
+    const isRepo = await this.git.checkIsRepo();
+    if (!isRepo) throw new Error(`${this.repoPath} is not a git repository`);
+  }
+
+  branchName(proposalId: number): string {
+    return `tune/proposal-${proposalId}`;
+  }
+
+  async createProposalBranch(proposalId: number, baseBranch = 'main'): Promise<string> {
+    const name = this.branchName(proposalId);
+    const branches = await this.git.branchLocal();
+    if (branches.all.includes(name)) {
+      await this.git.checkout(name);
+      return name;
+    }
+    // Always branch from baseBranch (not the current HEAD) so successive
+    // auto-merged proposals don't stack on each other.
+    if (!branches.all.includes(baseBranch)) {
+      throw new Error(
+        `Base branch '${baseBranch}' not found in repo. Cannot create proposal branch — refusing to branch from current HEAD which would let proposals stack on each other. Set baseBranch explicitly if your repo doesn't use 'main'.`
+      );
+    }
+    await this.git.checkout(baseBranch);
+    await this.git.checkoutLocalBranch(name);
+    return name;
+  }
+
+  // Switch to a specific proposal branch (used before revert)
+  async checkoutProposalBranch(proposalId: number): Promise<string> {
+    const name = this.branchName(proposalId);
+    await this.git.checkout(name);
+    return name;
+  }
+
+  async commitPatch(patch: Patch, proposal: Proposal, alternativeId: string): Promise<string> {
+    const target = resolve(patch.target_path.replace(/^~/, homedir()));
+    const repoRoot = resolve(this.repoPath);
+    if (!target.startsWith(repoRoot + sep) && target !== repoRoot) {
+      throw new Error(`BranchManager refusing to write outside repo: target=${target}, repo=${repoRoot}`);
+    }
+    // Symlink traversal check: resolve the real path if the target already exists as a symlink
+    if (existsSync(target)) {
+      const resolvedTarget = realpathSync(target);
+      if (!resolvedTarget.startsWith(repoRoot + sep) && resolvedTarget !== repoRoot) {
+        throw new Error(`BranchManager refusing symlink traversal: target=${target} resolves to ${resolvedTarget} which is outside repo=${repoRoot}`);
+      }
+    }
+    if (patch.applied_content) {
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, patch.applied_content, 'utf8');
+      await this.git.add(target);
+    } else {
+      // Empty content: only add the specific target if it exists/changed.
+      // Never fall through to `git add .` — that stages unrelated WIP files.
+      await this.git.add(target);
+    }
+    const msg = `tune: ${proposal.subject} — alternative ${alternativeId}\nProposal-ID: ${proposal.id}`;
+    // Refuse empty commits: an empty commit with no diff would be reverted
+    // as a no-op, masking the fact that nothing actually changed.
+    const status = await this.git.status();
+    if (status.staged.length === 0) {
+      throw new Error(`commitPatch refused: no staged changes for proposal #${proposal.id} — refusing to create empty commit (would mask revert as no-op)`);
+    }
+    const result = await this.git.commit(msg);
+    return result.commit;
+  }
+
+  async revertPatch(commitSha: string): Promise<void> {
+    await this.git.revert(commitSha, ['--no-edit']);
+  }
+
+  async listProposalBranches(): Promise<string[]> {
+    const branches = await this.git.branchLocal();
+    return branches.all.filter(b => b.startsWith('tune/proposal-'));
+  }
+}

--- a/src/skills-tuner/scripts/migrate-from-python.ts
+++ b/src/skills-tuner/scripts/migrate-from-python.ts
@@ -1,0 +1,244 @@
+#!/usr/bin/env bun
+/**
+ * migrate-from-python.ts
+ *
+ * One-shot migration: converts legacy Python flat-record proposals.jsonl
+ * into the TypeScript wrapped-event format.
+ *
+ * Usage:
+ *   bun run scripts/migrate-from-python.ts [--dry-run]
+ *
+ * Exports migrateRecord() for unit tests.
+ */
+
+import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+
+import { loadSecret, computeProposalSignature } from '../core/security.js';
+import type { ProposalRecord } from '../storage/proposals.js';
+import type { Proposal } from '../core/types.js';
+
+export const DEFAULT_PROPOSALS_PATH = join(homedir(), '.config', 'tuner', 'proposals.jsonl');
+
+// Fields that exist only in the Python format and must be stripped
+const LEGACY_FIELDS = new Set([
+  'status', 'applied_at', 'applied_alternative', 'feedback', 'feedback_at',
+  'git_branch', 'git_commit', 'git_merged',
+  // Extra Python fields not in UnsignedProposalSchema
+  'recommended', 'confidence', 'justification', 'subjects_touched', 'sentiment_evidence',
+  'estimated_impact',
+  // Stale empty signature — will be re-computed
+  'signature',
+]);
+
+/**
+ * Strip legacy-only keys from a flat Python record, leaving only the fields
+ * that map to UnsignedProposalSchema (plus any extra TS-safe fields).
+ */
+function stripLegacyFields(raw: Record<string, unknown>): Record<string, unknown> {
+  const cleaned: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (!LEGACY_FIELDS.has(k)) cleaned[k] = v;
+  }
+  return cleaned;
+}
+
+/**
+ * Convert a single raw JSON-parsed line into zero or more ProposalRecord events.
+ *
+ * Rules:
+ *  - Meta lines (_meta: true)         → returned as-is (pass-through)
+ *  - Already-wrapped (has `event`)    → returned as-is (idempotent)
+ *  - Legacy flat (has `status`)       → emit created + applied/refused as needed
+ */
+export function migrateRecord(
+  raw: unknown,
+  secret: Buffer,
+): { events: ProposalRecord[]; meta?: unknown } {
+  if (typeof raw !== 'object' || raw === null) return { events: [] };
+  const obj = raw as Record<string, unknown>;
+
+  // Pass-through: meta line
+  if (obj._meta === true) return { events: [], meta: obj };
+
+  // Pass-through: already wrapped TS format
+  if (typeof obj.event === 'string') {
+    return { events: [obj as unknown as ProposalRecord] };
+  }
+
+  // Legacy flat Python record — must have 'status'
+  if (typeof obj.status !== 'string') {
+    // Unknown format — skip with warning
+    process.stderr.write(`WARN: skipping unrecognized line (no event, no status): ${JSON.stringify(obj).slice(0, 80)}\n`);
+    return { events: [] };
+  }
+
+  // Build UnsignedProposal by stripping legacy-only fields
+  const unsignedObj = stripLegacyFields(obj);
+
+  // Coerce created_at to Date for signing then back to string for serialisation
+  const createdAt: Date =
+    typeof unsignedObj.created_at === 'string'
+      ? new Date(unsignedObj.created_at as string)
+      : new Date();
+
+  // Ensure alternatives have tradeoff field (default '')
+  const alternatives = (unsignedObj.alternatives as Array<Record<string, unknown>> | undefined) ?? [];
+  const normalizedAlts = alternatives.map((a) => ({
+    id: a.id ?? '',
+    label: a.label ?? '',
+    diff_or_content: a.diff_or_content ?? '',
+    tradeoff: a.tradeoff ?? '',
+  }));
+
+  const unsignedProposal = {
+    ...unsignedObj,
+    alternatives: normalizedAlts,
+    created_at: createdAt,
+  };
+
+  // Compute fresh HMAC signature
+  const signature = computeProposalSignature(
+    unsignedProposal as Parameters<typeof computeProposalSignature>[0],
+    secret,
+  );
+
+  const proposal: Proposal = {
+    ...(unsignedProposal as Omit<Proposal, 'signature'>),
+    signature,
+  };
+
+  const events: ProposalRecord[] = [];
+  const createdTs = createdAt.toISOString();
+
+  // Always emit a 'created' event
+  events.push({ event: 'created', ts: createdTs, proposal });
+
+  const status = obj.status as string;
+
+  if (status === 'applied' || status === 'reverted') {
+    const appliedTs =
+      typeof obj.applied_at === 'string' ? new Date(obj.applied_at as string).toISOString() : createdTs;
+    const alternativeId =
+      typeof obj.applied_alternative === 'string'
+        ? (obj.applied_alternative as string)
+        : 'A';
+    events.push({
+      event: 'applied',
+      ts: appliedTs,
+      proposal,
+      alternative_id: alternativeId,
+    });
+  }
+
+  if (status === 'refused' || status === 'skipped' || status === 'reverted') {
+    const refusedTs =
+      typeof obj.feedback_at === 'string'
+        ? new Date(obj.feedback_at as string).toISOString()
+        : typeof obj.applied_at === 'string'
+          ? new Date(obj.applied_at as string).toISOString()
+          : createdTs;
+    events.push({ event: 'refused', ts: refusedTs, proposal });
+  }
+
+  return { events };
+}
+
+// ── Main entrypoint ────────────────────────────────────────────────────────────
+
+if (import.meta.main) {
+  const dryRun = process.argv.includes('--dry-run');
+  const proposalsPath = DEFAULT_PROPOSALS_PATH;
+
+  if (!existsSync(proposalsPath)) {
+    console.log(`No proposals.jsonl found at ${proposalsPath} — nothing to migrate.`);
+    process.exit(0);
+  }
+
+  const raw = readFileSync(proposalsPath, 'utf8');
+  const lines = raw.split('\n').filter((l) => l.trim().length > 0);
+
+  if (lines.length === 0) {
+    console.log('proposals.jsonl is empty — nothing to migrate.');
+    process.exit(0);
+  }
+
+  // Check if all lines are already in TS format (has 'event' field or is meta)
+  const needsMigration = lines.some((l) => {
+    try {
+      const obj = JSON.parse(l) as Record<string, unknown>;
+      return !obj._meta && typeof obj.event !== 'string';
+    } catch {
+      return false;
+    }
+  });
+
+  if (!needsMigration) {
+    console.log('proposals.jsonl is already in TS format — no migration needed.');
+    process.exit(0);
+  }
+
+  const secret = loadSecret();
+  const outputLines: string[] = [];
+  let legacyCount = 0;
+  let createdCount = 0;
+  let appliedCount = 0;
+  let refusedCount = 0;
+
+  for (const line of lines) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      process.stderr.write(`WARN: skipping invalid JSON line: ${line.slice(0, 80)}\n`);
+      continue;
+    }
+
+    const obj = parsed as Record<string, unknown>;
+
+    // Meta line — copy as-is
+    if (obj._meta === true) {
+      outputLines.push(JSON.stringify(obj));
+      continue;
+    }
+
+    // Already wrapped — copy as-is
+    if (typeof obj.event === 'string') {
+      outputLines.push(line.trim());
+      continue;
+    }
+
+    // Legacy flat record
+    legacyCount++;
+    const { events } = migrateRecord(parsed, secret);
+    for (const ev of events) {
+      outputLines.push(JSON.stringify(ev));
+      if (ev.event === 'created') createdCount++;
+      else if (ev.event === 'applied') appliedCount++;
+      else if (ev.event === 'refused') refusedCount++;
+    }
+  }
+
+  const summary = `Migrated ${legacyCount} legacy records -> ${outputLines.length} lines (${createdCount} created, ${appliedCount} applied, ${refusedCount} refused)`;
+
+  if (dryRun) {
+    console.log(`[DRY RUN] ${summary}`);
+    console.log('First 5 output lines:');
+    for (const l of outputLines.slice(0, 5)) console.log(' ', l.slice(0, 120));
+    process.exit(0);
+  }
+
+  // Backup original
+  const backupTs = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = `${proposalsPath}.python-backup-${backupTs}`;
+  copyFileSync(proposalsPath, backupPath);
+  console.log(`Backup created: ${backupPath}`);
+
+  // Write migrated output
+  mkdirSync(dirname(proposalsPath), { recursive: true });
+  writeFileSync(proposalsPath, outputLines.join('\n') + '\n');
+
+  console.log(summary);
+  console.log(`Written to: ${proposalsPath}`);
+}

--- a/src/skills-tuner/storage/migrations.ts
+++ b/src/skills-tuner/storage/migrations.ts
@@ -1,0 +1,29 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type MigrationFn = (record: any) => any;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const MIGRATIONS: Record<number, MigrationFn> = {
+  // future migrations: 2: (r) => ({ ...r, newField: 'default' }),
+};
+
+export const CURRENT_SCHEMA_VERSION = 1;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function migrateRecord(record: any, fromVersion = 1): any {
+  let current = fromVersion;
+  while (current < CURRENT_SCHEMA_VERSION) {
+    const fn = MIGRATIONS[current + 1];
+    if (fn) record = fn(record);
+    current++;
+  }
+  return record;
+}
+
+export function detectSchemaVersion(firstLine: string): number {
+  try {
+    const data = JSON.parse(firstLine) as Record<string, unknown>;
+    return typeof data.schema_version === 'number' ? data.schema_version : 1;
+  } catch {
+    return 1;
+  }
+}

--- a/src/skills-tuner/storage/proposals.ts
+++ b/src/skills-tuner/storage/proposals.ts
@@ -1,0 +1,88 @@
+import { existsSync, mkdirSync, readFileSync, appendFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import type { Proposal } from '../core/types.js';
+
+export interface ProposalRecord {
+  proposal: Proposal;
+  event: 'created' | 'applied' | 'refused';
+  ts: string;
+  alternative_id?: string;
+  commit_sha?: string;
+  applied_target_path?: string;  // actual path written (may differ from proposal.target_path for new_skill kind)
+}
+
+export const DEFAULT_PROPOSALS_PATH = join(homedir(), '.config', 'tuner', 'proposals.jsonl');
+
+export class ProposalsStore {
+  constructor(public readonly path: string) {}
+
+  append(record: ProposalRecord): void {
+    mkdirSync(dirname(this.path), { recursive: true });
+    appendFileSync(this.path, JSON.stringify(record) + '\n');
+  }
+
+  readAll(): ProposalRecord[] {
+    if (!existsSync(this.path)) return [];
+    const raw = readFileSync(this.path, 'utf8');
+    const records: ProposalRecord[] = [];
+    for (const line of raw.split('\n')) {
+      const l = line.trim();
+      if (!l) continue;
+      try {
+        const data = JSON.parse(l) as ProposalRecord;
+        if (data.proposal?.created_at) {
+          data.proposal.created_at = new Date(data.proposal.created_at as unknown as string);
+        }
+        records.push(data);
+      } catch {
+        // skip corrupt lines
+      }
+    }
+    return records;
+  }
+
+  pendingSignatures(opts?: { subject?: string }): Set<string> {
+    const all = this.readAll();
+    const resolved = new Set(
+      all
+        .filter(r => r.event === 'applied' || r.event === 'refused')
+        .map(r => r.proposal.pattern_signature),
+    );
+    const result = new Set<string>();
+    for (const r of all) {
+      if (r.event !== 'created') continue;
+      if (opts?.subject && r.proposal.subject !== opts.subject) continue;
+      const sig = r.proposal.pattern_signature;
+      if (!resolved.has(sig)) result.add(sig);
+    }
+    return result;
+  }
+
+  appliedSignatures(opts?: { withinDays?: number }): Set<string> {
+    const withinDays = opts?.withinDays ?? 7;
+    const cutoff = new Date(Date.now() - withinDays * 86_400_000);
+    const sigs = new Set<string>();
+    for (const r of this.readAll()) {
+      if (r.event !== 'applied') continue;
+      const ts = new Date(r.ts);
+      if (ts < cutoff) continue;
+      const sig = r.proposal.pattern_signature;
+      // Prefer the actual applied path (relevant for new_skill kind where proposal.target_path is a placeholder)
+      const targetRaw = r.applied_target_path ?? r.proposal.target_path;
+      const target = targetRaw.replace(/^~/, homedir());
+      if (sig) {
+        if (existsSync(target)) {
+          const mtime = new Date(statSync(target).mtimeMs);
+          if (mtime > ts) continue; // skill changed since applied — bypass cooldown
+        }
+        sigs.add(sig);
+      }
+    }
+    return sigs;
+  }
+
+  signatureRefused(sig: string, refusedSigs: Set<string>): boolean {
+    return refusedSigs.has(sig);
+  }
+}

--- a/src/skills-tuner/storage/refused.ts
+++ b/src/skills-tuner/storage/refused.ts
@@ -1,0 +1,65 @@
+import { existsSync, mkdirSync, readFileSync, appendFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+export interface RefusedRecord {
+  pattern_signature: string;
+  subject: string;
+  user_reason: string;
+  ts: string;
+  expires_at: string;
+}
+
+export const DEFAULT_REFUSED_PATH = join(homedir(), '.config', 'tuner', 'refused.jsonl');
+
+export class RefusedStore {
+  constructor(public readonly path: string, public ttlDays = 30) {}
+
+  add(signature: string, subject: string, userReason = 'skip'): void {
+    mkdirSync(dirname(this.path), { recursive: true });
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + this.ttlDays * 86_400_000);
+    const record: RefusedRecord = {
+      pattern_signature: signature,
+      subject,
+      user_reason: userReason,
+      ts: now.toISOString(),
+      expires_at: expiresAt.toISOString(),
+    };
+    appendFileSync(this.path, JSON.stringify(record) + '\n');
+  }
+
+  activeSignatures(): Set<string> {
+    const now = Date.now();
+    const sigs = new Set<string>();
+    for (const r of this._readRecords()) {
+      try {
+        if (new Date(r.expires_at).getTime() > now) {
+          sigs.add(r.pattern_signature);
+        }
+      } catch {
+        // skip
+      }
+    }
+    return sigs;
+  }
+
+  isRefused(sig: string): boolean {
+    return this.activeSignatures().has(sig);
+  }
+
+  private _readRecords(): RefusedRecord[] {
+    if (!existsSync(this.path)) return [];
+    const records: RefusedRecord[] = [];
+    for (const line of readFileSync(this.path, 'utf8').split('\n')) {
+      const l = line.trim();
+      if (!l) continue;
+      try {
+        records.push(JSON.parse(l) as RefusedRecord);
+      } catch {
+        // skip corrupt
+      }
+    }
+    return records;
+  }
+}


### PR DESCRIPTION
## Summary

This PR adds the **core engine** of `skills-tuner` — a modular human-in-loop tuner that addresses #14 (skill self-improvement via Telegram inline approval) by treating skills as just one type of `TunableSubject` in a broader self-improvement framework.

It is the first of three stacked PRs:
- **PR1 (this one)** — core framework: types, engine, security, storage, git ops. No subjects, no integrations.
- PR2 — adapters (Telegram + claude_cli backend + Plus event stub) + `ExternalProcessSubject` (the ML connector for Optuna/sklearn/etc via stdio JSON-RPC).
- PR3 — `SkillsSubject` (concrete answer to #14) + companion `/tuner` skill + CLI.

All written in pure TypeScript (Bun runtime) for native Plus integration. Lives under `src/skills-tuner/`.

## What's included

- `src/skills-tuner/core/` — `TunableSubject` ABC, `Proposal`/`Cluster`/`Observation` types (zod-validated), `Engine` orchestrator, `Registry`, HMAC-signed proposal primitives, append-only audit log, observation sanitization (XML and bracket markers), YAML config loader, claude_cli + anthropic_api LLM backends.
- `src/skills-tuner/storage/` — JSONL stores for proposals + refused signatures (TTL 30d) + schema migration scaffolding.
- `src/skills-tuner/git_ops/branches.ts` — branch isolation per proposal (`tune/proposal-{id}`, branched from `main`), commit + revert helpers.
- `src/skills-tuner/scripts/migrate-from-python.ts` — one-shot migration from the Python reference implementation.
- `src/skills-tuner/README.md` — local readme + architecture diagram.

## Security model — built in from day one

8 defense layers, all in this PR:

1. **HMAC-SHA256 signed proposals** — every proposal signed with a per-user secret (`~/.config/tuner/.secret`, mode 0600). `applyProposal` refuses any proposal whose signature doesn't verify (timing-safe comparison). Defends against tampering and replay.
2. **Append-only audit log** — `~/.config/tuner/audit.jsonl` records every lifecycle event. Never truncated.
3. **Observation sanitization** — strips zero-width chars + neutralizes both XML (`<system>`) and bracket-style (`[system]`) prompt-injection markers.
4. **Path traversal guards** — `realpath()` + containment check before any write. Enforced at multiple layers (subject + BranchManager).
5. **Branch isolation per proposal** — every apply creates `tune/proposal-{id}` branched from `main`. Rollback is `git revert`.
6. **Refused-pattern TTL** — 30-day cooldown on rejected signatures.
7. **Risk-tier enforcement** — `high` and `critical` tier subjects never auto-merge regardless of YAML config (logged + audited).
8. **Structured outputs only** — Pydantic-equivalent zod strict validation. No free-form LLM output reaches storage or git.

## Compliance angle

Built with regulated environments in mind:

- **Immutable history** — append-only JSONL with HMAC-signed entries + git history.
- **Justification mandatory** — every `Proposal` carries `pattern_signature` + alternatives with `tradeoff` strings.
- **Hard gate on high-stakes** — `risk_tier` is a per-subject contract, not a config knob the user can flip.
- **Full rollback path** — branch-per-proposal means every change is reversible to the byte.
- **Defense in depth** — failure of one layer doesn't compromise the rest.

## Engine-agnostic design

The framework decouples **when/how to surface** (engine) from **how to propose** (subject). A subject's `proposeChange()` can use:
- LLMs (default story: Haiku for intent classification, Sonnet for proposers, Opus for high-stakes / detector / judge — stratified per role, override per subject).
- ML libraries (Optuna for Bayesian hyperparameter tuning, sklearn/xgboost). Plugged in via `ExternalProcessSubject` (PR2).
- Rule-based heuristics.

Engine never references a specific subject by name. `apply()` dispatches on `proposal.kind in CREATE_KINDS` for create-vs-modify. Subjects and adapters depend only on `core/interfaces.ts`.

## Dependencies added

- `zod` — runtime schema validation
- `simple-git` — git operations (branch isolation)
- `js-yaml` + `@types/js-yaml` — YAML config loading
- `@anthropic-ai/sdk` — LLM backend (anthropic_api mode; `claude_cli` mode uses subprocess and needs no SDK)

## Tests

Test suite lives in the canonical companion repo at https://github.com/Nibbler1250/skills-tuner-ts (125 tests pass under strict tsconfig, 0 fail). Adapting them to Plus's tsconfig is a follow-up PR — runtime semantics are identical.

## Relation to #14

#14 asks for a self-improving skill capture mechanism. After design exploration the same machinery (cron, approval UI, git isolation, audit log, feedback loop) generalizes cleanly to skills, voice lexicon, RAG ranking weights, MCP server config, and ML hyperparameters. PR1 ships the generalization. PR3 ships the literal #14 ask as the canonical `SkillsSubject` example.


## Security hardening (Tier 1+2)

This PR includes **11 adversarial tests** beyond the functional baseline, covering:

**Tier 1 — Edge cases**:
- `applyProposal` race condition (two concurrent calls on same proposal)
- Path traversal via symlinks (target inside scan_dir but link to /etc/passwd)
- JSONL mid-write corruption (kill -9 during append)
- Audit log atomicity (audit_attempted before any side effect)
- Skill cache invalidated after apply/rename

**Tier 2 — Adversarial security**:
- HMAC canonical bypass via JSON key reordering
- Prompt injection via skill content (not just observation verbatim)
- Telegram callback replay attack
- ExternalProcessSubject with encoded target_path (URL-encoded path traversal)
- Audit log tampering (documented limitation — no hash chain at v1)
- Regex DoS on triggers (catastrophic backtracking — N/A, uses `string.includes()`)

**Real bugs caught and fixed via these tests**:
1. `applyProposal` race condition — added `_applying: Set<number>` lock
2. Symlink traversal in `commitPatch` — added `realpathSync()` check
3. Prompt injection via `skillContent` — `sanitizeObservationContent()` now applied to skill bodies, not just verbatims
4. Empty commits in `commitPatch` — refused when nothing staged (otherwise `revert` was silent no-op)

**Total tests**: 163 unit + integration tests passing. 0 fail.

Full test suite in companion repo: https://github.com/Nibbler1250/skills-tuner-ts