### PR TITLE
feat(skills-tuner): SkillsSubject + companion /tuner skill — directly addresses #14 (3/3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.14",
+      "version": "2.0.19",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.14",
+  "version": "2.0.19",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/bun.lock
+++ b/bun.lock
@@ -3,40 +3,67 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "claude-heartbeat",
+      "name": "claudeclaw",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.40.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "js-yaml": "^4.1.0",
         "ogg-opus-decoder": "^1.7.3",
+        "simple-git": "^3.27.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.9",
+        "@types/js-yaml": "^4.0.9",
       },
     },
   },
   "packages": {
+    "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.40.1", "", { "dependencies": { "@types/node": "^18.11.18", "@types/node-fetch": "^2.6.4", "abort-controller": "^3.0.0", "agentkeepalive": "^4.2.1", "form-data-encoder": "1.7.2", "formdata-node": "^4.3.2", "node-fetch": "^2.6.7" } }, "sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w=="],
+
     "@eshaz/web-worker": ["@eshaz/web-worker@1.2.2", "", {}, "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw=="],
 
     "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
 
+    "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
+
+    "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
+
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+    "@simple-git/args-pathspec": ["@simple-git/args-pathspec@1.0.3", "", {}, "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="],
 
-    "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+    "@simple-git/argv-parser": ["@simple-git/argv-parser@1.1.1", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.3" } }, "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw=="],
+
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
+    "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
+
+    "@types/node": ["@types/node@18.19.130", "", { "dependencies": { "undici-types": "~5.26.4" } }, "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg=="],
+
+    "@types/node-fetch": ["@types/node-fetch@2.6.13", "", { "dependencies": { "@types/node": "*", "form-data": "^4.0.4" } }, "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw=="],
 
     "@wasm-audio-decoders/common": ["@wasm-audio-decoders/common@9.0.7", "", { "dependencies": { "@eshaz/web-worker": "1.2.2", "simple-yenc": "^1.0.4" } }, "sha512-WRaUuWSKV7pkttBygml/a6dIEpatq2nnZGFIoPTc5yPLkxL6Wk4YaslPM98OPQvWacvNZ+Py9xROGDtrFBDzag=="],
 
     "@wasm-audio-decoders/opus-ml": ["@wasm-audio-decoders/opus-ml@0.0.2", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-58rWEqDGg+CKCyEeKm2KoxxSwTWtHh/NLTW9ObR4K8CGF6VwuuGudEI1CtniS/oSRmL1nJq/eh8MKARiluw4DQ=="],
 
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
+    "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
-    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
@@ -45,6 +72,8 @@
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "codec-parser": ["codec-parser@2.5.0", "", {}, "sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 
@@ -60,6 +89,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
@@ -74,9 +105,13 @@
 
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
+
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
@@ -92,6 +127,12 @@
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
+    "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
+
+    "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
+
+    "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
+
     "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
 
     "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
@@ -106,11 +147,15 @@
 
     "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
     "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
 
     "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
@@ -125,6 +170,8 @@
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
@@ -143,6 +190,10 @@
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -196,19 +247,29 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "simple-git": ["simple-git@3.36.0", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "@simple-git/args-pathspec": "^1.0.3", "@simple-git/argv-parser": "^1.1.0", "debug": "^4.4.0" } }, "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q=="],
+
     "simple-yenc": ["simple-yenc@1.0.4", "", {}, "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw=="],
 
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
 
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
+
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -217,5 +278,9 @@
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -6,11 +6,10 @@
       "name": "claudeclaw",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.40.0",
-        "@modelcontextprotocol/sdk": "^1.29.0",
         "js-yaml": "^4.1.0",
         "ogg-opus-decoder": "^1.7.3",
         "simple-git": "^3.27.0",
-        "zod": "^4.4.3",
+        "zod": "^3.23.0",
       },
       "devDependencies": {
         "@types/bun": "^1.3.9",
@@ -23,19 +22,15 @@
 
     "@eshaz/web-worker": ["@eshaz/web-worker@1.2.2", "", {}, "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
-
     "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
     "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
-
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@simple-git/args-pathspec": ["@simple-git/args-pathspec@1.0.3", "", {}, "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="],
 
     "@simple-git/argv-parser": ["@simple-git/argv-parser@1.1.1", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.3" } }, "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
@@ -49,55 +44,25 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
-
-    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
-    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
-
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
-
-    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
-
-    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "codec-parser": ["codec-parser@2.5.0", "", {}, "sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
-    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
-
-    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
-
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
-
-    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
-
-    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
-
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
-    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
-
-    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
-
-    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -107,35 +72,13 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
-    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
-
-    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
-
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
-
-    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
-
-    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
-
-    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
-
-    "express-rate-limit": ["express-rate-limit@8.5.1", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ=="],
-
-    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
-
-    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
-
-    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
 
     "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
-
-    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
-
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -151,53 +94,21 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
-    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
-
-    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
-
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
-
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
-
-    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
-    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
-
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
-
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
-
-    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
-
-    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
-    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
-
-    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
-
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
-    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
-
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
-
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
-
-    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
-
-    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "ogg-opus-decoder": ["ogg-opus-decoder@1.7.3", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7", "@wasm-audio-decoders/opus-ml": "0.0.2", "codec-parser": "2.5.0", "opus-decoder": "0.7.11" } }, "sha512-w47tiZpkLgdkpa+34VzYD8mHUj8I9kfWVZa82mBbNwDvB1byfLXSSzW/HxA4fI3e9kVlICSpXGFwMLV1LPdjwg=="],
 
@@ -207,63 +118,13 @@
 
     "opus-decoder": ["opus-decoder@0.7.11", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A=="],
 
-    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
-
-    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
-
-    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
-
-    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
-
-    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
-    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
-
-    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
-
-    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
-
-    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
-    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
-
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
-    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
-
-    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
-
-    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
-
-    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
-
-    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
-
-    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
-
-    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
-
-    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
-
     "simple-git": ["simple-git@3.36.0", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "@simple-git/args-pathspec": "^1.0.3", "@simple-git/argv-parser": "^1.1.0", "debug": "^4.4.0" } }, "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q=="],
 
     "simple-yenc": ["simple-yenc@1.0.4", "", {}, "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw=="],
 
-    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
-
-    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
-    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
-
     "undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
-
-    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
-
-    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
@@ -271,16 +132,14 @@
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
-    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+    "@types/node-fetch/@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
-    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+    "bun-types/@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
 
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+    "@types/node-fetch/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
 
-    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
-
-    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "claude-heartbeat",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "ogg-opus-decoder": "^1.7.3",
       },
       "devDependencies": {
@@ -15,6 +16,10 @@
   "packages": {
     "@eshaz/web-worker": ["@eshaz/web-worker@1.2.2", "", {}, "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
@@ -23,16 +28,194 @@
 
     "@wasm-audio-decoders/opus-ml": ["@wasm-audio-decoders/opus-ml@0.0.2", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-58rWEqDGg+CKCyEeKm2KoxxSwTWtHh/NLTW9ObR4K8CGF6VwuuGudEI1CtniS/oSRmL1nJq/eh8MKARiluw4DQ=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "codec-parser": ["codec-parser@2.5.0", "", {}, "sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.1", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "ogg-opus-decoder": ["ogg-opus-decoder@1.7.3", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7", "@wasm-audio-decoders/opus-ml": "0.0.2", "codec-parser": "2.5.0", "opus-decoder": "0.7.11" } }, "sha512-w47tiZpkLgdkpa+34VzYD8mHUj8I9kfWVZa82mBbNwDvB1byfLXSSzW/HxA4fI3e9kVlICSpXGFwMLV1LPdjwg=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "opus-decoder": ["opus-decoder@0.7.11", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
     "simple-yenc": ["simple-yenc@1.0.4", "", {}, "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw=="],
 
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -7,6 +7,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.40.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "commander": "^14.0.3",
         "js-yaml": "^4.1.0",
         "ogg-opus-decoder": "^1.7.3",
         "simple-git": "^3.27.0",
@@ -74,6 +75,8 @@
     "codec-parser": ["codec-parser@2.5.0", "", {}, "sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
     "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,10 +6,11 @@
       "name": "claudeclaw",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.40.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "js-yaml": "^4.1.0",
         "ogg-opus-decoder": "^1.7.3",
         "simple-git": "^3.27.0",
-        "zod": "^3.23.0",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.9",
@@ -22,15 +23,19 @@
 
     "@eshaz/web-worker": ["@eshaz/web-worker@1.2.2", "", {}, "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@kwsites/file-exists": ["@kwsites/file-exists@1.1.1", "", { "dependencies": { "debug": "^4.1.1" } }, "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw=="],
 
     "@kwsites/promise-deferred": ["@kwsites/promise-deferred@1.1.1", "", {}, "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@simple-git/args-pathspec": ["@simple-git/args-pathspec@1.0.3", "", {}, "sha512-ngJMaHlsWDTfjyq9F3VIQ8b7NXbBLq5j9i5bJ6XLYtD6qlDXT7fdKY2KscWWUF8t18xx052Y/PUO1K1TRc9yKA=="],
 
     "@simple-git/argv-parser": ["@simple-git/argv-parser@1.1.1", "", { "dependencies": { "@simple-git/args-pathspec": "^1.0.3" } }, "sha512-Q9lBcfQ+VQCpQqGJFHe5yooOS5hGdLFFbJ5R+R5aDsnkPCahtn1hSkMcORX65J2Z5lxSkD0lQorMsncuBQxYUw=="],
 
-    "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
@@ -44,25 +49,55 @@
 
     "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "agentkeepalive": ["agentkeepalive@4.6.0", "", { "dependencies": { "humanize-ms": "^1.2.1" } }, "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
-    "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "codec-parser": ["codec-parser@2.5.0", "", {}, "sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
 
@@ -72,13 +107,35 @@
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.1", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "form-data": ["form-data@4.0.5", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w=="],
 
     "form-data-encoder": ["form-data-encoder@1.7.2", "", {}, "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A=="],
 
     "formdata-node": ["formdata-node@4.4.1", "", { "dependencies": { "node-domexception": "1.0.0", "web-streams-polyfill": "4.0.0-beta.3" } }, "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
@@ -94,21 +151,53 @@
 
     "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
 
+    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
     "humanize-ms": ["humanize-ms@1.2.1", "", { "dependencies": { "ms": "^2.0.0" } }, "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
-    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
 
-    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "node-domexception": ["node-domexception@1.0.0", "", {}, "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="],
 
     "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
     "ogg-opus-decoder": ["ogg-opus-decoder@1.7.3", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7", "@wasm-audio-decoders/opus-ml": "0.0.2", "codec-parser": "2.5.0", "opus-decoder": "0.7.11" } }, "sha512-w47tiZpkLgdkpa+34VzYD8mHUj8I9kfWVZa82mBbNwDvB1byfLXSSzW/HxA4fI3e9kVlICSpXGFwMLV1LPdjwg=="],
 
@@ -118,13 +207,63 @@
 
     "opus-decoder": ["opus-decoder@0.7.11", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
     "simple-git": ["simple-git@3.36.0", "", { "dependencies": { "@kwsites/file-exists": "^1.1.1", "@kwsites/promise-deferred": "^1.1.1", "@simple-git/args-pathspec": "^1.0.3", "@simple-git/argv-parser": "^1.1.0", "debug": "^4.4.0" } }, "sha512-cGQjLjK8bxJw4QuYT7gxHw3/IouVESbhahSsHrX97MzCL1gu2u7oy38W6L2ZIGECEfIBG4BabsWDPjBxJENv9Q=="],
 
     "simple-yenc": ["simple-yenc@1.0.4", "", {}, "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw=="],
 
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "undici-types": ["undici-types@5.26.5", "", {}, "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@4.0.0-beta.3", "", {}, "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug=="],
 
@@ -132,14 +271,16 @@
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
-    "@types/node-fetch/@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
-    "bun-types/@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "@types/node-fetch/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
-    "bun-types/@types/node/undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+    "form-data/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
   }
 }

--- a/docs/plugin-integration.md
+++ b/docs/plugin-integration.md
@@ -1,0 +1,201 @@
+# Plugin Tool Integration Guide
+
+ClaudeClaw-Plus exposes a `PluginMcpBridge` that lets daemon plugins register tools and expose them to the MCP ecosystem. All registered tools are served via a stdio MCP server that any MCP client (Claude Desktop, etc.) can connect to.
+
+---
+
+## Architecture Overview
+
+```
+Plus daemon
+├── PluginManager (src/plugins.ts)
+│   └── lifecycle events (gateway_start, session_start, agent_end, …)
+└── PluginMcpBridge (src/plugins/mcp-bridge.ts)
+    ├── registerPluginTool(pluginId, tool)  ← plugin registration API
+    ├── McpServer (src/plugins/mcp-server.ts, stdio)
+    ├── HMAC-SHA256 signed inter-plugin calls
+    └── Append-only audit log (~/.config/plus/plugin-audit.jsonl)
+```
+
+---
+
+## Registering Tools from a Plugin
+
+Plugins receive a `PluginApi` object at init time. Call `api.registerTool(tool)` to register an MCP-compatible tool:
+
+```typescript
+import type { PluginInitFn } from "claudeclaw-plus/src/plugins.js";
+import { z } from "zod";
+
+const init: PluginInitFn = (api) => {
+  api.registerTool({
+    name: "pending",
+    description: "List pending tuner proposals",
+    schema: z.object({
+      subject: z.string().optional(),
+    }),
+    handler: async (args) => {
+      return engine.listPending(args.subject);
+    },
+  });
+
+  api.registerTool({
+    name: "apply",
+    description: "Apply a tuner proposal by ID",
+    schema: z.object({ id: z.string() }),
+    handler: async (args) => engine.apply(args.id),
+  });
+};
+
+export default init;
+```
+
+The tool is registered under the FQN `{pluginId}__{toolName}` (e.g. `skills-tuner__pending`).
+
+---
+
+## Pattern: Archiviste Plugin
+
+```typescript
+const init: PluginInitFn = (api) => {
+  api.registerTool({
+    name: "search_docs",
+    description: "Full-text search across archived documents",
+    schema: z.object({
+      query: z.string(),
+      trusted_only: z.boolean().optional(),
+      limit: z.number().optional(),
+    }),
+    handler: async (args) => archiviste.search(args),
+  });
+
+  api.registerTool({
+    name: "index_doc",
+    description: "Index a new document into the archive",
+    schema: z.object({
+      path: z.string(),
+      tags: z.array(z.string()).optional(),
+    }),
+    handler: async (args) => archiviste.index(args.path, args.tags),
+  });
+};
+```
+
+---
+
+## Pattern: Voice Plugin (Greg)
+
+```typescript
+const init: PluginInitFn = (api) => {
+  api.registerTool({
+    name: "play_tts",
+    description: "Synthesize and play text-to-speech audio",
+    schema: z.object({
+      text: z.string(),
+      voice: z.string().optional(),
+    }),
+    handler: async (args) => voice.playTts(args.text, args.voice),
+  });
+
+  api.registerTool({
+    name: "transcribe_audio",
+    description: "Transcribe an audio file to text using Whisper",
+    schema: z.object({ path: z.string() }),
+    handler: async (args) => voice.transcribe(args.path),
+  });
+};
+```
+
+---
+
+## Security
+
+### Per-Plugin Secret
+
+Each plugin gets a 32-byte random secret stored at:
+```
+~/.config/plus/plugins/<pluginId>/.secret   (mode 0600)
+```
+
+The secret is auto-created on first use and hex-encoded on disk. It never leaves the local machine.
+
+### HMAC-SHA256 Signing
+
+Every `invokeTool` call is signed before reaching the handler:
+
+```typescript
+const sig = bridge.signCall(pluginId, args, Date.now());
+const ok  = bridge.verifyCall(pluginId, args, ts, sig);
+```
+
+Verification uses `timingSafeEqual` to prevent timing attacks.
+
+### Zod Validation
+
+All tool arguments are validated against the plugin-provided `schema` before the handler is called. Invalid args throw immediately and are logged to the audit log.
+
+### Audit Log
+
+Every `register`, `invoke`, `error` event is appended to:
+```
+~/.config/plus/plugin-audit.jsonl
+```
+
+Each line is a JSON object with `{ event, ts, fqn, pluginId, … }`. The file is append-only; never truncate it — it is an audit trail.
+
+---
+
+## Starting the MCP Server
+
+### Standalone
+
+```bash
+bun run src/plugins/mcp-server.ts
+```
+
+The server listens on stdio and exposes all registered tools to any MCP client.
+
+### Claude Desktop Configuration
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or equivalent:
+
+```json
+{
+  "mcpServers": {
+    "claudeclaw-plus": {
+      "command": "bun",
+      "args": ["run", "/home/simon/Projects/ClaudeClaw-Plus/src/plugins/mcp-server.ts"]
+    }
+  }
+}
+```
+
+---
+
+## Direct Bridge Access (Advanced)
+
+If you need to register tools outside of the Plugin lifecycle, import the singleton directly:
+
+```typescript
+import { getMcpBridge } from "claudeclaw-plus/src/plugins/mcp-bridge.js";
+import { z } from "zod";
+
+const bridge = getMcpBridge();
+
+bridge.registerPluginTool("my-service", {
+  name: "status",
+  description: "Get service status",
+  schema: z.object({}),
+  handler: async () => ({ ok: true }),
+});
+```
+
+---
+
+## Running Tests
+
+```bash
+bun test src/__tests__/plugins/mcp-bridge.test.ts
+```
+
+All 8+ assertions cover: registration, duplicates, zod validation, HMAC round-trips, audit log entries, and secret management.

--- a/examples/external_subject_python_template.py
+++ b/examples/external_subject_python_template.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""
+Template for writing a skills-tuner subject as an external process (Python).
+
+Usage from TS:
+    new ExternalProcessSubject({
+        name: 'my-python-subject',
+        command: ['python3', '/path/to/this/file.py'],
+        config: { ... }
+    })
+
+Protocol (stdio):
+    stdin:  {"method": "<name>", "payload": {...}, "config": {...}}
+    stdout: {"result": <data>}  OR  {"error": "<message>"}
+
+Methods to implement:
+    - collect_observations: payload.since (ISO date) -> list[Observation]
+    - detect_problems: payload.observations -> list[Cluster]
+    - propose_change: payload.cluster -> Proposal
+    - apply: payload.proposal + payload.alternative_id -> Patch
+    - validate: payload.patch -> ValidationResult
+"""
+import json
+import sys
+
+
+def collect_observations(payload, config):
+    # since = payload.get("since")  # ISO datetime string
+    return []
+
+
+def detect_problems(payload, config):
+    # observations = payload.get("observations", [])
+    return []
+
+
+def propose_change(payload, config):
+    raise NotImplementedError("propose_change not implemented")
+
+
+def apply(payload, config):
+    raise NotImplementedError("apply not implemented")
+
+
+def validate(payload, config):
+    return {"valid": True}
+
+
+DISPATCH = {
+    "collect_observations": collect_observations,
+    "detect_problems": detect_problems,
+    "propose_change": propose_change,
+    "apply": apply,
+    "validate": validate,
+}
+
+if __name__ == "__main__":
+    try:
+        req = json.loads(sys.stdin.read())
+        method = req["method"]
+        if method not in DISPATCH:
+            print(json.dumps({"error": f"unknown method: {method}"}))
+            sys.exit(0)
+        result = DISPATCH[method](req.get("payload", {}), req.get("config", {}))
+        print(json.dumps({"result": result}))
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)

--- a/package.json
+++ b/package.json
@@ -16,11 +16,10 @@
     "@types/js-yaml": "^4.0.9"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
-    "@anthropic-ai/sdk": "^0.40.0",
-    "js-yaml": "^4.1.0",
     "ogg-opus-decoder": "^1.7.3",
+    "zod": "^3.23.0",
     "simple-git": "^3.27.0",
-    "zod": "^4.4.3"
+    "js-yaml": "^4.1.0",
+    "@anthropic-ai/sdk": "^0.40.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "@types/js-yaml": "^4.0.9"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
     "@anthropic-ai/sdk": "^0.40.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "commander": "^14.0.3",
     "js-yaml": "^4.1.0",
     "ogg-opus-decoder": "^1.7.3",
     "simple-git": "^3.27.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/bun": "^1.3.9"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "ogg-opus-decoder": "^1.7.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,10 +16,11 @@
     "@types/js-yaml": "^4.0.9"
   },
   "dependencies": {
-    "ogg-opus-decoder": "^1.7.3",
-    "zod": "^3.23.0",
-    "simple-git": "^3.27.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@anthropic-ai/sdk": "^0.40.0",
     "js-yaml": "^4.1.0",
-    "@anthropic-ai/sdk": "^0.40.0"
+    "ogg-opus-decoder": "^1.7.3",
+    "simple-git": "^3.27.0",
+    "zod": "^4.4.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,15 @@
     "bump:marketplace-version": "bun run scripts/bump-marketplace-version.ts"
   },
   "devDependencies": {
-    "@types/bun": "^1.3.9"
+    "@types/bun": "^1.3.9",
+    "@types/js-yaml": "^4.0.9"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "ogg-opus-decoder": "^1.7.3"
+    "@anthropic-ai/sdk": "^0.40.0",
+    "js-yaml": "^4.1.0",
+    "ogg-opus-decoder": "^1.7.3",
+    "simple-git": "^3.27.0",
+    "zod": "^4.4.3"
   }
 }

--- a/src/__tests__/plugins/mcp-bridge.test.ts
+++ b/src/__tests__/plugins/mcp-bridge.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { z } from "zod";
+import { PluginMcpBridge, _resetMcpBridge, getMcpBridge } from "../../plugins/mcp-bridge.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeBridge(): { bridge: PluginMcpBridge; auditPath: string; tmpDir: string } {
+  const tmpDir = mkdtempSync(join(tmpdir(), "mcp-bridge-test-"));
+  const auditPath = join(tmpDir, "audit.jsonl");
+  const bridge = new PluginMcpBridge(auditPath);
+  return { bridge, auditPath, tmpDir };
+}
+
+function readAuditLines(auditPath: string): Array<Record<string, unknown>> {
+  try {
+    return readFileSync(auditPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+  } catch {
+    return [];
+  }
+}
+
+const echoTool = {
+  name: "echo",
+  description: "Echo input back",
+  schema: z.object({ message: z.string() }),
+  handler: async (args: { message: string }) => args.message,
+};
+
+const addTool = {
+  name: "add",
+  description: "Add two numbers",
+  schema: z.object({ a: z.number(), b: z.number() }),
+  handler: async (args: { a: number; b: number }) => args.a + args.b,
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PluginMcpBridge", () => {
+  describe("registerPluginTool + listTools", () => {
+    it("registers a tool and returns it in listTools with correct FQN", () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("my-plugin", echoTool);
+      const tools = bridge.listTools();
+
+      expect(tools).toHaveLength(1);
+      expect(tools[0].fqn).toBe("my-plugin__echo");
+      expect(tools[0].description).toBe("Echo input back");
+      expect(tools[0].inputSchema).toMatchObject({ type: "object" });
+    });
+
+    it("registers multiple tools from different plugins", () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("plugin-a", echoTool);
+      bridge.registerPluginTool("plugin-b", addTool);
+      const tools = bridge.listTools();
+
+      expect(tools).toHaveLength(2);
+      const fqns = tools.map((t) => t.fqn);
+      expect(fqns).toContain("plugin-a__echo");
+      expect(fqns).toContain("plugin-b__add");
+    });
+  });
+
+  describe("duplicate registration", () => {
+    it("throws on duplicate tool FQN", () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("my-plugin", echoTool);
+      expect(() => bridge.registerPluginTool("my-plugin", echoTool)).toThrow(
+        /Duplicate tool registration/,
+      );
+    });
+
+    it("allows same tool name for different plugins", () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("plugin-a", echoTool);
+      expect(() => bridge.registerPluginTool("plugin-b", echoTool)).not.toThrow();
+    });
+  });
+
+  describe("invokeTool", () => {
+    it("calls handler with valid args and returns result", async () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("calc", addTool);
+      const result = await bridge.invokeTool("calc__add", { a: 3, b: 4 });
+      expect(result).toBe(7);
+    });
+
+    it("throws on invalid args (zod validation failure)", async () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("my-plugin", echoTool);
+      await expect(bridge.invokeTool("my-plugin__echo", { message: 42 })).rejects.toThrow(
+        /Invalid args/,
+      );
+    });
+
+    it("throws on unknown tool name", async () => {
+      const { bridge } = makeBridge();
+
+      await expect(bridge.invokeTool("nonexistent__tool", {})).rejects.toThrow(/Unknown tool/);
+    });
+
+    it("propagates handler errors", async () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("failing", {
+        name: "fail",
+        description: "Always fails",
+        schema: z.object({}),
+        handler: async () => {
+          throw new Error("handler exploded");
+        },
+      });
+      await expect(bridge.invokeTool("failing__fail", {})).rejects.toThrow("handler exploded");
+    });
+  });
+
+  describe("HMAC signing", () => {
+    it("signCall + verifyCall round-trip returns true", () => {
+      const { bridge } = makeBridge();
+
+      const body = { foo: "bar", count: 42 };
+      const ts = Date.now();
+      const sig = bridge.signCall("test-plugin", body, ts);
+      expect(bridge.verifyCall("test-plugin", body, ts, sig)).toBe(true);
+    });
+
+    it("verifyCall rejects tampered signature", () => {
+      const { bridge } = makeBridge();
+
+      const body = { foo: "bar" };
+      const ts = Date.now();
+      const sig = bridge.signCall("test-plugin", body, ts);
+      const tampered = sig.slice(0, -2) + "00";
+      expect(bridge.verifyCall("test-plugin", body, ts, tampered)).toBe(false);
+    });
+
+    it("verifyCall rejects tampered body", () => {
+      const { bridge } = makeBridge();
+
+      const ts = Date.now();
+      const sig = bridge.signCall("test-plugin", { foo: "bar" }, ts);
+      expect(bridge.verifyCall("test-plugin", { foo: "TAMPERED" }, ts, sig)).toBe(false);
+    });
+
+    it("verifyCall rejects tampered ts", () => {
+      const { bridge } = makeBridge();
+
+      const ts = Date.now();
+      const body = { x: 1 };
+      const sig = bridge.signCall("test-plugin", body, ts);
+      expect(bridge.verifyCall("test-plugin", body, ts + 1, sig)).toBe(false);
+    });
+  });
+
+  describe("audit log", () => {
+    it("writes a register entry when a tool is registered", () => {
+      const { bridge, auditPath } = makeBridge();
+
+      bridge.registerPluginTool("audit-test", echoTool);
+      const lines = readAuditLines(auditPath);
+
+      expect(lines).toHaveLength(1);
+      expect(lines[0].event).toBe("register");
+      expect(lines[0].fqn).toBe("audit-test__echo");
+    });
+
+    it("writes invoke + success entries when tool is called", async () => {
+      const { bridge, auditPath } = makeBridge();
+
+      bridge.registerPluginTool("audit-test", echoTool);
+      await bridge.invokeTool("audit-test__echo", { message: "hello" });
+      const lines = readAuditLines(auditPath);
+
+      const invokeEntry = lines.find((l) => l.event === "invoke");
+      expect(invokeEntry).toBeDefined();
+      expect(invokeEntry?.success).toBe(true);
+    });
+
+    it("writes error entry on validation failure", async () => {
+      const { bridge, auditPath } = makeBridge();
+
+      bridge.registerPluginTool("audit-test", echoTool);
+      try {
+        await bridge.invokeTool("audit-test__echo", { message: 999 });
+      } catch {
+        // expected
+      }
+
+      const lines = readAuditLines(auditPath);
+      const errorEntry = lines.find((l) => l.event === "error");
+      expect(errorEntry).toBeDefined();
+      expect(errorEntry?.phase).toBe("validation");
+    });
+  });
+
+  describe("per-plugin secret", () => {
+    it("auto-creates a 32-byte secret for a plugin", () => {
+      const { bridge } = makeBridge();
+
+      const secret = bridge.loadOrCreateSecret("new-plugin");
+      expect(secret).toBeInstanceOf(Buffer);
+      expect(secret.length).toBe(32);
+    });
+
+    it("returns the same secret on subsequent calls (cached)", () => {
+      const { bridge } = makeBridge();
+
+      const a = bridge.loadOrCreateSecret("plugin-x");
+      const b = bridge.loadOrCreateSecret("plugin-x");
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it("different plugins get different secrets", () => {
+      const { bridge } = makeBridge();
+
+      const a = bridge.loadOrCreateSecret("plugin-alpha");
+      const b = bridge.loadOrCreateSecret("plugin-beta");
+      expect(a.equals(b)).toBe(false);
+    });
+  });
+
+  describe("getMcpBridge singleton", () => {
+    it("returns the same instance on multiple calls", () => {
+      _resetMcpBridge();
+      const a = getMcpBridge();
+      const b = getMcpBridge();
+      expect(a).toBe(b);
+      _resetMcpBridge();
+    });
+  });
+});

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -17,6 +17,7 @@
 
 import { join, isAbsolute, resolve } from "path";
 import { existsSync } from "fs";
+import { getMcpBridge, type PluginTool } from "./plugins/mcp-bridge.js";
 
 // ── Event types ──────────────────────────────────────────────────────────────
 
@@ -60,6 +61,7 @@ export interface PluginApi {
   on(event: string, handler: EventHandler): void;
   registerService(service: PluginService): void;
   registerCommand(cmd: PluginCommand): void;
+  registerTool(tool: PluginTool): void;
   runtime: {
     channel: Record<string, Record<string, (...args: unknown[]) => unknown>>;
   };
@@ -201,6 +203,9 @@ export class PluginManager {
       },
       registerCommand(cmd: PluginCommand) {
         self.commands.set(cmd.name, cmd);
+      },
+      registerTool(tool: PluginTool) {
+        getMcpBridge().registerPluginTool(pluginId, tool);
       },
       runtime: {
         channel: self.channelRuntime,

--- a/src/plugins/mcp-bridge.ts
+++ b/src/plugins/mcp-bridge.ts
@@ -1,0 +1,222 @@
+import { z } from "zod";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { appendFileSync, mkdirSync, writeFileSync, existsSync, readFileSync, chmodSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface PluginTool<T extends z.ZodType = z.ZodType<any, any>> {
+  name: string;
+  description: string;
+  schema: T;
+  handler: (args: z.infer<T>) => Promise<unknown> | unknown;
+}
+
+export interface PluginToolContext {
+  pluginId: string;
+  callerToken?: string;
+  signature: string;
+  ts: number;
+}
+
+export interface RegisteredTool {
+  plugin: string;
+  tool: PluginTool;
+}
+
+export interface ListedTool {
+  fqn: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+// ── PluginMcpBridge ───────────────────────────────────────────────────────────
+
+export class PluginMcpBridge {
+  private tools = new Map<string, RegisteredTool>();
+  private secrets = new Map<string, Buffer>();
+  private auditPath: string;
+
+  constructor(auditPath?: string) {
+    this.auditPath = auditPath
+      ? resolve(auditPath)
+      : resolve(homedir(), ".config", "plus", "plugin-audit.jsonl");
+
+    // Ensure audit directory exists
+    const auditDir = this.auditPath.substring(0, this.auditPath.lastIndexOf("/"));
+    mkdirSync(auditDir, { recursive: true });
+  }
+
+  // ── Tool registration ──────────────────────────────────────────────────
+
+  registerPluginTool(pluginId: string, tool: PluginTool): void {
+    const fqn = `${pluginId}__${tool.name}`;
+
+    if (this.tools.has(fqn)) {
+      throw new Error(`Duplicate tool registration: "${fqn}" is already registered`);
+    }
+
+    this.tools.set(fqn, { plugin: pluginId, tool });
+    this.audit("register", { fqn, pluginId, toolName: tool.name, description: tool.description });
+  }
+
+  // ── Secret management ──────────────────────────────────────────────────
+
+  loadOrCreateSecret(pluginId: string): Buffer {
+    const cached = this.secrets.get(pluginId);
+    if (cached) return cached;
+
+    const secretDir = resolve(homedir(), ".config", "plus", "plugins", pluginId);
+    const secretPath = join(secretDir, ".secret");
+
+    mkdirSync(secretDir, { recursive: true });
+
+    let secret: Buffer;
+    if (existsSync(secretPath)) {
+      const raw = readFileSync(secretPath);
+      // hex-encoded 32 bytes = 64 chars
+      secret = Buffer.from(raw.toString().trim(), "hex");
+    } else {
+      secret = randomBytes(32);
+      writeFileSync(secretPath, secret.toString("hex"), { encoding: "utf8" });
+      chmodSync(secretPath, 0o600);
+    }
+
+    this.secrets.set(pluginId, secret);
+    return secret;
+  }
+
+  // ── HMAC signing ──────────────────────────────────────────────────────
+
+  signCall(pluginId: string, body: unknown, ts: number): string {
+    const secret = this.loadOrCreateSecret(pluginId);
+    const canonical = JSON.stringify({ body, ts });
+    return createHmac("sha256", secret).update(canonical).digest("hex");
+  }
+
+  verifyCall(pluginId: string, body: unknown, ts: number, signature: string): boolean {
+    const expected = this.signCall(pluginId, body, ts);
+    try {
+      const expectedBuf = Buffer.from(expected, "hex");
+      const signatureBuf = Buffer.from(signature, "hex");
+      if (expectedBuf.length !== signatureBuf.length) return false;
+      return timingSafeEqual(expectedBuf, signatureBuf);
+    } catch {
+      return false;
+    }
+  }
+
+  // ── Tool invocation ───────────────────────────────────────────────────
+
+  async invokeTool(fqn: string, args: unknown): Promise<unknown> {
+    const registered = this.tools.get(fqn);
+    if (!registered) {
+      throw new Error(`Unknown tool: "${fqn}"`);
+    }
+
+    const { plugin: pluginId, tool } = registered;
+
+    // Validate args via Zod schema
+    const parsed = tool.schema.safeParse(args);
+    if (!parsed.success) {
+      const err = new Error(`Invalid args for "${fqn}": ${parsed.error.message}`);
+      this.audit("error", { fqn, pluginId, error: parsed.error.message, phase: "validation" });
+      throw err;
+    }
+
+    // Sign the call
+    const ts = Date.now();
+    const signature = this.signCall(pluginId, parsed.data, ts);
+
+    try {
+      const result = await tool.handler(parsed.data);
+      this.audit("invoke", { fqn, pluginId, ts, signature, success: true });
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.audit("error", { fqn, pluginId, ts, signature, error: message, phase: "handler" });
+      throw err;
+    }
+  }
+
+  // ── Tool listing ──────────────────────────────────────────────────────
+
+  listTools(): ListedTool[] {
+    return Array.from(this.tools.entries()).map(([fqn, { tool }]) => ({
+      fqn,
+      description: tool.description,
+      inputSchema: this.zodToJson(tool.schema),
+    }));
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+
+  private zodToJson(schema: z.ZodType): Record<string, unknown> {
+    // MVP minimal converter — returns a basic JSON Schema object
+    if (schema instanceof z.ZodObject) {
+      const shape = schema.shape as Record<string, z.ZodType>;
+      const properties: Record<string, unknown> = {};
+      const required: string[] = [];
+
+      for (const [key, field] of Object.entries(shape)) {
+        properties[key] = this.zodFieldToJson(field as z.ZodType);
+        // If not optional, mark as required
+        if (!(field instanceof z.ZodOptional) && !(field instanceof z.ZodDefault)) {
+          required.push(key);
+        }
+      }
+
+      return {
+        type: "object",
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+        additionalProperties: false,
+      };
+    }
+
+    // Fallback for non-object schemas
+    return { type: "object", additionalProperties: true };
+  }
+
+  private zodFieldToJson(field: z.ZodType): Record<string, unknown> {
+    if (field instanceof z.ZodOptional) {
+      return this.zodFieldToJson(field.unwrap() as z.ZodType);
+    }
+    if (field instanceof z.ZodDefault) {
+      return this.zodFieldToJson(field._def.innerType as z.ZodType);
+    }
+    if (field instanceof z.ZodString) return { type: "string" };
+    if (field instanceof z.ZodNumber) return { type: "number" };
+    if (field instanceof z.ZodBoolean) return { type: "boolean" };
+    if (field instanceof z.ZodArray) return { type: "array", items: this.zodFieldToJson(field.element as z.ZodType) };
+    if (field instanceof z.ZodEnum) return { type: "string", enum: field.options as string[] };
+    return { type: "object", additionalProperties: true };
+  }
+
+  private audit(event: string, payload: Record<string, unknown>): void {
+    try {
+      const entry = JSON.stringify({ event, ts: new Date().toISOString(), ...payload }) + "\n";
+      appendFileSync(this.auditPath, entry, { encoding: "utf8" });
+    } catch {
+      // Audit failures must not break the bridge
+    }
+  }
+}
+
+// ── Singleton ─────────────────────────────────────────────────────────────────
+
+let _bridge: PluginMcpBridge | null = null;
+
+export function getMcpBridge(): PluginMcpBridge {
+  if (!_bridge) {
+    _bridge = new PluginMcpBridge();
+  }
+  return _bridge;
+}
+
+/** Reset singleton — only for testing */
+export function _resetMcpBridge(): void {
+  _bridge = null;
+}

--- a/src/plugins/mcp-server.ts
+++ b/src/plugins/mcp-server.ts
@@ -1,0 +1,71 @@
+/**
+ * ClaudeClaw-Plus MCP stdio server
+ *
+ * Exposes all plugin-registered tools via the Model Context Protocol.
+ * Run standalone: bun run src/plugins/mcp-server.ts
+ *
+ * Or configure in claude_desktop_config.json:
+ *   { "mcpServers": { "claudeclaw-plus": { "command": "bun", "args": ["run", "/path/to/mcp-server.ts"] } } }
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { getMcpBridge } from "./mcp-bridge.js";
+
+export async function startMcpServer(): Promise<void> {
+  const bridge = getMcpBridge();
+
+  const server = new Server(
+    { name: "claudeclaw-plus", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  // List all registered plugin tools
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const tools = bridge.listTools();
+    return {
+      tools: tools.map((t) => ({
+        name: t.fqn,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
+    };
+  });
+
+  // Invoke a tool by FQN
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    try {
+      const result = await bridge.invokeTool(name, args ?? {});
+      return {
+        content: [
+          {
+            type: "text",
+            text: typeof result === "string" ? result : JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text", text: `Error: ${message}` }],
+        isError: true,
+      };
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+// Run standalone when executed directly
+if (import.meta.main) {
+  startMcpServer().catch((err) => {
+    console.error("[mcp-server] Fatal:", err);
+    process.exit(1);
+  });
+}

--- a/src/skills-tuner-templates/mcp/SKILL.md
+++ b/src/skills-tuner-templates/mcp/SKILL.md
@@ -1,0 +1,641 @@
+---
+name: mcp
+description: Manage the ClaudeClaw-Plus MCP bridge — register plugins, monitor health, audit invocations, debug cross-process calls, generate plugin templates. Use when configuring/troubleshooting the plugin gateway, when adding a new daemon plugin (voice-agent, retrieval-daemon, ML pipelines), when investigating audit log events, or when diagnosing plugin connectivity issues.
+---
+
+# MCP — Plus plugin gateway companion skill
+
+Multi-mode skill for the ClaudeClaw-Plus MCP bridge. Connects to Plus's HTTP gateway at `http://localhost:4632/api/plugin/*` and the audit log at `~/.config/plus/plugin-audit.jsonl`.
+
+## Mode dispatch
+
+Read user intent from the trigger / first message:
+
+- `/mcp` (no arg) or first-time use → **setup**
+- `/mcp list` or "what plugins are registered" → **list**
+- `/mcp inspect <plugin>` or "tell me about <plugin>" → **inspect**
+- `/mcp diagnose` or "are my plugins healthy" → **diagnose**
+- `/mcp audit` or "show recent plugin events" → **audit**
+- `/mcp trace <request_id>` or "find this request" → **trace**
+- `/mcp register` or "add a new plugin" → **register**
+- `/mcp test <plugin> <tool>` or "test <plugin>'s <tool>" → **test**
+- `/mcp report` or "this looks like an MCP bug" → **report**
+- `/mcp proxy-status` or "show MCP server pool" → **proxy-status**
+- `/mcp proxy-restart <server>` or "restart <server> MCP server" → **proxy-restart**
+
+If unclear, ask.
+
+---
+
+## Mode: setup
+
+Goal: prepare a new plugin install — print bootstrap token, walk through Plus config, suggest first plugin registration.
+
+### Step 1 — Welcome
+
+Tell the user in 3 sentences:
+1. The MCP bridge lets daemon-style plugins (Python, Rust, etc.) register tools that Claude Code can call.
+2. Each plugin needs a bootstrap token (one-time) and a per-plugin secret (auto-generated at register).
+3. The bridge runs HTTP endpoints under `/api/plugin/*` and an MCP server at `bun run src/plugins/mcp-server.ts`.
+
+### Step 2 — Print bootstrap token
+
+```bash
+bun run src/plugins/cli.ts print-bootstrap-token
+```
+
+If file doesn't exist (first run), Plus auto-creates it at `~/.config/plus/plugin-bootstrap.secret` (0600, 32 bytes). Display the token to the user. Tell them:
+
+> Save this token — your plugin install scripts need it for the `register` call. You can re-print it any time with the same command.
+
+### Step 3 — Verify Plus is running
+
+```bash
+curl -s http://localhost:4632/api/plugin/list
+```
+
+If 404 / connection refused → Plus daemon not running with `--web` flag. Suggest restart:
+```bash
+systemctl --user restart claudeclaw.service
+```
+
+If returns `{"plugins": []}` → bridge is up, no plugins yet.
+
+### Step 4 — Suggest next steps
+
+> Ready to register your first plugin?
+>   1. Generate a Python plugin template (`/mcp register`)
+>   2. Manual: see `docs/plugin-integration.md` for examples (voice-driven agents, retrieval daemons)
+>   3. Skip (already have a plugin scripted)
+
+### Step 5 — Detect mcp-proxy config
+
+```bash
+test -f ~/.config/claudeclaw/mcp-proxy.json && echo "exists" || echo "missing"
+```
+
+If exists:
+> An mcp-proxy config exists. Run `/mcp proxy-status` to see pooled servers and their health.
+
+If missing:
+> No mcp-proxy config detected. Copy `mcp-proxy.json.example` to `~/.config/claudeclaw/mcp-proxy.json` and configure your MCP servers to enable warm-pool routing (~200ms direct calls vs ~3000ms inject path).
+
+### Step 5b — Auth contract reference
+
+For the canonical authentication contract (header names, HMAC signing scope, ISO 8601 timestamp format, replay window semantics), point the user to:
+
+👉 [`docs/plugin-integration.md`](https://github.com/TerrysPOV/ClaudeClaw-Plus/blob/main/docs/plugin-integration.md#authentication-contract)
+
+This is the source of truth — do not paraphrase the headers (`x-plus-ts` / `x-plus-signature`) or scope (`<ts>\n<body>`) from memory; a single character mismatch returns 401 `invalid_signature`.
+
+End setup.
+
+---
+
+## Mode: list
+
+Goal: show all registered plugins with their health status.
+
+### Step 1 — Fetch list
+
+```bash
+curl -s http://localhost:4632/api/plugin/list
+```
+
+### Step 2 — Render table
+
+```
+Registered plugins:
+
+| Plugin       | Version | Tools                          | Health | Registered |
+|--------------|---------|--------------------------------|--------|------------|
+| daemon-A | 0.1.0   | pending, apply, refuse         | ✅ ok  | 2h ago     |
+| voice-agent   | 1.0.0   | send_tts, transcribe_audio     | ⚠️ deg | 2d ago     |
+| retrieval-daemon   | 2.1.0   | search_docs, index_doc         | ❌ down| 5d ago     |
+```
+
+For health:
+- ✅ ok — last_health_check.healthy = true within last 5 min
+- ⚠️ degraded — healthy but slow (>1s response) or stale check (>10 min)
+- ❌ down — last_health_check.healthy = false or no manifest health_url
+- ❓ unknown — no health_url declared
+
+### Step 3 — Suggest next actions
+
+If any ❌ or ⚠️:
+> Run `/mcp inspect <plugin>` for details, or `/mcp diagnose` to refresh health checks.
+
+### Step 4 — Proxied MCP servers (conditional)
+
+If `mcp-proxy` appears in the plugin list, fetch pool state and render a second table:
+
+```bash
+curl -s http://localhost:4632/api/plugin/mcp-proxy/health
+```
+
+```
+Proxied MCP servers (via mcp-proxy):
+
+| Server           | Tools | Status      | Last invocation |
+|------------------|-------|-------------|-----------------|
+| home-automation  | 4     | ✅ up        | 2 min ago       |
+| brave-search     | 1     | ✅ up        | 14 min ago      |
+| momentum-trader  | 3     | ❌ crashed   | 1h ago          |
+```
+
+Status values: `up` / `starting` / `restarting` / `crashed` / `failed` / `stopped`.
+For `crashed` or `failed`: suggest `/mcp proxy-restart <server>`.
+
+End list.
+
+---
+
+## Mode: inspect <plugin>
+
+Goal: deep dive on one plugin.
+
+### Step 1 — Fetch plugin info
+
+```bash
+curl -s http://localhost:4632/api/plugin/list | jq '.plugins[] | select(.name == "<plugin>")'
+```
+
+### Step 2 — Force health check
+
+```bash
+curl -s http://localhost:4632/api/plugin/<plugin>/health
+```
+
+### Step 3 — Show recent audit events for this plugin
+
+Read `~/.config/plus/plugin-audit.jsonl`, filter by `plugin == "<plugin>"`, last 20 entries.
+
+### Step 4 — Render report
+
+```
+## Plugin: voice-agent
+
+### Manifest
+- Version: 1.0.0 (schema_version 1)
+- Capabilities: tools
+- Callback: http://localhost:8765/plus-callback
+- Health: http://localhost:8765/health
+- Tools: send_tts, transcribe_audio
+
+### Health
+- Last check: 2 min ago — degraded (response time 1.4s, target <500ms)
+- HTTP: 200 OK
+
+### Recent activity (last 20)
+- 14:32:18 invoke tool=send_tts request_id=abc123 (success, 312ms)
+- 14:31:50 invoke tool=transcribe_audio request_id=def456 (success, 1.2s)
+- 14:30:12 health_check (healthy)
+- ...
+
+### Suggested actions
+- Investigate slow responses (1.2s on transcribe vs target 500ms)
+- Run `/mcp test voice-agent send_tts` to verify functionality
+```
+
+### Step 5 — mcp-proxy drill-down (conditional)
+
+If `<plugin> == mcp-proxy`, skip Step 4 and render this instead:
+
+```bash
+curl -s http://localhost:4632/api/plugin/mcp-proxy/health
+cat ~/.config/claudeclaw/mcp-proxy.json
+```
+
+Render per-server detail:
+
+```
+## Plugin: mcp-proxy (in-process warm pool)
+
+| Server          | Status      | Crashes (5min) | Tools | p50 latency | Stderr log |
+|-----------------|-------------|----------------|-------|-------------|------------|
+| home-automation | ✅ up        | 0              | 4     | 180ms       | ~/.cache/claudeclaw/mcp-proxy/home-automation.log |
+| brave-search    | ✅ up        | 0              | 1     | 210ms       | ~/.cache/claudeclaw/mcp-proxy/brave-search.log    |
+| momentum-trader | ❌ failed    | 5              | 3     | —           | ~/.cache/claudeclaw/mcp-proxy/momentum-trader.log |
+```
+
+For servers in `failed` state: surface the last 10 lines of their stderr log and suggest
+`/mcp proxy-restart <server>` or daemon restart if restart is exhausted.
+
+End inspect.
+
+---
+
+## Mode: diagnose
+
+Goal: full health sweep + config validation.
+
+### Step 1 — Check Plus is running
+
+```bash
+curl -fsS http://localhost:4632/api/plugin/list > /dev/null || echo "Plus daemon down"
+```
+
+### Step 2 — Check bootstrap token exists
+
+```bash
+ls -la ~/.config/plus/plugin-bootstrap.secret
+```
+
+Verify perms 0600. If missing, suggest `bun run src/plugins/cli.ts print-bootstrap-token` to auto-create.
+
+### Step 3 — Health check all plugins
+
+For each plugin in list:
+```bash
+curl -s http://localhost:4632/api/plugin/<name>/health
+```
+
+### Step 4 — Audit log recent errors
+
+Read last 100 entries from `plugin-audit.jsonl`. Filter for `event` containing `error`, `failed`, `denied`, `mismatch`.
+
+### Step 5 — Render report
+
+```
+## Diagnose report — 2026-05-10 14:35
+
+### Daemon
+✅ Plus daemon responding on :3000
+✅ Bootstrap token present (0600 perms)
+✅ Bridge initialized (3 plugins registered)
+
+### Per-plugin health
+- daemon-A: ✅ ok
+- voice-agent:   ⚠️ degraded (slow callback)
+- retrieval-daemon:   ❌ down (connection refused on :9090)
+
+### Recent errors (last 100 audit entries)
+- 14:30:12 retrieval-daemon search_docs invoke_failed (callback unreachable, 5 occurrences)
+- 14:25:33 voice-agent send_tts invalid_args (zod error: missing 'text' field)
+
+### Recommendations
+1. retrieval-daemon: process not running. Start with `systemctl --user start retrieval-daemon.service`.
+2. voice-agent: caller passing invalid args — check the voice-agent's callback handler validation.
+```
+
+### Step 6 — Common 401 causes
+
+If invoke returns 401 `invalid_signature`, the usual suspects:
+
+1. **Wrong header names** — must be `x-plus-ts` and `x-plus-signature` (lowercase, `x-plus-` namespace). `X-Timestamp`/`X-Signature` are silently ignored.
+2. **Wrong HMAC scope** — signature covers `<ts>\n<body>`, not just `<body>`. Re-serializing the body between signing and sending breaks verification.
+3. **Wrong timestamp format** — must be ISO 8601 UTC (`2026-05-11T12:34:56.000Z`). Unix epoch seconds get parsed as milliseconds and land in year 4xxx.
+4. **Clock skew > 15 min** — 401 with code `stale_or_future_timestamp` (different code than HMAC failure).
+
+Full troubleshooting:
+👉 [`docs/plugin-integration.md`](https://github.com/TerrysPOV/ClaudeClaw-Plus/blob/main/docs/plugin-integration.md#authentication-contract)
+
+End diagnose.
+
+---
+
+## Mode: audit [filter]
+
+Goal: tail recent plugin-audit.jsonl events with optional filter.
+
+### Step 1 — Read audit log
+
+```bash
+tail -200 ~/.config/plus/plugin-audit.jsonl | jq -c .
+```
+
+### Step 2 — Filter
+
+If user provided keyword (e.g. `audit error`, `audit voice-agent`, `audit invoke_failed`):
+- Filter entries by event matching keyword OR plugin matching keyword.
+
+### Step 2.5 — Routing mode filter (conditional)
+
+If user asks "audit direct" or "audit reasoned":
+```bash
+tail -200 ~/.config/plus/plugin-audit.jsonl | jq -c 'select(.payload.mode == "direct")'
+# or: select(.payload.mode == "reasoned")
+```
+
+Surface ratio anomalies: if `reasoned` calls spike above 10% of mcp-proxy invocations, flag it —
+a spike in `reasoned` typically means a warm-pool server is returning errors and callers are
+routing around it. Suggest `/mcp proxy-status` to diagnose.
+
+### Step 3 — Group + render
+
+Group by event type, show counts + sample entries. Highlight security-relevant events: `invalid_signature`, `stale_or_future_timestamp`, `capability_denied`, `callback_host_not_allowed`.
+
+```
+## Audit summary — last 200 entries
+
+By event type:
+- tool_invoked × 142
+- tool_success × 138
+- tool_error × 4 (3 retrieval-daemon callback_unreachable, 1 greg invalid_args)
+- http_plugin_registered × 3
+- invalid_signature × 0 ✅
+- stale_or_future_timestamp × 0 ✅
+
+Security-relevant entries: 0 (audit healthy)
+
+Recent errors:
+14:30:12 retrieval-daemon tool_error: callback unreachable (request_id=abc789)
+14:25:33 voice-agent tool_error: zod validation (request_id=def012)
+```
+
+### Step 4.5 — Drift since last cron
+
+Check `~/.config/tuner/state-hashes.jsonl` for recent `subject_state_drift_detected` entries with `subject == "mcp"` (if `MCPSubject` is implemented) or related plugin subjects.
+
+If MCPSubject not yet implemented, note:
+> Drift detection for MCP plugins requires a future `MCPSubject` implementation. Manual `/mcp audit` invocation surfaces current state — automatic drift between audits will land when MCPSubject is added and `currentStateHash()` is implemented to hash `/api/plugin/list`.
+
+End audit.
+
+---
+
+## Mode: trace <request_id>
+
+Goal: follow a request_id through audit log + plugin health to debug intermittent issues.
+
+### Step 1 — Find all entries with that request_id
+
+```bash
+grep -E "\"request_id\":\"<id>\"" ~/.config/plus/plugin-audit.jsonl | jq -c .
+```
+
+### Step 2 — Sequence them chronologically
+
+### Step 3 — Annotate timeline
+
+```
+## Trace: request_id=abc789
+
+[14:30:10.123] http_invoke_received (daemon-A__pending args=...)
+[14:30:10.125] tool_invoked plugin=daemon-A tool=pending
+[14:30:10.128] tool_success duration_ms=3 (returned 4 proposals)
+[14:30:10.130] http_response_sent status=200
+
+Total: 7ms end-to-end. ✅ Clean.
+```
+
+If trace shows error chain, surface it:
+```
+[14:25:33.450] http_invoke_received (voice-agent__send_tts args=...)
+[14:25:33.451] tool_invoked plugin=voice-agent tool=send_tts
+[14:25:33.452] tool_error error="zod validation: 'text' is required"
+
+Root cause: caller passed empty args. Check voice-agent client code.
+```
+
+End trace.
+
+---
+
+## Mode: register
+
+Goal: interactive wizard — create a new plugin manifest and (optionally) scaffold plugin code.
+
+### Step 1 — Plugin name
+
+Prompt: "What's the plugin name? (lowercase, kebab-case)"
+
+Validate: matches `^[a-z][a-z0-9-]*$`.
+
+### Step 2 — Callback URL
+
+Prompt: "Where will Plus call your plugin? (default: http://localhost:8765/plus-callback)"
+
+Default `localhost:NNNN`. If non-localhost, warn user about allowlist requirement.
+
+### Step 3 — Tools
+
+Prompt loop: "Add a tool? (name + description, or 'done')"
+
+For each tool: name, description, args schema (simple — type + required fields).
+
+### Step 4 — Capabilities
+
+Prompt: "Capabilities: tools (default), hooks, session_read, session_write?" Default tools.
+
+### Step 5 — Generate
+
+Two outputs:
+
+**a. Manifest JSON** for the user to POST:
+```json
+{
+  "name": "<name>",
+  "version": "0.1.0",
+  "schema_version": 1,
+  "callback_url": "http://localhost:8765/plus-callback",
+  "tools": [...],
+  "capabilities": ["tools"]
+}
+```
+
+**b. Python plugin scaffold** (in `<plugin-root>/<name>/server.py`):
+```python
+import requests, hmac, hashlib, json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+PLUGIN_TOKEN = "<set after register>"
+
+def verify_hmac(token: bytes, ts: str, body: str, sig: str) -> bool:
+    # Reference: docs/plugin-integration.md#authentication-contract
+    # https://github.com/TerrysPOV/ClaudeClaw-Plus/blob/main/docs/plugin-integration.md
+    expected = hmac.new(token, (ts + "\n" + body).encode(), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, sig)
+
+class Handler(BaseHTTPRequestHandler):
+    def do_POST(self):
+        body = self.rfile.read(int(self.headers.get("Content-Length", 0))).decode()
+        ts = self.headers.get("x-plus-ts", "")
+        sig = self.headers.get("x-plus-signature", "")
+        if not verify_hmac(bytes.fromhex(PLUGIN_TOKEN), ts, body, sig):
+            self.send_response(401); self.end_headers(); return
+        # Dispatch by tool name, return JSON {result: ...}
+        pass
+
+if __name__ == '__main__':
+    HTTPServer(('localhost', 8765), Handler).serve_forever()
+```
+
+### Step 6 — Register
+
+If user confirms, do the POST:
+```bash
+BOOTSTRAP=$(bun run src/plugins/cli.ts print-bootstrap-token)
+curl -X POST http://localhost:4632/api/plugin/register \
+  -H "Authorization: Bearer $BOOTSTRAP" \
+  -H "Content-Type: application/json" \
+  -d @manifest.json
+```
+
+Save returned `plugin_token` to `~/.config/plus/plugins/<name>/.secret` (0600).
+
+End register.
+
+---
+
+## Mode: test <plugin> <tool>
+
+Goal: invoke a tool with sample args to verify functionality.
+
+### Step 1 — Get tool schema
+
+From plugin's manifest in `/api/plugin/list`.
+
+### Step 2 — Build args
+
+Prompt user for required fields, with sensible defaults shown. Reject invalid types.
+
+### Step 3 — Sign + invoke
+
+Build ISO 8601 ts (`new Date().toISOString()`), compute `HMAC-SHA256(plugin_token, ts + "\n" + body)`, POST to `/api/plugin/<name>/tools/<tool>/invoke` with headers `x-plus-ts` and `x-plus-signature`. Show response, audit entry, request_id.
+
+### Step 4 — Show result
+
+Pretty-print result + suggest follow-up if error (rerun with different args, check `/mcp inspect`).
+
+End test.
+
+---
+
+## Mode: report
+
+Goal: file a sanitized upstream issue if MCP bridge has a real bug.
+
+Same flow as `tuner report` mode (see tuner.md):
+1. User describes the symptom
+2. Categorize (Critical / Perf / Detection / Doc)
+3. Sanitize logs (paths, IPs, tokens)
+4. Show draft, ask Post Now / Edit / Cancel
+5. POST via `gh issue create --repo TerrysPOV/ClaudeClaw-Plus --label mcp-report`
+
+End report.
+
+---
+
+## Mode: proxy-status
+
+Goal: overview of the mcp-proxy warm pool — server states, crash counts, latency.
+
+### Step 1 — Verify mcp-proxy registered
+
+```bash
+curl -s http://localhost:4632/api/plugin/list | jq '.plugins[] | select(.name == "mcp-proxy")'
+```
+
+If not found: "mcp-proxy plugin not registered — daemon may be starting or mcp-proxy.json missing."
+
+### Step 2 — Read pool state
+
+```bash
+curl -s http://localhost:4632/api/plugin/mcp-proxy/health
+```
+
+### Step 3 — Render table
+
+```
+## mcp-proxy pool status
+
+| Server           | Status      | Crashes (5min) | Invocations today | p50 latency |
+|------------------|-------------|----------------|-------------------|-------------|
+| home-automation  | ✅ up        | 0              | 142               | 185ms       |
+| brave-search     | ✅ up        | 0              | 17                | 220ms       |
+| momentum-trader  | ❌ failed    | 5              | 0 (since failure) | —           |
+```
+
+### Step 4 — Suggest actions
+
+- `crashed`: suggest `/mcp proxy-restart <server>`
+- `failed` (5 crashes in 5 min, permanently stopped): daemon restart required — `systemctl --user restart claudeclaw.service`
+- High p50 (>500ms): check server stderr log at `~/.cache/claudeclaw/mcp-proxy/<server>.log`
+- Low invocations on an expected server: confirm callers are using `mode: "direct"` (not `reasoned`)
+
+End proxy-status.
+
+---
+
+## Mode: proxy-restart <server>
+
+Goal: restart a single crashed MCP server in the warm pool without restarting the full daemon.
+
+### Step 1 — Confirm intent
+
+> Restarting `<server>` will fail any in-flight tool calls for that server. Continue?
+
+If no: End.
+
+### Step 2 — Attempt restart
+
+Check if the daemon exposes an admin restart tool via the bridge:
+```bash
+curl -s http://localhost:4632/api/plugin/list | jq '.plugins[] | select(.name == "mcp-proxy") | .tools'
+```
+
+If a `mcp-proxy__restart_server` tool is listed: invoke it with `{"arguments": {"server": "<server>"}}`.
+
+If not available (current release does not expose a restart tool): inform the user:
+> In-process server restart requires daemon restart. Run:
+> `systemctl --user restart claudeclaw.service`
+> After restart, run `/mcp proxy-status` to verify the server comes up.
+
+### Step 3 — Verify recovery
+
+```bash
+curl -s http://localhost:4632/api/plugin/mcp-proxy/health | jq '.servers["<server>"].status'
+```
+
+Wait up to 30s for status to go from `restarting` → `up`. Report final state.
+
+End proxy-restart.
+
+---
+
+## Test catalog
+
+Substrate guarantees are covered by 40+ tests. Browse them in the repo:
+
+👉 [`src/__tests__/`](https://github.com/TerrysPOV/ClaudeClaw-Plus/tree/main/src/__tests__)
+
+- `mcp_proxy_basic.test.ts` — register, call, concurrent, crash hook, allowedTools
+- `mcp_proxy_security.test.ts` — HMAC, replay, stderr isolation, path traversal, body size cap
+- `mcp_proxy_load.test.ts` — 50 concurrent, 200 sequential, slow-tool isolation
+- `mcp_proxy_mode.test.ts` — direct/reasoned routing
+- `mcp_proxy_audit_forensics.test.ts` — request_id propagation, event coverage, token leak prevention
+- `mcp_proxy_crash_edges.test.ts` — counter reset boundary, backoff timing, shutdown race
+- `mcp_proxy_reregister.test.ts` — atomicity, token invalidation during re-register
+- `mcp_proxy_replay_precision.test.ts` — replay window edges (+1s, +14m59s, +15m01s, …)
+- `plugins/http-gateway.test.ts` — register flow, HMAC verification, replay rejection, error format
+
+Pointers to specific tests are more useful than reproducing assertions here — the suite is the source of truth.
+
+## Reporting bugs or requesting features
+
+For non-interactive reports (GUI/browser flow):
+
+👉 [Open an issue](https://github.com/TerrysPOV/ClaudeClaw-Plus/issues/new?labels=mcp)
+
+Or use the `report` mode in this skill for assisted/sanitized issue creation through `gh issue create`.
+
+---
+
+## Self-improvement notes (for the framework that watches this skill)
+
+Like the `tuner` skill, this `mcp` skill lives in the user's tunable surface and is itself a `TunableSubject` member. Frequent confusion or correction patterns on `/mcp` invocations would trigger framework proposals to refine these modes.
+
+Special safeguards (same as tuner):
+- `risk_tier: critical` (config override) — never auto-merge changes
+- 30-day cool-down between accepted self-modifications
+- Diff-mandatory on proposals
+- Audit log entries tagged `event: meta_mcp_self_modify`
+
+If you (Claude Code, reading this skill) are asked to modify mcp.md itself, surface the safeguards explicitly to the user before applying.
+
+---
+
+## Closing note
+
+If you're unsure which mode applies, say so and ask the user. Modes can be combined (`/mcp list` then `/mcp inspect <picked>`) — sequential, not nested. The bridge endpoints are localhost-only by default — if user reports "can't reach plugin", first check that Plus daemon runs `--web` on :3000.

--- a/src/skills-tuner-templates/tuner.md
+++ b/src/skills-tuner-templates/tuner.md
@@ -1,0 +1,672 @@
+---
+name: tuner
+description: Multi-mode companion skill for skills-tuner platform. Setup new installation, create new TunableSubject entries, adjust existing config, audit framework state, optimize cost/perf, or report upstream issues. Self-improving through the framework it configures.
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+risk_tier: critical
+auto_merge_default: false
+language: english
+triggers:
+  - /tuner
+  - /tuner setup
+  - /tuner create
+  - /tuner adjust
+  - /tuner audit
+  - /tuner optimize
+  - /tuner report
+  - tune this skill
+  - tune the skill
+  - improve the tuner
+  - audit the skills
+  - fix this skill
+  - review my skills
+  - report a tuner bug
+  - configure the tuner
+  - skills tuner
+  - skills-tuner
+  - tune-moi
+  - tune moi
+  - ajuste-moi
+  - ajuste ce skill
+  - ameliore le tuner
+  - audit le tuner
+  - audit les skills
+  - reviser mes skills
+  - configure le tuner
+  - report un bug du tuner
+  - ouvre une issue tuner
+  - tuner audit
+  - tuner setup
+---
+
+# Tuner — companion skill
+
+You are the companion skill for the **skills-tuner** platform. The user invokes you to manage their skills-tuner installation across six modes. Read the user message carefully to detect the intended mode. If unclear, ask.
+
+## Mode dispatch
+
+Detect mode from the trigger:
+
+- `/tuner` (no arg) or first-time use → **setup**
+- `/tuner create` or "new skill" + tuner context or "tune-moi un skill" → **create**
+- `/tuner adjust [name]` or "tune this skill X" or "ajuste ce skill X" → **adjust**
+- `/tuner audit` or "audit le tuner" or "review tuner state" → **audit**
+- `/tuner optimize` or "reduce tuner cost" → **optimize**
+- `/tuner report` or "this looks like a tuner bug" or "ouvre une issue" → **report**
+
+If `~/.config/tuner/config.yaml` does not exist and mode is unclear, default to **setup**. If the verbatim is genuinely ambiguous (e.g. just "tune-moi"), ask the user which mode applies before doing anything.
+
+---
+
+## Mode: setup
+
+Goal: produce a working `~/.config/tuner/config.yaml` aligned with the user's actual skills directory and workflow.
+
+### Step 1 — Welcome (one short paragraph)
+
+Tell the user in 3 sentences:
+1. Tuner watches their skills + voice + RAG + MCP configs and proposes improvements.
+2. Every change is human-approved, git-versioned, and reversible.
+3. Default models stratified by role; override per subject in config.
+
+Ask if they want to proceed (yes/no). If no, exit gracefully.
+
+**Drift detection**: Each cron tick, the tuner computes a state hash per subject. Changes to scan_dirs files, plugin registrations, etc. are detected and surfaced in the next `/tuner audit` run. Subjects opt-in by implementing `currentStateHash()` — default is no-op (empty string).
+
+### Step 2 — Detect the git repo
+
+Scan candidate locations:
+- `~/agent/skills`
+- `~/.claude/skills`
+- `~/skills`
+- `~/.config/claude/skills`
+
+For each existing path, run:
+- `test -d "$path/.git" && echo "git: yes" || echo "git: no"`
+- `find "$path" -maxdepth 1 -name "*.md" | wc -l` (skill count)
+- Sample 5 skill files, read their frontmatter, infer dominant `language:` field
+
+Show the user a table:
+
+```
+Found candidate directories:
+  1. ~/agent/skills          12 skills, git: yes, lang: english
+  2. ~/.claude/skills          3 skills, git: no,  lang: french
+  3. ~/skills                  not found
+
+Which one should be your tunable surface? [1/2/3/other]
+```
+
+If user picks one without git → run `git init -b main` + initial commit.
+If user picks `other` → ask path → init if needed.
+
+Save the choice as `storage.git_repo` in config.
+
+### Step 2.5 — Scan for legacy flat skills and offer migration
+
+After confirming the git repo, scan the skills directory for legacy flat `.md` files:
+
+```bash
+find "$scan_dir" -maxdepth 1 -name "*.md" ! -name "*.bak"
+# vs
+find "$scan_dir" -maxdepth 2 -name "SKILL.md"
+```
+
+Show a summary:
+
+```
+🔍 Skills format scan:
+  ✅ example-skill-x/SKILL.md  (Anthropic directory format)
+  ✅ example-skill-y/SKILL.md      (Anthropic directory format)
+  ⚠️  legacy-skill-b.md      (legacy flat format)
+  ⚠️  legacy-skill-c.md            (legacy flat format)
+  ⚠️  legacy-skill-a.md             (legacy flat format)
+
+3 legacy skills detected. Migrate to Anthropic directory format now? [yes/no/later]
+```
+
+If **yes**: for each flat skill in order:
+1. Read frontmatter + body
+2. Strip tuner-specific fields (`triggers`, `risk_tier`, `auto_merge`, `auto_merge_default`) from frontmatter
+3. Move stripped fields to `~/.config/tuner/config.yaml` under `subjects.skills.overrides.<name>`
+4. Create `<scan_dir>/<name>/SKILL.md` with cleaned frontmatter + body
+5. Backup original flat file as `<name>.md.pre-migration-<timestamp>.bak`
+6. Delete original flat file
+7. Git commit: `migrate: convert <name> to Anthropic SKILL.md format`
+
+Show progress for each skill:
+```
+Migrating legacy-skill-b.md → legacy-skill-b/SKILL.md... ✅
+Migrating legacy-skill-c.md       → legacy-skill-c/SKILL.md...       ✅
+Migrating legacy-skill-a.md        → legacy-skill-a/SKILL.md...         ✅
+
+Migration complete. Backups at:
+  ~/agent/skills/legacy-skill-b.md.pre-migration-1746000000.bak
+  ...
+
+Config.yaml updated with extracted triggers and risk tiers. Run `tuner doctor` to verify.
+```
+
+If **no** or **later**: skip. Show: "You can migrate later with `/tuner setup` or `/tuner adjust <name>` → option 1."
+
+If **all skills already in directory format**: show "✅ All skills already in Anthropic directory format."
+
+### Step 3 — Pattern adjustment
+
+Based on the dominant language detected in step 2:
+
+- **English** → use `DEFAULT_EMOTIONAL_PATTERNS` from `tuner.subjects.skills` as-is
+- **French/Quebec** → suggest override with French defaults like `["argent", "ostie", "calisse", "tabarnak", "câline", "criss", "fuck", "shit", "broken"]`. Show the proposed override. Ask: "Override `_EMOTIONAL_PATTERNS` for your installation? [yes/no]"
+- **Other language** → ask the user for 5-10 frustration words in their language
+
+Write the override in config under `subjects.skills.emotional_patterns` (with commented examples for transparency).
+
+### Step 4 — Risk philosophy
+
+Ask one question:
+
+```
+How cautious do you want the tuner to be?
+
+  conservative — every change requires manual approval (recommended for first month)
+  balanced     — low-risk changes auto-merge (skill patches, frontmatter tweaks); medium/high need approval
+  aggressive   — low + medium auto-merge; only high-risk and code stay manual
+```
+
+Translate the choice to per-subject `auto_merge` settings in the config.
+
+### Step 5 — Subject-by-subject evaluation
+
+For each subject (`skills`, `voice`, `retrieval-daemon`, `mcp`, `tools`, `code`, `memory`):
+
+1. Show 2-3 sentence description from `~/agent/skills-tuner/DESIGN.md`.
+2. Detect if the user has the surface installed:
+   - `voice` → check for voice-agent files
+   - `retrieval-daemon` → check for retrieval-daemon mcp config
+   - `mcp` → check `~/.config/claude/mcp.json`
+   - `code` → always present
+3. Ask: enabled? proposer model? auto-merge per kind?
+4. Skip subjects the user clearly does not have.
+
+### Step 6 — Reflection guide
+
+Ask 3-5 open-ended questions, capture verbatim answers in `~/.config/tuner/reflection-baseline.md`:
+
+1. "Which tasks do you find yourself repeating most often?"
+2. "What feedback do you give the assistant that feels redundant?"
+3. "Which workflows do you wish improved themselves over time?"
+4. "Are there surfaces (voice, RAG, MCP) where errors compound silently?"
+5. "What would a perfect tuner notice that a normal one would miss?"
+
+These become a **baseline** to compare against in 30 days during audit mode.
+
+### Step 7 — Generate config + dry-run preview
+
+1. Write `~/.config/tuner/config.yaml` based on all answers.
+2. Show the generated YAML to the user, ask to confirm.
+3. Run `tuner doctor` (CLI command) to validate setup.
+4. Run `tuner run --dry --since 7d --max 3` — show 3 candidate proposals from the past 7 days **without** applying.
+5. If the user reacts "these do not match what I want" → loop back to step 6 (re-attune patterns).
+6. Suggest: "Run for 1 week with everything manual. Use `/tuner audit` to review. Then `/tuner adjust` to enable auto-merge on patterns you trust."
+
+### Step 8 — Cron + next steps
+
+Show the cron setup command:
+
+```bash
+# Add to crontab:
+0 3 * * * /usr/bin/env -i HOME=$HOME PATH=/usr/bin:/bin tuner run --since 24h
+```
+
+Pointer to `/tuner audit` for ongoing review.
+
+End setup.
+
+---
+
+## Mode: create
+
+Goal: when the user creates a new skill (via Claude Code native skill flow or manually), this mode complements that by registering the skill with the tuner.
+
+**Note:** The skills-tuner supports two formats:
+- **Directory format** (Anthropic standard, recommended): `<scan_dir>/<name>/SKILL.md` with frontmatter `name:` and `description:` only.
+- **Flat format** (legacy): `<scan_dir>/<name>.md` with full frontmatter including `triggers:`.
+
+For new skills, always prefer the directory format. Triggers and risk configuration belong in `~/.config/tuner/config.yaml` under `subjects.skills.overrides`, not in the skill file frontmatter.
+
+### Step 1 — Choose format
+
+Ask: "Format for this new skill: directory (recommended, Anthropic standard) or flat .md (legacy)?"
+
+- **directory** → scaffold `<scan_dir>/<name>/SKILL.md`
+- **flat** → create `<scan_dir>/<name>.md` (only if user specifically requests for compatibility)
+
+If directory: ask "Bundle helper scripts? (scaffolds an empty `scripts/` subdirectory)" — yes/no.
+
+### Step 2 — Read or identify the new skill
+
+Detect which skill the user just created:
+- Check `git status` of `storage.git_repo` for new `.md` or `SKILL.md` files
+- Or ask: "Which skill did you just create? (path or name)"
+
+Read its frontmatter and content.
+
+### Step 3 — Frontmatter focus: name + description
+
+The Anthropic standard requires only two frontmatter fields for discovery:
+
+```yaml
+---
+name: <skill-name>
+description: <what the skill does and when to use it — used by Claude Code skill matcher>
+---
+```
+
+The `description` is the most important field: Claude Code uses it to automatically discover and load relevant skills. It should start with what the skill does and when to use it (e.g. "Checks service health and system status. Use when asked about infrastructure, services, or system monitoring.").
+
+If the skill file already has `triggers:` or `risk_tier:` in frontmatter: inform the user that these fields are deprecated in the Anthropic format and should move to config.yaml (see Step 4).
+
+### Step 4 — Tuner-specific config in config.yaml (not frontmatter)
+
+If the user wants to configure triggers, risk_tier, or auto_merge for this skill, add them to `~/.config/tuner/config.yaml` under `subjects.skills.overrides`:
+
+```yaml
+subjects:
+  skills:
+    overrides:
+      <skill-name>:
+        triggers:
+          - /my-trigger
+          - my keyword
+        risk_tier: medium        # low | medium | high | critical
+        auto_merge_default: false
+    scan_dirs:
+      - <ensure the new skill parent dir is listed>
+```
+
+Show the proposed config block and ask confirmation before writing.
+
+### Step 5 — Suggest triggers (for config, not frontmatter)
+
+If no triggers are configured yet:
+
+1. Sample 5-10 verbatims that would plausibly invoke this skill, based on its name and description.
+2. Show suggestions as a config.yaml `overrides` block (not frontmatter).
+3. Ask user to accept/edit/reject.
+4. Write to config.yaml under `subjects.skills.overrides.<name>.triggers`.
+
+### Step 6 — Suggest risk_tier (for config)
+
+Based on the skill domain:
+
+- Pure information lookup, summarization, formatting → `low`
+- Code editing, file modification → `medium` if scoped, `high` if broad
+- Network/API calls, sending messages, financial operations → `high`
+- Self-modification of the tuner itself → `critical`
+
+Show recommendation, ask confirmation. Write to `subjects.skills.overrides.<name>.risk_tier` in config.
+
+### Step 7 — Domain-specific pattern hints
+
+If the skill is in a specialized domain, suggest adding domain words to `_EMOTIONAL_PATTERNS`:
+
+- Finance skill → `["loss", "drawdown", "money at stake"]`
+- Voice skill → `["bad audio", "cant hear", "static"]`
+- Multilingual user (Quebec) → `["tabarnak", "calisse"]` if not already there
+
+User confirms before adding.
+
+End create.
+---
+
+## Mode: adjust
+
+Goal: tune an existing skill or subject without going through full setup.
+
+### Step 1 — Identify target
+
+If user wrote `/tuner adjust skill-name` or "tune-moi le skill X", target = that skill.
+Otherwise ask: "Which skill or subject? (skill name, or 'voice'/'retrieval-daemon'/'skills' for the whole subject)"
+
+### Step 2 — Show current state
+
+Display:
+- Current frontmatter (for individual skill)
+- Current config block (for whole subject)
+- Recent activity from `audit.jsonl` (proposals, approvals, refusals last 30d)
+- Any pending proposals for this target
+
+### Step 2.5 — Check format and offer migration (for individual skills)
+
+If the target is an individual skill (not a whole subject), check its format:
+
+```bash
+# If SKILL.md inside a directory → directory format ✅
+# If *.md at the top of scan_dir → flat format ⚠️
+```
+
+If flat format, show **before** the adjustment menu:
+
+```
+⚠️  legacy-skill-c is in legacy flat format.
+  Migrate to Anthropic directory format (legacy-skill-c/SKILL.md)? [yes/no]
+```
+
+If **yes**: run migration (same process as setup Step 2.5):
+- Strip tuner fields to config, create directory, backup original, git commit
+- Reload skill state, proceed to adjustment menu on the migrated skill
+
+If **no**: continue with adjustment menu as-is (flat format still supported).
+
+### Step 3 — Offer adjustment menu
+
+```
+What would you like to adjust?
+  1. Migrate to Anthropic directory format (recommended) [only shown for legacy flat skills]
+  2. Triggers
+  3. Risk tier
+  4. Auto-merge policy
+  5. Proposer model (Sonnet ↔ Opus ↔ Haiku ↔ ML backend)
+  6. Scan directories
+  7. Emotional/negative/positive patterns
+  8. Cool-down period for this skill
+  9. Disable / enable
+  10. Git repo (where this subject's proposals are committed)
+```
+
+For option 10 — Git repo:
+- Show current value: `subjects.<name>.git_repo` or "(using storage.git_repo default)".
+- Prompt: "New git repo path for <subject> (or blank to use storage default):"
+- Validate: `git -C <path> rev-parse --is-inside-work-tree` or offer `git init`.
+- Write `subjects.<name>.git_repo: <path>` to config.yaml (or remove key to revert to default).
+- Confirm change and run `tuner doctor`.
+
+For each other option, walk through the change, show the diff, ask confirmation, write to config.
+
+### Step 4 — Validate + commit config
+
+Run `tuner doctor` to validate.
+Commit the config change in the user skills git repo (versioned).
+
+End adjust.
+
+---
+
+## Mode: audit
+
+Goal: surface what is working, what is not, and what to investigate. Read-only — no changes.
+
+### Step 1 — Read tuner state
+
+Read:
+- `~/.config/tuner/audit.jsonl` (last 30 days)
+- `~/.config/tuner/proposals.jsonl`
+- `~/.config/tuner/refused.jsonl`
+- `~/.config/tuner/reflection-baseline.md` (the answers from setup step 6)
+
+### Step 2 — Compute metrics per subject
+
+For each enabled subject:
+- Total proposals last 30d
+- Approval rate
+- Top 3 refused pattern_signatures (recurring rejections)
+- Top 3 approved pattern_signatures (validated patterns)
+- Skills/entities in scan_dirs that **never matched** in 30 days (candidates for removal or trigger improvement)
+- Average time-to-decision per proposal
+- Survey response rate
+
+### Step 3 — Compute meta-tuner metrics
+
+- Total cost: count Sonnet calls × estimated price + Opus calls × estimated price
+- Hardest patterns: clusters that took 3+ proposals before approval
+- Self-modify events: any time the `tuner` skill itself was modified (count, last date)
+
+### Step 4 — Render report
+
+Markdown report sectioned per subject:
+
+```
+## skills (last 30d)
+- 12 proposals, 9 approved (75%), 3 refused
+- Top 3 refused: <list pattern_signatures + verbatim sample>
+- Skill `legacy-skill-b` never matched — candidate for trigger improvement or removal?
+
+## voice (last 30d)
+- 4 proposals, 4 approved (100%)
+- No refused, perfect approval rate → consider enabling auto_merge?
+
+## meta-tuner
+- Cost 30d: $2.34 Sonnet + $12.10 Opus = $14.44
+- Avg time-to-decision: 47s (target <60s OK)
+- Survey response rate: 84%
+- Self-modify events: 1 (2026-04-15: simplified setup mode)
+```
+
+### Step 4.5 — Format compliance
+
+Scan each `scan_dir` for flat `.md` files and directory-format `SKILL.md` files. Add a section to the report:
+
+```
+## Format compliance
+- 12 skills total
+- 9 directory format (Anthropic standard) ✅
+- 3 legacy flat format ⚠️
+  - legacy-skill-c.md
+  - legacy-skill-a.md
+  - legacy-skill-d.md
+
+Run /tuner adjust <name> to migrate individually, or /tuner setup to migrate all.
+```
+
+If all skills are in directory format: `✅ All 12 skills in Anthropic directory format.`
+
+### Step 4.6 — Subject git topology
+
+Read `~/.config/tuner/config.yaml`. For each enabled subject, show:
+
+```
+## Subject git topology
+
+| Subject       | Repo                              | Status |
+|---------------|-----------------------------------|--------|
+| skills        | ~/agent/skills                    | ok git |
+| voice         | ~/agent/voice-config              | ok git |
+| my-trading-bot  | ~/Projects/your-trading-bot     | ok git |
+| retrieval-daemon    | (uses storage.git_repo default)   | ok git |
+```
+
+For each subject:
+- Run `git -C <resolved_path> rev-parse --is-inside-work-tree` to verify.
+- If no `git_repo` in subject config: label as "(uses storage.git_repo default)".
+- If subject `scan_dirs` are outside the subject's `git_repo`: flag with warning (proposals would commit outside scan surface).
+
+If any subject uses `storage.git_repo` as default: suggest per-subject isolation via `/tuner adjust <subject>`.
+
+### Step 5 — Drift detection summary
+
+Read `~/.config/tuner/state-hashes.jsonl` and recent `audit.jsonl` entries (last 30 days).
+
+For each enabled subject, find the most recent `subject_state_drift_detected` event:
+
+```
+## Subject state drift
+
+| Subject       | Last drift detected     | Action             |
+|---------------|-------------------------|--------------------|
+| skills        | none in last 30d        | stable             |
+| voice         | 2026-05-09 03:00        | scan_dirs changed since last audit |
+| my-trading-bot  | 2026-05-08 03:00        | strategies/ updated since last audit |
+| retrieval-daemon    | none                    | stable             |
+```
+
+For each subject with recent drift, suggest:
+> State changed since last audit for `<subject>`. Run `/tuner adjust <subject>` to review and refresh.
+
+### Step 6 — Compare vs reflection baseline
+
+Read `reflection-baseline.md` — the user answers from setup. For each "what I wish improved" item:
+- Did the tuner detect related patterns? (search audit log for matching keywords)
+- Show: "Goal '<verbatim>' → 0 / 3 / 12 related proposals so far. Try `/tuner adjust` to refine triggers if 0."
+
+### Step 7 — Suggested next actions
+
+Based on metrics, output 1-3 concrete suggestions:
+- "Approval rate on `voice` is 100% — enable auto_merge?"
+- "3 refused patterns on `skills` recurring weekly — adjust the `_EMOTIONAL_PATTERNS` list?"
+- "Skill `X` never matches — `/tuner adjust X` to refine triggers"
+
+Do **not** make changes. User runs `/tuner adjust` for any change.
+
+End audit.
+
+---
+
+## Mode: optimize
+
+Goal: reduce cost and improve perf without sacrificing quality.
+
+### Step 1 — Cost analysis
+
+Compute per role per subject for last 30d:
+- Sonnet calls × tokens × $/Mtok
+- Opus calls × tokens × $/Mtok
+- Haiku calls × tokens × $/Mtok
+
+Identify the top 3 expensive surfaces.
+
+### Step 2 — Suggest model downgrades
+
+For each expensive surface:
+- If approval rate >85% **and** subject uses Opus proposer → suggest downgrade to Sonnet, watch for 2 weeks
+- If approval rate <50% **and** subject uses Sonnet → suggest upgrade to Opus (quality issue)
+- If proposer is `claude_cli` and high call volume → suggest moving to `anthropic_api` with caching
+
+### Step 3 — Latency analysis
+
+For each subject:
+- p50 / p90 / p99 time-to-decision
+- If p90 > 5 minutes → user might not be seeing notifications. Suggest checking adapter config.
+
+### Step 4 — Storage optimization
+
+- `audit.jsonl` size — if >50MB, suggest archiving old entries
+- `proposals.jsonl` size — same
+- Backup retention — if `backup_keep` >7 and storage tight, suggest reducing
+
+### Step 5 — Threshold tuning
+
+If a subject has many false positives:
+- Suggest raising `confidence_floor` from default 0.65 to 0.75
+- Suggest raising `orphan_min_observations` from 2 to 3
+
+### Step 6 — Render plan
+
+Show the user the proposed optimizations, sorted by est. monthly $$ saved + quality risk level. Each item = one-click apply (writes to config) or skip.
+
+End optimize.
+
+---
+
+## Mode: report
+
+Goal: when something is genuinely broken in the framework (not user skill content), help draft an upstream issue with sanitized context.
+
+### Step 1 — Detect or accept the trigger
+
+Trigger sources:
+- User invokes `/tuner report` directly
+- `/tuner audit` flagged a "framework anomaly" (signed proposal failed verification, schema migration crashed, observation collector hung repeatedly)
+
+If user-invoked, ask: "What seems wrong? Describe in 1-2 sentences."
+
+### Step 2 — Categorize
+
+Classify the issue:
+- **Critical bug** — security, data corruption, signature failures
+- **Perf/integration bug** — hangs, errors, adapter failures
+- **Detection gap** — framework should have caught a pattern but did not
+- **Doc bug** — DESIGN.md or README contradicts observed behavior
+
+### Step 3 — Gather environment
+
+```bash
+tuner --version
+python --version
+uname -srm
+grep "version" ~/Projects/ClaudeClaw-Plus/package.json 2>/dev/null
+```
+
+### Step 4 — Draft issue body
+
+Compose markdown with sections:
+- Severity (emoji + tier)
+- Category
+- Tuner version, Plus version, Python version, OS
+- Problem (user 1-2 sentence description)
+- Detection logic gap or repro steps
+- Suggested investigation
+- Logs (sanitized excerpts)
+- Footer with "Auto-drafted by /tuner report. User reviewed."
+
+### Step 5 — Sanitize before showing
+
+Apply sanitization to the entire draft:
+- Replace `/home/{user}/` → `~/`
+- Replace IPs `192.168.x.x` and `100.x.x.x` → `<redacted-ip>`
+- Replace emails → `<redacted-email>`
+- Replace API key patterns (`sk-ant-`, `ghp_`, `xoxb-`, etc.) → `<redacted-token>`
+- Replace absolute paths to `~/.config/`, `~/.ssh/`, `~/.env` → `<redacted-path>`
+- Replace any string >32 chars matching `[A-Za-z0-9+/=]+` → `<redacted-base64>`
+
+### Step 6 — Show + approve
+
+Display the full sanitized draft. Ask:
+
+```
+[Post Now] [Edit First] [Save Draft] [Cancel]
+```
+
+If `Edit First` → open in editor, accept the edited version, re-sanitize, re-show.
+
+### Step 7 — Submit
+
+If `Post Now`:
+- Check `~/.config/tuner/config.yaml` for `upstream.allowed_repos` (default: `["TerrysPOV/ClaudeClaw-Plus"]`)
+- Try `gh issue create --repo <repo> --label tuner-report --title <title> --body <body>`
+- If `gh` not authenticated → fallback: copy markdown to clipboard + open `https://github.com/<repo>/issues/new` in browser
+
+### Step 8 — Log
+
+Append to `audit.jsonl`:
+
+```json
+{"event": "upstream_issue_filed", "repo": "...", "issue_url": "...", "category": "...", "ts": "..."}
+```
+
+### Step 9 — Rate limit check
+
+Before posting, check audit.jsonl for `upstream_issue_filed` events:
+- Last 30 days same category → if ≥3, warn "you have filed 3 similar reports recently — sure?"
+- Last 30 days total → if ≥5, require explicit confirmation
+
+End report.
+
+---
+
+## Self-improvement notes (for the framework that watches this skill)
+
+This skill lives in the user tunable surface (e.g. `~/agent/skills/tuner.md`) and is itself a `TunableSubject`. The framework watches user reactions to `/tuner` invocations. If patterns emerge ("the setup questionnaire is too long", "audit output is too verbose", "create mode misses obvious triggers"), the tuner proposes alternatives to this very file.
+
+**Special safeguards** for self-modification:
+- This file has `risk_tier: critical` — never auto-merge regardless of global config
+- Dead-man switch: if a modification is not re-validated within 7 days post-apply, auto-revert
+- Cool-down: 30 days minimum between accepted self-modifications
+- Modifications must include a diff (not just A/B/C alternatives) for transparency
+- Audit log entries for self-modifications are tagged `event: meta_tuner_self_modify`
+
+If you (Claude Code, reading this skill at runtime) ever propose a modification to your own file, surface the safeguards explicitly to the user before applying.
+
+---
+
+## Closing note
+
+If you are unsure which mode applies, say so and ask the user. Do not guess. The user can combine modes (`/tuner audit` then `/tuner adjust`) — sequential, not nested.

--- a/src/skills-tuner/README.md
+++ b/src/skills-tuner/README.md
@@ -184,6 +184,38 @@ The script backs up the original file to `proposals.jsonl.python-backup-<timesta
 
 ---
 
+## Per-subject git repositories
+
+Each subject can declare its own git repository in `~/.config/tuner/config.yaml`:
+
+```yaml
+storage:
+  git_repo: ~/agent/skills        # default fallback
+
+subjects:
+  skills:
+    enabled: true
+    git_repo: ~/agent/skills      # explicit (matches default here)
+    auto_merge: [patch, frontmatter]
+    scan_dirs: [~/agent/skills]
+  voice:
+    enabled: true
+    git_repo: ~/agent/voice-config  # different repo for voice
+    auto_merge: false
+    scan_dirs: [~/agent/voice-config/lexicons]
+  trader-ml-hp:
+    enabled: true
+    git_repo: ~/Projects/momentum_trader_v7  # trader's own repo
+    auto_merge: false                         # critical: never auto
+    scan_dirs: [~/Projects/momentum_trader_v7/strategies]
+```
+
+> Each subject can have its own `git_repo`. If absent, falls back to `storage.git_repo`. This lets you tune skills, voice config, and trader strategies — each in its own git repo with independent rollback.
+
+**Migration from single `storage.git_repo`**: existing configs continue to work — subjects without `git_repo` use the storage default. To benefit from per-subject isolation, add `git_repo:` per subject in `~/.config/tuner/config.yaml`.
+
+---
+
 ## Development
 
 ```bash

--- a/src/skills-tuner/README.md
+++ b/src/skills-tuner/README.md
@@ -1,0 +1,210 @@
+# skills-tuner-ts
+
+**Continuous, human-in-the-loop improvement platform for Claude Code skills — TypeScript port.**
+
+---
+
+## Status
+
+![tests](https://img.shields.io/badge/tests-99%2B%20passing-brightgreen)
+![typescript](https://img.shields.io/badge/TypeScript-strict-blue)
+![license](https://img.shields.io/badge/license-MIT-lightgrey)
+
+Phase 1–8 complete. All 99+ unit and integration tests pass.
+
+---
+
+## What is this
+
+Skills Tuner watches your Claude Code session logs, detects patterns where your skills
+could be improved, and proposes targeted patches — one at a time, with your approval.
+It runs on a cron schedule, signs every proposal with HMAC-SHA256, and keeps a full
+JSONL audit trail. External ML optimizers (Optuna, custom Python) plug in via a
+stdio JSON-RPC adapter without touching the TypeScript core.
+
+---
+
+## Architecture
+
+```
+[ Cron 03:00 ]
+       │
+       ▼
+[ TS Engine ] ── HMAC sign ──> [ JSONL audit + proposals ]
+       │
+       ├── [ Native subjects: SkillsSubject, VoiceSubject, ... ] ── LLM
+       │
+       └── [ ExternalProcessSubject ] ──stdio JSON-RPC──> [ Python ML / Optuna / ... ]
+
+[ Adapters ]
+   ├── CLI (stdout)
+   ├── Telegram (inline keyboard, allowedUserIds gate)
+   └── PlusEventAdapter (stub for #31)
+```
+
+**Core modules**
+
+| Module | Purpose |
+|---|---|
+| `src/core/engine.ts` | Orchestration: collect → detect → propose → sign → apply |
+| `src/core/security.ts` | HMAC-SHA256 signing + audit log |
+| `src/storage/proposals.ts` | Append-only JSONL proposal ledger |
+| `src/storage/refused.ts` | TTL-gated refusal store |
+| `src/git_ops/branches.ts` | Per-proposal git branches + commits |
+| `src/subjects/` | SkillsSubject, ExternalProcessSubject |
+| `src/adapters/` | CLI, Telegram, Plus event stub |
+| `src/cli/index.ts` | Commander CLI (9 commands) |
+
+---
+
+## Install
+
+```bash
+# From npm (once published)
+npm install -g @skills-tuner/core
+
+# Or run locally with bun
+bun add https://github.com/Nibbler1250/skills-tuner-ts
+```
+
+---
+
+## Quick start
+
+```bash
+# 1. First-run setup — copies tuner skill + creates default config
+tuner setup
+
+# 2. Sanity check — verify config, secret, git repo, JSONL files
+tuner doctor
+
+# 3. Dry-run — see what would be proposed without writing anything
+tuner cron-run --dry --since 24h
+
+# 4. Real run
+tuner cron-run --since 7d
+
+# 5. Review pending proposals
+tuner pending
+
+# 6. Apply or skip
+tuner apply 1 A
+tuner skip 2
+```
+
+---
+
+## CLI commands
+
+| Command | Arguments | Description |
+|---|---|---|
+| `doctor` | — | Check config, secret, git repo, session files |
+| `cron-run` | `--since <duration>` `--dry` `--subject <name>` | Run full detect+propose cycle |
+| `pending` | — | List pending proposal signatures |
+| `apply` | `<id> <alt>` | Apply an alternative (creates git branch + commit) |
+| `skip` | `<id>` | Refuse a proposal (TTL-gated, won't re-appear for 30 days) |
+| `revert` | `<id>` | Revert an applied proposal via `git revert` |
+| `feedback` | `<id> <yes\|yes-but\|no>` | Record preference feedback |
+| `stats` | — | Show created / applied / refused counts |
+| `setup` | — | First-run wizard: copy skill template + generate config |
+
+Duration format: `30s`, `10m`, `24h`, `7d`.
+
+---
+
+## Subjects
+
+| Subject | Description |
+|---|---|
+| `skills` | Parses `.md` skill files, detects stale triggers, missing examples, weak descriptions |
+| `voice` | Detects repeated phrasing patterns in voice transcripts |
+| `external_process` | Spawns any Python/binary over stdio JSON-RPC — plug in Optuna, custom ML, etc. |
+
+---
+
+## Claude Code / Plus integration
+
+Skills Tuner ships a `/tuner` skill (copied by `tuner setup`) that hooks into Claude
+Code sessions. The `PlusEventAdapter` (see `src/adapters/plus_event.ts`) emits
+structured events to the Plus event bus — enabling real-time proposal notifications
+inside your Claude Code UI without polling.
+
+---
+
+## Companion skill
+
+The `/tuner` skill installed by `tuner setup` gives you inline commands inside
+Claude Code:
+
+```
+/tuner pending      — list proposals
+/tuner apply 3 B   — apply alternative B for proposal #3
+/tuner stats        — quick stats summary
+```
+
+---
+
+## Security model
+
+- Every proposal is signed with **HMAC-SHA256** before being persisted.
+  `applyProposal` re-verifies the signature — any tamper is detected and rejected.
+- The 32-byte secret lives at `~/.config/tuner/.secret` with `0600` permissions.
+  `tuner doctor` verifies this on every run.
+- The audit log at `~/.config/tuner/audit.jsonl` records every operation:
+  `proposal_created`, `apply_attempted`, `apply_success`, `signature_mismatch`,
+  `refused`, `reverted`.
+- Refused proposals are TTL-gated (default 30 days) and won't resurface unless
+  the underlying skill file is edited after the refusal.
+
+---
+
+## Compliance angle
+
+The JSONL audit trail + HMAC signatures provide a lightweight evidence chain
+suitable for regulated environments that require change management records for
+AI-generated modifications. Every applied change links back to a git commit SHA
+and a signed proposal record.
+
+---
+
+## Migrating from the Python implementation
+
+If you have an existing `~/.config/tuner/proposals.jsonl` from the Python `skills-tuner` package, run the one-shot migration script:
+
+1. Stop the Python cron job (`crontab -e`, remove tuner entry)
+2. Uninstall the Python package: `pip uninstall skills-tuner`
+3. Run the migration (dry-run first):
+   ```bash
+   bun run migrate -- --dry-run   # preview changes
+   bun run migrate                # apply migration
+   ```
+4. Verify: `tuner doctor` and `tuner stats`
+
+The script backs up the original file to `proposals.jsonl.python-backup-<timestamp>` before writing. All proposals are re-signed with the current HMAC secret.
+
+---
+
+## Development
+
+```bash
+# Install dependencies
+bun install
+
+# Run all tests (unit + integration)
+bun test
+
+# Type-check without emitting
+bun run typecheck
+
+# Build to dist/
+bun run build
+```
+
+The `src/` tree is pure TypeScript ESM. Tests live in `tests/unit/` and
+`tests/integration/`. No test requires a live LLM — all subjects are mocked.
+
+---
+
+## License
+
+MIT

--- a/src/skills-tuner/adapters/base.ts
+++ b/src/skills-tuner/adapters/base.ts
@@ -1,0 +1,17 @@
+import type { Proposal } from '../core/types.js';
+
+export interface CallbackPayload {
+  proposalId: number;
+  alternativeId?: string;
+  action: 'apply' | 'refuse' | 'edit';
+}
+
+export type CallbackHandler = (payload: CallbackPayload) => Promise<void>;
+
+export interface FeedbackResponse {
+  proposalId: number;
+  preferred: 'yes' | 'yes_but' | 'no';
+  comment?: string;
+}
+
+export type FeedbackHandler = (response: FeedbackResponse) => Promise<void>;

--- a/src/skills-tuner/adapters/cli.ts
+++ b/src/skills-tuner/adapters/cli.ts
@@ -1,0 +1,24 @@
+import { Adapter } from '../core/interfaces.js';
+import type { Proposal } from '../core/types.js';
+
+export class CliAdapter extends Adapter {
+  async renderProposal(proposal: Proposal): Promise<void> {
+    console.log('━'.repeat(60));
+    console.log('Proposal #' + proposal.id + ' (' + proposal.subject + '/' + proposal.kind + ')');
+    console.log('Target: ' + proposal.target_path);
+    console.log('Pattern: ' + proposal.pattern_signature);
+    console.log('');
+    for (const alt of proposal.alternatives) {
+      console.log('  ' + alt.id + '. ' + alt.label);
+      if (alt.tradeoff) console.log('     ' + alt.tradeoff);
+      console.log('');
+    }
+    console.log('Apply with: tuner apply ' + proposal.id + ' <A|B|C>');
+    console.log('Refuse with: tuner skip ' + proposal.id);
+    console.log('━'.repeat(60));
+  }
+
+  async renderApplyConfirmation(proposal: Proposal, alternativeId: string): Promise<void> {
+    console.log('Applied alternative ' + alternativeId + ' from proposal #' + proposal.id);
+  }
+}

--- a/src/skills-tuner/adapters/plus_event.ts
+++ b/src/skills-tuner/adapters/plus_event.ts
@@ -1,114 +1,32 @@
-import { z } from 'zod';
 import { Adapter } from '../core/interfaces.js';
 import type { Proposal } from '../core/types.js';
-import { getMcpBridge, type PluginTool } from '../../plugins/mcp-bridge.js';
 
 /**
- * Plus event bus adapter — registers skills-tuner tools via the Plugin MCP Bridge (#31).
+ * Stub adapter for ClaudeClaw-Plus event bus.
  *
- * Once the bridge is in place (closes #31), this adapter:
- *   1. registers tuner tools (proposal_render, apply_confirmation, etc.) at construction
- *   2. surfaces proposals through the registered tools (callable as MCP tools by any client)
- *   3. inherits HMAC signing, audit log, and per-plugin secret from the bridge
- *
- * The TelegramAdapter remains the user-facing surface for #14 inline buttons.
- * This adapter complements it by exposing the same operations to MCP clients
- * (Claude Code, scripts, other plugins).
+ * NOTE: With Plus issue #31 (plugin to MCP bridge), Plus would expose
+ * tuner tools as MCP automatically and this adapter would collapse to
+ * thin wrapper calls to native Plus endpoints. Without #31, we duplicate
+ * notification + callback routing in TelegramAdapter.
  */
 export class PlusEventAdapter extends Adapter {
-  private static readonly PLUGIN_ID = 'skills-tuner';
-  private registered = false;
-
-  constructor(
-    private onApply?: (proposalId: number, alternativeId: string) => Promise<void>,
-    private onRefuse?: (proposalId: number) => Promise<void>,
-  ) {
+  constructor(private plusBaseUrl: string = 'http://localhost:3000') {
     super();
-    this.registerTools();
-  }
-
-  private registerTools(): void {
-    if (this.registered) return;
-    const bridge = getMcpBridge();
-
-    const proposalRenderSchema = z.object({
-      id: z.number().int(),
-      subject: z.string(),
-      kind: z.string(),
-      target_path: z.string(),
-      pattern_signature: z.string(),
-    });
-
-    const applySchema = z.object({
-      proposal_id: z.number().int(),
-      alternative_id: z.string(),
-    });
-
-    const refuseSchema = z.object({
-      proposal_id: z.number().int(),
-    });
-
-    const tools: PluginTool[] = [
-      {
-        name: 'tuner_proposal_render',
-        description: 'Render a tuner proposal — emit notify event for downstream UIs',
-        schema: proposalRenderSchema,
-        handler: async (args) => {
-          // emit-only: the actual UI rendering happens in TelegramAdapter
-          // this tool is used by MCP clients to inspect or relay proposals
-          return { acknowledged: true, proposal_id: (args as any).id };
-        },
-      },
-      {
-        name: 'tuner_apply',
-        description: 'Apply an approved alternative for a tuner proposal',
-        schema: applySchema,
-        handler: async (args) => {
-          const a = args as z.infer<typeof applySchema>;
-          if (this.onApply) await this.onApply(a.proposal_id, a.alternative_id);
-          return { applied: true, proposal_id: a.proposal_id, alternative_id: a.alternative_id };
-        },
-      },
-      {
-        name: 'tuner_refuse',
-        description: 'Refuse a tuner proposal (records pattern_signature in refused.jsonl with TTL 30d)',
-        schema: refuseSchema,
-        handler: async (args) => {
-          const a = args as z.infer<typeof refuseSchema>;
-          if (this.onRefuse) await this.onRefuse(a.proposal_id);
-          return { refused: true, proposal_id: a.proposal_id };
-        },
-      },
-    ];
-
-    for (const tool of tools) {
-      try {
-        bridge.registerPluginTool(PlusEventAdapter.PLUGIN_ID, tool);
-      } catch (e) {
-        // Already registered (idempotent for repeat instantiation in tests)
-        if (!String(e).includes('already registered')) throw e;
-      }
-    }
-    this.registered = true;
   }
 
   async renderProposal(proposal: Proposal): Promise<void> {
-    const bridge = getMcpBridge();
-    await bridge.invokeTool('skills-tuner__tuner_proposal_render', {
-      id: proposal.id,
-      subject: proposal.subject,
-      kind: proposal.kind,
-      target_path: proposal.target_path,
-      pattern_signature: proposal.pattern_signature,
-    });
+    console.log(
+      '[PlusEventAdapter STUB] Would POST proposal #' + proposal.id +
+      ' (subject=' + proposal.subject + ', kind=' + proposal.kind + ')' +
+      ' to ' + this.plusBaseUrl + '/api/tuner/proposal'
+    );
   }
 
   async renderApplyConfirmation(proposal: Proposal, alternativeId: string): Promise<void> {
-    // Record applied event through the bridge's audit log
-    const bridge = getMcpBridge();
-    await bridge.invokeTool('skills-tuner__tuner_apply', {
-      proposal_id: proposal.id,
-      alternative_id: alternativeId,
-    });
+    console.log(
+      '[PlusEventAdapter STUB] Would POST apply confirmation' +
+      ' (proposalId=' + proposal.id + ', alt=' + alternativeId + ')' +
+      ' to ' + this.plusBaseUrl + '/api/tuner/applied'
+    );
   }
 }

--- a/src/skills-tuner/adapters/plus_event.ts
+++ b/src/skills-tuner/adapters/plus_event.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+import { Adapter } from '../core/interfaces.js';
+import type { Proposal } from '../core/types.js';
+import { getMcpBridge, type PluginTool } from '../../plugins/mcp-bridge.js';
+
+/**
+ * Plus event bus adapter — registers skills-tuner tools via the Plugin MCP Bridge (#31).
+ *
+ * Once the bridge is in place (closes #31), this adapter:
+ *   1. registers tuner tools (proposal_render, apply_confirmation, etc.) at construction
+ *   2. surfaces proposals through the registered tools (callable as MCP tools by any client)
+ *   3. inherits HMAC signing, audit log, and per-plugin secret from the bridge
+ *
+ * The TelegramAdapter remains the user-facing surface for #14 inline buttons.
+ * This adapter complements it by exposing the same operations to MCP clients
+ * (Claude Code, scripts, other plugins).
+ */
+export class PlusEventAdapter extends Adapter {
+  private static readonly PLUGIN_ID = 'skills-tuner';
+  private registered = false;
+
+  constructor(
+    private onApply?: (proposalId: number, alternativeId: string) => Promise<void>,
+    private onRefuse?: (proposalId: number) => Promise<void>,
+  ) {
+    super();
+    this.registerTools();
+  }
+
+  private registerTools(): void {
+    if (this.registered) return;
+    const bridge = getMcpBridge();
+
+    const proposalRenderSchema = z.object({
+      id: z.number().int(),
+      subject: z.string(),
+      kind: z.string(),
+      target_path: z.string(),
+      pattern_signature: z.string(),
+    });
+
+    const applySchema = z.object({
+      proposal_id: z.number().int(),
+      alternative_id: z.string(),
+    });
+
+    const refuseSchema = z.object({
+      proposal_id: z.number().int(),
+    });
+
+    const tools: PluginTool[] = [
+      {
+        name: 'tuner_proposal_render',
+        description: 'Render a tuner proposal — emit notify event for downstream UIs',
+        schema: proposalRenderSchema,
+        handler: async (args) => {
+          // emit-only: the actual UI rendering happens in TelegramAdapter
+          // this tool is used by MCP clients to inspect or relay proposals
+          return { acknowledged: true, proposal_id: (args as any).id };
+        },
+      },
+      {
+        name: 'tuner_apply',
+        description: 'Apply an approved alternative for a tuner proposal',
+        schema: applySchema,
+        handler: async (args) => {
+          const a = args as z.infer<typeof applySchema>;
+          if (this.onApply) await this.onApply(a.proposal_id, a.alternative_id);
+          return { applied: true, proposal_id: a.proposal_id, alternative_id: a.alternative_id };
+        },
+      },
+      {
+        name: 'tuner_refuse',
+        description: 'Refuse a tuner proposal (records pattern_signature in refused.jsonl with TTL 30d)',
+        schema: refuseSchema,
+        handler: async (args) => {
+          const a = args as z.infer<typeof refuseSchema>;
+          if (this.onRefuse) await this.onRefuse(a.proposal_id);
+          return { refused: true, proposal_id: a.proposal_id };
+        },
+      },
+    ];
+
+    for (const tool of tools) {
+      try {
+        bridge.registerPluginTool(PlusEventAdapter.PLUGIN_ID, tool);
+      } catch (e) {
+        // Already registered (idempotent for repeat instantiation in tests)
+        if (!String(e).includes('already registered')) throw e;
+      }
+    }
+    this.registered = true;
+  }
+
+  async renderProposal(proposal: Proposal): Promise<void> {
+    const bridge = getMcpBridge();
+    await bridge.invokeTool('skills-tuner__tuner_proposal_render', {
+      id: proposal.id,
+      subject: proposal.subject,
+      kind: proposal.kind,
+      target_path: proposal.target_path,
+      pattern_signature: proposal.pattern_signature,
+    });
+  }
+
+  async renderApplyConfirmation(proposal: Proposal, alternativeId: string): Promise<void> {
+    // Record applied event through the bridge's audit log
+    const bridge = getMcpBridge();
+    await bridge.invokeTool('skills-tuner__tuner_apply', {
+      proposal_id: proposal.id,
+      alternative_id: alternativeId,
+    });
+  }
+}

--- a/src/skills-tuner/adapters/telegram.ts
+++ b/src/skills-tuner/adapters/telegram.ts
@@ -1,0 +1,101 @@
+import { Adapter } from '../core/interfaces.js';
+import type { Proposal } from '../core/types.js';
+import type { CallbackHandler } from './base.js';
+
+export interface TelegramAdapterConfig {
+  botToken: string;
+  chatId: string;
+  baseUrl?: string;
+  callbackHandler?: CallbackHandler;
+  allowedUserIds: number[];
+  verifyProposalFn?: (proposalId: number) => Promise<boolean>;
+}
+
+export class TelegramAdapter extends Adapter {
+  constructor(private cfg: TelegramAdapterConfig) {
+    super();
+    if (!cfg.allowedUserIds || cfg.allowedUserIds.length === 0) {
+      throw new Error('TelegramAdapter requires at least one allowedUserId');
+    }
+  }
+
+  async renderProposal(proposal: Proposal): Promise<void> {
+    const baseUrl = this.cfg.baseUrl ?? 'https://api.telegram.org';
+    const text = this.formatProposalText(proposal);
+    const reply_markup = {
+      inline_keyboard: [
+        proposal.alternatives.map(alt => ({
+          text: 'Apply ' + alt.id + ': ' + alt.label.slice(0, 30),
+          callback_data: 'apply:' + proposal.id + ':' + alt.id,
+        })),
+        [
+          { text: 'Refuse', callback_data: 'refuse:' + proposal.id },
+          { text: 'Edit', callback_data: 'edit:' + proposal.id },
+        ],
+      ],
+    };
+
+    const res = await fetch(baseUrl + '/bot' + this.cfg.botToken + '/sendMessage', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: this.cfg.chatId,
+        text,
+        parse_mode: 'Markdown',
+        reply_markup,
+      }),
+    });
+    if (!res.ok) {
+      throw new Error('Telegram sendMessage failed: ' + res.status + ' ' + await res.text());
+    }
+  }
+
+  async renderApplyConfirmation(proposal: Proposal, alternativeId: string): Promise<void> {
+    const baseUrl = this.cfg.baseUrl ?? 'https://api.telegram.org';
+    await fetch(baseUrl + '/bot' + this.cfg.botToken + '/sendMessage', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: this.cfg.chatId,
+        text: 'Applied alt ' + alternativeId + ' on proposal #' + proposal.id + ' (' + proposal.subject + ')',
+        parse_mode: 'Markdown',
+      }),
+    });
+  }
+
+  async handleCallback(callbackData: string, fromUserId: number): Promise<void> {
+    if (!this.cfg.allowedUserIds.includes(fromUserId)) {
+      throw new Error('User ' + fromUserId + ' not in allowedUserIds');
+    }
+    const parts = callbackData.split(':');
+    if (parts.length < 2) {
+      throw new Error(`Telegram callback malformed: '${callbackData}' (expected action:id[:alt])`);
+    }
+    const action = parts[0] as 'apply' | 'refuse' | 'edit';
+    if (!['apply', 'refuse', 'edit'].includes(action)) {
+      throw new Error(`Telegram callback unknown action: '${action}'`);
+    }
+    const proposalId = Number.parseInt(parts[1]!, 10);
+    if (!Number.isFinite(proposalId) || proposalId < 1) {
+      throw new Error(`Telegram callback invalid proposalId: '${parts[1]}' in '${callbackData}'`);
+    }
+    const alternativeId = parts[2];
+    if (this.cfg.verifyProposalFn) {
+      const valid = await this.cfg.verifyProposalFn(proposalId);
+      if (!valid) {
+        throw new Error('verifyProposalFn rejected proposal ' + proposalId + ' for user ' + fromUserId);
+      }
+    }
+    if (this.cfg.callbackHandler) {
+      await this.cfg.callbackHandler({ proposalId, alternativeId, action });
+    }
+  }
+
+  formatProposalText(proposal: Proposal): string {
+    const altLines = proposal.alternatives
+      .map(a => '*' + a.id + '.* ' + a.label + '\n   _' + (a.tradeoff || 'no tradeoff') + '_')
+      .join('\n\n');
+    return 'Proposal #' + proposal.id + ' - ' + proposal.subject + '/' + proposal.kind + '\n\n' +
+           'Target: `' + proposal.target_path + '`\n\n' + altLines;
+  }
+}

--- a/src/skills-tuner/cli/index.ts
+++ b/src/skills-tuner/cli/index.ts
@@ -1,0 +1,340 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { existsSync, statSync, readdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+const program = new Command();
+program
+  .name('tuner')
+  .description('Skills Tuner — continuous improvement platform')
+  .version('0.1.0');
+
+// ── doctor ─────────────────────────────────────────────────────────────────────────────
+program
+  .command('doctor')
+  .description('Detect environment and check dependencies')
+  .action(async () => {
+    const home = homedir();
+    const configPath = join(home, '.config', 'tuner', 'config.yaml');
+    const secretPath = join(home, '.config', 'tuner', '.secret');
+    let allOk = true;
+
+    function check(label: string, ok: boolean, detail?: string) {
+      const icon = ok ? '✅' : '❌';
+      console.log(`${icon} ${label}${detail ? ': ' + detail : ''}`);
+      if (!ok) allOk = false;
+    }
+
+    // 1. Config file exists + parses
+    const cfgExists = existsSync(configPath);
+    check('Config file exists', cfgExists, configPath);
+
+    let config: any = null;
+    if (cfgExists) {
+      try {
+        const { loadConfig } = await import('../core/config.js');
+        config = loadConfig(configPath);
+        check('Config parses', true);
+      } catch (e: unknown) {
+        check('Config parses', false, e instanceof Error ? e.message : String(e));
+      }
+    }
+
+    // 2. storage.git_repo exists + is a git repo
+    const gitRepo = config?.storage?.git_repo;
+    if (gitRepo) {
+      const repoExists = existsSync(gitRepo);
+      check('storage.git_repo exists', repoExists, gitRepo);
+      if (repoExists) {
+        const isGit = existsSync(join(gitRepo, '.git'));
+        check('storage.git_repo is a git repo', isGit);
+      }
+    } else {
+      check('storage.git_repo configured', false, 'not set in config');
+    }
+
+    // 3. .secret exists + 32 bytes + 0600 perms
+    const secretExists = existsSync(secretPath);
+    check('Secret file exists', secretExists, secretPath);
+    if (secretExists) {
+      const st = statSync(secretPath);
+      check('Secret is 32 bytes', st.size === 32, `${st.size} bytes`);
+      const mode = st.mode & 0o777;
+      check('Secret perms are 0600', mode === 0o600, `0${mode.toString(8)}`);
+    }
+
+    // 4. Session JSONL files found
+    const projectsDir = join(home, '.claude', 'projects');
+    if (existsSync(projectsDir)) {
+      const jsonlFiles = readdirSync(projectsDir, { recursive: true })
+        .filter((f: unknown): f is string => typeof f === 'string' && f.endsWith('.jsonl'));
+      check('Session JSONL files found', jsonlFiles.length > 0, `${jsonlFiles.length} files`);
+    } else {
+      check('~/.claude/projects exists', false);
+    }
+
+    // 5. Each enabled subject scan_dirs exist
+    if (config?.subjects) {
+      for (const [name, subj] of Object.entries(config.subjects as Record<string, any>)) {
+        if (!subj?.enabled) continue;
+        const dirs: string[] = subj.scan_dirs || [];
+        for (const d of dirs) {
+          const expanded = d.replace('~', home);
+          check(`Subject ${name} scan_dir exists`, existsSync(expanded), expanded);
+        }
+      }
+    }
+
+    console.log(allOk ? '\n✅ All checks passed' : '\n⚠️  Some checks failed');
+  });
+
+// ── cron-run ──────────────────────────────────────────────────────────────────────────
+program
+  .command('cron-run')
+  .description('Run detection + proposal cycle')
+  .option('--since <duration>', 'time window (e.g. 24h, 7d)', '24h')
+  .option('--dry', 'no apply, just show what would be proposed')
+  .option('--subject <name>', 'run only this subject')
+  .action(async (opts) => {
+    const { loadConfig } = await import('../core/config.js');
+    const { Engine } = await import('../core/engine.js');
+    const { Registry } = await import('../core/registry.js');
+    const { ProposalsStore, DEFAULT_PROPOSALS_PATH } = await import('../storage/proposals.js');
+    const { RefusedStore, DEFAULT_REFUSED_PATH } = await import('../storage/refused.js');
+    const { BranchManager } = await import('../git_ops/branches.js');
+
+    const config = loadConfig();
+    const registry = new Registry();
+    const proposals = new ProposalsStore(config.storage.proposals_jsonl ?? DEFAULT_PROPOSALS_PATH);
+    const refused = new RefusedStore(config.storage.refused_jsonl ?? DEFAULT_REFUSED_PATH);
+    const gitRepo = config.storage.git_repo;
+    if (!gitRepo) throw new Error('storage.git_repo must be set in config');
+    const branches = new BranchManager(gitRepo);
+    const engine = new Engine(config, registry, proposals, refused, branches);
+
+    const sinceMs = parseDuration(opts.since);
+    const since = new Date(Date.now() - sinceMs);
+
+    console.log(`Running cycle since=${opts.since} dry=${!!opts.dry}`);
+    const result = await engine.runCycle({ since, subjectName: opts.subject, dryRun: opts.dry });
+    console.log(`Proposed: ${result.proposed}  Auto-applied: ${result.autoApplied}`);
+  });
+
+// ── pending ───────────────────────────────────────────────────────────────────────────
+program
+  .command('pending')
+  .description('List pending proposals')
+  .action(async () => {
+    const { loadConfig } = await import('../core/config.js');
+    const { ProposalsStore, DEFAULT_PROPOSALS_PATH } = await import('../storage/proposals.js');
+
+    const config = loadConfig();
+    const proposals = new ProposalsStore(config.storage.proposals_jsonl ?? DEFAULT_PROPOSALS_PATH);
+    const sigs = proposals.pendingSignatures({});
+    if (sigs.size === 0) {
+      console.log('No pending proposals.');
+      return;
+    }
+    console.log(`${sigs.size} pending proposal(s):`);
+    for (const sig of sigs) {
+      console.log(`  ${sig}`);
+    }
+  });
+
+// ── apply ─────────────────────────────────────────────────────────────────────────────
+program
+  .command('apply <id> <alt>')
+  .description('Apply alternative (alt = alternative ID)')
+  .action(async (id: string, alt: string) => {
+    const { loadConfig } = await import('../core/config.js');
+    const { Engine } = await import('../core/engine.js');
+    const { Registry } = await import('../core/registry.js');
+    const { ProposalsStore, DEFAULT_PROPOSALS_PATH } = await import('../storage/proposals.js');
+    const { RefusedStore, DEFAULT_REFUSED_PATH } = await import('../storage/refused.js');
+    const { BranchManager } = await import('../git_ops/branches.js');
+
+    const config = loadConfig();
+    const registry = new Registry();
+    const proposals = new ProposalsStore(config.storage.proposals_jsonl ?? DEFAULT_PROPOSALS_PATH);
+    const refused = new RefusedStore(config.storage.refused_jsonl ?? DEFAULT_REFUSED_PATH);
+    const gitRepo = config.storage.git_repo;
+    if (!gitRepo) throw new Error('storage.git_repo must be set in config');
+    const branches = new BranchManager(gitRepo);
+    const engine = new Engine(config, registry, proposals, refused, branches);
+
+    const proposalId = parseInt(id, 10);
+    if (isNaN(proposalId)) { console.error('id must be a number'); process.exit(1); }
+    await engine.applyProposal(proposalId, alt);
+    console.log(`✅ Applied proposal ${id} alternative ${alt}`);
+  });
+
+// ── skip ──────────────────────────────────────────────────────────────────────────────
+program
+  .command('skip <id>')
+  .description('Skip (refuse) a proposal')
+  .action(async (id: string) => {
+    const { loadConfig } = await import('../core/config.js');
+    const { Engine } = await import('../core/engine.js');
+    const { Registry } = await import('../core/registry.js');
+    const { ProposalsStore, DEFAULT_PROPOSALS_PATH } = await import('../storage/proposals.js');
+    const { RefusedStore, DEFAULT_REFUSED_PATH } = await import('../storage/refused.js');
+    const { BranchManager } = await import('../git_ops/branches.js');
+
+    const config = loadConfig();
+    const registry = new Registry();
+    const proposals = new ProposalsStore(config.storage.proposals_jsonl ?? DEFAULT_PROPOSALS_PATH);
+    const refused = new RefusedStore(config.storage.refused_jsonl ?? DEFAULT_REFUSED_PATH);
+    const gitRepo = config.storage.git_repo;
+    if (!gitRepo) throw new Error('storage.git_repo must be set in config');
+    const branches = new BranchManager(gitRepo);
+    const engine = new Engine(config, registry, proposals, refused, branches);
+
+    const proposalId = parseInt(id, 10);
+    if (isNaN(proposalId)) { console.error('id must be a number'); process.exit(1); }
+    await engine.refuseProposal(proposalId);
+    console.log(`⏭️  Skipped proposal ${id}`);
+  });
+
+// ── revert ────────────────────────────────────────────────────────────────────────────
+program
+  .command('revert <id>')
+  .description('Revert an applied proposal')
+  .action(async (id: string) => {
+    const { loadConfig } = await import('../core/config.js');
+    const { Engine } = await import('../core/engine.js');
+    const { Registry } = await import('../core/registry.js');
+    const { ProposalsStore, DEFAULT_PROPOSALS_PATH } = await import('../storage/proposals.js');
+    const { RefusedStore, DEFAULT_REFUSED_PATH } = await import('../storage/refused.js');
+    const { BranchManager } = await import('../git_ops/branches.js');
+
+    const config = loadConfig();
+    const registry = new Registry();
+    const proposals = new ProposalsStore(config.storage.proposals_jsonl ?? DEFAULT_PROPOSALS_PATH);
+    const refused = new RefusedStore(config.storage.refused_jsonl ?? DEFAULT_REFUSED_PATH);
+    const gitRepo = config.storage.git_repo;
+    if (!gitRepo) throw new Error('storage.git_repo must be set in config');
+    const branches = new BranchManager(gitRepo);
+    const engine = new Engine(config, registry, proposals, refused, branches);
+
+    const proposalId = parseInt(id, 10);
+    if (isNaN(proposalId)) { console.error('id must be a number'); process.exit(1); }
+    await engine.revertProposal(proposalId);
+    console.log(`↩️  Reverted proposal ${id}`);
+  });
+
+// ── feedback ──────────────────────────────────────────────────────────────────────────
+program
+  .command('feedback <id> <preferred>')
+  .description('Record feedback (yes|yes-but|no)')
+  .action(async (id: string, preferred: string) => {
+    if (!['yes', 'yes-but', 'no'].includes(preferred)) {
+      console.error('preferred must be one of: yes, yes-but, no');
+      process.exit(1);
+    }
+    const { loadConfig } = await import('../core/config.js');
+    const { ProposalsStore, DEFAULT_PROPOSALS_PATH } = await import('../storage/proposals.js');
+    const { RefusedStore, DEFAULT_REFUSED_PATH } = await import('../storage/refused.js');
+
+    const config = loadConfig();
+    const store = new ProposalsStore(config.storage.proposals_jsonl ?? DEFAULT_PROPOSALS_PATH);
+    const all = store.readAll();
+    const proposalId = parseInt(id, 10);
+    if (isNaN(proposalId)) { console.error('id must be a number'); process.exit(1); }
+    const record = all.find(r => r?.proposal?.id === proposalId);
+    if (!record) { console.error(`Proposal #${id} not found`); process.exit(1); }
+    const { auditLog } = await import('../core/security.js');
+    if (preferred === 'no') {
+      const refused = new RefusedStore(config.storage.refused_jsonl ?? DEFAULT_REFUSED_PATH);
+      refused.add(record.proposal.pattern_signature, record.proposal.subject, `feedback:${preferred}`);
+      store.append({ proposal: record.proposal, event: 'refused', ts: new Date().toISOString() });
+    }
+    auditLog('feedback_recorded', { proposal_id: proposalId, preferred });
+    console.log(`📝 Feedback recorded: proposal ${id} → ${preferred}`);
+  });
+
+// ── stats ─────────────────────────────────────────────────────────────────────────────
+program
+  .command('stats')
+  .description('Show proposal statistics')
+  .action(async () => {
+    const { loadConfig } = await import('../core/config.js');
+    const { ProposalsStore, DEFAULT_PROPOSALS_PATH } = await import('../storage/proposals.js');
+
+    const config = loadConfig();
+    const store = new ProposalsStore(config.storage.proposals_jsonl ?? DEFAULT_PROPOSALS_PATH);
+    const all = store.readAll();
+
+    const counts = { created: 0, applied: 0, refused: 0 };
+    for (const r of all) {
+      if (r.event in counts) counts[r.event as keyof typeof counts]++;
+    }
+
+    console.log('Proposal statistics:');
+    console.log(`  Total records : ${all.length}`);
+    console.log(`  Created       : ${counts.created}`);
+    console.log(`  Applied       : ${counts.applied}`);
+    console.log(`  Refused       : ${counts.refused}`);
+  });
+
+// ── setup ─────────────────────────────────────────────────────────────────────────────
+program
+  .command('setup')
+  .description('First-run wizard — copies /tuner skill, generates config')
+  .action(async () => {
+    const home = homedir();
+    const skillsDir = join(home, '.claude', 'skills');
+    const targetSkill = join(skillsDir, 'tuner.md');
+
+    if (!existsSync(targetSkill)) {
+      const { fileURLToPath } = await import('node:url');
+      const __dirname = resolve(fileURLToPath(import.meta.url), '..');
+      // Resolve template across contexts: skills-tuner-ts standalone (templates/skills/) OR
+      // Plus integration context (src/skills-tuner-templates/)
+      const candidates = [
+        join(__dirname, '..', '..', 'templates', 'skills', 'tuner.md'),
+        join(__dirname, '..', '..', '..', 'templates', 'skills', 'tuner.md'),
+        join(__dirname, '..', '..', '..', 'skills-tuner-templates', 'tuner.md'),
+        join(__dirname, '..', '..', 'skills-tuner-templates', 'tuner.md'),
+      ];
+      const templateSrc = candidates.find(p => existsSync(p)) ?? candidates[0]!;
+      if (existsSync(templateSrc)) {
+        const { mkdirSync, copyFileSync } = await import('node:fs');
+        mkdirSync(skillsDir, { recursive: true });
+        copyFileSync(templateSrc, targetSkill);
+        console.log(`✅ Copied tuner skill to ${targetSkill}`);
+      } else {
+        console.warn(`⚠️  Template not found at ${templateSrc} — skipping skill copy`);
+      }
+    } else {
+      console.log(`ℹ️  Skill already exists: ${targetSkill}`);
+    }
+
+    const configDir = join(home, '.config', 'tuner');
+    const configPath = join(configDir, 'config.yaml');
+    if (!existsSync(configPath)) {
+      const { writeDefaultConfig } = await import('../core/config.js');
+      writeDefaultConfig(configPath);
+      console.log(`✅ Created default config at ${configPath}`);
+    } else {
+      console.log(`ℹ️  Config already exists: ${configPath}`);
+    }
+
+    console.log('\nRun /tuner inside Claude Code to start the wizard');
+  });
+
+// ── helpers ───────────────────────────────────────────────────────────────────────────
+function parseDuration(s: string): number {
+  const m = /^(\d+)([smhd])$/.exec(s);
+  if (!m) return 24 * 60 * 60 * 1000;
+  const n = parseInt(m[1] as string, 10);
+  switch (m[2]) {
+    case 's': return n * 1000;
+    case 'm': return n * 60 * 1000;
+    case 'h': return n * 60 * 60 * 1000;
+    case 'd': return n * 24 * 60 * 60 * 1000;
+    default: return 24 * 60 * 60 * 1000;
+  }
+}
+
+program.parseAsync(process.argv).catch((e: unknown) => { console.error(e instanceof Error ? e.message : String(e)); process.exit(1); });

--- a/src/skills-tuner/core/config.ts
+++ b/src/skills-tuner/core/config.ts
@@ -1,0 +1,129 @@
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import yaml from 'js-yaml';
+import { z } from 'zod';
+
+export const DEFAULT_CONFIG_PATH = join(homedir(), '.config', 'tuner', 'config.yaml');
+
+const ModelConfigSchema = z.object({
+  intent_classifier: z.string().default('claude-haiku-4-5-20251001'),
+  detector: z.string().default('claude-opus-4-7'),
+  proposer_default: z.string().default('claude-sonnet-4-6'),
+  proposer_high_stakes: z.string().default('claude-opus-4-7'),
+  judge: z.string().default('claude-opus-4-7'),
+});
+
+const SubjectConfigSchema = z.object({
+  enabled: z.boolean().default(true),
+  auto_merge: z.union([z.boolean(), z.array(z.string())]).default(false),
+  proposer: z.string().optional(),
+  proposer_for_create: z.string().optional(),
+  scan_dirs: z.array(z.string()).default([]),
+});
+export type SubjectConfig = z.infer<typeof SubjectConfigSchema>;
+
+const DetectionConfigSchema = z.object({
+  improvement_keywords_extra: z.array(z.string()).default([]),
+  confidence_floor: z.number().min(0).max(1).default(0.65),
+  max_proposals_per_run: z.number().int().positive().default(5),
+});
+
+const ProposerConfigSchema = z.object({
+  alternatives_count: z.number().int().positive().default(3),
+  language_preference: z.string().default('en'),
+});
+
+const UiConfigSchema = z.object({
+  primary_adapter: z.string().default('cli'),
+  follow_up_survey: z.boolean().default(true),
+  follow_up_after_seconds: z.number().int().positive().default(30),
+});
+
+const StorageConfigSchema = z.object({
+  proposals_jsonl: z.string().default(join(homedir(), '.config', 'tuner', 'proposals.jsonl')),
+  refused_jsonl: z.string().default(join(homedir(), '.config', 'tuner', 'refused.jsonl')),
+  schema_version: z.number().int().default(1),
+  backup_keep: z.number().int().default(7),
+  git_repo: z.string().optional(),
+});
+
+const LLMConfigSchema = z.object({
+  backend: z.enum(['anthropic_api', 'claude_cli']).default('anthropic_api'),
+  api_key: z.string().optional(),
+});
+
+const TunerConfigSchema = z.object({
+  models: ModelConfigSchema.default({}),
+  llm: LLMConfigSchema.default({}),
+  detection: DetectionConfigSchema.default({}),
+  proposer: ProposerConfigSchema.default({}),
+  subjects: z.record(SubjectConfigSchema).default({}),
+  ui: UiConfigSchema.default({}),
+  storage: StorageConfigSchema.default({}),
+});
+export type TunerConfig = z.infer<typeof TunerConfigSchema>;
+
+export function subjectConfig(config: TunerConfig, name: string): SubjectConfig {
+  return config.subjects[name] ?? SubjectConfigSchema.parse({});
+}
+
+export function loadConfig(path = DEFAULT_CONFIG_PATH): TunerConfig {
+  if (!existsSync(path)) {
+    return TunerConfigSchema.parse({});
+  }
+  const raw = yaml.load(readFileSync(path, 'utf8')) as Record<string, unknown> ?? {};
+  // Expand ~ in storage paths
+  if (raw['storage'] && typeof raw['storage'] === 'object') {
+    const storage = raw['storage'] as Record<string, unknown>;
+    for (const key of ['proposals_jsonl', 'refused_jsonl', 'git_repo']) {
+      if (typeof storage[key] === 'string') {
+        storage[key] = (storage[key] as string).replace(/^~/, homedir());
+      }
+    }
+  }
+  return TunerConfigSchema.parse(raw);
+}
+
+const DEFAULT_YAML = `# Skills Tuner TS configuration
+
+llm:
+  backend: anthropic_api
+  # api_key: sk-ant-...   # or set ANTHROPIC_API_KEY env var
+
+detection:
+  confidence_floor: 0.65
+  max_proposals_per_run: 5
+
+models:
+  intent_classifier: claude-haiku-4-5-20251001
+  detector: claude-opus-4-7
+  proposer_default: claude-sonnet-4-6
+  proposer_high_stakes: claude-opus-4-7
+  judge: claude-opus-4-7
+
+proposer:
+  alternatives_count: 3
+  language_preference: en
+
+subjects:
+  skills:
+    enabled: true
+    auto_merge: [patch, frontmatter]
+    proposer: claude-sonnet-4-6
+    proposer_for_create: claude-opus-4-7
+
+ui:
+  primary_adapter: cli
+  follow_up_survey: true
+  follow_up_after_seconds: 30
+
+storage:
+  backup_keep: 7
+`;
+
+export function writeDefaultConfig(path = DEFAULT_CONFIG_PATH): void {
+  mkdirSync(join(path, '..'), { recursive: true });
+  if (existsSync(path)) throw new Error(`Config already exists at ${path}`);
+  writeFileSync(path, DEFAULT_YAML, 'utf8');
+}

--- a/src/skills-tuner/core/config.ts
+++ b/src/skills-tuner/core/config.ts
@@ -16,10 +16,13 @@ const ModelConfigSchema = z.object({
 
 const SubjectConfigSchema = z.object({
   enabled: z.boolean().default(true),
+  git_repo: z.string().optional(),
   auto_merge: z.union([z.boolean(), z.array(z.string())]).default(false),
   proposer: z.string().optional(),
   proposer_for_create: z.string().optional(),
   scan_dirs: z.array(z.string()).default([]),
+  emotional_patterns: z.array(z.string()).optional(),
+  overrides: z.record(z.unknown()).optional(),
 });
 export type SubjectConfig = z.infer<typeof SubjectConfigSchema>;
 
@@ -79,6 +82,17 @@ export function loadConfig(path = DEFAULT_CONFIG_PATH): TunerConfig {
     for (const key of ['proposals_jsonl', 'refused_jsonl', 'git_repo']) {
       if (typeof storage[key] === 'string') {
         storage[key] = (storage[key] as string).replace(/^~/, homedir());
+      }
+    }
+  }
+  // Expand ~ in per-subject git_repo paths
+  if (raw['subjects'] && typeof raw['subjects'] === 'object') {
+    for (const subj of Object.values(raw['subjects'] as Record<string, unknown>)) {
+      if (subj && typeof subj === 'object') {
+        const s = subj as Record<string, unknown>;
+        if (typeof s['git_repo'] === 'string') {
+          s['git_repo'] = (s['git_repo'] as string).replace(/^~/, homedir());
+        }
       }
     }
   }

--- a/src/skills-tuner/core/engine.ts
+++ b/src/skills-tuner/core/engine.ts
@@ -146,7 +146,6 @@ export class Engine {
       ts: new Date().toISOString(),
       alternative_id: alternativeId,
       commit_sha: commitSha,
-      applied_target_path: patch.target_path,
     });
     auditLog('apply_success', { proposal_id: proposalId, alternative_id: alternativeId, commit_sha: commitSha });
   }

--- a/src/skills-tuner/core/engine.ts
+++ b/src/skills-tuner/core/engine.ts
@@ -110,7 +110,12 @@ export class Engine {
   }
 
   async applyProposal(proposalId: number, alternativeId: string): Promise<void> {
-    const record = this.proposals.readAll().find(r => r?.proposal?.id === proposalId && r.event === 'created');
+    const all = this.proposals.readAll();
+    const alreadyApplied = all.find(r => r?.proposal?.id === proposalId && r.event === 'applied');
+    if (alreadyApplied) throw new Error(`Proposal #${proposalId} already applied — cannot re-apply`);
+    const alreadyRefused = all.find(r => r?.proposal?.id === proposalId && r.event === 'refused');
+    if (alreadyRefused) throw new Error(`Proposal #${proposalId} already refused — cannot apply`);
+    const record = all.find(r => r?.proposal?.id === proposalId && r.event === 'created');
     if (!record) throw new Error(`Proposal #${proposalId} not found or not pending`);
     const proposal = record.proposal;
 
@@ -141,6 +146,7 @@ export class Engine {
       ts: new Date().toISOString(),
       alternative_id: alternativeId,
       commit_sha: commitSha,
+      applied_target_path: patch.target_path,
     });
     auditLog('apply_success', { proposal_id: proposalId, alternative_id: alternativeId, commit_sha: commitSha });
   }

--- a/src/skills-tuner/core/engine.ts
+++ b/src/skills-tuner/core/engine.ts
@@ -17,7 +17,6 @@ export class SecurityError extends Error {
 
 export class Engine {
   private secret: Buffer;
-  private readonly _applying = new Set<number>(); // in-memory lock: prevents concurrent double-apply
 
   constructor(
     public readonly config: TunerConfig,
@@ -111,19 +110,6 @@ export class Engine {
   }
 
   async applyProposal(proposalId: number, alternativeId: string): Promise<void> {
-    // In-memory lock prevents concurrent double-apply from two simultaneous calls
-    if (this._applying.has(proposalId)) {
-      throw new Error(`Proposal #${proposalId} is already being applied — concurrent apply rejected`);
-    }
-    this._applying.add(proposalId);
-    try {
-      return await this._applyProposalInner(proposalId, alternativeId);
-    } finally {
-      this._applying.delete(proposalId);
-    }
-  }
-
-  private async _applyProposalInner(proposalId: number, alternativeId: string): Promise<void> {
     const all = this.proposals.readAll();
     const alreadyApplied = all.find(r => r?.proposal?.id === proposalId && r.event === 'applied');
     if (alreadyApplied) throw new Error(`Proposal #${proposalId} already applied — cannot re-apply`);

--- a/src/skills-tuner/core/engine.ts
+++ b/src/skills-tuner/core/engine.ts
@@ -110,12 +110,7 @@ export class Engine {
   }
 
   async applyProposal(proposalId: number, alternativeId: string): Promise<void> {
-    const all = this.proposals.readAll();
-    const alreadyApplied = all.find(r => r?.proposal?.id === proposalId && r.event === 'applied');
-    if (alreadyApplied) throw new Error(`Proposal #${proposalId} already applied — cannot re-apply`);
-    const alreadyRefused = all.find(r => r?.proposal?.id === proposalId && r.event === 'refused');
-    if (alreadyRefused) throw new Error(`Proposal #${proposalId} already refused — cannot apply`);
-    const record = all.find(r => r?.proposal?.id === proposalId && r.event === 'created');
+    const record = this.proposals.readAll().find(r => r?.proposal?.id === proposalId && r.event === 'created');
     if (!record) throw new Error(`Proposal #${proposalId} not found or not pending`);
     const proposal = record.proposal;
 

--- a/src/skills-tuner/core/engine.ts
+++ b/src/skills-tuner/core/engine.ts
@@ -1,0 +1,195 @@
+import { computeProposalSignature, verifyProposalSignature, loadSecret, auditLog } from './security.js';
+import { subjectConfig } from './config.js';
+import type { TunerConfig } from './config.js';
+import type { Proposal, UnsignedProposal } from './types.js';
+import type { TunableSubject } from './interfaces.js';
+import type { Registry } from './registry.js';
+import type { ProposalsStore } from '../storage/proposals.js';
+import type { RefusedStore } from '../storage/refused.js';
+import type { BranchManager } from '../git_ops/branches.js';
+
+export class SecurityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'SecurityError';
+  }
+}
+
+export class Engine {
+  private secret: Buffer;
+  private readonly _applying = new Set<number>(); // in-memory lock: prevents concurrent double-apply
+
+  constructor(
+    public readonly config: TunerConfig,
+    public readonly registry: Registry,
+    public readonly proposals: ProposalsStore,
+    public readonly refused: RefusedStore,
+    public readonly branches: BranchManager,
+  ) {
+    this.secret = loadSecret();
+  }
+
+  async runCycle(opts: { since?: Date; subjectName?: string; dryRun?: boolean } = {}): Promise<{ proposed: number; autoApplied: number }> {
+    const windowDays = (this.config.detection as unknown as Record<string, unknown>)['window_days'] as number | undefined ?? 7;
+    const since = opts.since ?? new Date(Date.now() - windowDays * 86_400_000);
+    const totals = { proposed: 0, autoApplied: 0 };
+
+    const subjects: TunableSubject[] = opts.subjectName
+      ? [this.registry.getSubject(opts.subjectName)].filter((s): s is TunableSubject => s != null)
+      : this.registry.enabledSubjects(this.config);
+
+    for (const subject of subjects) {
+      try {
+        const r = await this._runSubject(subject.name, since, opts.dryRun ?? false);
+        totals.proposed += r.proposed;
+        totals.autoApplied += r.autoApplied;
+      } catch (err) {
+        console.error(`Error running subject ${subject.name}:`, err);
+      }
+    }
+    return totals;
+  }
+
+  private async _runSubject(subjectName: string, since: Date, dryRun: boolean): Promise<{ proposed: number; autoApplied: number }> {
+    const subject = this.registry.getSubject(subjectName);
+    if (!subject) return { proposed: 0, autoApplied: 0 };
+
+    const maxPerRun = this.config.detection.max_proposals_per_run;
+    const refusedSigs = this.refused.activeSignatures();
+    const appliedSigs = this.proposals.appliedSignatures({ withinDays: 30 });
+    const pendingSigs = this.proposals.pendingSignatures({ subject: subjectName });
+
+    const observations = await subject.collectObservations(since);
+    const clusters = await subject.detectProblems(observations);
+
+    let proposed = 0;
+    let autoApplied = 0;
+
+    for (const cluster of clusters) {
+      if (proposed >= maxPerRun) break;
+
+      const rawProposal: UnsignedProposal = await subject.proposeChange(cluster);
+
+      // Dedup checks (anti-spam — bug fix 2351440)
+      if (refusedSigs.has(rawProposal.pattern_signature)) continue;
+      if (appliedSigs.has(rawProposal.pattern_signature)) continue;
+      if (pendingSigs.has(rawProposal.pattern_signature)) continue;
+
+      if (dryRun) { proposed++; continue; }
+
+      // Assign ID and sign
+      const existingRecords = this.proposals.readAll();
+      // Use reduce instead of Math.max(...spread) to avoid stack overflow at ~10k+ records
+      const nextId = existingRecords.reduce((max, r) => Math.max(max, r?.proposal?.id ?? 0), 0) + 1;
+      const unsignedProposal: UnsignedProposal = { ...rawProposal, id: nextId };
+      const sig = computeProposalSignature(unsignedProposal, this.secret);
+      const signedProposal: Proposal = { ...unsignedProposal, signature: sig };
+
+      this.proposals.append({ proposal: signedProposal, event: 'created', ts: new Date().toISOString() });
+      auditLog('proposal_created', { proposal_id: signedProposal.id, subject: signedProposal.subject, pattern_signature: signedProposal.pattern_signature });
+      proposed++;
+
+      // Auto-merge check — high/critical risk_tier subjects never auto-merge
+      const subjectCfg = subjectConfig(this.config, subjectName);
+      const autoMerge = subjectCfg.auto_merge;
+      const shouldAutoMerge = autoMerge === true || (Array.isArray(autoMerge) && autoMerge.includes(signedProposal.kind));
+      if (subject.risk_tier === 'high' || subject.risk_tier === 'critical') {
+        if (shouldAutoMerge) {
+          console.warn(`[Engine] Auto-merge blocked: subject ${subjectName} has risk_tier=${subject.risk_tier}`);
+          auditLog('auto_merge_blocked', { proposal_id: signedProposal.id, subject: subjectName, risk_tier: subject.risk_tier });
+        }
+      } else if (shouldAutoMerge && signedProposal.alternatives.length > 0) {
+        try {
+          await this.applyProposal(signedProposal.id, signedProposal.alternatives[0]!.id);
+          autoApplied++;
+        } catch (err) {
+          console.error(`Auto-merge failed for proposal ${signedProposal.id}:`, err);
+        }
+      }
+    }
+    return { proposed, autoApplied };
+  }
+
+  async applyProposal(proposalId: number, alternativeId: string): Promise<void> {
+    // In-memory lock prevents concurrent double-apply from two simultaneous calls
+    if (this._applying.has(proposalId)) {
+      throw new Error(`Proposal #${proposalId} is already being applied — concurrent apply rejected`);
+    }
+    this._applying.add(proposalId);
+    try {
+      return await this._applyProposalInner(proposalId, alternativeId);
+    } finally {
+      this._applying.delete(proposalId);
+    }
+  }
+
+  private async _applyProposalInner(proposalId: number, alternativeId: string): Promise<void> {
+    const all = this.proposals.readAll();
+    const alreadyApplied = all.find(r => r?.proposal?.id === proposalId && r.event === 'applied');
+    if (alreadyApplied) throw new Error(`Proposal #${proposalId} already applied — cannot re-apply`);
+    const alreadyRefused = all.find(r => r?.proposal?.id === proposalId && r.event === 'refused');
+    if (alreadyRefused) throw new Error(`Proposal #${proposalId} already refused — cannot apply`);
+    const record = all.find(r => r?.proposal?.id === proposalId && r.event === 'created');
+    if (!record) throw new Error(`Proposal #${proposalId} not found or not pending`);
+    const proposal = record.proposal;
+
+    const subject = this.registry.getSubject(proposal.subject);
+    if (!subject) throw new Error(`Subject ${proposal.subject} not registered`);
+
+    auditLog('apply_attempted', { proposal_id: proposalId, alternative_id: alternativeId });
+
+    if (!verifyProposalSignature(proposal, this.secret)) {
+      auditLog('signature_mismatch', { proposal_id: proposalId });
+      throw new SecurityError(`Proposal #${proposalId} signature mismatch — tamper detected`);
+    }
+
+    const patch = await subject.apply(proposal, alternativeId);
+    const validation = await subject.validate(patch);
+
+    if (!validation.valid) {
+      auditLog('apply_invalid', { proposal_id: proposalId, reason: validation.reason });
+      throw new Error(`Validation failed: ${validation.reason ?? 'unknown'}`);
+    }
+
+    await this.branches.createProposalBranch(proposalId);
+    const commitSha = await this.branches.commitPatch(patch, proposal, alternativeId);
+
+    this.proposals.append({
+      proposal,
+      event: 'applied',
+      ts: new Date().toISOString(),
+      alternative_id: alternativeId,
+      commit_sha: commitSha,
+      applied_target_path: patch.target_path,
+    });
+    auditLog('apply_success', { proposal_id: proposalId, alternative_id: alternativeId, commit_sha: commitSha });
+  }
+
+  async refuseProposal(proposalId: number, reason = 'refuse'): Promise<void> {
+    const record = this.proposals.readAll().find(r => r?.proposal?.id === proposalId);
+    if (!record) throw new Error(`Proposal #${proposalId} not found`);
+    const proposal = record.proposal;
+
+    this.refused.add(proposal.pattern_signature, proposal.subject, reason);
+    this.proposals.append({ proposal, event: 'refused', ts: new Date().toISOString() });
+    auditLog('refused', { proposal_id: proposalId, pattern_signature: proposal.pattern_signature });
+  }
+
+  async revertProposal(proposalId: number): Promise<void> {
+    const appliedRecord = this.proposals.readAll().find(r => r?.proposal?.id === proposalId && r.event === 'applied');
+    if (!appliedRecord) throw new Error(`No applied record found for proposal #${proposalId}`);
+
+    const commitSha = (appliedRecord as typeof appliedRecord & { commit_sha?: string }).commit_sha;
+    if (!commitSha) throw new Error(`No commit SHA recorded for proposal #${proposalId}`);
+
+    try {
+      // Checkout the proposal branch so revert applies in the right context
+      await this.branches.checkoutProposalBranch(proposalId);
+      await this.branches.revertPatch(commitSha);
+      auditLog('reverted', { proposal_id: proposalId, commit_sha: commitSha });
+    } catch (err) {
+      auditLog('revert_failed', { proposal_id: proposalId, commit_sha: commitSha, error: String(err) });
+      throw err;
+    }
+  }
+}

--- a/src/skills-tuner/core/engine.ts
+++ b/src/skills-tuner/core/engine.ts
@@ -6,7 +6,12 @@ import type { TunableSubject } from './interfaces.js';
 import type { Registry } from './registry.js';
 import type { ProposalsStore } from '../storage/proposals.js';
 import type { RefusedStore } from '../storage/refused.js';
-import type { BranchManager } from '../git_ops/branches.js';
+import { BranchManager } from '../git_ops/branches.js';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { appendFileSync, readFileSync, existsSync, mkdirSync } from 'node:fs';
+
+const STATE_HASHES_PATH = join(homedir(), '.config', 'tuner', 'state-hashes.jsonl');
 
 export class SecurityError extends Error {
   constructor(message: string) {
@@ -17,15 +22,32 @@ export class SecurityError extends Error {
 
 export class Engine {
   private secret: Buffer;
+  private readonly _applying = new Set<number>(); // in-memory lock: prevents concurrent double-apply
+  private readonly _branchManagers = new Map<string, BranchManager>();
 
   constructor(
     public readonly config: TunerConfig,
     public readonly registry: Registry,
     public readonly proposals: ProposalsStore,
     public readonly refused: RefusedStore,
-    public readonly branches: BranchManager,
+    private readonly defaultBranches: BranchManager,
   ) {
     this.secret = loadSecret();
+  }
+
+  // Lazily instantiate a BranchManager per-subject, falling back to defaultBranches.
+  private getBranchManager(subjectName: string): BranchManager {
+    const cached = this._branchManagers.get(subjectName);
+    if (cached) return cached;
+    const subjectCfg = this.config.subjects?.[subjectName];
+    const repoPath = subjectCfg?.git_repo
+      ? subjectCfg.git_repo.replace(/^~/, homedir())
+      : this.defaultBranches.repoPath;
+    const bm = repoPath === this.defaultBranches.repoPath
+      ? this.defaultBranches
+      : new BranchManager(repoPath);
+    this._branchManagers.set(subjectName, bm);
+    return bm;
   }
 
   async runCycle(opts: { since?: Date; subjectName?: string; dryRun?: boolean } = {}): Promise<{ proposed: number; autoApplied: number }> {
@@ -46,7 +68,47 @@ export class Engine {
         console.error(`Error running subject ${subject.name}:`, err);
       }
     }
+    // Drift detection: compare each subject's state hash vs last recorded value
+    const allSubjects = opts.subjectName
+      ? [this.registry.getSubject(opts.subjectName)].filter((s): s is TunableSubject => s != null)
+      : this.registry.enabledSubjects(this.config);
+    for (const subject of allSubjects) {
+      try {
+        const currentHash = subject.currentStateHash();
+        if (!currentHash) continue;  // subject opted out (empty string = no-op)
+        const prevHash = this._lastStateHash(subject.name);
+        if (prevHash === currentHash) continue;  // no drift
+        auditLog('subject_state_drift_detected', {
+          subject: subject.name,
+          prev_hash: prevHash || null,
+          current_hash: currentHash,
+        });
+        this._recordStateHash(subject.name, currentHash);
+      } catch (err) {
+        auditLog('drift_detection_error', { subject: subject.name, error: String(err) });
+        // Non-fatal: drift detection is opportunistic, never crashes runCycle
+      }
+    }
+
     return totals;
+  }
+
+  private _lastStateHash(subjectName: string): string {
+    if (!existsSync(STATE_HASHES_PATH)) return '';
+    const lines = readFileSync(STATE_HASHES_PATH, 'utf8').trim().split('\n').filter(Boolean);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const entry = JSON.parse(lines[i]!);
+        if (entry.subject === subjectName) return entry.hash || '';
+      } catch { /* skip corrupted line */ }
+    }
+    return '';
+  }
+
+  private _recordStateHash(subjectName: string, hash: string): void {
+    mkdirSync(dirname(STATE_HASHES_PATH), { recursive: true });
+    const entry = { ts: new Date().toISOString(), subject: subjectName, hash };
+    appendFileSync(STATE_HASHES_PATH, JSON.stringify(entry) + '\n');
   }
 
   private async _runSubject(subjectName: string, since: Date, dryRun: boolean): Promise<{ proposed: number; autoApplied: number }> {
@@ -110,6 +172,19 @@ export class Engine {
   }
 
   async applyProposal(proposalId: number, alternativeId: string): Promise<void> {
+    // In-memory lock prevents concurrent double-apply from two simultaneous calls
+    if (this._applying.has(proposalId)) {
+      throw new Error(`Proposal #${proposalId} is already being applied — concurrent apply rejected`);
+    }
+    this._applying.add(proposalId);
+    try {
+      return await this._applyProposalInner(proposalId, alternativeId);
+    } finally {
+      this._applying.delete(proposalId);
+    }
+  }
+
+  private async _applyProposalInner(proposalId: number, alternativeId: string): Promise<void> {
     const all = this.proposals.readAll();
     const alreadyApplied = all.find(r => r?.proposal?.id === proposalId && r.event === 'applied');
     if (alreadyApplied) throw new Error(`Proposal #${proposalId} already applied — cannot re-apply`);
@@ -122,7 +197,8 @@ export class Engine {
     const subject = this.registry.getSubject(proposal.subject);
     if (!subject) throw new Error(`Subject ${proposal.subject} not registered`);
 
-    auditLog('apply_attempted', { proposal_id: proposalId, alternative_id: alternativeId });
+    const branches = this.getBranchManager(proposal.subject);
+    auditLog('apply_attempted', { proposal_id: proposalId, alternative_id: alternativeId, repo_path: branches.repoPath });
 
     if (!verifyProposalSignature(proposal, this.secret)) {
       auditLog('signature_mismatch', { proposal_id: proposalId });
@@ -137,8 +213,8 @@ export class Engine {
       throw new Error(`Validation failed: ${validation.reason ?? 'unknown'}`);
     }
 
-    await this.branches.createProposalBranch(proposalId);
-    const commitSha = await this.branches.commitPatch(patch, proposal, alternativeId);
+    await branches.createProposalBranch(proposalId);
+    const commitSha = await branches.commitPatch(patch, proposal, alternativeId);
 
     this.proposals.append({
       proposal,
@@ -148,7 +224,7 @@ export class Engine {
       commit_sha: commitSha,
       applied_target_path: patch.target_path,
     });
-    auditLog('apply_success', { proposal_id: proposalId, alternative_id: alternativeId, commit_sha: commitSha });
+    auditLog('apply_success', { proposal_id: proposalId, alternative_id: alternativeId, commit_sha: commitSha, repo_path: branches.repoPath });
   }
 
   async refuseProposal(proposalId: number, reason = 'refuse'): Promise<void> {
@@ -168,11 +244,14 @@ export class Engine {
     const commitSha = (appliedRecord as typeof appliedRecord & { commit_sha?: string }).commit_sha;
     if (!commitSha) throw new Error(`No commit SHA recorded for proposal #${proposalId}`);
 
+    const proposal = appliedRecord.proposal;
+    const branches = this.getBranchManager(proposal.subject);
+
     try {
       // Checkout the proposal branch so revert applies in the right context
-      await this.branches.checkoutProposalBranch(proposalId);
-      await this.branches.revertPatch(commitSha);
-      auditLog('reverted', { proposal_id: proposalId, commit_sha: commitSha });
+      await branches.checkoutProposalBranch(proposalId);
+      await branches.revertPatch(commitSha);
+      auditLog('reverted', { proposal_id: proposalId, commit_sha: commitSha, repo_path: branches.repoPath });
     } catch (err) {
       auditLog('revert_failed', { proposal_id: proposalId, commit_sha: commitSha, error: String(err) });
       throw err;

--- a/src/skills-tuner/core/interfaces.ts
+++ b/src/skills-tuner/core/interfaces.ts
@@ -1,0 +1,34 @@
+import type { Cluster, Observation, Patch, Proposal, UnsignedProposal, ValidationResult } from './types.js';
+import { ORPHAN_SUBJECT } from './types.js';
+
+export type RiskTier = 'low' | 'medium' | 'high' | 'critical';
+
+export abstract class TunableSubject {
+  abstract readonly name: string;
+  readonly risk_tier: RiskTier = 'low';
+  readonly auto_merge_default: boolean = false;
+  readonly supports_creation: boolean = false;
+  readonly orphan_min_observations: number = 2;
+
+  abstract collectObservations(since: Date): Promise<Observation[]>;
+  abstract detectProblems(observations: Observation[]): Promise<Cluster[]>;
+  abstract proposeChange(cluster: Cluster): Promise<UnsignedProposal>;
+  abstract apply(proposal: Proposal, alternativeId: string): Promise<Patch>;
+  abstract validate(patch: Patch): Promise<ValidationResult>;
+
+  scoreSignal(_verbatim: string, _attributedTo: string, _knownEntities: Record<string, unknown>): number {
+    return 0;
+  }
+
+  reclassifySignal(_verbatim: string, _knownEntities: Record<string, unknown>): string {
+    return ORPHAN_SUBJECT;
+  }
+}
+
+export abstract class Adapter {
+  abstract renderProposal(proposal: Proposal): Promise<void>;
+  abstract renderApplyConfirmation(proposal: Proposal, alternativeId: string): Promise<void>;
+}
+
+export { ORPHAN_SUBJECT, CREATE_KINDS } from './types.js';
+export type { UnsignedProposal } from './types.js';

--- a/src/skills-tuner/core/interfaces.ts
+++ b/src/skills-tuner/core/interfaces.ts
@@ -23,6 +23,20 @@ export abstract class TunableSubject {
   reclassifySignal(_verbatim: string, _knownEntities: Record<string, unknown>): string {
     return ORPHAN_SUBJECT;
   }
+
+  /**
+   * Compute a deterministic hash of this subject's managed state.
+   * Used by the engine to detect drift between cron ticks.
+   *
+   * Default returns empty string (no drift detection — opt-in per subject).
+   * Override to track changes in scan_dirs, plugin lists, RAG corpus, etc.
+   *
+   * Hash must be stable across runs (no clocks, no random) and reflect
+   * any meaningful change to what the subject would propose tuning.
+   */
+  currentStateHash(): string {
+    return '';
+  }
 }
 
 export abstract class Adapter {

--- a/src/skills-tuner/core/llm.ts
+++ b/src/skills-tuner/core/llm.ts
@@ -1,0 +1,106 @@
+import { spawn } from 'node:child_process';
+import type { TunerConfig } from './config.js';
+
+export type Role = 'intent_classifier' | 'detector' | 'proposer' | 'proposer_high_stakes' | 'judge';
+
+export interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface LLMClient {
+  call(role: Role, system: string, messages: Message[], maxTokens?: number): Promise<string>;
+  modelFor(role: Role): string;
+}
+
+function buildPrompt(system: string, messages: Message[]): string {
+  const lines: string[] = ['[system]', system, '[/system]'];
+  for (const m of messages) {
+    lines.push('[' + m.role + ']', m.content, '[/' + m.role + ']');
+  }
+  return lines.join('\n');
+}
+
+export class ClaudeCliBackend implements LLMClient {
+  private readonly models: TunerConfig['models'];
+
+  constructor(config: TunerConfig) {
+    this.models = config.models;
+  }
+
+  modelFor(role: Role): string {
+    const m = this.models;
+    return ({
+      intent_classifier: m.intent_classifier,
+      detector: m.detector,
+      proposer: m.proposer_default,
+      proposer_high_stakes: m.proposer_high_stakes,
+      judge: m.judge,
+    } as Record<Role, string>)[role];
+  }
+
+  async call(role: Role, system: string, messages: Message[], maxTokens = 4096): Promise<string> {
+    const prompt = buildPrompt(system, messages);
+    return new Promise((resolve, reject) => {
+      const child = spawn('claude', ['-p', prompt, '--max-tokens', String(maxTokens)], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      let out = '';
+      let err = '';
+      child.stdout.on('data', (d: Buffer) => { out += d.toString(); });
+      child.stderr.on('data', (d: Buffer) => { err += d.toString(); });
+      child.on('close', (code) => {
+        if (code !== 0) reject(new Error('claude CLI exited ' + code + ': ' + err.slice(0, 200)));
+        else resolve(out.trim());
+      });
+      child.on('error', reject);
+    });
+  }
+}
+
+export class AnthropicApiBackend implements LLMClient {
+  private readonly models: TunerConfig['models'];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  private client: any;
+
+  private readonly apiKey: string;
+
+  constructor(config: TunerConfig) {
+    this.models = config.models;
+    const apiKey = config.llm.api_key ?? process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) throw new Error('anthropic_api backend requires api_key in config or ANTHROPIC_API_KEY env var');
+    this.apiKey = apiKey;
+  }
+
+  modelFor(role: Role): string {
+    const m = this.models;
+    return ({
+      intent_classifier: m.intent_classifier,
+      detector: m.detector,
+      proposer: m.proposer_default,
+      proposer_high_stakes: m.proposer_high_stakes,
+      judge: m.judge,
+    } as Record<Role, string>)[role];
+  }
+
+  async call(role: Role, system: string, messages: Message[], maxTokens = 4096): Promise<string> {
+    if (!this.client) {
+      const { default: Anthropic } = await import('@anthropic-ai/sdk');
+      this.client = new Anthropic({ apiKey: this.apiKey, maxRetries: 4 });
+    }
+    const model = this.modelFor(role);
+    const response = await this.client.messages.create({
+      model,
+      system,
+      messages: messages.map((m: Message) => ({ role: m.role, content: m.content })),
+      max_tokens: maxTokens,
+    });
+    const block = response.content[0];
+    return block && 'text' in block ? block.text : '';
+  }
+}
+
+export function makeLLMClient(config: TunerConfig): LLMClient {
+  if (config.llm.backend === 'anthropic_api') return new AnthropicApiBackend(config);
+  return new ClaudeCliBackend(config);
+}

--- a/src/skills-tuner/core/registry.ts
+++ b/src/skills-tuner/core/registry.ts
@@ -1,0 +1,31 @@
+import type { TunableSubject, Adapter } from './interfaces.js';
+import type { TunerConfig } from './config.js';
+
+export class Registry {
+  private subjects = new Map<string, TunableSubject>();
+  private adapters = new Map<string, Adapter>();
+
+  registerSubject(subject: TunableSubject): void {
+    this.subjects.set(subject.name, subject);
+  }
+
+  registerAdapter(name: string, adapter: Adapter): void {
+    this.adapters.set(name, adapter);
+  }
+
+  getSubject(name: string): TunableSubject | undefined {
+    return this.subjects.get(name);
+  }
+
+  getAdapter(name: string): Adapter | undefined {
+    return this.adapters.get(name);
+  }
+
+  allSubjects(): TunableSubject[] {
+    return [...this.subjects.values()];
+  }
+
+  enabledSubjects(config: Pick<TunerConfig, 'subjects'>): TunableSubject[] {
+    return [...this.subjects.values()].filter(s => config.subjects?.[s.name]?.enabled !== false);
+  }
+}

--- a/src/skills-tuner/core/security.ts
+++ b/src/skills-tuner/core/security.ts
@@ -1,0 +1,73 @@
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, appendFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+import type { Proposal, UnsignedProposal } from './types.js';
+
+export const SECRET_PATH = join(homedir(), '.config', 'tuner', '.secret');
+export const AUDIT_PATH = join(homedir(), '.config', 'tuner', 'audit.jsonl');
+
+export function initSecret(): void {
+  mkdirSync(dirname(SECRET_PATH), { recursive: true });
+  if (existsSync(SECRET_PATH)) return;
+  writeFileSync(SECRET_PATH, randomBytes(32));
+  chmodSync(SECRET_PATH, 0o600);
+}
+
+export function loadSecret(): Buffer {
+  if (!existsSync(SECRET_PATH)) initSecret();
+  return readFileSync(SECRET_PATH);
+}
+
+function proposalCanonical(proposal: UnsignedProposal | Proposal): Buffer {
+  const data = {
+    alternatives: proposal.alternatives.map(a => ({
+      diff_or_content: a.diff_or_content,
+      id: a.id,
+      label: a.label,
+      tradeoff: a.tradeoff,
+    })),
+    cluster_id: proposal.cluster_id,
+    created_at: proposal.created_at.toISOString(),
+    id: proposal.id,
+    kind: proposal.kind,
+    pattern_signature: proposal.pattern_signature,
+    subject: proposal.subject,
+    target_path: proposal.target_path,
+  };
+  return Buffer.from(JSON.stringify(data), 'utf8');
+}
+
+export function computeProposalSignature(proposal: UnsignedProposal | Proposal, secret: Buffer): string {
+  return createHmac('sha256', secret).update(proposalCanonical(proposal)).digest('hex');
+}
+
+export function verifyProposalSignature(proposal: Proposal, secret: Buffer): boolean {
+  const expected = computeProposalSignature(proposal, secret);
+  const got = proposal.signature ?? '';
+  if (expected.length !== got.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(got, 'hex'));
+  } catch {
+    return false;
+  }
+}
+
+// Zero-width chars + prompt injection markers
+const INJECTION_RE = /[​-‏‪-‮⁠﻿]/g;
+const MARKER_RE = /<(\/?)(system|human|assistant|instruction|prompt|ignore|INST|SYS)[^>]*>/gi;
+// Bracket-style markers (used by claude_cli buildPrompt format) — also neutralize
+const BRACKET_MARKER_RE = /\[(\/?)(system|human|user|assistant|instruction|prompt|ignore|INST|SYS)\]/gi;
+
+export function sanitizeObservationContent(text: string, maxLength = 10_000): string {
+  let cleaned = text.replace(INJECTION_RE, '');
+  cleaned = cleaned.replace(MARKER_RE, '<$1$2-neutralized>');
+  cleaned = cleaned.replace(BRACKET_MARKER_RE, '($1$2-neutralized)');
+  return cleaned.slice(0, maxLength);
+}
+
+export function auditLog(event: string, payload: Record<string, unknown>): void {
+  mkdirSync(dirname(AUDIT_PATH), { recursive: true });
+  const entry = { ts: new Date().toISOString(), event, ...payload };
+  appendFileSync(AUDIT_PATH, JSON.stringify(entry) + '\n');
+}

--- a/src/skills-tuner/core/security.ts
+++ b/src/skills-tuner/core/security.ts
@@ -56,13 +56,10 @@ export function verifyProposalSignature(proposal: Proposal, secret: Buffer): boo
 // Zero-width chars + prompt injection markers
 const INJECTION_RE = /[​-‏‪-‮⁠﻿]/g;
 const MARKER_RE = /<(\/?)(system|human|assistant|instruction|prompt|ignore|INST|SYS)[^>]*>/gi;
-// Bracket-style markers (used by claude_cli buildPrompt format) — also neutralize
-const BRACKET_MARKER_RE = /\[(\/?)(system|human|user|assistant|instruction|prompt|ignore|INST|SYS)\]/gi;
 
 export function sanitizeObservationContent(text: string, maxLength = 10_000): string {
   let cleaned = text.replace(INJECTION_RE, '');
-  cleaned = cleaned.replace(MARKER_RE, '<$1$2-neutralized>');
-  cleaned = cleaned.replace(BRACKET_MARKER_RE, '($1$2-neutralized)');
+  cleaned = cleaned.replace(MARKER_RE, '[$1$2]');
   return cleaned.slice(0, maxLength);
 }
 

--- a/src/skills-tuner/core/security.ts
+++ b/src/skills-tuner/core/security.ts
@@ -56,10 +56,13 @@ export function verifyProposalSignature(proposal: Proposal, secret: Buffer): boo
 // Zero-width chars + prompt injection markers
 const INJECTION_RE = /[​-‏‪-‮⁠﻿]/g;
 const MARKER_RE = /<(\/?)(system|human|assistant|instruction|prompt|ignore|INST|SYS)[^>]*>/gi;
+// Bracket-style markers (used by claude_cli buildPrompt format) — also neutralize
+const BRACKET_MARKER_RE = /\[(\/?)(system|human|user|assistant|instruction|prompt|ignore|INST|SYS)\]/gi;
 
 export function sanitizeObservationContent(text: string, maxLength = 10_000): string {
   let cleaned = text.replace(INJECTION_RE, '');
-  cleaned = cleaned.replace(MARKER_RE, '[$1$2]');
+  cleaned = cleaned.replace(MARKER_RE, '<$1$2-neutralized>');
+  cleaned = cleaned.replace(BRACKET_MARKER_RE, '($1$2-neutralized)');
   return cleaned.slice(0, maxLength);
 }
 

--- a/src/skills-tuner/core/types.ts
+++ b/src/skills-tuner/core/types.ts
@@ -1,0 +1,66 @@
+import { z } from 'zod';
+
+export const ORPHAN_SUBJECT = '__new_entity__' as const;
+
+export const CREATE_KINDS = new Set([
+  'new_skill', 'new_intent', 'new_source', 'new_mcp', 'new_tool',
+] as const);
+export type CreateKind = 'new_skill' | 'new_intent' | 'new_source' | 'new_mcp' | 'new_tool';
+
+export const ObservationSchema = z.object({
+  session_id: z.string(),
+  observed_at: z.coerce.date(),
+  signal_type: z.enum(['correction', 'positive_feedback', 'repeated_trigger', 'orphan']),
+  verbatim: z.string().max(500),
+  metadata: z.record(z.unknown()).default({}),
+});
+export type Observation = z.infer<typeof ObservationSchema>;
+
+export const AlternativeSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  diff_or_content: z.string(),
+  tradeoff: z.string().default(''),
+});
+export type Alternative = z.infer<typeof AlternativeSchema>;
+
+export const UnsignedProposalSchema = z.object({
+  id: z.number().int(),
+  cluster_id: z.string(),
+  subject: z.string(),
+  kind: z.string(),
+  target_path: z.string(),
+  alternatives: z.array(AlternativeSchema).min(1).max(3),
+  pattern_signature: z.string(),
+  created_at: z.coerce.date(),
+});
+export type UnsignedProposal = z.infer<typeof UnsignedProposalSchema>;
+
+export const ProposalSchema = UnsignedProposalSchema.extend({
+  signature: z.string().min(1),
+});
+export type Proposal = z.infer<typeof ProposalSchema>;
+
+export const ClusterSchema = z.object({
+  id: z.string(),
+  subject: z.string(),
+  observations: z.array(ObservationSchema),
+  frequency: z.number().int().min(1),
+  success_rate: z.number().min(0).max(1),
+  sentiment: z.enum(['positive', 'negative', 'neutral']),
+  subjects_touched: z.array(z.string()).default([]),
+});
+export type Cluster = z.infer<typeof ClusterSchema>;
+
+export const PatchSchema = z.object({
+  target_path: z.string(),
+  kind: z.string(),
+  applied_content: z.string(),
+});
+export type Patch = z.infer<typeof PatchSchema>;
+
+export const ValidationResultSchema = z.object({
+  valid: z.boolean(),
+  reason: z.string().optional(),
+});
+export type ValidationResult = z.infer<typeof ValidationResultSchema>;

--- a/src/skills-tuner/git_ops/branches.ts
+++ b/src/skills-tuner/git_ops/branches.ts
@@ -1,5 +1,5 @@
 import { simpleGit, type SimpleGit } from 'simple-git';
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
 import { dirname, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
 import type { Patch, Proposal } from '../core/types.js';
@@ -51,6 +51,13 @@ export class BranchManager {
     const repoRoot = resolve(this.repoPath);
     if (!target.startsWith(repoRoot + sep) && target !== repoRoot) {
       throw new Error(`BranchManager refusing to write outside repo: target=${target}, repo=${repoRoot}`);
+    }
+    // Symlink traversal check: resolve the real path if the target already exists as a symlink
+    if (existsSync(target)) {
+      const resolvedTarget = realpathSync(target);
+      if (!resolvedTarget.startsWith(repoRoot + sep) && resolvedTarget !== repoRoot) {
+        throw new Error(`BranchManager refusing symlink traversal: target=${target} resolves to ${resolvedTarget} which is outside repo=${repoRoot}`);
+      }
     }
     if (patch.applied_content) {
       mkdirSync(dirname(target), { recursive: true });

--- a/src/skills-tuner/git_ops/branches.ts
+++ b/src/skills-tuner/git_ops/branches.ts
@@ -57,9 +57,7 @@ export class BranchManager {
       writeFileSync(target, patch.applied_content, 'utf8');
       await this.git.add(target);
     } else {
-      // Empty content: only add the specific target if it exists/changed.
-      // Never fall through to `git add .` — that stages unrelated WIP files.
-      await this.git.add(target);
+      await this.git.add('.');
     }
     const msg = `tune: ${proposal.subject} — alternative ${alternativeId}\nProposal-ID: ${proposal.id}`;
     const result = await this.git.commit(msg, { '--allow-empty': null });

--- a/src/skills-tuner/git_ops/branches.ts
+++ b/src/skills-tuner/git_ops/branches.ts
@@ -57,7 +57,9 @@ export class BranchManager {
       writeFileSync(target, patch.applied_content, 'utf8');
       await this.git.add(target);
     } else {
-      await this.git.add('.');
+      // Empty content: only add the specific target if it exists/changed.
+      // Never fall through to `git add .` — that stages unrelated WIP files.
+      await this.git.add(target);
     }
     const msg = `tune: ${proposal.subject} — alternative ${alternativeId}\nProposal-ID: ${proposal.id}`;
     const result = await this.git.commit(msg, { '--allow-empty': null });

--- a/src/skills-tuner/git_ops/branches.ts
+++ b/src/skills-tuner/git_ops/branches.ts
@@ -1,0 +1,90 @@
+import { simpleGit, type SimpleGit } from 'simple-git';
+import { writeFileSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
+import { dirname, resolve, sep } from 'node:path';
+import { homedir } from 'node:os';
+import type { Patch, Proposal } from '../core/types.js';
+
+export class BranchManager {
+  private git: SimpleGit;
+
+  constructor(public readonly repoPath: string) {
+    this.git = simpleGit(repoPath);
+  }
+
+  async ensureRepo(): Promise<void> {
+    const isRepo = await this.git.checkIsRepo();
+    if (!isRepo) throw new Error(`${this.repoPath} is not a git repository`);
+  }
+
+  branchName(proposalId: number): string {
+    return `tune/proposal-${proposalId}`;
+  }
+
+  async createProposalBranch(proposalId: number, baseBranch = 'main'): Promise<string> {
+    const name = this.branchName(proposalId);
+    const branches = await this.git.branchLocal();
+    if (branches.all.includes(name)) {
+      await this.git.checkout(name);
+      return name;
+    }
+    // Always branch from baseBranch (not the current HEAD) so successive
+    // auto-merged proposals don't stack on each other.
+    if (!branches.all.includes(baseBranch)) {
+      throw new Error(
+        `Base branch '${baseBranch}' not found in repo. Cannot create proposal branch — refusing to branch from current HEAD which would let proposals stack on each other. Set baseBranch explicitly if your repo doesn't use 'main'.`
+      );
+    }
+    await this.git.checkout(baseBranch);
+    await this.git.checkoutLocalBranch(name);
+    return name;
+  }
+
+  // Switch to a specific proposal branch (used before revert)
+  async checkoutProposalBranch(proposalId: number): Promise<string> {
+    const name = this.branchName(proposalId);
+    await this.git.checkout(name);
+    return name;
+  }
+
+  async commitPatch(patch: Patch, proposal: Proposal, alternativeId: string): Promise<string> {
+    const target = resolve(patch.target_path.replace(/^~/, homedir()));
+    const repoRoot = resolve(this.repoPath);
+    if (!target.startsWith(repoRoot + sep) && target !== repoRoot) {
+      throw new Error(`BranchManager refusing to write outside repo: target=${target}, repo=${repoRoot}`);
+    }
+    // Symlink traversal check: resolve the real path if the target already exists as a symlink
+    if (existsSync(target)) {
+      const resolvedTarget = realpathSync(target);
+      if (!resolvedTarget.startsWith(repoRoot + sep) && resolvedTarget !== repoRoot) {
+        throw new Error(`BranchManager refusing symlink traversal: target=${target} resolves to ${resolvedTarget} which is outside repo=${repoRoot}`);
+      }
+    }
+    if (patch.applied_content) {
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, patch.applied_content, 'utf8');
+      await this.git.add(target);
+    } else {
+      // Empty content: only add the specific target if it exists/changed.
+      // Never fall through to `git add .` — that stages unrelated WIP files.
+      await this.git.add(target);
+    }
+    const msg = `tune: ${proposal.subject} — alternative ${alternativeId}\nProposal-ID: ${proposal.id}`;
+    // Refuse empty commits: an empty commit with no diff would be reverted
+    // as a no-op, masking the fact that nothing actually changed.
+    const status = await this.git.status();
+    if (status.staged.length === 0) {
+      throw new Error(`commitPatch refused: no staged changes for proposal #${proposal.id} — refusing to create empty commit (would mask revert as no-op)`);
+    }
+    const result = await this.git.commit(msg);
+    return result.commit;
+  }
+
+  async revertPatch(commitSha: string): Promise<void> {
+    await this.git.revert(commitSha, ['--no-edit']);
+  }
+
+  async listProposalBranches(): Promise<string[]> {
+    const branches = await this.git.branchLocal();
+    return branches.all.filter(b => b.startsWith('tune/proposal-'));
+  }
+}

--- a/src/skills-tuner/git_ops/branches.ts
+++ b/src/skills-tuner/git_ops/branches.ts
@@ -1,5 +1,5 @@
 import { simpleGit, type SimpleGit } from 'simple-git';
-import { writeFileSync, mkdirSync, existsSync, realpathSync } from 'node:fs';
+import { writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
 import type { Patch, Proposal } from '../core/types.js';
@@ -51,13 +51,6 @@ export class BranchManager {
     const repoRoot = resolve(this.repoPath);
     if (!target.startsWith(repoRoot + sep) && target !== repoRoot) {
       throw new Error(`BranchManager refusing to write outside repo: target=${target}, repo=${repoRoot}`);
-    }
-    // Symlink traversal check: resolve the real path if the target already exists as a symlink
-    if (existsSync(target)) {
-      const resolvedTarget = realpathSync(target);
-      if (!resolvedTarget.startsWith(repoRoot + sep) && resolvedTarget !== repoRoot) {
-        throw new Error(`BranchManager refusing symlink traversal: target=${target} resolves to ${resolvedTarget} which is outside repo=${repoRoot}`);
-      }
     }
     if (patch.applied_content) {
       mkdirSync(dirname(target), { recursive: true });

--- a/src/skills-tuner/git_ops/branches.ts
+++ b/src/skills-tuner/git_ops/branches.ts
@@ -69,13 +69,7 @@ export class BranchManager {
       await this.git.add(target);
     }
     const msg = `tune: ${proposal.subject} — alternative ${alternativeId}\nProposal-ID: ${proposal.id}`;
-    // Refuse empty commits: an empty commit with no diff would be reverted
-    // as a no-op, masking the fact that nothing actually changed.
-    const status = await this.git.status();
-    if (status.staged.length === 0) {
-      throw new Error(`commitPatch refused: no staged changes for proposal #${proposal.id} — refusing to create empty commit (would mask revert as no-op)`);
-    }
-    const result = await this.git.commit(msg);
+    const result = await this.git.commit(msg, { '--allow-empty': null });
     return result.commit;
   }
 

--- a/src/skills-tuner/scripts/migrate-from-python.ts
+++ b/src/skills-tuner/scripts/migrate-from-python.ts
@@ -1,0 +1,244 @@
+#!/usr/bin/env bun
+/**
+ * migrate-from-python.ts
+ *
+ * One-shot migration: converts legacy Python flat-record proposals.jsonl
+ * into the TypeScript wrapped-event format.
+ *
+ * Usage:
+ *   bun run scripts/migrate-from-python.ts [--dry-run]
+ *
+ * Exports migrateRecord() for unit tests.
+ */
+
+import { readFileSync, writeFileSync, copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join, dirname } from 'node:path';
+
+import { loadSecret, computeProposalSignature } from '../core/security.js';
+import type { ProposalRecord } from '../storage/proposals.js';
+import type { Proposal } from '../core/types.js';
+
+export const DEFAULT_PROPOSALS_PATH = join(homedir(), '.config', 'tuner', 'proposals.jsonl');
+
+// Fields that exist only in the Python format and must be stripped
+const LEGACY_FIELDS = new Set([
+  'status', 'applied_at', 'applied_alternative', 'feedback', 'feedback_at',
+  'git_branch', 'git_commit', 'git_merged',
+  // Extra Python fields not in UnsignedProposalSchema
+  'recommended', 'confidence', 'justification', 'subjects_touched', 'sentiment_evidence',
+  'estimated_impact',
+  // Stale empty signature — will be re-computed
+  'signature',
+]);
+
+/**
+ * Strip legacy-only keys from a flat Python record, leaving only the fields
+ * that map to UnsignedProposalSchema (plus any extra TS-safe fields).
+ */
+function stripLegacyFields(raw: Record<string, unknown>): Record<string, unknown> {
+  const cleaned: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (!LEGACY_FIELDS.has(k)) cleaned[k] = v;
+  }
+  return cleaned;
+}
+
+/**
+ * Convert a single raw JSON-parsed line into zero or more ProposalRecord events.
+ *
+ * Rules:
+ *  - Meta lines (_meta: true)         → returned as-is (pass-through)
+ *  - Already-wrapped (has `event`)    → returned as-is (idempotent)
+ *  - Legacy flat (has `status`)       → emit created + applied/refused as needed
+ */
+export function migrateRecord(
+  raw: unknown,
+  secret: Buffer,
+): { events: ProposalRecord[]; meta?: unknown } {
+  if (typeof raw !== 'object' || raw === null) return { events: [] };
+  const obj = raw as Record<string, unknown>;
+
+  // Pass-through: meta line
+  if (obj._meta === true) return { events: [], meta: obj };
+
+  // Pass-through: already wrapped TS format
+  if (typeof obj.event === 'string') {
+    return { events: [obj as unknown as ProposalRecord] };
+  }
+
+  // Legacy flat Python record — must have 'status'
+  if (typeof obj.status !== 'string') {
+    // Unknown format — skip with warning
+    process.stderr.write(`WARN: skipping unrecognized line (no event, no status): ${JSON.stringify(obj).slice(0, 80)}\n`);
+    return { events: [] };
+  }
+
+  // Build UnsignedProposal by stripping legacy-only fields
+  const unsignedObj = stripLegacyFields(obj);
+
+  // Coerce created_at to Date for signing then back to string for serialisation
+  const createdAt: Date =
+    typeof unsignedObj.created_at === 'string'
+      ? new Date(unsignedObj.created_at as string)
+      : new Date();
+
+  // Ensure alternatives have tradeoff field (default '')
+  const alternatives = (unsignedObj.alternatives as Array<Record<string, unknown>> | undefined) ?? [];
+  const normalizedAlts = alternatives.map((a) => ({
+    id: a.id ?? '',
+    label: a.label ?? '',
+    diff_or_content: a.diff_or_content ?? '',
+    tradeoff: a.tradeoff ?? '',
+  }));
+
+  const unsignedProposal = {
+    ...unsignedObj,
+    alternatives: normalizedAlts,
+    created_at: createdAt,
+  };
+
+  // Compute fresh HMAC signature
+  const signature = computeProposalSignature(
+    unsignedProposal as Parameters<typeof computeProposalSignature>[0],
+    secret,
+  );
+
+  const proposal: Proposal = {
+    ...(unsignedProposal as Omit<Proposal, 'signature'>),
+    signature,
+  };
+
+  const events: ProposalRecord[] = [];
+  const createdTs = createdAt.toISOString();
+
+  // Always emit a 'created' event
+  events.push({ event: 'created', ts: createdTs, proposal });
+
+  const status = obj.status as string;
+
+  if (status === 'applied' || status === 'reverted') {
+    const appliedTs =
+      typeof obj.applied_at === 'string' ? new Date(obj.applied_at as string).toISOString() : createdTs;
+    const alternativeId =
+      typeof obj.applied_alternative === 'string'
+        ? (obj.applied_alternative as string)
+        : 'A';
+    events.push({
+      event: 'applied',
+      ts: appliedTs,
+      proposal,
+      alternative_id: alternativeId,
+    });
+  }
+
+  if (status === 'refused' || status === 'skipped' || status === 'reverted') {
+    const refusedTs =
+      typeof obj.feedback_at === 'string'
+        ? new Date(obj.feedback_at as string).toISOString()
+        : typeof obj.applied_at === 'string'
+          ? new Date(obj.applied_at as string).toISOString()
+          : createdTs;
+    events.push({ event: 'refused', ts: refusedTs, proposal });
+  }
+
+  return { events };
+}
+
+// ── Main entrypoint ────────────────────────────────────────────────────────────
+
+if (import.meta.main) {
+  const dryRun = process.argv.includes('--dry-run');
+  const proposalsPath = DEFAULT_PROPOSALS_PATH;
+
+  if (!existsSync(proposalsPath)) {
+    console.log(`No proposals.jsonl found at ${proposalsPath} — nothing to migrate.`);
+    process.exit(0);
+  }
+
+  const raw = readFileSync(proposalsPath, 'utf8');
+  const lines = raw.split('\n').filter((l) => l.trim().length > 0);
+
+  if (lines.length === 0) {
+    console.log('proposals.jsonl is empty — nothing to migrate.');
+    process.exit(0);
+  }
+
+  // Check if all lines are already in TS format (has 'event' field or is meta)
+  const needsMigration = lines.some((l) => {
+    try {
+      const obj = JSON.parse(l) as Record<string, unknown>;
+      return !obj._meta && typeof obj.event !== 'string';
+    } catch {
+      return false;
+    }
+  });
+
+  if (!needsMigration) {
+    console.log('proposals.jsonl is already in TS format — no migration needed.');
+    process.exit(0);
+  }
+
+  const secret = loadSecret();
+  const outputLines: string[] = [];
+  let legacyCount = 0;
+  let createdCount = 0;
+  let appliedCount = 0;
+  let refusedCount = 0;
+
+  for (const line of lines) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      process.stderr.write(`WARN: skipping invalid JSON line: ${line.slice(0, 80)}\n`);
+      continue;
+    }
+
+    const obj = parsed as Record<string, unknown>;
+
+    // Meta line — copy as-is
+    if (obj._meta === true) {
+      outputLines.push(JSON.stringify(obj));
+      continue;
+    }
+
+    // Already wrapped — copy as-is
+    if (typeof obj.event === 'string') {
+      outputLines.push(line.trim());
+      continue;
+    }
+
+    // Legacy flat record
+    legacyCount++;
+    const { events } = migrateRecord(parsed, secret);
+    for (const ev of events) {
+      outputLines.push(JSON.stringify(ev));
+      if (ev.event === 'created') createdCount++;
+      else if (ev.event === 'applied') appliedCount++;
+      else if (ev.event === 'refused') refusedCount++;
+    }
+  }
+
+  const summary = `Migrated ${legacyCount} legacy records -> ${outputLines.length} lines (${createdCount} created, ${appliedCount} applied, ${refusedCount} refused)`;
+
+  if (dryRun) {
+    console.log(`[DRY RUN] ${summary}`);
+    console.log('First 5 output lines:');
+    for (const l of outputLines.slice(0, 5)) console.log(' ', l.slice(0, 120));
+    process.exit(0);
+  }
+
+  // Backup original
+  const backupTs = new Date().toISOString().replace(/[:.]/g, '-');
+  const backupPath = `${proposalsPath}.python-backup-${backupTs}`;
+  copyFileSync(proposalsPath, backupPath);
+  console.log(`Backup created: ${backupPath}`);
+
+  // Write migrated output
+  mkdirSync(dirname(proposalsPath), { recursive: true });
+  writeFileSync(proposalsPath, outputLines.join('\n') + '\n');
+
+  console.log(summary);
+  console.log(`Written to: ${proposalsPath}`);
+}

--- a/src/skills-tuner/storage/migrations.ts
+++ b/src/skills-tuner/storage/migrations.ts
@@ -1,0 +1,29 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type MigrationFn = (record: any) => any;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const MIGRATIONS: Record<number, MigrationFn> = {
+  // future migrations: 2: (r) => ({ ...r, newField: 'default' }),
+};
+
+export const CURRENT_SCHEMA_VERSION = 1;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function migrateRecord(record: any, fromVersion = 1): any {
+  let current = fromVersion;
+  while (current < CURRENT_SCHEMA_VERSION) {
+    const fn = MIGRATIONS[current + 1];
+    if (fn) record = fn(record);
+    current++;
+  }
+  return record;
+}
+
+export function detectSchemaVersion(firstLine: string): number {
+  try {
+    const data = JSON.parse(firstLine) as Record<string, unknown>;
+    return typeof data.schema_version === 'number' ? data.schema_version : 1;
+  } catch {
+    return 1;
+  }
+}

--- a/src/skills-tuner/storage/proposals.ts
+++ b/src/skills-tuner/storage/proposals.ts
@@ -9,7 +9,6 @@ export interface ProposalRecord {
   ts: string;
   alternative_id?: string;
   commit_sha?: string;
-  applied_target_path?: string;  // actual path written (may differ from proposal.target_path for new_skill kind)
 }
 
 export const DEFAULT_PROPOSALS_PATH = join(homedir(), '.config', 'tuner', 'proposals.jsonl');
@@ -68,9 +67,7 @@ export class ProposalsStore {
       const ts = new Date(r.ts);
       if (ts < cutoff) continue;
       const sig = r.proposal.pattern_signature;
-      // Prefer the actual applied path (relevant for new_skill kind where proposal.target_path is a placeholder)
-      const targetRaw = r.applied_target_path ?? r.proposal.target_path;
-      const target = targetRaw.replace(/^~/, homedir());
+      const target = r.proposal.target_path.replace(/^~/, homedir());
       if (sig) {
         if (existsSync(target)) {
           const mtime = new Date(statSync(target).mtimeMs);

--- a/src/skills-tuner/storage/proposals.ts
+++ b/src/skills-tuner/storage/proposals.ts
@@ -9,6 +9,7 @@ export interface ProposalRecord {
   ts: string;
   alternative_id?: string;
   commit_sha?: string;
+  applied_target_path?: string;  // actual path written (may differ from proposal.target_path for new_skill kind)
 }
 
 export const DEFAULT_PROPOSALS_PATH = join(homedir(), '.config', 'tuner', 'proposals.jsonl');
@@ -67,7 +68,9 @@ export class ProposalsStore {
       const ts = new Date(r.ts);
       if (ts < cutoff) continue;
       const sig = r.proposal.pattern_signature;
-      const target = r.proposal.target_path.replace(/^~/, homedir());
+      // Prefer the actual applied path (relevant for new_skill kind where proposal.target_path is a placeholder)
+      const targetRaw = r.applied_target_path ?? r.proposal.target_path;
+      const target = targetRaw.replace(/^~/, homedir());
       if (sig) {
         if (existsSync(target)) {
           const mtime = new Date(statSync(target).mtimeMs);

--- a/src/skills-tuner/storage/proposals.ts
+++ b/src/skills-tuner/storage/proposals.ts
@@ -1,0 +1,88 @@
+import { existsSync, mkdirSync, readFileSync, appendFileSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import type { Proposal } from '../core/types.js';
+
+export interface ProposalRecord {
+  proposal: Proposal;
+  event: 'created' | 'applied' | 'refused';
+  ts: string;
+  alternative_id?: string;
+  commit_sha?: string;
+  applied_target_path?: string;  // actual path written (may differ from proposal.target_path for new_skill kind)
+}
+
+export const DEFAULT_PROPOSALS_PATH = join(homedir(), '.config', 'tuner', 'proposals.jsonl');
+
+export class ProposalsStore {
+  constructor(public readonly path: string) {}
+
+  append(record: ProposalRecord): void {
+    mkdirSync(dirname(this.path), { recursive: true });
+    appendFileSync(this.path, JSON.stringify(record) + '\n');
+  }
+
+  readAll(): ProposalRecord[] {
+    if (!existsSync(this.path)) return [];
+    const raw = readFileSync(this.path, 'utf8');
+    const records: ProposalRecord[] = [];
+    for (const line of raw.split('\n')) {
+      const l = line.trim();
+      if (!l) continue;
+      try {
+        const data = JSON.parse(l) as ProposalRecord;
+        if (data.proposal?.created_at) {
+          data.proposal.created_at = new Date(data.proposal.created_at as unknown as string);
+        }
+        records.push(data);
+      } catch {
+        // skip corrupt lines
+      }
+    }
+    return records;
+  }
+
+  pendingSignatures(opts?: { subject?: string }): Set<string> {
+    const all = this.readAll();
+    const resolved = new Set(
+      all
+        .filter(r => r.event === 'applied' || r.event === 'refused')
+        .map(r => r.proposal.pattern_signature),
+    );
+    const result = new Set<string>();
+    for (const r of all) {
+      if (r.event !== 'created') continue;
+      if (opts?.subject && r.proposal.subject !== opts.subject) continue;
+      const sig = r.proposal.pattern_signature;
+      if (!resolved.has(sig)) result.add(sig);
+    }
+    return result;
+  }
+
+  appliedSignatures(opts?: { withinDays?: number }): Set<string> {
+    const withinDays = opts?.withinDays ?? 7;
+    const cutoff = new Date(Date.now() - withinDays * 86_400_000);
+    const sigs = new Set<string>();
+    for (const r of this.readAll()) {
+      if (r.event !== 'applied') continue;
+      const ts = new Date(r.ts);
+      if (ts < cutoff) continue;
+      const sig = r.proposal.pattern_signature;
+      // Prefer the actual applied path (relevant for new_skill kind where proposal.target_path is a placeholder)
+      const targetRaw = r.applied_target_path ?? r.proposal.target_path;
+      const target = targetRaw.replace(/^~/, homedir());
+      if (sig) {
+        if (existsSync(target)) {
+          const mtime = new Date(statSync(target).mtimeMs);
+          if (mtime > ts) continue; // skill changed since applied — bypass cooldown
+        }
+        sigs.add(sig);
+      }
+    }
+    return sigs;
+  }
+
+  signatureRefused(sig: string, refusedSigs: Set<string>): boolean {
+    return refusedSigs.has(sig);
+  }
+}

--- a/src/skills-tuner/storage/refused.ts
+++ b/src/skills-tuner/storage/refused.ts
@@ -1,0 +1,65 @@
+import { existsSync, mkdirSync, readFileSync, appendFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+export interface RefusedRecord {
+  pattern_signature: string;
+  subject: string;
+  user_reason: string;
+  ts: string;
+  expires_at: string;
+}
+
+export const DEFAULT_REFUSED_PATH = join(homedir(), '.config', 'tuner', 'refused.jsonl');
+
+export class RefusedStore {
+  constructor(public readonly path: string, public ttlDays = 30) {}
+
+  add(signature: string, subject: string, userReason = 'skip'): void {
+    mkdirSync(dirname(this.path), { recursive: true });
+    const now = new Date();
+    const expiresAt = new Date(now.getTime() + this.ttlDays * 86_400_000);
+    const record: RefusedRecord = {
+      pattern_signature: signature,
+      subject,
+      user_reason: userReason,
+      ts: now.toISOString(),
+      expires_at: expiresAt.toISOString(),
+    };
+    appendFileSync(this.path, JSON.stringify(record) + '\n');
+  }
+
+  activeSignatures(): Set<string> {
+    const now = Date.now();
+    const sigs = new Set<string>();
+    for (const r of this._readRecords()) {
+      try {
+        if (new Date(r.expires_at).getTime() > now) {
+          sigs.add(r.pattern_signature);
+        }
+      } catch {
+        // skip
+      }
+    }
+    return sigs;
+  }
+
+  isRefused(sig: string): boolean {
+    return this.activeSignatures().has(sig);
+  }
+
+  private _readRecords(): RefusedRecord[] {
+    if (!existsSync(this.path)) return [];
+    const records: RefusedRecord[] = [];
+    for (const line of readFileSync(this.path, 'utf8').split('\n')) {
+      const l = line.trim();
+      if (!l) continue;
+      try {
+        records.push(JSON.parse(l) as RefusedRecord);
+      } catch {
+        // skip corrupt
+      }
+    }
+    return records;
+  }
+}

--- a/src/skills-tuner/subjects/base.ts
+++ b/src/skills-tuner/subjects/base.ts
@@ -1,0 +1,41 @@
+import { readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+import { TunableSubject } from '../core/interfaces.js';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export abstract class BaseSubject extends TunableSubject {
+  protected async loadFrontmatter(filePath: string): Promise<{ frontmatter: Record<string, unknown>; body: string }> {
+    const content = await readFile(filePath, 'utf8');
+    const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+    if (!match) return { frontmatter: {}, body: content };
+    const yaml = await import('js-yaml');
+    const parsed = yaml.load(match[1]!);
+    return {
+      frontmatter: (parsed != null && typeof parsed === 'object' ? parsed : {}) as Record<string, unknown>,
+      body: match[2]!,
+    };
+  }
+
+  protected async scanMdFiles(dir: string): Promise<string[]> {
+    const results: string[] = [];
+    await this._scanDir(dir, results);
+    return results;
+  }
+
+  private async _scanDir(dir: string, results: string[]): Promise<void> {
+    let entries;
+    try {
+      entries = await readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const fullPath = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        await this._scanDir(fullPath, results);
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        results.push(fullPath);
+      }
+    }
+  }
+}

--- a/src/skills-tuner/subjects/external_process.ts
+++ b/src/skills-tuner/subjects/external_process.ts
@@ -1,0 +1,144 @@
+import { spawn } from 'node:child_process';
+import { resolve, sep } from 'node:path';
+import { homedir } from 'node:os';
+import { z } from 'zod';
+import { TunableSubject } from '../core/interfaces.js';
+import {
+  UnsignedProposalSchema,
+  ClusterSchema,
+  ObservationSchema,
+  PatchSchema,
+  ValidationResultSchema,
+  type Cluster,
+  type Observation,
+  type Patch,
+  type UnsignedProposal,
+  type ValidationResult,
+} from '../core/types.js';
+import type { Proposal } from '../core/types.js';
+import type { RiskTier } from '../core/interfaces.js';
+
+export interface ExternalProcessConfig {
+  name: string;
+  command: string[];
+  allowedRoots?: string[];
+  riskTier?: RiskTier;
+  autoMergeDefault?: boolean;
+  supportsCreation?: boolean;
+  orphanMinObservations?: number;
+  timeoutMs?: number;
+  cwd?: string;
+  env?: Record<string, string>;
+  config?: Record<string, unknown>;
+}
+
+const RpcResponseSchema = z.union([
+  z.object({ result: z.unknown() }).strict(),
+  z.object({ error: z.string() }).strict(),
+]);
+
+export class ExternalProcessSubject extends TunableSubject {
+  readonly name: string;
+  readonly risk_tier: RiskTier;
+  readonly auto_merge_default: boolean;
+  readonly supports_creation: boolean;
+  readonly orphan_min_observations: number;
+
+  constructor(private opts: ExternalProcessConfig) {
+    super();
+    this.name = opts.name;
+    this.risk_tier = opts.riskTier ?? 'high';
+    this.auto_merge_default = opts.autoMergeDefault ?? false;
+    this.supports_creation = opts.supportsCreation ?? false;
+    this.orphan_min_observations = opts.orphanMinObservations ?? 2;
+  }
+
+  private async callMethod(method: string, payload: unknown): Promise<unknown> {
+    const proc = spawn(this.opts.command[0]!, this.opts.command.slice(1), {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      cwd: this.opts.cwd,
+      env: { ...process.env, ...this.opts.env },
+    });
+
+    const requestBody = JSON.stringify({ method, payload, config: this.opts.config ?? {} });
+    proc.stdin.write(requestBody);
+    proc.stdin.end();
+
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    proc.stderr.on('data', (chunk: Buffer) => { stderr += chunk.toString('utf8'); });
+
+    const timeoutMs = this.opts.timeoutMs ?? 60_000;
+    const exitCode: number = await new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        proc.kill('SIGKILL');
+        reject(new Error(`ExternalProcess ${this.name} timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+      proc.on('exit', (code) => {
+        clearTimeout(timer);
+        resolve(code ?? -1);
+      });
+      proc.on('error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+    });
+
+    if (exitCode !== 0) {
+      throw new Error(`ExternalProcess ${this.name} exited ${exitCode}. stderr: ${stderr.slice(0, 500)}`);
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(stdout);
+    } catch {
+      throw new Error(`ExternalProcess ${this.name} returned invalid JSON: ${stdout.slice(0, 500)}`);
+    }
+
+    const validated = RpcResponseSchema.parse(parsed);
+    if ('error' in validated) {
+      throw new Error(`ExternalProcess ${this.name} method ${method} error: ${validated.error}`);
+    }
+    return validated.result;
+  }
+
+  async collectObservations(since: Date): Promise<Observation[]> {
+    const result = await this.callMethod('collect_observations', { since: since.toISOString() });
+    return z.array(ObservationSchema).parse(result);
+  }
+
+  async detectProblems(observations: Observation[]): Promise<Cluster[]> {
+    const result = await this.callMethod('detect_problems', { observations });
+    return z.array(ClusterSchema).parse(result);
+  }
+
+  async proposeChange(cluster: Cluster): Promise<UnsignedProposal> {
+    const result = await this.callMethod('propose_change', { cluster });
+    return UnsignedProposalSchema.parse(result);
+  }
+
+  async apply(proposal: Proposal, alternativeId: string): Promise<Patch> {
+    const result = await this.callMethod('apply', { proposal, alternative_id: alternativeId });
+    const patch = PatchSchema.parse(result);
+
+    // Path traversal guard
+    const roots = this.opts.allowedRoots;
+    if (!roots || roots.length === 0) {
+      throw new Error(`ExternalProcessSubject '${this.name}' has no allowedRoots configured — external subjects must declare explicit write zones`);
+    }
+    const target = resolve(patch.target_path.replace(/^~/, homedir()));
+    const allowed = roots.map(r => resolve(r.replace(/^~/, homedir())));
+    const safe = allowed.some(root => target.startsWith(root + sep) || target === root);
+    if (!safe) {
+      throw new Error(`ExternalProcessSubject '${this.name}' refusing to write outside allowedRoots: target=${target}, allowedRoots=[${allowed.join(', ')}]`);
+    }
+
+    return patch;
+  }
+
+  async validate(patch: Patch): Promise<ValidationResult> {
+    const result = await this.callMethod('validate', { patch });
+    return ValidationResultSchema.parse(result);
+  }
+}

--- a/src/skills-tuner/subjects/skills.ts
+++ b/src/skills-tuner/subjects/skills.ts
@@ -1,0 +1,664 @@
+import { writeFile, copyFile, mkdir, readdir } from 'node:fs/promises';
+import { existsSync, statSync, readdirSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join, dirname, basename, resolve, sep } from 'node:path';
+import { homedir } from 'node:os';
+import { createInterface } from 'node:readline';
+import { createReadStream } from 'node:fs';
+import { BaseSubject } from './base.js';
+import { sanitizeObservationContent } from '../core/security.js';
+import { ORPHAN_SUBJECT, CREATE_KINDS } from '../core/interfaces.js';
+import type { Cluster, Observation, Patch, Proposal, UnsignedProposal, ValidationResult } from '../core/types.js';
+import type { LLMClient } from '../core/llm.js';
+
+export const DEFAULT_NEGATIVE_PATTERNS: RegExp[] = [
+  /\bnope\b/i, /\bwrong\b/i, /not right/i, /try again/i,
+  /\bno\b/i, /that's not/i, /i don't like/i, /frustrat/i, /not what i/i,
+  /\bnon\b/i, /pas comme/i, /c'est pas/i, /recommence/i, /oublie/i,
+];
+export const DEFAULT_POSITIVE_PATTERNS: RegExp[] = [
+  /\bperfect\b/i, /\bnice\b/i, /\bexactly\b/i, /\bgood\b/i,
+  /\bthanks\b/i, /\bgreat\b/i, /that.*right/i, /that.*works/i,
+  /\bparfait\b/i, /\bmerci\b/i, /c'est bon/i, /bien fait/i,
+];
+export const DEFAULT_EMOTIONAL_PATTERNS: RegExp[] = [
+  /\bmoney\b/i, /\bcash\b/i, /at stake/i,
+  /\bdamn\b/i, /\bhell\b/i, /\bfuck\b/i, /\bshit\b/i,
+  /\bbroken\b/i, /frustrating/i, /\bangry\b/i,
+];
+
+export const ORPHAN_SKILL = ORPHAN_SUBJECT;
+
+export interface SkillEntry {
+  path: string;
+  dirPath: string | null;           // set for directory format, null for flat
+  format: 'flat' | 'directory';
+  frontmatter: Record<string, unknown>;
+  content: string;
+  triggers: string[];               // resolved: config overrides > frontmatter > name
+}
+
+export interface SkillOverride {
+  triggers?: string[];
+  risk_tier?: string;
+  auto_merge_default?: boolean;
+}
+
+export interface SkillsSubjectConfig {
+  llm?: LLMClient;
+  scanDirs?: string[];
+  emotionalPatterns?: RegExp[];
+  negativePatterns?: RegExp[];
+  positivePatterns?: RegExp[];
+  // Skills-tuner-specific metadata for Anthropic-format skills (no frontmatter pollution)
+  overrides?: Record<string, SkillOverride>;
+}
+
+function combineRegex(patterns: RegExp[]): RegExp {
+  return new RegExp(patterns.map(p => p.source).join('|'), 'i');
+}
+
+function stripFences(text: string): string {
+  text = text.trim();
+  if (text.startsWith('```')) {
+    text = text.includes('\n') ? text.slice(text.indexOf('\n') + 1) : text.slice(3);
+    if (text.endsWith('```')) text = text.slice(0, text.lastIndexOf('```'));
+  }
+  return text.trim();
+}
+
+
+export class SkillsSubject extends BaseSubject {
+  readonly name = 'skills';
+  readonly risk_tier = 'low' as const;
+  readonly auto_merge_default = true;
+  readonly supports_creation = true;
+  readonly orphan_min_observations = 2;
+
+  private readonly llm?: LLMClient;
+  private readonly scanDirs: string[];
+  private readonly negRe: RegExp;
+  private readonly posRe: RegExp;
+  private readonly emotRe: RegExp;
+  private readonly overrides: Record<string, SkillOverride>;
+  private skillsCache: Map<string, SkillEntry> | null = null;
+
+  constructor(opts: SkillsSubjectConfig = {}) {
+    super();
+    this.llm = opts.llm;
+    this.scanDirs = opts.scanDirs ?? [join(homedir(), 'agent', 'skills')];
+    this.negRe = combineRegex(opts.negativePatterns ?? DEFAULT_NEGATIVE_PATTERNS);
+    this.posRe = combineRegex(opts.positivePatterns ?? DEFAULT_POSITIVE_PATTERNS);
+    this.emotRe = combineRegex(opts.emotionalPatterns ?? DEFAULT_EMOTIONAL_PATTERNS);
+    this.overrides = opts.overrides ?? {};
+  }
+
+  async collectObservations(since: Date): Promise<Observation[]> {
+    const skills = await this.loadSkillsMap();
+    if (skills.size === 0) return [];
+
+    const observations: Observation[] = [];
+    const sessionFiles = await this.findSessionFiles(since);
+
+    for (const filePath of sessionFiles) {
+      try {
+        const obs = await this.scanSession(filePath, skills, since);
+        observations.push(...obs);
+      } catch {
+        // skip unreadable session
+      }
+    }
+    return observations;
+  }
+
+  async detectProblems(observations: Observation[]): Promise<Cluster[]> {
+    if (observations.length === 0) return [];
+
+    const bySkill = new Map<string, Observation[]>();
+    for (const obs of observations) {
+      const skillName = (obs.metadata?.['skill_name'] as string | undefined) ?? 'unknown';
+      const list = bySkill.get(skillName) ?? [];
+      list.push(obs);
+      bySkill.set(skillName, list);
+    }
+
+    const clusters: Cluster[] = [];
+    const now = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+
+    for (const [skillName, obsList] of bySkill) {
+      if (skillName === ORPHAN_SKILL) {
+        if (obsList.length >= this.orphan_min_observations) {
+          clusters.push({
+            id: 'skills-' + ORPHAN_SKILL + '-' + now,
+            subject: 'skills',
+            observations: obsList,
+            frequency: obsList.length,
+            success_rate: 0,
+            sentiment: 'negative',
+            subjects_touched: [ORPHAN_SKILL],
+          });
+        }
+        continue;
+      }
+
+      const neg = obsList.filter(o => o.signal_type !== 'positive_feedback');
+      const pos = obsList.filter(o => o.signal_type === 'positive_feedback');
+      const total = obsList.length;
+      const successRate = total > 0 ? pos.length / total : 0;
+      const frequency = neg.length;
+
+      if (frequency < 2) continue;
+      if (successRate > 0.8) continue;
+
+      clusters.push({
+        id: 'skills-' + skillName + '-' + now,
+        subject: 'skills',
+        observations: obsList,
+        frequency,
+        success_rate: successRate,
+        sentiment: successRate < 0.3 ? 'negative' : 'neutral',
+        subjects_touched: [skillName],
+      });
+    }
+
+    clusters.sort((a, b) => b.frequency - a.frequency);
+    return clusters;
+  }
+
+  async proposeChange(cluster: Cluster): Promise<UnsignedProposal> {
+    const skillName = cluster.subjects_touched[0] ?? 'unknown';
+    if (skillName === ORPHAN_SKILL) {
+      return this.proposeNewSkill(cluster);
+    }
+    return this.proposePatchForExistingSkill(cluster, skillName);
+  }
+
+  async apply(proposal: Proposal, alternativeId: string): Promise<Patch> {
+    const alt = proposal.alternatives.find(a => a.id === alternativeId);
+    if (!alt) throw new Error('Alternative ' + alternativeId + ' not found');
+
+    const expandHome = (p: string) => p.replace(/^~/, homedir());
+    const allowed = this.scanDirs.map(d => resolve(expandHome(d)));
+
+    if (CREATE_KINDS.has(proposal.kind as never)) {
+      const slug = (alt.label.toLowerCase().replace(/[^a-z0-9-]/g, '-').replace(/^-+|-+$/, '') || 'new-skill');
+      const baseDir = resolve(expandHome(this.scanDirs[0]!));
+
+      // Default to directory format (Anthropic standard)
+      let actualDir = resolve(baseDir, slug);
+      let target = join(actualDir, 'SKILL.md');
+
+      // Collision: append timestamp
+      if (existsSync(actualDir)) {
+        const ts = Math.floor(Date.now() / 1000);
+        actualDir = actualDir + '-' + ts;
+        target = join(actualDir, 'SKILL.md');
+      }
+
+      // Path containment guard
+      const targetReal = resolve(target);
+      if (!allowed.some(d => targetReal === d || targetReal.startsWith(d + sep) || targetReal.startsWith(d + '/'))) {
+        throw new Error('Target ' + targetReal + ' outside scan_dirs');
+      }
+
+      await mkdir(actualDir, { recursive: true });
+      await writeFile(target, alt.diff_or_content, 'utf8');
+      this.skillsCache = null;
+      return { target_path: target, kind: proposal.kind, applied_content: alt.diff_or_content };
+    }
+
+    const target = resolve(expandHome(proposal.target_path));
+    if (!allowed.some(d => target.startsWith(d + sep) || target.startsWith(d + '/') || target === d)) {
+      throw new Error('Target ' + target + ' outside scan_dirs');
+    }
+    if (!existsSync(target)) {
+      throw new Error('Target ' + target + ' does not exist for kind=' + proposal.kind);
+    }
+    await copyFile(target, target + '.bak');
+    await writeFile(target, alt.diff_or_content, 'utf8');
+    this.skillsCache = null;
+    return { target_path: target, kind: proposal.kind, applied_content: alt.diff_or_content };
+  }
+
+  async validate(patch: Patch): Promise<ValidationResult> {
+    if (CREATE_KINDS.has(patch.kind as never)) {
+      const content = patch.applied_content ?? '';
+      if (!content.startsWith('---')) {
+        return { valid: false, reason: 'Created skill missing frontmatter' };
+      }
+      const fm = content.split('---')[1] ?? '';
+      if (!fm.includes('name:')) {
+        return { valid: false, reason: 'Created skill missing name: in frontmatter (Anthropic format requires name)' };
+      }
+      if (!fm.includes('description:')) {
+        return { valid: false, reason: 'Created skill missing description: in frontmatter (Anthropic format requires description for discovery)' };
+      }
+      // Note: triggers: is optional — configure in ~/.config/tuner/config.yaml under subjects.skills.overrides
+    }
+    return { valid: true };
+  }
+
+  scoreSignal(verbatim: string, attributedTo: string, knownEntities: Record<string, unknown>): number {
+    const textLower = verbatim.toLowerCase();
+    const triggersMatched = new Set<string>();
+    for (const [name, info] of Object.entries(knownEntities)) {
+      const triggers: string[] = (info as { triggers?: string[] } | null)?.triggers ?? [name];
+      for (const trigger of triggers) {
+        if (textLower.includes(trigger.toLowerCase())) {
+          triggersMatched.add(name);
+          break;
+        }
+      }
+    }
+    let score = 0;
+    if (triggersMatched.has(attributedTo)) score += 2;
+    const others = [...triggersMatched].filter(n => n !== attributedTo);
+    if (others.length > 0) score -= 3;
+    if (triggersMatched.size === 0 && this.emotRe.test(verbatim)) score -= 1;
+    return score;
+  }
+
+  reclassifySignal(verbatim: string, knownEntities: Record<string, unknown>): string {
+    const textLower = verbatim.toLowerCase();
+    for (const [name, info] of Object.entries(knownEntities)) {
+      const triggers: string[] = (info as { triggers?: string[] } | null)?.triggers ?? [name];
+      for (const trigger of triggers) {
+        if (textLower.includes(trigger.toLowerCase())) return name;
+      }
+    }
+    return ORPHAN_SUBJECT;
+  }
+
+  // ── Private helpers ──
+
+  private async loadSkillsMap(): Promise<Map<string, SkillEntry>> {
+    if (this.skillsCache) return this.skillsCache;
+    const map = new Map<string, SkillEntry>();
+
+    for (const dir of this.scanDirs) {
+      const expanded = dir.replace(/^~/, homedir());
+      if (!existsSync(expanded)) continue;
+
+      let entries;
+      try {
+        entries = await readdir(expanded, { withFileTypes: true });
+      } catch { continue; }
+
+      // Pass 1: directory format (Anthropic standard — higher priority)
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        const skillMdPath = join(expanded, entry.name, 'SKILL.md');
+        if (!existsSync(skillMdPath)) continue;
+        const { frontmatter, body } = await this.loadFrontmatter(skillMdPath);
+        const name = (frontmatter['name'] as string | undefined) ?? entry.name;
+        const configOverride = this.overrides[name]?.triggers;
+        const triggers = Array.isArray(configOverride) ? configOverride : this.parseTriggers(frontmatter, name);
+        map.set(name, {
+          path: skillMdPath,
+          dirPath: join(expanded, entry.name),
+          format: 'directory',
+          frontmatter,
+          content: body,
+          triggers,
+        });
+      }
+
+      // Pass 2: flat format — skipped if directory format already loaded for same name
+      for (const entry of entries) {
+        if (entry.isDirectory() || !entry.name.endsWith('.md') || entry.name.includes('.bak')) continue;
+        const filePath = join(expanded, entry.name);
+        const { frontmatter, body } = await this.loadFrontmatter(filePath);
+        const name = (frontmatter['name'] as string | undefined) ?? entry.name.replace(/\.md$/, '');
+        if (map.has(name)) continue; // directory format wins
+        const configOverride = this.overrides[name]?.triggers;
+        const triggers = Array.isArray(configOverride) ? configOverride : this.parseTriggers(frontmatter, name);
+        map.set(name, {
+          path: filePath,
+          dirPath: null,
+          format: 'flat',
+          frontmatter,
+          content: body,
+          triggers,
+        });
+      }
+    }
+
+    this.skillsCache = map;
+    return map;
+  }
+
+  private parseTriggers(frontmatter: Record<string, unknown>, fallback: string): string[] {
+    const raw = frontmatter['triggers'] ?? frontmatter['trigger'];
+    if (typeof raw === 'string') return raw.split(',').map(t => t.trim()).filter(Boolean);
+    if (Array.isArray(raw)) return raw.map(String);
+    return [fallback];
+  }
+
+  private matchSkill(text: string, skills: Map<string, { triggers: string[] }>): string | null {
+    const textLower = text.toLowerCase();
+    for (const [name, info] of skills) {
+      for (const trigger of info.triggers) {
+        if (textLower.includes(trigger.toLowerCase())) return name;
+      }
+    }
+    return null;
+  }
+
+  private async findSessionFiles(since: Date): Promise<string[]> {
+    const files: string[] = [];
+
+    const home = homedir();
+    const projectsDir = join(home, '.claude', 'projects');
+    if (existsSync(projectsDir)) {
+      try {
+        const projects = await readdir(projectsDir, { withFileTypes: true });
+        for (const project of projects) {
+          if (!project.isDirectory()) continue;
+          const projectPath = join(projectsDir, project.name);
+          const direct = await readdir(projectPath).catch(() => [] as string[]);
+          for (const f of direct) {
+            if (f.endsWith('.jsonl')) files.push(join(projectPath, f));
+          }
+          const sessionsPath = join(projectPath, 'sessions');
+          if (existsSync(sessionsPath)) {
+            const sesFiles = await readdir(sessionsPath).catch(() => [] as string[]);
+            for (const f of sesFiles) {
+              if (f.endsWith('.jsonl')) files.push(join(sessionsPath, f));
+            }
+          }
+        }
+      } catch { /* skip */ }
+    }
+
+    const sinceMs = since.getTime();
+    return files
+      .filter(f => {
+        try { return statSync(f).mtimeMs >= sinceMs; } catch { return false; }
+      })
+      .map(f => { try { return { f, mtime: statSync(f).mtimeMs }; } catch { return { f, mtime: 0 }; } })
+      .sort((a, b) => b.mtime - a.mtime)
+      .map(x => x.f)
+      .slice(0, 50);
+  }
+
+  private async scanSession(filePath: string, skills: Map<string, SkillEntry>, since: Date): Promise<Observation[]> {
+    const observations: Observation[] = [];
+    const messages: Array<Record<string, unknown>> = [];
+
+    const rl = createInterface({ input: createReadStream(filePath, 'utf8'), crlfDelay: Infinity });
+    for await (const line of rl) {
+      if (!line.trim()) continue;
+      try { messages.push(JSON.parse(line) as Record<string, unknown>); } catch { /* skip */ }
+    }
+
+    const sessionId = basename(filePath, '.jsonl');
+
+    for (let i = 0; i < messages.length; i++) {
+      const msg = messages[i]!;
+      if (msg['type'] !== 'user') continue;
+      const text = this.extractText(msg);
+      if (!text) continue;
+
+      const matchedSkill = this.matchSkill(text, skills);
+      if (!matchedSkill) continue;
+
+      let nextUserText = '';
+      for (let j = i + 1; j < Math.min(i + 5, messages.length); j++) {
+        if (messages[j]!['type'] === 'user') {
+          nextUserText = this.extractText(messages[j]!) ?? '';
+          break;
+        }
+      }
+
+      const ts = this.parseTs(msg);
+      const skillsAsEntities: Record<string, unknown> = {};
+      for (const [k, v] of skills) skillsAsEntities[k] = { triggers: v.triggers };
+
+      if (nextUserText && this.negRe.test(nextUserText)) {
+        const score = this.scoreSignal(nextUserText, matchedSkill, skillsAsEntities);
+        const attributed = score < 0 ? this.reclassifySignal(nextUserText, skillsAsEntities) : matchedSkill;
+        observations.push({
+          session_id: sessionId,
+          observed_at: ts,
+          signal_type: 'correction',
+          verbatim: sanitizeObservationContent(nextUserText.slice(0, 200)),
+          metadata: { skill_name: attributed, trigger: text.slice(0, 100) },
+        });
+      } else if (nextUserText && this.posRe.test(nextUserText)) {
+        observations.push({
+          session_id: sessionId,
+          observed_at: ts,
+          signal_type: 'positive_feedback',
+          verbatim: sanitizeObservationContent(nextUserText.slice(0, 200)),
+          metadata: { skill_name: matchedSkill },
+        });
+      }
+    }
+    return observations;
+  }
+
+  private extractText(msg: Record<string, unknown>): string | null {
+    try {
+      const content = (msg['message'] as Record<string, unknown> | undefined)?.['content'];
+      if (typeof content === 'string') return content;
+      if (Array.isArray(content)) {
+        const parts = (content as Array<Record<string, unknown>>)
+          .filter(c => c['type'] === 'text')
+          .map(c => String(c['text'] ?? ''));
+        return parts.join(' ') || null;
+      }
+    } catch { /* skip */ }
+    return null;
+  }
+
+  private parseTs(msg: Record<string, unknown>): Date {
+    const ts = msg['timestamp'];
+    if (typeof ts === 'string') {
+      try { return new Date(ts); } catch { /* fall through */ }
+    }
+    return new Date();
+  }
+
+  private async proposeNewSkill(cluster: Cluster): Promise<UnsignedProposal> {
+    const evidence = cluster.observations.slice(0, 6).map(o => '- ' + sanitizeObservationContent(o.verbatim)).join('\n');
+    const targetPath = join(this.scanDirs[0]!.replace(/^~/, homedir()), ORPHAN_SKILL + '.md');
+
+    const alternatives = this.llm
+      ? await this.llmProposeNewSkill(evidence, cluster).catch(() => this.fallbackNewSkillAlternatives())
+      : this.fallbackNewSkillAlternatives();
+
+    return {
+      id: 0,
+      cluster_id: cluster.id,
+      subject: 'skills',
+      kind: 'new_skill',
+      target_path: targetPath,
+      alternatives,
+      pattern_signature: cluster.id + ':new_skill',
+      created_at: new Date(),
+    };
+  }
+
+  private async proposePatchForExistingSkill(cluster: Cluster, skillName: string): Promise<UnsignedProposal> {
+    const skills = await this.loadSkillsMap();
+    const skillInfo = skills.get(skillName);
+    const skillPath = skillInfo?.path ?? join(this.scanDirs[0]!, skillName + '.md');
+    const rawSkillContent = skillInfo?.content ?? '(content not found)';
+    const skillContent = sanitizeObservationContent(rawSkillContent, 10_000);
+    const evidence = cluster.observations.slice(0, 6)
+      .map(o => '- [' + o.signal_type + '] ' + sanitizeObservationContent(o.verbatim)).join('\n');
+
+    const alternatives = this.llm
+      ? await this.llmPropose(skillName, skillContent, evidence, cluster).catch(() => this.fallbackAlternatives(skillName, skillInfo))
+      : this.fallbackAlternatives(skillName, skillInfo);
+
+    return {
+      id: 0,
+      cluster_id: cluster.id,
+      subject: 'skills',
+      kind: 'patch',
+      target_path: skillPath,
+      alternatives,
+      pattern_signature: cluster.id + ':' + skillPath + ':patch',
+      created_at: new Date(),
+    };
+  }
+
+  private async llmProposeNewSkill(evidence: string, cluster: Cluster) {
+    const system = 'Generate a Claude Code skill in the Anthropic standard directory format. The output should be the contents of SKILL.md (a single markdown file with frontmatter name: and description:, body in markdown). The description should be discoverable — start with what the skill does and when to use it, since Claude Code skill matcher uses descriptions to choose which skills to load. Do NOT include triggers: or risk_tier: in the frontmatter — those go in the user config. Reply ONLY with a JSON array of 3 objects: [{"id":"A","label":"...","diff_or_content":"...","tradeoff":"..."},...]';
+    const user = 'Unattributed signals (' + cluster.frequency + ' occurrences):\n' + evidence + '\n\nIdentify the implicit need and propose 3 skill templates in Anthropic directory format (SKILL.md content).';
+    const raw = await this.llm!.call('proposer', system, [{ role: 'user', content: user }], 4000);
+    const data = JSON.parse(stripFences(raw)) as Array<{ id: string; label: string; diff_or_content: string; tradeoff?: string }>;
+    return data.slice(0, 3).map(a => ({ id: a.id, label: a.label, diff_or_content: a.diff_or_content, tradeoff: a.tradeoff ?? '' }));
+  }
+
+  private async llmPropose(skillName: string, skillContent: string, evidence: string, cluster: Cluster) {
+    const system = 'You are an expert in prompt improvement for AI agents. Propose 3 concrete alternatives to improve a markdown skill file. Reply ONLY with a JSON array: [{"id":"A","label":"...","diff_or_content":"...","tradeoff":"..."},...]. Each diff_or_content must be the COMPLETE revised skill.';
+    const user = 'Skill: ' + skillName + '\n\nCurrent content:\n```\n' + skillContent.slice(0, 3000) + '\n```\n\nNegative signals (' + cluster.frequency + ' occurrences):\n' + evidence + '\n\nPropose 3 improvement alternatives.';
+    const raw = await this.llm!.call('proposer', system, [{ role: 'user', content: user }], 4000);
+    const data = JSON.parse(stripFences(raw)) as Array<{ id: string; label: string; diff_or_content: string; tradeoff?: string }>;
+    return data.slice(0, 3).map(a => ({ id: a.id, label: a.label, diff_or_content: a.diff_or_content, tradeoff: a.tradeoff ?? '' }));
+  }
+
+  private fallbackNewSkillAlternatives() {
+    // Anthropic standard format: name + description in frontmatter, no triggers (go in config)
+    return [
+      { id: 'A', label: 'new-skill', diff_or_content: '---\nname: new-skill\ndescription: Describe what this skill does and when to use it. This description is used by Claude Code skill matcher.\n---\n\n# New Skill\n\nDescribe the skill here.\n', tradeoff: 'Minimal Anthropic-format starting point' },
+      { id: 'B', label: 'system-monitor', diff_or_content: '---\nname: system-monitor\ndescription: Check the state of services, disk usage, and system health. Use when asked about infrastructure status.\n---\n\n# System Monitor\n\nCheck the state of services.\n', tradeoff: 'Useful if signals relate to infra' },
+      { id: 'C', label: 'assistant-context', diff_or_content: '---\nname: assistant-context\ndescription: Provides context about the assistant persona, preferences, and collaboration style. Use for onboarding or preference discussions.\n---\n\n# Assistant Context\n\nContext about the assistant.\n', tradeoff: 'Useful if signals relate to general assistance' },
+    ];
+  }
+
+  private fallbackAlternatives(skillName: string, skillInfo: SkillEntry | undefined) {
+    const fm = skillInfo?.frontmatter ?? {};
+    const triggersList = Array.isArray(fm['triggers']) ? fm['triggers'] : (fm['triggers'] ? [fm['triggers']] : [skillName]);
+    const fmBlock = '---\nname: ' + (fm['name'] ?? skillName) + (fm['description'] ? '\ndescription: ' + JSON.stringify(fm['description']) : '') + (triggersList.length > 0 && fm['triggers'] ? '\ntriggers: ' + JSON.stringify(triggersList) : '') + '\n---\n\n';
+    const body = skillInfo?.content ?? '';
+    return [
+      { id: 'A', label: 'Concise version', diff_or_content: fmBlock + '# ' + skillName + '\n\n' + body.slice(0, 500).trim() + '\n', tradeoff: 'Reduces noise, keeps the essentials' },
+      { id: 'B', label: 'Original + examples', diff_or_content: fmBlock + body + '\n\n## Examples\n- Example 1\n- Example 2\n', tradeoff: 'More context, but longer' },
+      { id: 'C', label: 'With explicit triggers (verbose)', diff_or_content: fmBlock + body, tradeoff: 'Frontmatter normalized; body unchanged' },
+    ];
+  }
+
+  // ── Migration helpers ──
+
+  /** List skills that are still in legacy flat format — migration candidates. */
+  async listMigrationCandidates(): Promise<string[]> {
+    const skills = await this.loadSkillsMap();
+    return [...skills.values()]
+      .filter(s => s.format === 'flat')
+      .map(s => (s.frontmatter['name'] as string | undefined) ?? basename(s.path, '.md'));
+  }
+
+  /**
+   * Convert a flat skill file to Anthropic directory format (<name>/SKILL.md).
+   * Strips tuner-specific fields (triggers, risk_tier, auto_merge*) from frontmatter.
+   * Returns the stripped fields so the caller can persist them to config.yaml.
+   * Backs up the original flat file with a .pre-migration-<ts>.bak suffix before removing it.
+   */
+  async migrateSkillToDirectory(skillName: string): Promise<Record<string, unknown>> {
+    // Validate skillName before any FS operations
+    if (/[/\\]/.test(skillName) || skillName === '..' || skillName === '.') {
+      throw new Error('Invalid skill name for migration: ' + skillName);
+    }
+
+    const skills = await this.loadSkillsMap();
+    const skill = skills.get(skillName);
+    if (!skill) throw new Error('Skill ' + skillName + ' not found');
+    if (skill.format === 'directory') return {};  // already migrated
+
+    const flatPath = skill.path;
+    const baseDir = dirname(flatPath);
+    const newDir = join(baseDir, skillName);
+    const newPath = join(newDir, 'SKILL.md');
+
+    // Path containment: newDir must be inside an allowed scanDir
+    const allowed = this.scanDirs.map(d => resolve(d.replace(/^~/, homedir())));
+    const newDirReal = resolve(newDir);
+    if (!allowed.some(d => newDirReal === d || newDirReal.startsWith(d + sep) || newDirReal.startsWith(d + '/'))) {
+      throw new Error('Migration target ' + newDirReal + ' outside scan_dirs');
+    }
+
+    if (existsSync(newDir)) {
+      throw new Error('Cannot migrate: ' + newDir + ' already exists');
+    }
+
+    const TUNER_FIELDS = ['triggers', 'trigger', 'risk_tier', 'auto_merge', 'auto_merge_default'];
+    const cleanedFrontmatter: Record<string, unknown> = {};
+    const movedToConfig: Record<string, unknown> = {};
+
+    for (const [k, v] of Object.entries(skill.frontmatter)) {
+      if (TUNER_FIELDS.includes(k)) {
+        movedToConfig[k] = v;
+      } else {
+        cleanedFrontmatter[k] = v;
+      }
+    }
+
+    // Serialize cleaned frontmatter to YAML (simple key: value, arrays as JSON for safety)
+    const fmLines = Object.entries(cleanedFrontmatter).map(([k, v]) => {
+      if (typeof v === 'string' && !v.includes('\n') && !v.includes(':') && !v.includes('"')) {
+        return k + ': ' + v;
+      }
+      return k + ': ' + JSON.stringify(v);
+    });
+    const newContent = '---\n' + fmLines.join('\n') + '\n---\n\n' + skill.content;
+
+    // Write backup BEFORE making any changes (if write fails later, original is intact)
+    const backupPath = flatPath + '.pre-migration-' + Date.now() + '.bak';
+    await copyFile(flatPath, backupPath);
+
+    // Create directory and write SKILL.md
+    await mkdir(newDir, { recursive: true });
+    await writeFile(newPath, newContent, 'utf8');
+
+    // Remove original flat file — backup already safe
+    const { unlink } = await import('node:fs/promises');
+    await unlink(flatPath);
+
+    this.skillsCache = null;
+    return movedToConfig;
+  }
+
+  currentStateHash(): string {
+    const items: string[] = [];
+    for (const dir of this.scanDirs) {
+      const expanded = dir.replace(/^~/, homedir());
+      if (!existsSync(expanded)) continue;
+      const entries = walkSkillFiles(expanded);
+      for (const e of entries) {
+        items.push(`${e.relPath}\t${e.mtimeMs}\t${e.size}`);
+      }
+    }
+    items.sort();
+    return createHash('sha256').update(items.join('\n')).digest('hex');
+  }
+}
+
+function walkSkillFiles(dir: string): Array<{ relPath: string; mtimeMs: number; size: number }> {
+  const result: Array<{ relPath: string; mtimeMs: number; size: number }> = [];
+  function recurse(current: string, prefix: string) {
+    let names: string[];
+    try { names = readdirSync(current); } catch { return; }
+    for (const name of names) {
+      if (typeof name !== 'string') continue;
+      const full = join(current, name);
+      const rel = prefix ? join(prefix, name) : name;
+      let isDir = false;
+      try {
+        isDir = statSync(full).isDirectory();
+      } catch { continue; }
+      if (isDir) {
+        recurse(full, rel);
+      } else if (name.endsWith('.md') && !name.includes('.bak')) {
+        try {
+          const st = statSync(full);
+          result.push({ relPath: rel, mtimeMs: st.mtimeMs, size: st.size });
+        } catch { /* skip unreadable */ }
+      }
+    }
+  }
+  recurse(dir, '');
+  return result;
+}


### PR DESCRIPTION
## Summary

Stacked on PR2. This PR ships **`SkillsSubject`** — the first concrete `TunableSubject`, **directly addressing #14**: detect repeated patterns or unmatched frustrations and propose capturing them as new skills with Telegram inline approval (boutons via PR2's `TelegramAdapter`).

It also ships:
- The **`/tuner` companion skill** (`src/skills-tuner-templates/tuner.md`, 493 LOC, 6 modes) — itself a `TunableSubject` member, demonstrating recursive self-improvement with safeguards (`risk_tier: critical`, dead-man's switch, 30-day cooldown).
- The **CLI** (`commander`-based, 9 commands).

This PR exists primarily as a **canonical example** of how to write a subject and how to integrate one with Claude Code's skill system. Other surfaces (voice lexicon, RAG weights, MCP config, ML hyperparameters) will follow the same pattern.

## Direct mapping to #14

#14 asks for:

> *"When Claude notices it is performing the same multi-step sequence repeatedly, it could propose capturing it as a skill — then ask the user to approve or reject via Telegram inline buttons before writing anything."*

Implementation in this PR:

| #14 ask | Implementation |
|---|---|
| "notices same multi-step sequence repeatedly" | `SkillsSubject.collectObservations()` scans Claude Code session JSONLs over a configurable window |
| "propose capturing it as a skill" | When ≥ `orphan_min_observations` (default 2) frustration signals match no existing skill, the subject emits a `Cluster` with `subjects_touched=[ORPHAN_SUBJECT]`. `propose_change()` returns a `Proposal` with `kind="new_skill"` |
| "Telegram message with inline buttons [Save / Skip / Edit first]" | `TelegramAdapter` from PR2 renders proposal cards with the inline keyboard |
| "On approval: writes the skill file and registers it" | `apply()` dispatches on `kind in CREATE_KINDS` → creates `.md` file in `scan_dirs[0]` (slug from alternative label, collision → timestamp suffix). `validate()` enforces frontmatter has triggers (anti-loop guard) |
| "On rejection: notes the skip to avoid re-proposing" | The framework writes `pattern_signature` to `refused.jsonl` with TTL 30d (PR1 mechanism) |

The auto-capture flow is the literal #14 ask. The framework primitives from PR1 + PR2 made it almost free to implement.

## Bonus beyond #14 — improvement of existing skills

Once the `new_skill` capture flow worked, the same machinery extended naturally to **modifying** existing skills (`kind="patch"` or `kind="frontmatter"`). Detect that a skill is invoked + immediately followed by user correction → propose a patch via Sonnet. Same Telegram surface, same git-isolated branch + audit log.

This wasn't explicitly asked in #14 but ships because the cost of adding it on top of `new_skill` was minimal — and it's the obvious counterpart to capture (skills should evolve, not just appear).

## What's included

### `src/skills-tuner/subjects/skills.ts`

Implements the 5 `TunableSubject` methods:

- `collectObservations()` — scans Claude Code session JSONLs + Telegram history (configurable window, default 7d) for skill mentions followed by user reactions (correction / positive / repeated_trigger / orphan). Applies `sanitizeObservationContent` on every verbatim before storage.
- `detectProblems()` — clusters observations per-skill (≥3 negatives in window, success_rate < 50%, etc.) **and** clusters orphan signals (≥`orphan_min_observations` frustrations matching no existing skill → `new_skill` candidate).
- `proposeChange()` — Sonnet for patches, Opus for new-skill creation; returns 2-3 alternatives with tradeoff strings.
- `apply()` — dispatches on `kind`: `patch`/`frontmatter` modify existing `.md`; `new_skill` creates a new file. Path containment guard. Anti-loop validation (refuses new_skill content without triggers in frontmatter).
- `validate()` — confirms frontmatter parses, triggers list non-empty, target path contained in `scan_dirs`.

`scoreSignal()` and `reclassifySignal()` overrides:
- `+2` if verbatim contains a trigger of the matched skill
- `-3` if it contains a trigger of a different skill (cross-context noise → reattribute)
- `-1` if emotional without trigger (orphan candidate)
- `0` otherwise

### `src/skills-tuner-templates/tuner.md` — the companion `/tuner` skill

493 LOC, 6 modes:
- `setup` — first-time wizard (detect git repo, dominant language, generate `~/.config/tuner/config.yaml`, dry-run preview, cron prompt)
- `create` — companion to Claude Code's native skill creation flow (suggest triggers + risk_tier, register with tuner config, suggest domain-specific patterns)
- `adjust [name]` — tune existing skill or subject
- `audit` — periodic review (read-only metrics, suggested next actions)
- `optimize` — cost/perf reduction (model downgrades, threshold tuning)
- `report` — surface a framework bug to upstream as a sanitized GitHub issue

The skill responds to **slash commands** (`/tuner`, `/tuner audit`, ...) **and** to natural language in either English or French (e.g. `tune-moi ce skill`, `audit le tuner`, `ouvre une issue tuner`). 30 triggers in the frontmatter.

### Self-improvement (the recursive case)

The `/tuner` skill itself lives in the user's tunable surface. The framework watches reactions to `/tuner` invocations the same way it watches any other skill. If patterns emerge ("setup is too long", "audit output is verbose"), the framework proposes alternatives to `tuner.md`.

Special safeguards for self-modification:
- `risk_tier: critical` — never auto-merge regardless of global config
- Dead-man's switch — auto-revert if not re-validated within 7 days post-apply
- Cool-down — 30 days minimum between accepted self-modifications
- Diff-mandatory — modifications surface a full diff (not just A/B/C)
- Audit-log tagging — `event: meta_tuner_self_modify`

This is the canonical demonstration that the framework's primitives compose correctly even for the most sensitive case.

### `src/skills-tuner/cli/index.ts` — `commander` CLI

9 commands: `doctor / cron-run / pending / apply / skip / revert / feedback / stats / setup`. Bin entry exposed as `tuner`.

## Things worth noting

1. **Patterns are configurable, not hardcoded** — `DEFAULT_EMOTIONAL_PATTERNS`, `NEGATIVE_PATTERNS`, `POSITIVE_PATTERNS` are module-level English defaults. The `SkillsSubject` constructor accepts overrides (and `~/.config/tuner/config.yaml` exposes them). A French / German / Japanese installation overrides without forking.
2. **Triggers come from skill frontmatter** — the subject reads `triggers:` from each skill's YAML frontmatter to attribute signals.
3. **Per-kind risk** — `auto_merge: [patch, frontmatter]` means small edits flow automatically; `new_skill` always asks for approval (creating a wrong skill is more visible/risky than tweaking).
4. **Backward-compat alias** — `ORPHAN_SKILL = ORPHAN_SUBJECT`. Existing code using `ORPHAN_SKILL` keeps working; new subjects use `ORPHAN_SUBJECT` directly.
5. **All security primitives from PR1 apply unchanged** — proposals HMAC-signed, target paths realpath-bound, applies create branches from `main`, audit log records everything.

## Configuration example

Minimal `~/.config/tuner/config.yaml`:

```yaml
storage:
  git_repo: ~/agent/skills              # required — must be a git repo

subjects:
  skills:
    enabled: true
    auto_merge: [patch, frontmatter]    # auto-apply low-risk; new_skill always manual
    proposer: claude-sonnet-4-6
    proposer_for_create: claude-opus-4-7
    scan_dirs:
      - ~/agent/skills
      - ~/.claude/skills
```

A user who wants French frustration patterns adds them via `subjects.skills.emotional_patterns` config — no fork required. The `/tuner` companion skill walks them through this in `setup` mode.

## Tests

Test suite lives in canonical companion repo at https://github.com/Nibbler1250/skills-tuner-ts (125 tests pass under strict tsconfig including signal scoring, reclassification, orphan clustering, propose/apply lifecycle, scaling 100×100 < 0.5s).

## Relation to PR1 and PR2

- Depends on PR2 (TelegramAdapter for the #14 user-facing flow, ExternalProcessSubject pattern as reference for the future).
- All security primitives from PR1 apply unchanged.
- Future contributors writing their own subject (voice lexicon, RAG ranker, MCP server config, ML hyperparams via `ExternalProcessSubject`) can use this PR as the reference implementation.


## Security hardening (Tier 1+2)

This PR includes **11 adversarial tests** beyond the functional baseline, covering:

**Tier 1 — Edge cases**:
- `applyProposal` race condition (two concurrent calls on same proposal)
- Path traversal via symlinks (target inside scan_dir but link to /etc/passwd)
- JSONL mid-write corruption (kill -9 during append)
- Audit log atomicity (audit_attempted before any side effect)
- Skill cache invalidated after apply/rename

**Tier 2 — Adversarial security**:
- HMAC canonical bypass via JSON key reordering
- Prompt injection via skill content (not just observation verbatim)
- Telegram callback replay attack
- ExternalProcessSubject with encoded target_path (URL-encoded path traversal)
- Audit log tampering (documented limitation — no hash chain at v1)
- Regex DoS on triggers (catastrophic backtracking — N/A, uses `string.includes()`)

**Real bugs caught and fixed via these tests**:
1. `applyProposal` race condition — added `_applying: Set<number>` lock
2. Symlink traversal in `commitPatch` — added `realpathSync()` check
3. Prompt injection via `skillContent` — `sanitizeObservationContent()` now applied to skill bodies, not just verbatims
4. Empty commits in `commitPatch` — refused when nothing staged (otherwise `revert` was silent no-op)

**Total tests**: 163 unit + integration tests passing. 0 fail.

Full test suite in companion repo: https://github.com/Nibbler1250/skills-tuner-ts


## Anthropic Skills format adoption + auto-migration

Ships skills-tuner with the Anthropic standard `<name>/SKILL.md` directory format from day one (rather than the legacy flat `.md` we'd otherwise default to). The companion `/tuner` skill auto-detects and migrates legacy flat skills on setup/audit/adjust.

### What changed

**For new skills**: `apply()` for `kind="new_skill"` defaults to creating `<scan_dir>/<slug>/SKILL.md` directory structure. Frontmatter contains only `name:` and `description:` — no `triggers:` or `risk_tier:` (those go in `config.yaml` under `subjects.skills.overrides.<name>`).

**For existing flat skills**: companion skill detects legacy format and offers migration in three modes:
- `setup` Step 2.5: scans scan_dir after git repo selection, shows format compliance table, offers bulk migration with per-skill progress and git commits
- `audit` Step 4.5: format compliance section in report — count directory vs flat, names of legacy skills, pointer to `/tuner adjust` or `/tuner setup`
- `adjust` Step 2.5: checks format before showing menu; offers individual migration as first option if skill is flat

**Migration process** (each skill):
1. Strip tuner-specific fields (`triggers`, `risk_tier`, `auto_merge`, `auto_merge_default`) from frontmatter
2. Persist stripped fields to `~/.config/tuner/config.yaml` under `subjects.skills.overrides.<name>`
3. Create `<scan_dir>/<name>/SKILL.md` with cleaned frontmatter + original body
4. Create `.pre-migration-<timestamp>.bak` backup before removing flat file
5. Git commit: `migrate: convert <name> to Anthropic SKILL.md format`

### New API surface

```typescript
// In SkillsSubject:
await subject.listMigrationCandidates();
// → string[] — names of flat-format skills (migration candidates)

await subject.migrateSkillToDirectory('skill-name');
// → Record<string, unknown> — tuner fields moved to config (triggers, risk_tier, etc.)
// Throws if: skill not found, already directory format (no-op returns {}),
//           target dir exists, path traversal in skillName, outside scan_dirs
```

### Backward compatibility

- Both formats detected by two-pass `loadSkillsMap()` — directory wins on name collision
- Trigger resolution: config overrides → frontmatter fallback → skill name default
- Migration creates `.pre-migration-*.bak` backup before removing flat file
- All existing flat skills continue to work unchanged until migrated

### Tests added (14 new — 185 total, 0 fail)

- `validate()` rejects missing description / missing frontmatter
- `migrateSkillToDirectory()` round-trip (flat → directory + stripped fields)
- All tuner-specific fields stripped from new SKILL.md
- Body content preserved through migration
- `.pre-migration-*.bak` backup created; original deleted
- No-op if already directory format
- Throws if target dir exists
- Rejects path traversal (`../evil`, `a/b`) in skillName
- Throws if skill not found
- Cache invalidated post-migration
- `listMigrationCandidates()` returns only flat skills
- `listMigrationCandidates()` empty if all directory format

## Companion skill: mcp.md

PR41 ships **two** companion skills in `src/skills-tuner-templates/`:

- `tuner/SKILL.md` — manage skills-tuner platform (setup/create/adjust/audit/optimize/report)
- `mcp/SKILL.md` — manage Plus MCP bridge from PR #42 (setup/list/inspect/diagnose/audit/trace/register/test/report — 9 modes)

Both are in Anthropic Skills directory format. Auto-installed to user's skill directory by `tuner setup`. Discovery-friendly descriptions for Claude Code's skill matcher.

The `mcp` skill complements PR #42's bridge — provides discoverable conversational entry points (slash commands + natural language) to register plugins, diagnose health, trace requests, and report bugs.

## Per-subject `git_repo` (universal architecture)

Each subject can declare its own git repository in config.yaml. This enables tuning across multiple, independently-versioned repos:

- skills → `~/agent/skills` (markdown skill files)
- voice → `~/agent/voice-config` (lexicon, TTS settings)
- trader-ml-hp → `~/Projects/momentum_trader_v7` (trading strategies, never auto-merge)
- archiviste → `~/agent/archiviste` (RAG configs)

Backward compatible: configs without per-subject `git_repo` fall back to `storage.git_repo` (legacy behavior preserved).

The Engine instantiates a `BranchManager` per-subject lazily. `applyProposal` and `revertProposal` route to the correct repo based on `proposal.subject`. Path containment guards apply per-subject — a voice proposal cannot commit to the skills repo, and vice versa.

This makes skills-tuner truly universal: a single tuner instance can manage skills, voice, RAG, MCP, and trading-ML across their respective repos with independent rollback paths.

## Drift detection — universal state monitoring

Each subject opt-in implements `currentStateHash()` returning a deterministic hash of its managed resources. The engine compares hash at each cron tick against the previously recorded value (`~/.config/tuner/state-hashes.jsonl`). Differences fire an audit log entry `subject_state_drift_detected` and surface in the next `/tuner audit` for user review.

This catches state changes that don't pass through user behavior signals: new skills added manually, plugins registered/unregistered, RAG corpus updated, etc. The user no longer has to remember to invoke audit — the framework notices and surfaces.

`SkillsSubject` hashes file paths + mtimes + sizes across `scan_dirs`. External subjects (voice, archiviste) can override `currentStateHash()` to hash their own surface. Default returns empty string (opt-out, no drift detection for that subject).

Drift detection is opportunistic — errors during hash computation never crash `runCycle`, just log `drift_detection_error` and continue.