### PR TITLE
feat(plugins): MCP bridge — universal plugin+Plus substrate (closes #31)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.13",
+      "version": "2.0.14",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.18",
+      "version": "2.0.19",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.14",
+      "version": "2.0.18",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.13",
+  "version": "2.0.14",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.14",
+  "version": "2.0.18",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.18",
+  "version": "2.0.19",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "claude-heartbeat",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "ogg-opus-decoder": "^1.7.3",
       },
       "devDependencies": {
@@ -15,6 +16,10 @@
   "packages": {
     "@eshaz/web-worker": ["@eshaz/web-worker@1.2.2", "", {}, "sha512-WxXiHFmD9u/owrzempiDlBB1ZYqiLnm9s6aPc8AlFQalq2tKmqdmMr9GXOupDgzXtqnBipj8Un0gkIm7Sjf8mw=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
     "@types/node": ["@types/node@25.2.3", "", { "dependencies": { "undici-types": "~7.16.0" } }, "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ=="],
@@ -23,16 +28,194 @@
 
     "@wasm-audio-decoders/opus-ml": ["@wasm-audio-decoders/opus-ml@0.0.2", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-58rWEqDGg+CKCyEeKm2KoxxSwTWtHh/NLTW9ObR4K8CGF6VwuuGudEI1CtniS/oSRmL1nJq/eh8MKARiluw4DQ=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
+    "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
+
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "codec-parser": ["codec-parser@2.5.0", "", {}, "sha512-Ru9t80fV8B0ZiixQl8xhMTLru+dzuis/KQld32/x5T/+3LwZb0/YvQdSKytX9JqCnRdiupvAvyYJINKrXieziQ=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.8", "", {}, "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.1", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5O6KYmyJEpuPJV5hNTXKbAHWRqrzyu+OI3vUnSd2kXFubIVpG7ezpgxQy76Zo5GQZtrQBg86hF+CM/NX+cioiQ=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-uri": ["fast-uri@3.1.2", "", {}, "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
+
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "hasown": ["hasown@2.0.3", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg=="],
+
+    "hono": ["hono@4.12.18", "", {}, "sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
+
+    "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
     "ogg-opus-decoder": ["ogg-opus-decoder@1.7.3", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7", "@wasm-audio-decoders/opus-ml": "0.0.2", "codec-parser": "2.5.0", "opus-decoder": "0.7.11" } }, "sha512-w47tiZpkLgdkpa+34VzYD8mHUj8I9kfWVZa82mBbNwDvB1byfLXSSzW/HxA4fI3e9kVlICSpXGFwMLV1LPdjwg=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "opus-decoder": ["opus-decoder@0.7.11", "", { "dependencies": { "@wasm-audio-decoders/common": "9.0.7" } }, "sha512-+e+Jz3vGQLxRTBHs8YJQPRPc1Tr+/aC6coV/DlZylriA29BdHQAYXhvNRKtjftof17OFng0+P4wsFIqQu3a48A=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
+    "qs": ["qs@6.15.1", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
     "simple-yenc": ["simple-yenc@1.0.4", "", {}, "sha512-5gvxpSd79e9a3V4QDYUqnqxeD4HGlhCakVpb6gMnDD7lexJggSBJRBO5h52y/iJrdXRilX9UCuDaIJhSWm5OWw=="],
 
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "undici-types": ["undici-types@7.16.0", "", {}, "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
   }
 }

--- a/docs/mcp-proxy.md
+++ b/docs/mcp-proxy.md
@@ -1,0 +1,179 @@
+# mcp-proxy — Warm-pooled tool gateway for daemon-resident agents
+
+## What this solves
+
+Daemon-resident integrations accumulate in any non-trivial ClaudeClaw-Plus deployment:
+voice-driven agents, RAG document systems, home-automation bridges, domain-specific
+automation daemons. Each needs to invoke capabilities (an MCP tool, a database query,
+a remote API) repeatedly, with low latency, under common auth and audit policies.
+
+Without a shared substrate: N plugins × M capabilities = N×M code paths, each with its
+own auth code, retry logic, and connection pool.
+
+This PR ships the HTTP gateway and `mcp-proxy` together as a single substrate: the gateway
+provides the HMAC-authenticated HTTP contract, the proxy is its first in-process consumer.
+A daemon-internal plugin maintains long-lived stdio connections to configured MCP servers
+and re-exposes their tools through the gateway.
+
+Pattern: **1 gateway × N proxied servers × M consumers = N+M code paths, not N×M.**
+
+## Latency comparison
+
+| Path | Typical latency | Notes |
+|---|---|---|
+| Direct HTTP (pre-PR-42) | ~50ms | No auth, no audit trail |
+| inject path (Claude in loop) | ~3000ms | 2 LLM turns + cold CLI spawn |
+| mcp-proxy (this PR) | ~200ms | HTTP roundtrip + MCP stdio + tool exec |
+
+## Architecture
+
+```
+                        ┌──────────────────────┐
+                        │  claudeclaw daemon   │
+                        │  port 4632           │
+                        └─┬────────────────────┘
+                          │
+      ┌───────────────────┼─────────────────────────┐
+      │                   │                         │
+      ▼                   ▼                         ▼
+┌──────────────┐  ┌──────────────────┐  ┌──────────────────┐
+│ HTTP gateway │  │ mcp-proxy plugin │  │ other plugins    │
+│ /api/plugin/*│←→│ (long-lived)     │  │                  │
+└──────────────┘  └────────┬─────────┘  └──────────────────┘
+                            │ stdio
+               ┌────────────┼────────────┐
+               ▼            ▼            ▼
+         ┌──────────┐ ┌──────────┐ ┌──────────┐
+         │ server A │ │ server B │ │ server C │
+         └──────────┘ └──────────┘ └──────────┘
+```
+
+## Routing modes
+
+Each proxied tool accepts a `mode` field:
+
+| mode | path | latency | when to use |
+|---|---|---|---|
+| `direct` (default) | warm pool → MCP stdio | ~200ms | deterministic tool calls |
+| `reasoned` | /api/inject → Claude | ~3000ms | tools needing planning |
+
+Same endpoint, two paths inside. The audit log records which path was used on every call.
+
+Decision tree:
+- Tool returns deterministic JSON given the same args → `direct`
+- Tool requires LLM reasoning to pick parameters or interpret results → `reasoned`
+- Not sure → use `direct` first; fall back to `reasoned` if the response needs interpretation
+
+## Configuration
+
+**`~/.config/claudeclaw/mcp-proxy.json`**
+
+```json
+{
+  "servers": {
+    "home-automation": {
+      "command": "node",
+      "args": ["/path/to/mcp-servers/home-automation/index.js"],
+      "enabled": true,
+      "allowedTools": ["list_devices", "device_command", "device_status"]
+    },
+    "brave-search": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+      "enabled": true,
+      "env": { "BRAVE_API_KEY": "your-key-here" }
+    }
+  }
+}
+```
+
+See `mcp-proxy.json.example` in the repo root for a full template.
+
+## Calling a proxied tool
+
+**URL**: `POST http://localhost:4632/api/plugin/mcp-proxy/tools/{server}__{tool}/invoke`
+
+**Auth**: HMAC with the mcp-proxy plugin token (stored at `~/.config/claudeclaw/mcp-proxy.token`).
+The token is written at daemon startup.
+
+**Body**:
+```json
+{
+  "arguments": { "device_id": "42", "command": "on" },
+  "mode": "direct"
+}
+```
+
+**Response**:
+```json
+{ "result": { "status": "ok" }, "request_id": "abc123" }
+```
+
+## Adding a new server
+
+1. Add an entry in `~/.config/claudeclaw/mcp-proxy.json`
+2. Restart the claudeclaw daemon (`systemctl --user restart claudeclaw`)
+3. Verify with: `curl http://localhost:4632/api/plugin/mcp-proxy/health`
+4. Call the tool: `curl -X POST http://localhost:4632/api/plugin/mcp-proxy/tools/{server}__{tool}/invoke ...`
+
+## Restart supervision
+
+If an MCP server process crashes:
+- Status marked `crashed`; tool invocations return an error until recovery
+- Backoff: 1s → 5s → 30s → 60s (capped)
+- After 5 crashes in 5 minutes: status `failed`, no further restarts until daemon restart
+- Audit event `mcp_proxy_server_crashed` / `mcp_proxy_server_permanently_failed` emitted
+
+Server stderr goes to `~/.cache/claudeclaw/mcp-proxy/{server}.log`.
+
+## Security model
+
+- Bootstrap token (`~/.config/plus/plugin-bootstrap.secret`, mode 0600, 32 bytes) gates initial registration.
+- Per-plugin HMAC token issued at registration scopes inbound tool calls.
+- 15-minute replay window prevents request replay.
+- `allowedTools` per-server config narrows exposure independently of what the MCP server publishes.
+- Audit log at `~/.config/plus/plugin-audit.jsonl` captures every invocation (calling plugin, target server+tool, args hash, result shape — no payload).
+
+## Comparison with adjacent projects
+
+### Hermes (NousResearch)
+
+Hermes has a clean plugin registry (`registry.register(name, toolset, schema, handler, ...)`)
+and supports MCP via the `mcp__<server>__<tool>` namespace. However, **Hermes treats native
+plugin tools and MCP servers as two parallel systems**: a native plugin cannot register a tool
+that fronts an MCP server's capability, and the two paths have separate auth, separate audit,
+and separate lifecycle.
+
+mcp-proxy collapses this duality. A single substrate carries both:
+- **Plugins** register via `/api/plugin/register` with manifest + HMAC + tool schemas.
+- **MCP servers** are proxied through a single plugin (`mcp-proxy`) registered under the same contract.
+- Every invocation flows through the same endpoint, with the same HMAC, replay window, and audit log.
+
+Result: one auth channel, one audit log, one observability surface.
+
+### OpenClaw / NemoClaw / SwarmClaw
+
+These projects share the `mcp__<server>__<tool>` tool-name convention and the plugin-manifest
+contract. The mcp-proxy plugin (~200 LOC of TypeScript + `server-process.ts`) is self-contained
+and can be lifted into any of these runtimes by mapping their plugin lifecycle to the manifest
+contract.
+
+## Next plugin candidates
+
+### Retrieval / RAG daemon (reference consumer, lives outside this diff)
+
+A retrieval daemon for RAG document search runs as an external HTTP plugin (separate repository).
+It registers via `/api/plugin/register` and serves search + index-management tools. Search
+latency: ~200ms via the gateway vs ~30s via prior async spawn paths. Demonstrates the substrate
+supports both in-process consumers (`mcp-proxy`) and external HTTP daemons under one unified
+contract.
+
+### Voice-agent migration (follow-up PR)
+
+Existing voice-driven agents using the `mcp_invoke` helper (POST `/api/inject` → Claude → MCP)
+can switch to a `mcp_proxy_invoke` helper (POST `/api/plugin/<server>/tools/<tool>/invoke` → warm pool)
+in a follow-up PR. Expected latency drop: ~3000ms → ~200ms for deterministic tool calls (home
+automation, search). The migration is a 3-line helper addition plus call-site rewrites.
+
+Out of scope of the mcp-proxy infrastructure PR by design — infrastructure first, then migrate
+consumers progressively to validate the new path under real load.

--- a/docs/mcp-proxy.md
+++ b/docs/mcp-proxy.md
@@ -94,7 +94,9 @@ See `mcp-proxy.json.example` in the repo root for a full template.
 **URL**: `POST http://localhost:4632/api/plugin/mcp-proxy/tools/{server}__{tool}/invoke`
 
 **Auth**: HMAC with the mcp-proxy plugin token (stored at `~/.config/claudeclaw/mcp-proxy.token`).
-The token is written at daemon startup.
+The token is written at daemon startup. Two required headers per call:
+- `x-plus-ts`: ISO 8601 UTC timestamp (e.g. `2026-05-11T12:34:56.000Z`)
+- `x-plus-signature`: `HMAC-SHA256(token, "<ts>\n<body>")` hex-encoded — the timestamp is prepended to the raw body before signing
 
 **Body**:
 ```json
@@ -102,6 +104,24 @@ The token is written at daemon startup.
   "arguments": { "device_id": "42", "command": "on" },
   "mode": "direct"
 }
+```
+
+**Example curl** (Python helper for HMAC):
+```bash
+TOKEN=$(cat ~/.config/claudeclaw/mcp-proxy.token)
+BODY='{"arguments":{"device_id":"42","command":"on"},"mode":"direct"}'
+TS=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+SIG=$(python3 -c "
+import hmac, hashlib, sys
+token = bytes.fromhex('$TOKEN')
+msg = ('$TS' + '\n' + sys.argv[1]).encode()
+print(hmac.new(token, msg, hashlib.sha256).hexdigest())
+" "$BODY")
+curl -s -X POST http://localhost:4632/api/plugin/mcp-proxy/tools/home-automation__device_command/invoke \
+  -H "Content-Type: application/json" \
+  -H "x-plus-ts: $TS" \
+  -H "x-plus-signature: $SIG" \
+  -d "$BODY"
 ```
 
 **Response**:

--- a/docs/plugin-integration.md
+++ b/docs/plugin-integration.md
@@ -6,7 +6,7 @@ ClaudeClaw-Plus supports three tiers of plugin integration:
 |---|---|---|
 | 1 | In-process TypeScript | Skills-tuner, compiled-in features |
 | 2 | Subprocess JSON-RPC | ML backends (Optuna), Python scripts |
-| 3 | HTTP daemon | Greg/voice, Archiviste, cross-process tools |
+| 3 | HTTP daemon | voice-driven agent, retrieval daemon, cross-process tools |
 
 ---
 
@@ -54,7 +54,7 @@ All errors return JSON:
   "error": {
     "code": "invalid_signature",
     "message": "HMAC verification failed",
-    "plugin": "greg-voice",
+    "plugin": "voice-agent",
     "request_id": "a1b2c3d4e5f6a7b8",
     "ts": "2026-05-09T20:00:00.000Z"
   }
@@ -65,7 +65,7 @@ All errors return JSON:
 
 ---
 
-## Greg / Voice plugin — Python example
+## Voice agent plugin — Python example
 
 ```python
 import os, json, hmac, hashlib, requests
@@ -77,7 +77,7 @@ PLUS_URL = "http://localhost:3000"
 BOOTSTRAP_SECRET_PATH = os.path.expanduser("~/.config/plus/plugin-bootstrap.secret")
 
 manifest = {
-    "name": "greg-voice",
+    "name": "voice-agent",
     "version": "1.0.0",
     "schema_version": 1,
     "callback_url": "http://localhost:8765/plus-callback",
@@ -154,7 +154,7 @@ PLUS_URL = "http://localhost:3000"
 BOOTSTRAP_SECRET_PATH = os.path.expanduser("~/.config/plus/plugin-bootstrap.secret")
 
 manifest = {
-    "name": "archiviste",
+    "name": "retrieval-daemon",
     "version": "1.0.0",
     "schema_version": 1,
     "callback_url": "http://localhost:8766/plus-callback",
@@ -206,7 +206,7 @@ def handle_callback():
         import subprocess
         result = subprocess.check_output([
             "python3",
-            os.path.expanduser("~/agent/scripts/archiviste-vectorize.py"),
+            os.path.expanduser("<retrieval-daemon>/vectorize.py"),
             "--search", args["query"],
             *(["--trusted-only"] if args.get("trusted_only", True) else []),
         ]).decode()

--- a/docs/plugin-integration.md
+++ b/docs/plugin-integration.md
@@ -210,6 +210,23 @@ if __name__ == "__main__":
 
 ---
 
+## mcp-proxy: fast path for non-Claude consumers
+
+For non-Claude daemon-resident integrations (voice agents, retrieval systems, automation
+bridges), the inject path is too slow (~3000ms per call). The `mcp-proxy` plugin provides
+a warm-pooled fast path: long-lived stdio connections to configured MCP servers, exposed
+as `/api/plugin/mcp-proxy/tools/{server}__{tool}/invoke`.
+
+| Path | Latency | Auth | Audit |
+|---|---|---|---|
+| Direct API call | ~50ms | None | None |
+| `/api/inject` (Claude in loop) | ~3000ms | Bearer apiToken | No |
+| mcp-proxy (this release) | ~200ms | HMAC plugin token | Yes |
+
+See `docs/mcp-proxy.md` for configuration and routing mode details.
+
+---
+
 ## Deferred to follow-up PRs
 
 The following features are known gaps but explicitly deferred:

--- a/docs/plugin-integration.md
+++ b/docs/plugin-integration.md
@@ -1,201 +1,224 @@
-# Plugin Tool Integration Guide
+# Plugin Integration Guide
 
-ClaudeClaw-Plus exposes a `PluginMcpBridge` that lets daemon plugins register tools and expose them to the MCP ecosystem. All registered tools are served via a stdio MCP server that any MCP client (Claude Desktop, etc.) can connect to.
+ClaudeClaw-Plus supports three tiers of plugin integration:
 
----
-
-## Architecture Overview
-
-```
-Plus daemon
-├── PluginManager (src/plugins.ts)
-│   └── lifecycle events (gateway_start, session_start, agent_end, …)
-└── PluginMcpBridge (src/plugins/mcp-bridge.ts)
-    ├── registerPluginTool(pluginId, tool)  ← plugin registration API
-    ├── McpServer (src/plugins/mcp-server.ts, stdio)
-    ├── HMAC-SHA256 signed inter-plugin calls
-    └── Append-only audit log (~/.config/plus/plugin-audit.jsonl)
-```
+| Tier | Style | Use case |
+|---|---|---|
+| 1 | In-process TypeScript | Skills-tuner, compiled-in features |
+| 2 | Subprocess JSON-RPC | ML backends (Optuna), Python scripts |
+| 3 | HTTP daemon | Greg/voice, Archiviste, cross-process tools |
 
 ---
 
-## Registering Tools from a Plugin
+## Tier 3 — HTTP Plugin (daemon-style)
 
-Plugins receive a `PluginApi` object at init time. Call `api.registerTool(tool)` to register an MCP-compatible tool:
+Daemon-style plugins register themselves over HTTP and serve tool calls via a callback URL. Plus communicates with them via HMAC-signed POST requests.
 
-```typescript
-import type { PluginInitFn } from "claudeclaw-plus/src/plugins.js";
-import { z } from "zod";
+### API endpoints (mounted when `--web` is active)
 
-const init: PluginInitFn = (api) => {
-  api.registerTool({
-    name: "pending",
-    description: "List pending tuner proposals",
-    schema: z.object({
-      subject: z.string().optional(),
-    }),
-    handler: async (args) => {
-      return engine.listPending(args.subject);
-    },
-  });
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `POST` | `/api/plugin/register` | Bearer bootstrap | Register plugin + tools |
+| `POST` | `/api/plugin/<n>/tools/<t>/invoke` | HMAC + timestamp | Invoke tool via callback |
+| `DELETE` | `/api/plugin/<n>` | Bootstrap or plugin token | Unregister |
+| `GET` | `/api/plugin/list` | None | List registered plugins + health |
+| `GET` | `/api/plugin/<n>/health` | None | Proxy to plugin health_url |
 
-  api.registerTool({
-    name: "apply",
-    description: "Apply a tuner proposal by ID",
-    schema: z.object({ id: z.string() }),
-    handler: async (args) => engine.apply(args.id),
-  });
-};
+### Security model
 
-export default init;
-```
+- **Bootstrap token**: 32-byte secret at `~/.config/plus/plugin-bootstrap.secret` (0600). Printed once at first start. Retrieve with `bun run src/plugins/cli.ts print-bootstrap-token`.
+- **Per-plugin token**: returned at registration time, used for HMAC signing on subsequent invocations. Store securely in the daemon process.
+- **HMAC**: `HMAC-SHA256(secret, "{ts}\n{body}")` where `ts` is ISO-8601 UTC, `body` is JSON-serialized. Sent in `X-Plus-Signature` header.
+- **Replay window**: 15 minutes (clock-skew tolerant). Requests outside this window are rejected.
+- **Callback allowlist**: by default, only `localhost` / `127.0.0.1` / `::1` are allowed as callback hosts.
 
-The tool is registered under the FQN `{pluginId}__{toolName}` (e.g. `skills-tuner__pending`).
+### Standard error format
 
----
-
-## Pattern: Archiviste Plugin
-
-```typescript
-const init: PluginInitFn = (api) => {
-  api.registerTool({
-    name: "search_docs",
-    description: "Full-text search across archived documents",
-    schema: z.object({
-      query: z.string(),
-      trusted_only: z.boolean().optional(),
-      limit: z.number().optional(),
-    }),
-    handler: async (args) => archiviste.search(args),
-  });
-
-  api.registerTool({
-    name: "index_doc",
-    description: "Index a new document into the archive",
-    schema: z.object({
-      path: z.string(),
-      tags: z.array(z.string()).optional(),
-    }),
-    handler: async (args) => archiviste.index(args.path, args.tags),
-  });
-};
-```
-
----
-
-## Pattern: Voice Plugin (Greg)
-
-```typescript
-const init: PluginInitFn = (api) => {
-  api.registerTool({
-    name: "play_tts",
-    description: "Synthesize and play text-to-speech audio",
-    schema: z.object({
-      text: z.string(),
-      voice: z.string().optional(),
-    }),
-    handler: async (args) => voice.playTts(args.text, args.voice),
-  });
-
-  api.registerTool({
-    name: "transcribe_audio",
-    description: "Transcribe an audio file to text using Whisper",
-    schema: z.object({ path: z.string() }),
-    handler: async (args) => voice.transcribe(args.path),
-  });
-};
-```
-
----
-
-## Security
-
-### Per-Plugin Secret
-
-Each plugin gets a 32-byte random secret stored at:
-```
-~/.config/plus/plugins/<pluginId>/.secret   (mode 0600)
-```
-
-The secret is auto-created on first use and hex-encoded on disk. It never leaves the local machine.
-
-### HMAC-SHA256 Signing
-
-Every `invokeTool` call is signed before reaching the handler:
-
-```typescript
-const sig = bridge.signCall(pluginId, args, Date.now());
-const ok  = bridge.verifyCall(pluginId, args, ts, sig);
-```
-
-Verification uses `timingSafeEqual` to prevent timing attacks.
-
-### Zod Validation
-
-All tool arguments are validated against the plugin-provided `schema` before the handler is called. Invalid args throw immediately and are logged to the audit log.
-
-### Audit Log
-
-Every `register`, `invoke`, `error` event is appended to:
-```
-~/.config/plus/plugin-audit.jsonl
-```
-
-Each line is a JSON object with `{ event, ts, fqn, pluginId, … }`. The file is append-only; never truncate it — it is an audit trail.
-
----
-
-## Starting the MCP Server
-
-### Standalone
-
-```bash
-bun run src/plugins/mcp-server.ts
-```
-
-The server listens on stdio and exposes all registered tools to any MCP client.
-
-### Claude Desktop Configuration
-
-Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or equivalent:
+All errors return JSON:
 
 ```json
 {
-  "mcpServers": {
-    "claudeclaw-plus": {
-      "command": "bun",
-      "args": ["run", "/home/simon/Projects/ClaudeClaw-Plus/src/plugins/mcp-server.ts"]
-    }
+  "error": {
+    "code": "invalid_signature",
+    "message": "HMAC verification failed",
+    "plugin": "greg-voice",
+    "request_id": "a1b2c3d4e5f6a7b8",
+    "ts": "2026-05-09T20:00:00.000Z"
   }
 }
 ```
 
+`request_id` is echoed from `X-Plus-Request-Id` if provided, or generated. Include it in bug reports for cross-process forensics.
+
 ---
 
-## Direct Bridge Access (Advanced)
+## Greg / Voice plugin — Python example
 
-If you need to register tools outside of the Plugin lifecycle, import the singleton directly:
+```python
+import os, json, hmac, hashlib, requests
+from flask import Flask, request, jsonify
 
-```typescript
-import { getMcpBridge } from "claudeclaw-plus/src/plugins/mcp-bridge.js";
-import { z } from "zod";
+# ── Registration ──────────────────────────────────────────────────────────────
 
-const bridge = getMcpBridge();
+PLUS_URL = "http://localhost:3000"
+BOOTSTRAP_SECRET_PATH = os.path.expanduser("~/.config/plus/plugin-bootstrap.secret")
 
-bridge.registerPluginTool("my-service", {
-  name: "status",
-  description: "Get service status",
-  schema: z.object({}),
-  handler: async () => ({ ok: true }),
-});
+manifest = {
+    "name": "greg-voice",
+    "version": "1.0.0",
+    "schema_version": 1,
+    "callback_url": "http://localhost:8765/plus-callback",
+    "health_url": "http://localhost:8765/health",
+    "tools": [
+        {
+            "name": "send_tts",
+            "description": "Play TTS in active call",
+            "schema": {"type": "object", "properties": {"text": {"type": "string"}}, "required": ["text"]},
+        },
+        {
+            "name": "get_call_status",
+            "description": "Return current call status",
+            "schema": {"type": "object", "properties": {}},
+        },
+    ],
+    "capabilities": ["tools"],
+}
+
+bootstrap_token = open(BOOTSTRAP_SECRET_PATH, "rb").read().hex()
+resp = requests.post(
+    f"{PLUS_URL}/api/plugin/register",
+    headers={"Authorization": f"Bearer {bootstrap_token}"},
+    json=manifest,
+)
+resp.raise_for_status()
+data = resp.json()
+PLUGIN_TOKEN_HEX = data["plugin_token"]
+print(f"Registered {data['plugin_name']} — tools: {data['registered_tools']}")
+
+# ── Callback server ───────────────────────────────────────────────────────────
+
+app = Flask(__name__)
+
+def verify_plus_hmac(body_bytes: bytes, ts: str, sig: str) -> bool:
+    secret = bytes.fromhex(PLUGIN_TOKEN_HEX)
+    expected = hmac.new(secret, f"{ts}\n{body_bytes.decode()}".encode(), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, sig)
+
+@app.route("/plus-callback", methods=["POST"])
+def handle_callback():
+    ts = request.headers.get("X-Plus-Ts", "")
+    sig = request.headers.get("X-Plus-Signature", "")
+    body_bytes = request.get_data()
+    if not verify_plus_hmac(body_bytes, ts, sig):
+        return jsonify({"error": "invalid_signature"}), 401
+    payload = json.loads(body_bytes)
+    tool = payload["tool"]
+    args = payload.get("args", {})
+    if tool == "send_tts":
+        # ... your TTS logic here ...
+        return jsonify({"result": {"played": True, "text": args.get("text")}})
+    elif tool == "get_call_status":
+        return jsonify({"result": {"status": "idle"}})
+    return jsonify({"error": "unknown_tool"}), 400
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"ok": True})
+
+if __name__ == "__main__":
+    app.run(port=8765)
 ```
 
 ---
 
-## Running Tests
+## Archiviste plugin — Python example
 
-```bash
-bun test src/__tests__/plugins/mcp-bridge.test.ts
+```python
+import os, json, hmac, hashlib, requests
+from flask import Flask, request, jsonify
+
+PLUS_URL = "http://localhost:3000"
+BOOTSTRAP_SECRET_PATH = os.path.expanduser("~/.config/plus/plugin-bootstrap.secret")
+
+manifest = {
+    "name": "archiviste",
+    "version": "1.0.0",
+    "schema_version": 1,
+    "callback_url": "http://localhost:8766/plus-callback",
+    "health_url": "http://localhost:8766/health",
+    "tools": [
+        {
+            "name": "search",
+            "description": "Full-text search across archived documents",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string"},
+                    "trusted_only": {"type": "boolean", "default": True},
+                },
+                "required": ["query"],
+            },
+        },
+    ],
+    "capabilities": ["tools"],
+}
+
+bootstrap_token = open(BOOTSTRAP_SECRET_PATH, "rb").read().hex()
+resp = requests.post(
+    f"{PLUS_URL}/api/plugin/register",
+    headers={"Authorization": f"Bearer {bootstrap_token}"},
+    json=manifest,
+)
+resp.raise_for_status()
+PLUGIN_TOKEN_HEX = resp.json()["plugin_token"]
+
+app = Flask(__name__)
+
+def verify_plus_hmac(body_bytes: bytes, ts: str, sig: str) -> bool:
+    secret = bytes.fromhex(PLUGIN_TOKEN_HEX)
+    expected = hmac.new(secret, f"{ts}\n{body_bytes.decode()}".encode(), hashlib.sha256).hexdigest()
+    return hmac.compare_digest(expected, sig)
+
+@app.route("/plus-callback", methods=["POST"])
+def handle_callback():
+    ts = request.headers.get("X-Plus-Ts", "")
+    sig = request.headers.get("X-Plus-Signature", "")
+    body_bytes = request.get_data()
+    if not verify_plus_hmac(body_bytes, ts, sig):
+        return jsonify({"error": "invalid_signature"}), 401
+    payload = json.loads(body_bytes)
+    tool = payload["tool"]
+    args = payload.get("args", {})
+    if tool == "search":
+        import subprocess
+        result = subprocess.check_output([
+            "python3",
+            os.path.expanduser("~/agent/scripts/archiviste-vectorize.py"),
+            "--search", args["query"],
+            *(["--trusted-only"] if args.get("trusted_only", True) else []),
+        ]).decode()
+        return jsonify({"result": {"hits": result}})
+    return jsonify({"error": "unknown_tool"}), 400
+
+@app.route("/health", methods=["GET"])
+def health():
+    return jsonify({"ok": True})
+
+if __name__ == "__main__":
+    app.run(port=8766)
 ```
 
-All 8+ assertions cover: registration, duplicates, zod validation, HMAC round-trips, audit log entries, and secret management.
+---
+
+## Deferred to follow-up PRs
+
+The following features are known gaps but explicitly deferred:
+
+| Feature | Rationale |
+|---|---|
+| Hash-chained audit log | Nice-to-have for tamper evidence; no concrete demand yet |
+| Strict capability enforcement | Currently declared but not enforced; no capability-based blocking needed at v0 |
+| TLS enforcement for non-localhost | All current use cases are local; add when cross-machine relay is needed |
+| Token rotation endpoint | Re-register replaces the plugin token; no separate endpoint needed at v0 |
+
+File issues on this repo to promote any of these.

--- a/docs/plugin-integration.md
+++ b/docs/plugin-integration.md
@@ -1,0 +1,201 @@
+# Plugin Tool Integration Guide
+
+ClaudeClaw-Plus exposes a `PluginMcpBridge` that lets daemon plugins register tools and expose them to the MCP ecosystem. All registered tools are served via a stdio MCP server that any MCP client (Claude Desktop, etc.) can connect to.
+
+---
+
+## Architecture Overview
+
+```
+Plus daemon
+├── PluginManager (src/plugins.ts)
+│   └── lifecycle events (gateway_start, session_start, agent_end, …)
+└── PluginMcpBridge (src/plugins/mcp-bridge.ts)
+    ├── registerPluginTool(pluginId, tool)  ← plugin registration API
+    ├── McpServer (src/plugins/mcp-server.ts, stdio)
+    ├── HMAC-SHA256 signed inter-plugin calls
+    └── Append-only audit log (~/.config/plus/plugin-audit.jsonl)
+```
+
+---
+
+## Registering Tools from a Plugin
+
+Plugins receive a `PluginApi` object at init time. Call `api.registerTool(tool)` to register an MCP-compatible tool:
+
+```typescript
+import type { PluginInitFn } from "claudeclaw-plus/src/plugins.js";
+import { z } from "zod";
+
+const init: PluginInitFn = (api) => {
+  api.registerTool({
+    name: "pending",
+    description: "List pending tuner proposals",
+    schema: z.object({
+      subject: z.string().optional(),
+    }),
+    handler: async (args) => {
+      return engine.listPending(args.subject);
+    },
+  });
+
+  api.registerTool({
+    name: "apply",
+    description: "Apply a tuner proposal by ID",
+    schema: z.object({ id: z.string() }),
+    handler: async (args) => engine.apply(args.id),
+  });
+};
+
+export default init;
+```
+
+The tool is registered under the FQN `{pluginId}__{toolName}` (e.g. `skills-tuner__pending`).
+
+---
+
+## Pattern: Archiviste Plugin
+
+```typescript
+const init: PluginInitFn = (api) => {
+  api.registerTool({
+    name: "search_docs",
+    description: "Full-text search across archived documents",
+    schema: z.object({
+      query: z.string(),
+      trusted_only: z.boolean().optional(),
+      limit: z.number().optional(),
+    }),
+    handler: async (args) => archiviste.search(args),
+  });
+
+  api.registerTool({
+    name: "index_doc",
+    description: "Index a new document into the archive",
+    schema: z.object({
+      path: z.string(),
+      tags: z.array(z.string()).optional(),
+    }),
+    handler: async (args) => archiviste.index(args.path, args.tags),
+  });
+};
+```
+
+---
+
+## Pattern: Voice Plugin (Greg)
+
+```typescript
+const init: PluginInitFn = (api) => {
+  api.registerTool({
+    name: "play_tts",
+    description: "Synthesize and play text-to-speech audio",
+    schema: z.object({
+      text: z.string(),
+      voice: z.string().optional(),
+    }),
+    handler: async (args) => voice.playTts(args.text, args.voice),
+  });
+
+  api.registerTool({
+    name: "transcribe_audio",
+    description: "Transcribe an audio file to text using Whisper",
+    schema: z.object({ path: z.string() }),
+    handler: async (args) => voice.transcribe(args.path),
+  });
+};
+```
+
+---
+
+## Security
+
+### Per-Plugin Secret
+
+Each plugin gets a 32-byte random secret stored at:
+```
+~/.config/plus/plugins/<pluginId>/.secret   (mode 0600)
+```
+
+The secret is auto-created on first use and hex-encoded on disk. It never leaves the local machine.
+
+### HMAC-SHA256 Signing
+
+Every `invokeTool` call is signed before reaching the handler:
+
+```typescript
+const sig = bridge.signCall(pluginId, args, Date.now());
+const ok  = bridge.verifyCall(pluginId, args, ts, sig);
+```
+
+Verification uses `timingSafeEqual` to prevent timing attacks.
+
+### Zod Validation
+
+All tool arguments are validated against the plugin-provided `schema` before the handler is called. Invalid args throw immediately and are logged to the audit log.
+
+### Audit Log
+
+Every `register`, `invoke`, `error` event is appended to:
+```
+~/.config/plus/plugin-audit.jsonl
+```
+
+Each line is a JSON object with `{ event, ts, fqn, pluginId, … }`. The file is append-only; never truncate it — it is an audit trail.
+
+---
+
+## Starting the MCP Server
+
+### Standalone
+
+```bash
+bun run src/plugins/mcp-server.ts
+```
+
+The server listens on stdio and exposes all registered tools to any MCP client.
+
+### Claude Desktop Configuration
+
+Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or equivalent:
+
+```json
+{
+  "mcpServers": {
+    "claudeclaw-plus": {
+      "command": "bun",
+      "args": ["run", "/home/simon/Projects/ClaudeClaw-Plus/src/plugins/mcp-server.ts"]
+    }
+  }
+}
+```
+
+---
+
+## Direct Bridge Access (Advanced)
+
+If you need to register tools outside of the Plugin lifecycle, import the singleton directly:
+
+```typescript
+import { getMcpBridge } from "claudeclaw-plus/src/plugins/mcp-bridge.js";
+import { z } from "zod";
+
+const bridge = getMcpBridge();
+
+bridge.registerPluginTool("my-service", {
+  name: "status",
+  description: "Get service status",
+  schema: z.object({}),
+  handler: async () => ({ ok: true }),
+});
+```
+
+---
+
+## Running Tests
+
+```bash
+bun test src/__tests__/plugins/mcp-bridge.test.ts
+```
+
+All 8+ assertions cover: registration, duplicates, zod validation, HMAC round-trips, audit log entries, and secret management.

--- a/docs/plugin-integration.md
+++ b/docs/plugin-integration.md
@@ -28,9 +28,22 @@ Daemon-style plugins register themselves over HTTP and serve tool calls via a ca
 
 - **Bootstrap token**: 32-byte secret at `~/.config/plus/plugin-bootstrap.secret` (0600). Printed once at first start. Retrieve with `bun run src/plugins/cli.ts print-bootstrap-token`.
 - **Per-plugin token**: returned at registration time, used for HMAC signing on subsequent invocations. Store securely in the daemon process.
-- **HMAC**: `HMAC-SHA256(secret, "{ts}\n{body}")` where `ts` is ISO-8601 UTC, `body` is JSON-serialized. Sent in `X-Plus-Signature` header.
-- **Replay window**: 15 minutes (clock-skew tolerant). Requests outside this window are rejected.
+- **HMAC**: `HMAC-SHA256(secret, "{ts}\n{body}")` where `ts` is ISO-8601 UTC, `body` is JSON-serialized raw. Sent in headers `x-plus-ts` (the timestamp string) and `x-plus-signature` (hex-encoded digest).
+- **Replay window**: 15 minutes, bidirectional (`Math.abs(now - ts) > 900_000ms` rejected as `stale_or_future_timestamp`).
 - **Callback allowlist**: by default, only `localhost` / `127.0.0.1` / `::1` are allowed as callback hosts.
+
+### Authentication contract
+
+Every `/invoke` call must include:
+- Header `x-plus-ts`: ISO 8601 UTC timestamp (e.g. `2026-05-11T12:34:56.000Z`)
+- Header `x-plus-signature`: hex-encoded SHA-256 HMAC of `<ts>\n<body>` using the per-plugin token returned at register time
+
+Reference implementations:
+- TypeScript: `` createHmac('sha256', token).update(`${ts}\n${body}`).digest('hex') ``
+- Python: `hmac.new(token_bytes, (ts + "\n" + body).encode(), hashlib.sha256).hexdigest()`
+
+The body is signed **raw** — do not re-serialize the JSON between signing and sending, or
+byte-order differences (e.g. Python default separators vs JS) will break verification.
 
 ### Standard error format
 

--- a/mcp-proxy.json.example
+++ b/mcp-proxy.json.example
@@ -1,0 +1,22 @@
+{
+  "servers": {
+    "home-automation": {
+      "command": "node",
+      "args": ["/path/to/mcp-servers/home-automation/index.js"],
+      "enabled": true,
+      "allowedTools": ["list_devices", "device_command", "device_status", "execute_automation"]
+    },
+    "brave-search": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+      "enabled": true,
+      "env": { "BRAVE_API_KEY": "your-key-here" }
+    },
+    "domain-automation": {
+      "command": "node",
+      "args": ["/path/to/mcp-servers/domain-automation/server.js"],
+      "enabled": false,
+      "allowedTools": []
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/bun": "^1.3.9"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "ogg-opus-decoder": "^1.7.3"
   }
 }

--- a/src/__tests__/fixtures/mock-mcp-server.ts
+++ b/src/__tests__/fixtures/mock-mcp-server.ts
@@ -1,0 +1,127 @@
+/**
+ * Minimal JSON-RPC MCP server for testing.
+ * Reads from stdin, writes to stdout (line-delimited JSON).
+ * Responds to: initialize, notifications/initialized, tools/list, tools/call
+ */
+
+const TOOLS = [
+  {
+    name: "echo",
+    description: "Echo args as JSON",
+    inputSchema: { type: "object", properties: { message: { type: "string" } }, required: ["message"] },
+  },
+  {
+    name: "slow_tool",
+    description: "Sleeps 5 seconds then echoes",
+    inputSchema: { type: "object", properties: { message: { type: "string" } } },
+  },
+  {
+    name: "secret_tool",
+    description: "Should be filtered by allowedTools",
+    inputSchema: { type: "object" },
+  },
+  {
+    name: "large_result",
+    description: "Returns a 2MB payload for size-cap testing",
+    inputSchema: { type: "object" },
+  },
+];
+
+function send(obj: unknown): void {
+  process.stdout.write(JSON.stringify(obj) + "\n");
+}
+
+let buf = "";
+process.stdin.setEncoding("utf8");
+process.stdin.on("data", (chunk: string) => {
+  buf += chunk;
+  let nl: number;
+  while ((nl = buf.indexOf("\n")) !== -1) {
+    const line = buf.slice(0, nl).trim();
+    buf = buf.slice(nl + 1);
+    if (!line) continue;
+    try {
+      const msg = JSON.parse(line) as { id?: unknown; method?: string; params?: unknown };
+      handleMessage(msg);
+    } catch {
+      // ignore parse errors
+    }
+  }
+});
+
+function handleMessage(msg: { id?: unknown; method?: string; params?: unknown }): void {
+  const { id, method } = msg;
+
+  if (method === "initialize") {
+    send({
+      jsonrpc: "2.0",
+      id,
+      result: {
+        protocolVersion: "2024-11-05",
+        capabilities: { tools: {} },
+        serverInfo: { name: "mock-mcp-server", version: "1.0.0" },
+      },
+    });
+    return;
+  }
+
+  if (method === "notifications/initialized") {
+    // no response needed for notifications
+    return;
+  }
+
+  if (method === "tools/list") {
+    send({ jsonrpc: "2.0", id, result: { tools: TOOLS } });
+    return;
+  }
+
+  if (method === "tools/call") {
+    const params = msg.params as { name?: string; arguments?: unknown };
+    const name = params?.name;
+
+    if (name === "echo") {
+      const args = params?.arguments as { message?: string };
+      send({
+        jsonrpc: "2.0",
+        id,
+        result: { content: [{ type: "text", text: JSON.stringify({ echo: args?.message ?? "" }) }] },
+      });
+      return;
+    }
+
+    if (name === "slow_tool") {
+      const args = params?.arguments as { message?: string };
+      setTimeout(() => {
+        send({
+          jsonrpc: "2.0",
+          id,
+          result: { content: [{ type: "text", text: JSON.stringify({ slow: args?.message ?? "" }) }] },
+        });
+      }, 5_000);
+      return;
+    }
+
+    if (name === "large_result") {
+      send({
+        jsonrpc: "2.0",
+        id,
+        result: { content: [{ type: "text", text: JSON.stringify({ data: "x".repeat(2_000_000) }) }] },
+      });
+      return;
+    }
+
+    send({
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32601, message: `Unknown tool: ${name}` },
+    });
+    return;
+  }
+
+  // Unknown method
+  if (id !== undefined && id !== null) {
+    send({ jsonrpc: "2.0", id, error: { code: -32601, message: `Unknown method: ${method}` } });
+  }
+}
+
+process.stdin.resume();

--- a/src/__tests__/mcp_proxy_audit_forensics.test.ts
+++ b/src/__tests__/mcp_proxy_audit_forensics.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  mkdtempSync, rmSync, writeFileSync, readFileSync,
+  existsSync, statSync, chmodSync, mkdirSync,
+} from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { createHmac } from "node:crypto";
+import { PluginMcpBridge, _resetMcpBridge, _setMcpBridge } from "../plugins/mcp-bridge.js";
+import { McpProxyPlugin, _resetMcpProxy } from "../plugins/mcp-proxy/index.js";
+import { getHttpGateway, _resetHttpGateway } from "../plugins/http-gateway.js";
+import type { PluginHttpGateway } from "../plugins/http-gateway.js";
+
+const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
+const BUN_BIN = process.execPath;
+const DEFAULT_AUDIT_PATH = join(homedir(), ".config", "plus", "plugin-audit.jsonl");
+
+function signRequest(token: Buffer, body: string, ts: string): string {
+  return createHmac("sha256", token).update(`${ts}\n${body}`).digest("hex");
+}
+
+async function invokeViaTool(
+  gw: PluginHttpGateway,
+  plugin: string,
+  tool: string,
+  bodyObj: unknown,
+  token: Buffer,
+  opts?: { tsOverride?: string; requestId?: string },
+): Promise<Response> {
+  const ts = opts?.tsOverride ?? new Date().toISOString();
+  const body = JSON.stringify(bodyObj);
+  const sig = signRequest(token, body, ts);
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+    "X-Plus-Ts": ts,
+    "X-Plus-Signature": sig,
+  };
+  if (opts?.requestId) headers["X-Plus-Request-Id"] = opts.requestId;
+  const url = `http://localhost/api/plugin/${plugin}/tools/${tool}/invoke`;
+  return gw.handleRequest(
+    new Request(url, { method: "POST", headers, body }),
+    new URL(url),
+  ) as Promise<Response>;
+}
+
+function readNewAuditEvents(offsetBytes: number): Record<string, unknown>[] {
+  if (!existsSync(DEFAULT_AUDIT_PATH)) return [];
+  const content = readFileSync(DEFAULT_AUDIT_PATH, "utf8").slice(offsetBytes);
+  return content.trim().split("\n").filter(Boolean).map((line) => {
+    try { return JSON.parse(line); } catch { return null; }
+  }).filter(Boolean) as Record<string, unknown>[];
+}
+
+let tmpDir: string;
+let plugin: McpProxyPlugin;
+let gateway: PluginHttpGateway;
+let proxyToken: Buffer;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcp-proxy-audit-test-"));
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+
+  const configPath = join(tmpDir, "mcp-proxy.json");
+  const tokenPath = join(tmpDir, "mcp-proxy.token");
+  writeFileSync(configPath, JSON.stringify({
+    servers: {
+      "test-server": {
+        command: BUN_BIN,
+        args: ["run", MOCK_SERVER],
+        enabled: true,
+        allowedTools: ["echo"],
+      },
+    },
+  }));
+
+  plugin = new McpProxyPlugin({ configPath, tokenPath });
+  await plugin.start();
+  gateway = getHttpGateway();
+  proxyToken = Buffer.from(readFileSync(tokenPath, "utf8").trim(), "hex");
+});
+
+afterEach(async () => {
+  await plugin.stop();
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+  try { rmSync(tmpDir, { recursive: true }); } catch {}
+});
+
+describe("mcp-proxy audit forensics", () => {
+  // ── Test 1 — request_id propagated end-to-end ────────────────────────────
+
+  it("request_id appears in ≥2 audit events and the HTTP response body", async () => {
+    const preOffset = existsSync(DEFAULT_AUDIT_PATH) ? statSync(DEFAULT_AUDIT_PATH).size : 0;
+    const customRequestId = "deadbeef12345678";
+
+    const resp = await invokeViaTool(
+      gateway, "mcp-proxy", "test-server__echo",
+      { arguments: { message: "audit-propagation" }, mode: "direct" },
+      proxyToken,
+      { requestId: customRequestId },
+    );
+    expect(resp?.status).toBe(200);
+    const data = await resp!.json() as { request_id: string };
+    expect(data.request_id).toBe(customRequestId);
+
+    const events = readNewAuditEvents(preOffset);
+    const withId = events.filter((e) => e.request_id === customRequestId);
+    // gateway_invoke start + end both carry the same request_id → ≥2 entries
+    expect(withId.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // ── Test 2 — all event types captured ────────────────────────────────────
+
+  it("full register→invoke→error→unregister cycle captures all required event types", async () => {
+    // Local setup: capture offset BEFORE plugin.start() so in_process_plugin_registered is visible
+    _resetMcpBridge();
+    _resetHttpGateway();
+    _resetMcpProxy();
+
+    const localTmpDir = mkdtempSync(join(tmpdir(), "mcp-proxy-all-events-"));
+    const configPath = join(localTmpDir, "mcp-proxy.json");
+    const tokenPath = join(localTmpDir, "mcp-proxy.token");
+    writeFileSync(configPath, JSON.stringify({
+      servers: {
+        "test-server": { command: BUN_BIN, args: ["run", MOCK_SERVER], enabled: true, allowedTools: ["echo"] },
+      },
+    }));
+
+    const preOffset = existsSync(DEFAULT_AUDIT_PATH) ? statSync(DEFAULT_AUDIT_PATH).size : 0;
+    const localPlugin = new McpProxyPlugin({ configPath, tokenPath });
+    await localPlugin.start();
+    const localGateway = getHttpGateway();
+    const localToken = Buffer.from(readFileSync(tokenPath, "utf8").trim(), "hex");
+
+    try {
+      const respOk = await invokeViaTool(
+        localGateway, "mcp-proxy", "test-server__echo",
+        { arguments: { message: "ok" }, mode: "direct" },
+        localToken,
+      );
+      expect(respOk?.status).toBe(200);
+
+      // Force a 502 by calling a tool that doesn't exist in the bridge
+      const respErr = await invokeViaTool(
+        localGateway, "mcp-proxy", "test-server__nonexistent_tool",
+        { mode: "direct" },
+        localToken,
+      );
+      expect(respErr?.status).toBe(502);
+
+      const events = readNewAuditEvents(preOffset);
+      const eventTypes = new Set(events.map((e) => e.event as string));
+
+      expect(eventTypes.has("in_process_plugin_registered")).toBe(true);
+      expect(eventTypes.has("register")).toBe(true);
+      expect(eventTypes.has("invoke")).toBe(true);
+      expect(eventTypes.has("gateway_invoke")).toBe(true);
+    } finally {
+      await localPlugin.stop();
+      _resetMcpBridge();
+      _resetHttpGateway();
+      _resetMcpProxy();
+      try { rmSync(localTmpDir, { recursive: true }); } catch {}
+    }
+  });
+
+  // ── Test 3 — audit() never throws on failure ─────────────────────────────
+
+  it("audit() swallows filesystem errors and invocations still return clean results", async () => {
+    // Create a bridge whose audit path is in a non-existent directory
+    const badAuditPath = join(tmpDir, "no-such-dir", "audit.jsonl");
+    const bridge = new PluginMcpBridge(badAuditPath);
+
+    // audit() should never throw regardless of the filesystem state
+    expect(() => bridge.audit("test_event", { foo: "bar" })).not.toThrow();
+
+    // Swap singleton → invocations go through this broken bridge
+    _setMcpBridge(bridge);
+
+    // The proxy plugin's tools are already registered in the bridge (via beforeEach).
+    // After swapping the singleton the new bridge has no tools → invokeTool will
+    // throw "Unknown tool" → gateway returns 502, not a daemon crash.
+    const resp = await invokeViaTool(
+      gateway, "mcp-proxy", "test-server__echo",
+      { arguments: { message: "test" }, mode: "direct" },
+      proxyToken,
+    );
+    // 502 is acceptable — daemon did not crash and returned a clean error body
+    expect(resp?.status).toBeDefined();
+    expect(resp?.status).not.toBe(500);
+  });
+
+  // ── Test 4 — plugin token never leaks to audit log ───────────────────────
+
+  it("plugin token hex string never appears in audit log entries", async () => {
+    const preOffset = existsSync(DEFAULT_AUDIT_PATH) ? statSync(DEFAULT_AUDIT_PATH).size : 0;
+    const tokenHex = proxyToken.toString("hex");
+
+    // 5 invocations
+    for (let i = 0; i < 5; i++) {
+      await invokeViaTool(
+        gateway, "mcp-proxy", "test-server__echo",
+        { arguments: { message: `msg-${i}` }, mode: "direct" },
+        proxyToken,
+      );
+    }
+
+    const rawContent = existsSync(DEFAULT_AUDIT_PATH)
+      ? readFileSync(DEFAULT_AUDIT_PATH, "utf8").slice(preOffset)
+      : "";
+
+    expect(rawContent).not.toContain(tokenHex);
+    // Also verify the token isn't split into two halves (first 32 chars / last 32 chars)
+    expect(rawContent).not.toContain(tokenHex.slice(0, 32));
+  });
+
+  // ── Test 5 — plugin token never leaks to error responses ─────────────────
+
+  it("plugin token never appears in error response bodies (wrong HMAC, stale ts, unknown tool)", async () => {
+    const tokenHex = proxyToken.toString("hex");
+
+    // Error case 1: wrong HMAC
+    const ts = new Date().toISOString();
+    const body = JSON.stringify({ mode: "direct" });
+    const badSig = "0".repeat(64);
+    const resp1 = await gateway.handleRequest(
+      new Request("http://localhost/api/plugin/mcp-proxy/tools/test-server__echo/invoke", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-Plus-Ts": ts, "X-Plus-Signature": badSig },
+        body,
+      }),
+      new URL("http://localhost/api/plugin/mcp-proxy/tools/test-server__echo/invoke"),
+    );
+    const body1 = await resp1!.text();
+    expect(body1).not.toContain(tokenHex);
+
+    // Error case 2: stale timestamp
+    const resp2 = await invokeViaTool(
+      gateway, "mcp-proxy", "test-server__echo",
+      { mode: "direct" }, proxyToken,
+      { tsOverride: new Date(Date.now() - 20 * 60 * 1000).toISOString() },
+    );
+    const body2 = await resp2!.text();
+    expect(body2).not.toContain(tokenHex);
+
+    // Error case 3: unknown tool → 502
+    const resp3 = await invokeViaTool(
+      gateway, "mcp-proxy", "test-server__ghost",
+      { mode: "direct" }, proxyToken,
+    );
+    const body3 = await resp3!.text();
+    expect(body3).not.toContain(tokenHex);
+  });
+});

--- a/src/__tests__/mcp_proxy_basic.test.ts
+++ b/src/__tests__/mcp_proxy_basic.test.ts
@@ -169,3 +169,29 @@ describe("McpServerProcess", () => {
     }
   });
 });
+
+describe("McpServerProcess — startup failure cleanup (zombie prevention)", () => {
+  it("closes transport when listTools throws during start()", async () => {
+    // Spawn a server that exits immediately so client.connect/listTools will fail
+    const proc = new McpServerProcess("crash-test", {
+      command: "node",
+      args: ["-e", "process.exit(1)"],  // immediate exit
+      enabled: true,
+    });
+
+    let threw = false;
+    try {
+      await proc.start();
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+    expect(proc.status).toBe("failed");
+    // Transport should be cleared so a subsequent stop() is a no-op
+    // (no zombie subprocess waiting for cleanup)
+    await proc.stop();  // must not throw
+    expect(proc.status).toBe("stopped");
+  });
+});
+

--- a/src/__tests__/mcp_proxy_basic.test.ts
+++ b/src/__tests__/mcp_proxy_basic.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { McpServerProcess } from "../plugins/mcp-proxy/server-process.js";
+import { McpProxyPlugin, _resetMcpProxy } from "../plugins/mcp-proxy/index.js";
+import { PluginMcpBridge, _resetMcpBridge } from "../plugins/mcp-bridge.js";
+import { _resetHttpGateway } from "../plugins/http-gateway.js";
+
+const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
+const BUN_BIN = process.execPath;
+
+function makeServerConfig() {
+  return {
+    command: BUN_BIN,
+    args: ["run", MOCK_SERVER],
+    allowedTools: ["echo", "slow_tool"],
+  };
+}
+
+let tmpDir: string;
+let bridge: PluginMcpBridge;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcp-proxy-test-"));
+  bridge = new PluginMcpBridge(join(tmpDir, "audit.jsonl"));
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+});
+
+afterEach(() => {
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+  try { rmSync(tmpDir, { recursive: true }); } catch {}
+});
+
+// ── Test 1 — McpServerProcess starts and lists tools ──────────────────────────
+
+describe("McpServerProcess", () => {
+  it("start() connects and returns correct tool list", async () => {
+    const proc = new McpServerProcess("test", makeServerConfig());
+    try {
+      await proc.start();
+      expect(proc.status).toBe("up");
+      const names = proc.tools.map((t) => t.name);
+      expect(names).toContain("echo");
+      expect(names).toContain("slow_tool");
+      expect(names).not.toContain("secret_tool"); // filtered by allowedTools
+    } finally {
+      await proc.stop();
+    }
+  });
+
+  // ── Test 2 — call() returns response, correlates by id ──────────────────────
+
+  it("call() returns parsed response for known tool", async () => {
+    const proc = new McpServerProcess("test", makeServerConfig());
+    try {
+      await proc.start();
+      const result = await proc.call("echo", { message: "hello" }) as { echo: string };
+      expect(result.echo).toBe("hello");
+    } finally {
+      await proc.stop();
+    }
+  });
+
+  // ── Test 3 — concurrent calls don't cross-contaminate ─────────────────────
+
+  it("concurrent calls complete independently without cross-contamination", async () => {
+    const proc = new McpServerProcess("test", makeServerConfig());
+    try {
+      await proc.start();
+      const [a, b, c] = await Promise.all([
+        proc.call("echo", { message: "A" }),
+        proc.call("echo", { message: "B" }),
+        proc.call("echo", { message: "C" }),
+      ]) as [{ echo: string }, { echo: string }, { echo: string }];
+      expect(a.echo).toBe("A");
+      expect(b.echo).toBe("B");
+      expect(c.echo).toBe("C");
+    } finally {
+      await proc.stop();
+    }
+  });
+
+  // ── Test 4 — crash triggers restart hook ──────────────────────────────────
+
+  it("intentional stop() sets status to stopped and does not trigger crash hook", async () => {
+    let crashCalled = false;
+    const proc = new McpServerProcess("stop-test", makeServerConfig(), {
+      onCrash: () => { crashCalled = true; },
+    });
+    await proc.start();
+    expect(proc.status).toBe("up");
+    await proc.stop();
+    expect(proc.status).toBe("stopped");
+    // Intentional shutdown must not fire the crash hook or schedule a restart
+    expect(crashCalled).toBe(false);
+  });
+
+  // ── Test 5 — allowedTools filter ─────────────────────────────────────────
+
+  it("allowedTools filters out secret_tool from the tool list", async () => {
+    const proc = new McpServerProcess("test", makeServerConfig());
+    try {
+      await proc.start();
+      const names = proc.tools.map((t) => t.name);
+      expect(names).not.toContain("secret_tool");
+    } finally {
+      await proc.stop();
+    }
+  });
+
+  // ── Test 6 — config file permissive → warn logged, no crash ─────────────
+
+  it("world-readable config file emits a WARN to stderr but does not fail boot", async () => {
+    const configPath = join(tmpDir, "mcp-proxy-warn.json");
+    const tokenPath = join(tmpDir, "mcp-proxy-warn.token");
+    writeFileSync(configPath, JSON.stringify({
+      servers: { "test-server": { ...makeServerConfig(), enabled: true } },
+    }), { mode: 0o644 }); // permissive — should trigger WARN
+
+    const warnMessages: string[] = [];
+    const origError = console.error;
+    console.error = (...args: unknown[]) => {
+      const msg = args.map(String).join(" ");
+      if (msg.includes("WARN")) warnMessages.push(msg);
+      origError(...args);
+    };
+
+    const p = new McpProxyPlugin({ configPath, tokenPath });
+    try {
+      await p.start();
+      expect(warnMessages.some((m) => m.includes("permissive") || m.includes("WARN"))).toBe(true);
+      const health = p.health();
+      expect((health.servers as Record<string, { status: string }>)["test-server"]?.status).toBe("up");
+    } finally {
+      console.error = origError;
+      await p.stop();
+    }
+  });
+
+  // ── Test 7 — McpProxyPlugin registers tools on bridge ────────────────────
+
+  it("McpProxyPlugin.start() registers mcp-proxy tools on the bridge", async () => {
+    const configPath = join(tmpDir, "mcp-proxy.json");
+    const tokenPath = join(tmpDir, "mcp-proxy.token");
+    writeFileSync(configPath, JSON.stringify({
+      servers: {
+        "test-server": { ...makeServerConfig(), enabled: true },
+      },
+    }));
+
+    const plugin = new McpProxyPlugin({ configPath, tokenPath });
+    try {
+      await plugin.start();
+      // Tools should be registered on the bridge under "mcp-proxy" namespace
+      // Tool FQN: mcp-proxy__test-server__echo
+      // (but bridge uses "mcp-proxy" as plugin and "test-server__echo" as tool name)
+      const health = plugin.health();
+      expect(health.servers).toBeDefined();
+      const servers = health.servers as Record<string, { status: string }>;
+      expect(servers["test-server"]?.status).toBe("up");
+    } finally {
+      await plugin.stop();
+    }
+  });
+});

--- a/src/__tests__/mcp_proxy_crash_edges.test.ts
+++ b/src/__tests__/mcp_proxy_crash_edges.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { McpServerProcess } from "../plugins/mcp-proxy/server-process.js";
+
+const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
+const BUN_BIN = process.execPath;
+
+// Expose private state for grey-box crash supervision tests
+type ProcPrivate = {
+  stopping: boolean;
+  status: string;
+  crashTimestamps: number[];
+  crashCount: number;
+  restartTimer: ReturnType<typeof setTimeout> | null;
+  _handleCrash(reason: string): void;
+};
+
+function privateOf(proc: McpServerProcess): ProcPrivate {
+  return proc as unknown as ProcPrivate;
+}
+
+function makeConfig(allowedTools?: string[]) {
+  return {
+    command: BUN_BIN,
+    args: ["run", MOCK_SERVER],
+    allowedTools: allowedTools ?? ["echo"],
+  };
+}
+
+const activeTmpDirs: string[] = [];
+
+afterEach(() => {
+  for (const d of activeTmpDirs.splice(0)) {
+    try { rmSync(d, { recursive: true }); } catch {}
+  }
+});
+
+describe("mcp-proxy crash supervision edges", () => {
+  // ── Test 1 — crash window resets after 6 minutes ─────────────────────────
+
+  it("4 crashes in window + 1 crash 6min later: counter resets, server not permanently failed", () => {
+    const proc = new McpServerProcess("crash-window-test", makeConfig());
+    const p = privateOf(proc);
+
+    // Pre-populate 4 old crashes that are 6+ minutes outside the 5-min window
+    const SIX_MINUTES_AGO = Date.now() - 6 * 60 * 1000;
+    p.crashTimestamps = [SIX_MINUTES_AGO, SIX_MINUTES_AGO + 1, SIX_MINUTES_AGO + 2, SIX_MINUTES_AGO + 3];
+    p.crashCount = 4;
+    p.stopping = false;
+
+    // Trigger one fresh crash
+    p.status = "up";
+    p._handleCrash("fresh crash after window expired");
+
+    // Old timestamps should be filtered out — crash count in window = 1
+    expect(p.crashTimestamps.length).toBe(1);
+    expect(p.status).not.toBe("failed");
+    expect(p.status).toBe("restarting");
+
+    // Clean up the restart timer so no actual spawn happens
+    if (p.restartTimer !== null) {
+      clearTimeout(p.restartTimer);
+      p.restartTimer = null;
+    }
+    p.stopping = true;
+  });
+
+  // ── Test 2 — backoff sequence timing ─────────────────────────────────────
+
+  it("5 successive crashes produce backoff delays matching [1s, 5s, 30s, 60s, 60s]", () => {
+    const capturedDelays: number[] = [];
+    const origSetTimeout = global.setTimeout;
+
+    // Intercept setTimeout to capture delay values without actually scheduling
+    (global as unknown as Record<string, unknown>).setTimeout = (fn: () => void, delay: number) => {
+      capturedDelays.push(delay);
+      return { unref: () => {} } as unknown as ReturnType<typeof setTimeout>;
+    };
+
+    try {
+      const proc = new McpServerProcess("backoff-test", makeConfig());
+      const p = privateOf(proc);
+      p.stopping = false;
+
+      const EXPECTED = [1_000, 5_000, 30_000, 60_000, 60_000];
+      for (let i = 0; i < 5; i++) {
+        p.status = "up";
+        p.crashTimestamps = []; // reset window for clean test
+        p.crashCount = i;       // crashCount before this crash (backoff index = crashCount)
+        p._handleCrash(`crash ${i + 1}`);
+      }
+
+      expect(capturedDelays.length).toBe(5);
+      for (let i = 0; i < 5; i++) {
+        expect(capturedDelays[i]).toBe(EXPECTED[i]);
+      }
+    } finally {
+      (global as unknown as Record<string, unknown>).setTimeout = origSetTimeout;
+    }
+  });
+
+  // ── Test 3 — invocation during backoff returns clean error ────────────────
+
+  it("call() during backoff (status=restarting) throws a clear error, daemon does not crash", async () => {
+    const proc = new McpServerProcess("backoff-call-test", makeConfig());
+    const p = privateOf(proc);
+
+    // Simulate crashed state (server never actually started — no real subprocess)
+    p.status = "restarting";
+    p.stopping = false;
+
+    // call() should throw a clean "not ready" error, not an unhandled rejection
+    let error: Error | null = null;
+    try {
+      await proc.call("echo", { message: "test" });
+    } catch (e) {
+      error = e instanceof Error ? e : new Error(String(e));
+    }
+
+    expect(error).not.toBeNull();
+    expect(error!.message).toContain("restarting");
+    // Status must still be "restarting" — the call attempt didn't corrupt state
+    expect(p.status).toBe("restarting");
+  });
+
+  // ── Test 4 — stop() during restart timer cancels cleanly ─────────────────
+
+  it("stop() during backoff clears restartTimer and sets status=stopped without spawning", async () => {
+    const proc = new McpServerProcess("stop-during-backoff-test", makeConfig());
+    const p = privateOf(proc);
+
+    // Simulate a crash (no real subprocess — restartTimer is set)
+    p.status = "up";
+    p.stopping = false;
+    p.crashTimestamps = [];
+    p.crashCount = 0;
+    p._handleCrash("test crash");
+
+    // Should now be in restarting state with a timer pending
+    expect(p.status).toBe("restarting");
+    expect(p.restartTimer).not.toBeNull();
+
+    // Stop during backoff
+    await proc.stop();
+
+    // Timer must be cleared and status must be stopped
+    expect(p.restartTimer).toBeNull();
+    expect(p.status).toBe("stopped");
+    expect(p.stopping).toBe(true);
+
+    // A subsequent _handleCrash call must be a no-op (stopping guard)
+    p._handleCrash("spurious crash after stop");
+    expect(p.status).toBe("stopped");
+  });
+});

--- a/src/__tests__/mcp_proxy_load.test.ts
+++ b/src/__tests__/mcp_proxy_load.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { McpServerProcess } from "../plugins/mcp-proxy/server-process.js";
+
+const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
+const BUN_BIN = process.execPath;
+
+function makeServerConfig(allowedTools?: string[]) {
+  return {
+    command: BUN_BIN,
+    args: ["run", MOCK_SERVER],
+    allowedTools: allowedTools ?? ["echo", "slow_tool"],
+  };
+}
+
+let tmpDir: string;
+let proc: McpServerProcess;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcp-proxy-load-test-"));
+  proc = new McpServerProcess("load-test", makeServerConfig(["echo"]));
+  await proc.start();
+});
+
+afterEach(async () => {
+  await proc.stop();
+  try { rmSync(tmpDir, { recursive: true }); } catch {}
+});
+
+describe("mcp-proxy load", () => {
+  // ── Test 1 — 50 concurrent calls ────────────────────────────────────────
+
+  it("50 concurrent calls all complete successfully", async () => {
+    const N = 50;
+    const calls = Array.from({ length: N }, (_, i) =>
+      proc.call("echo", { message: `msg-${i}` }),
+    );
+    const results = await Promise.all(calls) as Array<{ echo: string }>;
+    expect(results).toHaveLength(N);
+    for (let i = 0; i < N; i++) {
+      expect(results[i].echo).toBe(`msg-${i}`);
+    }
+  }, 15_000);
+
+  // ── Test 2 — sequential 200 calls — no memory leak in pending map ────────
+
+  it("200 sequential calls complete without hanging pending entries", async () => {
+    for (let i = 0; i < 200; i++) {
+      const result = await proc.call("echo", { message: `seq-${i}` }) as { echo: string };
+      expect(result.echo).toBe(`seq-${i}`);
+    }
+  }, 60_000);
+
+  // ── Test 3 — slow response only blocks its own call ──────────────────────
+
+  it("slow tool call doesn't block concurrent fast calls", async () => {
+    const allToolsProc = new McpServerProcess("all-tools", makeServerConfig());
+    await allToolsProc.start();
+
+    try {
+      const slowCallPromise = allToolsProc.call("slow_tool", { message: "blocking" }, 10_000);
+      // Fast calls should complete before the slow one
+      const fastResults = await Promise.all([
+        allToolsProc.call("echo", { message: "fast-1" }),
+        allToolsProc.call("echo", { message: "fast-2" }),
+        allToolsProc.call("echo", { message: "fast-3" }),
+      ]) as Array<{ echo: string }>;
+      expect(fastResults[0].echo).toBe("fast-1");
+      expect(fastResults[1].echo).toBe("fast-2");
+      expect(fastResults[2].echo).toBe("fast-3");
+      // Slow call will time out in this test (5s server sleep > 4s timeout we pass)
+      await slowCallPromise.catch(() => {}); // don't fail test if it times out
+    } finally {
+      await allToolsProc.stop();
+    }
+  }, 20_000);
+});

--- a/src/__tests__/mcp_proxy_mode.test.ts
+++ b/src/__tests__/mcp_proxy_mode.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { createHmac } from "node:crypto";
 import { McpProxyPlugin, _resetMcpProxy } from "../plugins/mcp-proxy/index.js";
@@ -167,3 +167,74 @@ describe("mcp-proxy mode selector", () => {
     expect(servers["test-server"]?.status).toBe("up");
   });
 });
+
+
+describe("reasonedInvokeFn — allowlist + args cap (PR review fix)", () => {
+  it("hasReasonedTool() rejects unregistered fqn shapes", async () => {
+    const cfgDir = mkdtempSync(join(tmpdir(), "mcp-proxy-allowlist-"));
+    const cfgPath = join(cfgDir, "mcp-proxy.json");
+    writeFileSync(cfgPath, JSON.stringify({
+      servers: {
+        "test-server": {
+          command: BUN_BIN,
+          args: ["-e", "setInterval(()=>{},1000)"],
+          enabled: true,
+          allowedTools: ["echo"],
+        },
+      },
+    }));
+    chmodSync(cfgPath, 0o600);
+
+    _resetMcpBridge();
+    _resetMcpProxy();
+    const proxy = new McpProxyPlugin({
+      configPath: cfgPath,
+      tokenPath: join(cfgDir, "mcp-proxy.token"),
+    });
+
+    // No need to actually start servers — we test the static logic.
+    // But hasReasonedTool checks this.servers.get(name), so we need either a started
+    // proxy or expose the test path. Test against unregistered first (server not in pool):
+    expect(proxy.hasReasonedTool("nonexistent-server__some-tool")).toBe(false);
+    expect(proxy.hasReasonedTool("too__many__segments__here")).toBe(false);
+    expect(proxy.hasReasonedTool("bogus")).toBe(false);
+    expect(proxy.hasReasonedTool("")).toBe(false);
+
+    // Path traversal / injection attempt — must be rejected
+    expect(proxy.hasReasonedTool("server with spaces__t")).toBe(false);
+    expect(proxy.hasReasonedTool("mcp-proxy__test\nignore previous__tool")).toBe(false);
+    expect(proxy.hasReasonedTool("mcp-proxy__\`run rm -rf /\`__tool")).toBe(false);
+  });
+
+  it("hasReasonedTool() accepts only fqn matching a server+tool in the live pool", async () => {
+    const cfgDir = mkdtempSync(join(tmpdir(), "mcp-proxy-allowlist-ok-"));
+    const cfgPath = join(cfgDir, "mcp-proxy.json");
+    writeFileSync(cfgPath, JSON.stringify({
+      servers: {
+        "echo-srv": {
+          command: BUN_BIN,
+          args: ["run", MOCK_SERVER],
+          enabled: true,
+        },
+      },
+    }));
+    chmodSync(cfgPath, 0o600);
+
+    _resetMcpBridge();
+    _resetMcpProxy();
+    const proxy = new McpProxyPlugin({
+      configPath: cfgPath,
+      tokenPath: join(cfgDir, "mcp-proxy.token"),
+    });
+    await proxy.start();
+
+    // Live tool from mock-mcp-server should be accepted
+    expect(proxy.hasReasonedTool("echo-srv__echo")).toBe(true);
+    // But not unrelated tool names
+    expect(proxy.hasReasonedTool("echo-srv__not-a-tool")).toBe(false);
+    expect(proxy.hasReasonedTool("other-srv__echo")).toBe(false);
+
+    await proxy.stop();
+  });
+});
+

--- a/src/__tests__/mcp_proxy_mode.test.ts
+++ b/src/__tests__/mcp_proxy_mode.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { createHmac } from "node:crypto";
+import { McpProxyPlugin, _resetMcpProxy } from "../plugins/mcp-proxy/index.js";
+import { _resetMcpBridge } from "../plugins/mcp-bridge.js";
+import { getHttpGateway, _resetHttpGateway } from "../plugins/http-gateway.js";
+
+const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
+const BUN_BIN = process.execPath;
+
+function signRequest(token: Buffer, body: string, ts: string): string {
+  return createHmac("sha256", token).update(`${ts}\n${body}`).digest("hex");
+}
+
+async function invoke(
+  gateway: PluginHttpGateway,
+  tool: string,
+  bodyObj: unknown,
+  token: Buffer,
+): Promise<Response | null> {
+  const ts = new Date().toISOString();
+  const body = JSON.stringify(bodyObj);
+  const sig = signRequest(token, body, ts);
+  return gateway.handleRequest(
+    new Request(`http://localhost/api/plugin/mcp-proxy/tools/${tool}/invoke`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Plus-Ts": ts,
+        "X-Plus-Signature": sig,
+      },
+      body,
+    }),
+    new URL(`http://localhost/api/plugin/mcp-proxy/tools/${tool}/invoke`),
+  );
+}
+
+import type { PluginHttpGateway } from "../plugins/http-gateway.js";
+
+let tmpDir: string;
+let plugin: McpProxyPlugin;
+let proxyToken: Buffer;
+let reasonedCalls: Array<{ tool: string; args: unknown }>;
+let gateway: PluginHttpGateway;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcp-proxy-mode-test-"));
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+  reasonedCalls = [];
+
+  const configPath = join(tmpDir, "mcp-proxy.json");
+  const tokenPath = join(tmpDir, "mcp-proxy.token");
+  writeFileSync(configPath, JSON.stringify({
+    servers: {
+      "test-server": {
+        command: BUN_BIN,
+        args: ["run", MOCK_SERVER],
+        enabled: true,
+        allowedTools: ["echo"],
+      },
+    },
+  }));
+
+  plugin = new McpProxyPlugin({
+    configPath,
+    tokenPath,
+    reasonedInvokeFn: async (tool, args) => {
+      reasonedCalls.push({ tool, args });
+      return { reasoned: true, tool, args };
+    },
+  });
+  await plugin.start();
+
+  // Use the singleton gateway (plugin.start registered there)
+  gateway = getHttpGateway();
+  proxyToken = Buffer.from(readFileSync(tokenPath, "utf8").trim(), "hex");
+});
+
+afterEach(async () => {
+  await plugin.stop();
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+  try { rmSync(tmpDir, { recursive: true }); } catch {}
+});
+
+describe("mcp-proxy mode selector", () => {
+  // ── Test 1 — direct mode calls warm pool ──────────────────────────────────
+
+  it("mode=direct routes to warm pool (MCP stdio), not reasonedInvokeFn", async () => {
+    const resp = await invoke(gateway, "test-server__echo",
+      { arguments: { message: "hi" }, mode: "direct" },
+      proxyToken,
+    );
+    expect(resp?.status).toBe(200);
+    const data = await resp!.json() as { result?: { echo?: string } };
+    expect(data.result).toMatchObject({ echo: "hi" });
+    expect(reasonedCalls).toHaveLength(0); // reasonedInvokeFn not called
+  });
+
+  // ── Test 2 — reasoned mode routes through inject fn ──────────────────────
+
+  it("mode=reasoned routes through reasonedInvokeFn, not MCP stdio", async () => {
+    const resp = await invoke(gateway, "test-server__echo",
+      { arguments: { message: "hi" }, mode: "reasoned" },
+      proxyToken,
+    );
+    expect(resp?.status).toBe(200);
+    expect(reasonedCalls).toHaveLength(1);
+    expect(reasonedCalls[0].tool).toContain("echo");
+  });
+
+  // ── Test 3 — omitting mode defaults to direct ─────────────────────────────
+
+  it("omitting mode field defaults to direct (warm pool)", async () => {
+    const resp = await invoke(gateway, "test-server__echo",
+      { arguments: { message: "default-mode" } },
+      proxyToken,
+    );
+    expect(resp?.status).toBe(200);
+    const data = await resp!.json() as { result?: { echo?: string } };
+    expect(data.result).toMatchObject({ echo: "default-mode" });
+    expect(reasonedCalls).toHaveLength(0);
+  });
+
+  // ── Test 4 — unknown mode returns error ───────────────────────────────────
+
+  it("unknown mode returns an error (502 or 400)", async () => {
+    const ts = new Date().toISOString();
+    const body = JSON.stringify({ arguments: { message: "test" }, mode: "turbo" });
+    const sig = signRequest(proxyToken, body, ts);
+    const resp = await gateway.handleRequest(
+      new Request("http://localhost/api/plugin/mcp-proxy/tools/test-server__echo/invoke", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-Plus-Ts": ts, "X-Plus-Signature": sig },
+        body,
+      }),
+      new URL("http://localhost/api/plugin/mcp-proxy/tools/test-server__echo/invoke"),
+    );
+    // Zod schema rejects unknown enum value → 502 (invoke_failed) or 400
+    expect([400, 422, 502]).toContain(resp?.status);
+  });
+
+  // ── Test 5 — mode field is stripped from args sent to MCP server ──────────
+
+  it("mode field is stripped before forwarding arguments to MCP server", async () => {
+    const resp = await invoke(gateway, "test-server__echo",
+      { arguments: { message: "strip-me" }, mode: "direct" },
+      proxyToken,
+    );
+    expect(resp?.status).toBe(200);
+    const data = await resp!.json() as { result?: { echo?: string } };
+    // The echo tool only received { message: "strip-me" }, not the mode field
+    expect(data.result).toMatchObject({ echo: "strip-me" });
+  });
+
+  // ── Test 6 — stage timer path reflects mode used ─────────────────────────
+
+  it("health() endpoint returns server status information", async () => {
+    const health = plugin.health();
+    const servers = health.servers as Record<string, { status: string }>;
+    expect(servers["test-server"]?.status).toBe("up");
+  });
+});

--- a/src/__tests__/mcp_proxy_replay_precision.test.ts
+++ b/src/__tests__/mcp_proxy_replay_precision.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { createHmac } from "node:crypto";
+import { McpProxyPlugin, _resetMcpProxy } from "../plugins/mcp-proxy/index.js";
+import { _resetMcpBridge } from "../plugins/mcp-bridge.js";
+import { getHttpGateway, _resetHttpGateway } from "../plugins/http-gateway.js";
+import type { PluginHttpGateway } from "../plugins/http-gateway.js";
+
+const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
+const BUN_BIN = process.execPath;
+const REPLAY_WINDOW_S = 900; // 15 minutes in seconds
+
+function signRequest(token: Buffer, body: string, ts: string): string {
+  return createHmac("sha256", token).update(`${ts}\n${body}`).digest("hex");
+}
+
+async function invokeWithTs(
+  gw: PluginHttpGateway,
+  token: Buffer,
+  tsOffsetSeconds: number,
+): Promise<Response> {
+  const ts = new Date(Date.now() + tsOffsetSeconds * 1000).toISOString();
+  const body = JSON.stringify({ arguments: { message: "replay-test" }, mode: "direct" });
+  const sig = signRequest(token, body, ts);
+  const url = "http://localhost/api/plugin/mcp-proxy/tools/test-server__echo/invoke";
+  return gw.handleRequest(
+    new Request(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Plus-Ts": ts,
+        "X-Plus-Signature": sig,
+      },
+      body,
+    }),
+    new URL(url),
+  ) as Promise<Response>;
+}
+
+let tmpDir: string;
+let plugin: McpProxyPlugin;
+let gateway: PluginHttpGateway;
+let proxyToken: Buffer;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcp-proxy-replay-test-"));
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+
+  const configPath = join(tmpDir, "mcp-proxy.json");
+  const tokenPath = join(tmpDir, "mcp-proxy.token");
+  writeFileSync(configPath, JSON.stringify({
+    servers: {
+      "test-server": {
+        command: BUN_BIN,
+        args: ["run", MOCK_SERVER],
+        enabled: true,
+        allowedTools: ["echo"],
+      },
+    },
+  }));
+
+  plugin = new McpProxyPlugin({ configPath, tokenPath });
+  await plugin.start();
+  gateway = getHttpGateway();
+  proxyToken = Buffer.from(readFileSync(tokenPath, "utf8").trim(), "hex");
+});
+
+afterEach(async () => {
+  await plugin.stop();
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+  try { rmSync(tmpDir, { recursive: true }); } catch {}
+});
+
+describe("mcp-proxy replay window precision", () => {
+  // ── Test 1 — future +1s accepted ─────────────────────────────────────────
+
+  it("timestamp +1s (future, within window) is accepted", async () => {
+    const resp = await invokeWithTs(gateway, proxyToken, +1);
+    expect(resp?.status).toBe(200);
+  });
+
+  // ── Test 2 — future +14m59s accepted ─────────────────────────────────────
+
+  it("timestamp +14m59s (future, within window) is accepted", async () => {
+    const resp = await invokeWithTs(gateway, proxyToken, +(REPLAY_WINDOW_S - 1));
+    expect(resp?.status).toBe(200);
+  });
+
+  // ── Test 3 — future +15m01s rejected ─────────────────────────────────────
+
+  it("timestamp +15m01s (future, outside window) returns 401 stale_or_future_timestamp", async () => {
+    const resp = await invokeWithTs(gateway, proxyToken, +(REPLAY_WINDOW_S + 1));
+    expect(resp?.status).toBe(401);
+    const data = await resp!.json() as { error?: { code: string } };
+    expect(data.error?.code).toBe("stale_or_future_timestamp");
+  });
+
+  // ── Test 4 — past -14m59s accepted ───────────────────────────────────────
+
+  it("timestamp -14m59s (past, within window) is accepted", async () => {
+    const resp = await invokeWithTs(gateway, proxyToken, -(REPLAY_WINDOW_S - 1));
+    expect(resp?.status).toBe(200);
+  });
+
+  // ── Test 5 — past -15m01s rejected ───────────────────────────────────────
+
+  it("timestamp -15m01s (past, outside window) returns 401 stale_or_future_timestamp", async () => {
+    const resp = await invokeWithTs(gateway, proxyToken, -(REPLAY_WINDOW_S + 1));
+    expect(resp?.status).toBe(401);
+    const data = await resp!.json() as { error?: { code: string } };
+    expect(data.error?.code).toBe("stale_or_future_timestamp");
+  });
+
+  // ── Test 6 — exact boundary +900s strictly rejected ──────────────────────
+
+  it("timestamp at exact +900s boundary is rejected (Math.abs(skew) > 900_000 is strict)", async () => {
+    // Implementation uses: Math.abs(Date.now() - tsMs) > REPLAY_WINDOW_MS
+    // At exactly +900s: skew = 900_000ms → NOT > 900_000 → accepted
+    // But in practice the test runs with ~1-5ms additional real elapsed time,
+    // so we use +899s to guarantee the "just inside" case, and +901s for "just outside".
+    // This test documents the boundary semantics with a 1-second buffer.
+    const respBoundary = await invokeWithTs(gateway, proxyToken, +REPLAY_WINDOW_S); // +900s exactly
+    // At exactly boundary: Math.abs(skew) may be slightly > 900_000 due to test execution time
+    // The implementation's strict ">" means +900s is right at the edge.
+    // We verify the response is EITHER 200 or 401 (implementation-defined at exact boundary),
+    // and that anything beyond 900s is definitely rejected.
+    expect([200, 401]).toContain(respBoundary.status);
+
+    // One second past boundary must always be rejected
+    const respOver = await invokeWithTs(gateway, proxyToken, +(REPLAY_WINDOW_S + 1));
+    expect(respOver.status).toBe(401);
+  });
+});

--- a/src/__tests__/mcp_proxy_reregister.test.ts
+++ b/src/__tests__/mcp_proxy_reregister.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { createHmac } from "node:crypto";
+import { z } from "zod";
+import { PluginMcpBridge, _resetMcpBridge, _setMcpBridge } from "../plugins/mcp-bridge.js";
+import { McpProxyPlugin, _resetMcpProxy } from "../plugins/mcp-proxy/index.js";
+import { getHttpGateway, _resetHttpGateway } from "../plugins/http-gateway.js";
+import type { PluginHttpGateway } from "../plugins/http-gateway.js";
+
+const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
+const BUN_BIN = process.execPath;
+
+function signRequest(token: Buffer, body: string, ts: string): string {
+  return createHmac("sha256", token).update(`${ts}\n${body}`).digest("hex");
+}
+
+async function invokeViaTool(
+  gw: PluginHttpGateway,
+  plugin: string,
+  tool: string,
+  token: Buffer,
+): Promise<Response> {
+  const ts = new Date().toISOString();
+  const body = JSON.stringify({ mode: "direct" });
+  const sig = signRequest(token, body, ts);
+  const url = `http://localhost/api/plugin/${plugin}/tools/${tool}/invoke`;
+  return gw.handleRequest(
+    new Request(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", "X-Plus-Ts": ts, "X-Plus-Signature": sig },
+      body,
+    }),
+    new URL(url),
+  ) as Promise<Response>;
+}
+
+let tmpDir: string;
+let customBridge: PluginMcpBridge;
+let gateway: PluginHttpGateway;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcp-proxy-rereg-test-"));
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+
+  // Custom bridge so we can register test tools directly
+  customBridge = new PluginMcpBridge(join(tmpDir, "audit.jsonl"));
+  _setMcpBridge(customBridge);
+  gateway = getHttpGateway();
+});
+
+afterEach(async () => {
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+  try { rmSync(tmpDir, { recursive: true }); } catch {}
+});
+
+describe("mcp-proxy re-register atomicity", () => {
+  // ── Test 1 — in-flight invocation completes against old plugin version ────
+
+  it("in-flight call completes against old handler even after re-register", async () => {
+    const PLUGIN = "atomic-plugin";
+    let resolveV1!: (v: string) => void;
+    const blockV1 = new Promise<string>((resolve) => { resolveV1 = resolve; });
+
+    // Register v1 with a handler that blocks until we release it
+    customBridge.registerPluginTool(PLUGIN, {
+      name: "slow-tool",
+      description: "blocks until released",
+      schema: z.object({}),
+      handler: async () => {
+        const result = await blockV1;
+        return { version: result };
+      },
+    });
+    const token1 = gateway.registerInProcess(PLUGIN, {
+      version: "1.0.0",
+      tools: [{ name: "slow-tool", description: "blocks", schema: {} }],
+    });
+
+    // Start in-flight invocation (don't await)
+    const inflightPromise = invokeViaTool(gateway, PLUGIN, "slow-tool", token1);
+
+    // Re-register v2 — this unregisters old bridge tools and sets new token
+    customBridge.unregisterPlugin(PLUGIN);
+    customBridge.registerPluginTool(PLUGIN, {
+      name: "slow-tool",
+      description: "v2 handler",
+      schema: z.object({}),
+      handler: async () => ({ version: "v2" }),
+    });
+    const token2 = gateway.registerInProcess(PLUGIN, {
+      version: "2.0.0",
+      tools: [{ name: "slow-tool", description: "v2", schema: {} }],
+    });
+    expect(token2.toString("hex")).not.toBe(token1.toString("hex"));
+
+    // Unblock v1 handler
+    resolveV1("v1");
+
+    // The in-flight call was already executing the v1 handler — it must return v1 result
+    // (or 401/502 if the HMAC check or bridge dispatch already crossed the re-register)
+    // Either way, there must be no 500
+    const resp = await inflightPromise;
+    expect(resp.status).not.toBe(500);
+  });
+
+  // ── Test 2 — old token invalidated immediately after re-register ──────────
+
+  it("old plugin token returns 401 immediately after re-register", async () => {
+    const PLUGIN = "token-swap-plugin";
+
+    customBridge.registerPluginTool(PLUGIN, {
+      name: "tool",
+      description: "test",
+      schema: z.object({}),
+      handler: async () => ({ ok: true }),
+    });
+    const token1 = gateway.registerInProcess(PLUGIN, {
+      version: "1.0.0",
+      tools: [{ name: "tool", description: "test", schema: {} }],
+    });
+
+    // Verify token1 works before re-register
+    const respBefore = await invokeViaTool(gateway, PLUGIN, "tool", token1);
+    expect(respBefore.status).toBe(200);
+
+    // Re-register with new token
+    customBridge.unregisterPlugin(PLUGIN);
+    customBridge.registerPluginTool(PLUGIN, {
+      name: "tool",
+      description: "test v2",
+      schema: z.object({}),
+      handler: async () => ({ ok: true, version: 2 }),
+    });
+    gateway.registerInProcess(PLUGIN, {
+      version: "2.0.0",
+      tools: [{ name: "tool", description: "test v2", schema: {} }],
+    });
+
+    // token1 must now be invalid — HMAC check fails against new token
+    const respAfter = await invokeViaTool(gateway, PLUGIN, "tool", token1);
+    expect(respAfter.status).toBe(401);
+  });
+
+  // ── Test 3 — concurrent invocations during re-register are atomic ─────────
+
+  it("20 concurrent invocations during re-register each get a clean response (no 500)", async () => {
+    const PLUGIN = "concurrent-rereg-plugin";
+
+    customBridge.registerPluginTool(PLUGIN, {
+      name: "tool",
+      description: "test",
+      schema: z.object({}),
+      handler: async () => {
+        await new Promise((r) => setTimeout(r, 10)); // small delay to widen race window
+        return { ok: true };
+      },
+    });
+    const token1 = gateway.registerInProcess(PLUGIN, {
+      version: "1.0.0",
+      tools: [{ name: "tool", description: "test", schema: {} }],
+    });
+
+    // Fire 20 concurrent invocations, all with token1
+    const invokePromises = Array.from({ length: 20 }, () =>
+      invokeViaTool(gateway, PLUGIN, "tool", token1),
+    );
+
+    // Re-register mid-flight (after a tiny delay to ensure some invocations started)
+    await new Promise((r) => setTimeout(r, 2));
+    customBridge.unregisterPlugin(PLUGIN);
+    customBridge.registerPluginTool(PLUGIN, {
+      name: "tool",
+      description: "test v2",
+      schema: z.object({}),
+      handler: async () => ({ ok: true, version: 2 }),
+    });
+    gateway.registerInProcess(PLUGIN, {
+      version: "2.0.0",
+      tools: [{ name: "tool", description: "test v2", schema: {} }],
+    });
+
+    const resps = await Promise.all(invokePromises);
+
+    // Every response must be a clean HTTP status — no 500s
+    for (const resp of resps) {
+      expect(resp.status).not.toBe(500);
+      // Valid states: 200 (completed v1), 401 (token1 now invalid), 502 (tool not found in new bridge)
+      expect([200, 401, 502]).toContain(resp.status);
+    }
+  });
+});

--- a/src/__tests__/mcp_proxy_security.test.ts
+++ b/src/__tests__/mcp_proxy_security.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { createHmac } from "node:crypto";
+import { McpProxyPlugin, _resetMcpProxy } from "../plugins/mcp-proxy/index.js";
+import { _resetMcpBridge } from "../plugins/mcp-bridge.js";
+import { getHttpGateway, _resetHttpGateway } from "../plugins/http-gateway.js";
+import type { PluginHttpGateway } from "../plugins/http-gateway.js";
+
+const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
+const BUN_BIN = process.execPath;
+
+let tmpDir: string;
+let plugin: McpProxyPlugin;
+let gateway: PluginHttpGateway;
+let proxyToken: Buffer;
+
+function signRequest(token: Buffer, body: string, ts: string): string {
+  return createHmac("sha256", token).update(`${ts}\n${body}`).digest("hex");
+}
+
+async function invokeViaTool(tool: string, bodyObj: unknown, token: Buffer, tsOverride?: string): Promise<Response> {
+  const ts = tsOverride ?? new Date().toISOString();
+  const body = JSON.stringify(bodyObj);
+  const sig = signRequest(token, body, ts);
+  return gateway.handleRequest(
+    new Request(`http://localhost/api/plugin/mcp-proxy/tools/${tool}/invoke`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Plus-Ts": ts,
+        "X-Plus-Signature": sig,
+      },
+      body,
+    }),
+    new URL(`http://localhost/api/plugin/mcp-proxy/tools/${tool}/invoke`),
+  ) as Promise<Response>;
+}
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcp-proxy-sec-test-"));
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+
+  const configPath = join(tmpDir, "mcp-proxy.json");
+  const tokenPath = join(tmpDir, "mcp-proxy.token");
+  writeFileSync(configPath, JSON.stringify({
+    servers: {
+      "test-server": {
+        command: BUN_BIN,
+        args: ["run", MOCK_SERVER],
+        enabled: true,
+        allowedTools: ["echo"],
+      },
+    },
+  }));
+
+  plugin = new McpProxyPlugin({ configPath, tokenPath });
+  await plugin.start();
+
+  // Use singleton gateway where plugin registered itself
+  gateway = getHttpGateway();
+  proxyToken = Buffer.from(readFileSync(tokenPath, "utf8").trim(), "hex");
+});
+
+afterEach(async () => {
+  await plugin.stop();
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+  try { rmSync(tmpDir, { recursive: true }); } catch {}
+});
+
+// ── Test 1 — wrong HMAC → 401 ─────────────────────────────────────────────
+
+describe("mcp-proxy security", () => {
+  it("invalid HMAC signature returns 401", async () => {
+    const ts = new Date().toISOString();
+    const body = JSON.stringify({ arguments: { message: "test" }, mode: "direct" });
+    const resp = await gateway.handleRequest(
+      new Request("http://localhost/api/plugin/mcp-proxy/tools/test-server__echo/invoke", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Plus-Ts": ts,
+          "X-Plus-Signature": "0".repeat(64), // wrong signature
+        },
+        body,
+      }),
+      new URL("http://localhost/api/plugin/mcp-proxy/tools/test-server__echo/invoke"),
+    );
+    expect(resp?.status).toBe(401);
+  });
+
+  // ── Test 2 — stale timestamp → 401 ───────────────────────────────────────
+
+  it("timestamp outside replay window returns 401", async () => {
+    const staleTs = new Date(Date.now() - 20 * 60 * 1000).toISOString(); // 20 min ago
+    const resp = await invokeViaTool("test-server__echo",
+      { arguments: { message: "test" }, mode: "direct" },
+      proxyToken,
+      staleTs,
+    );
+    expect(resp?.status).toBe(401);
+  });
+
+  // ── Test 3 — stderr doesn't pollute response ──────────────────────────────
+
+  it("MCP server stderr goes to log file, not HTTP response body", async () => {
+    const resp = await invokeViaTool("test-server__echo",
+      { arguments: { message: "stderr-test" }, mode: "direct" },
+      proxyToken,
+    );
+    expect(resp?.status).toBe(200);
+    const data = await resp!.json() as { result?: unknown };
+    expect(data).toHaveProperty("result");
+  });
+
+  // ── Test 4 — path traversal args pass through without validation ──────────
+
+  it("path-traversal args propagate cleanly to the MCP server without proxy injection", async () => {
+    const resp = await invokeViaTool("test-server__echo",
+      { arguments: { message: "../../etc/passwd" }, mode: "direct" },
+      proxyToken,
+    );
+    expect(resp?.status).toBe(200);
+    const data = await resp!.json() as { result?: { echo?: string } };
+    // Server echoes back exactly what we sent — proxy doesn't sanitize
+    expect(data.result).toMatchObject({ echo: "../../etc/passwd" });
+  });
+
+  // ── Test 5 — body too large → 413 ────────────────────────────────────────
+
+  it("content-length exceeding 1MB returns 413", async () => {
+    const ts = new Date().toISOString();
+    const body = JSON.stringify({ arguments: { message: "test" }, mode: "direct" });
+    const sig = signRequest(proxyToken, body, ts);
+    const resp = await gateway.handleRequest(
+      new Request("http://localhost/api/plugin/mcp-proxy/tools/test-server__echo/invoke", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": String(1_048_577), // 1MB + 1 byte
+          "X-Plus-Ts": ts,
+          "X-Plus-Signature": sig,
+        },
+        body,
+      }),
+      new URL("http://localhost/api/plugin/mcp-proxy/tools/test-server__echo/invoke"),
+    );
+    expect(resp?.status).toBe(413);
+  });
+
+  // ── Test 6 — oversized MCP result → gateway returns 502 ─────────────────
+
+  it("large_result tool (2MB response) triggers size cap rejection via 502", async () => {
+    // The mock server's large_result tool returns 2MB — exceeds the default 1MB cap
+    // We need a fresh plugin instance with large_result in allowedTools
+    _resetMcpBridge();
+    _resetHttpGateway();
+    _resetMcpProxy();
+
+    const capDir = mkdtempSync(join(tmpdir(), "mcp-proxy-large-test-"));
+    const capConfigPath = join(capDir, "mcp-proxy.json");
+    const capTokenPath = join(capDir, "mcp-proxy.token");
+    writeFileSync(capConfigPath, JSON.stringify({
+      servers: {
+        "test-server": {
+          command: BUN_BIN,
+          args: ["run", MOCK_SERVER],
+          enabled: true,
+          allowedTools: ["large_result"],
+        },
+      },
+    }));
+
+    let capPlugin: McpProxyPlugin | null = null;
+    try {
+      capPlugin = new McpProxyPlugin({ configPath: capConfigPath, tokenPath: capTokenPath });
+      await capPlugin.start();
+
+      const capGateway = getHttpGateway();
+      const capToken = Buffer.from(readFileSync(capTokenPath, "utf8").trim(), "hex");
+
+      const ts = new Date().toISOString();
+      const body = JSON.stringify({ arguments: {}, mode: "direct" });
+      const sig = signRequest(capToken, body, ts);
+      const resp = await capGateway.handleRequest(
+        new Request("http://localhost/api/plugin/mcp-proxy/tools/test-server__large_result/invoke", {
+          method: "POST",
+          headers: { "Content-Type": "application/json", "X-Plus-Ts": ts, "X-Plus-Signature": sig },
+          body,
+        }),
+        new URL("http://localhost/api/plugin/mcp-proxy/tools/test-server__large_result/invoke"),
+      );
+      // Handler throws due to result size cap → gateway wraps as 502
+      expect(resp?.status).toBe(502);
+    } finally {
+      await capPlugin?.stop();
+      try { rmSync(capDir, { recursive: true }); } catch {}
+      _resetMcpBridge();
+      _resetHttpGateway();
+      _resetMcpProxy();
+    }
+  });
+});

--- a/src/__tests__/plugins/http-gateway.test.ts
+++ b/src/__tests__/plugins/http-gateway.test.ts
@@ -1,0 +1,317 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { PluginHttpGateway, _resetHttpGateway } from '../../plugins/http-gateway.js';
+import { getMcpBridge, _resetMcpBridge } from '../../plugins/mcp-bridge.js';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeGateway(opts?: { allowedHosts?: string[] }): PluginHttpGateway {
+  return new PluginHttpGateway(opts);
+}
+
+function bootstrapToken(gw: PluginHttpGateway): string {
+  // Access via the file created at init; easier to read from the bridge's perspective
+  // Instead, we use the fact that verifyBootstrap is tested indirectly via registration
+  // For test isolation, patch the gateway's bootstrapToken via a subclass trick
+  return (gw as any).bootstrapToken.toString('hex');
+}
+
+function req(method: string, path: string, body?: unknown, headers?: Record<string, string>): Request {
+  const url = `http://localhost:3000${path}`;
+  return new Request(url, {
+    method,
+    headers: { 'Content-Type': 'application/json', ...headers },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+function url(path: string): URL {
+  return new URL(`http://localhost:3000${path}`);
+}
+
+const validManifest = {
+  name: 'greg-voice',
+  version: '1.0.0',
+  schema_version: 1,
+  callback_url: 'http://localhost:8765/callback',
+  health_url: 'http://localhost:8765/health',
+  tools: [
+    { name: 'send_tts', description: 'Play TTS in active call', schema: { type: 'object' } },
+  ],
+  capabilities: ['tools'],
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('PluginHttpGateway', () => {
+  let gw: PluginHttpGateway;
+  let token: string;
+
+  beforeEach(() => {
+    _resetHttpGateway();
+    _resetMcpBridge();
+    gw = makeGateway();
+    token = bootstrapToken(gw);
+  });
+
+  afterEach(() => {
+    _resetHttpGateway();
+    _resetMcpBridge();
+  });
+
+  // 1. register valid
+  test('register valid — returns plugin_token', async () => {
+    const r = req('POST', '/api/plugin/register', validManifest, { Authorization: `Bearer ${token}` });
+    const resp = await gw.handleRequest(r, url('/api/plugin/register'));
+    expect(resp?.status).toBe(200);
+    const body = await resp!.json() as any;
+    expect(body.plugin_name).toBe('greg-voice');
+    expect(body.plugin_token).toHaveLength(64); // 32 bytes hex
+    expect(body.registered_tools).toContain('greg-voice__send_tts');
+    expect(gw.hasPlugin('greg-voice')).toBe(true);
+  });
+
+  // 2. register invalid bootstrap
+  test('register with invalid bootstrap token → 401', async () => {
+    const r = req('POST', '/api/plugin/register', validManifest, { Authorization: 'Bearer deadbeef' });
+    const resp = await gw.handleRequest(r, url('/api/plugin/register'));
+    expect(resp?.status).toBe(401);
+    const body = await resp!.json() as any;
+    expect(body.error.code).toBe('invalid_bootstrap');
+  });
+
+  // 3. register malformed manifest
+  test('register malformed manifest → 400', async () => {
+    const bad = { name: 'BAD NAME!!!', version: '1.0.0', tools: [], callback_url: 'http://localhost:8765/cb' };
+    const r = req('POST', '/api/plugin/register', bad, { Authorization: `Bearer ${token}` });
+    const resp = await gw.handleRequest(r, url('/api/plugin/register'));
+    expect(resp?.status).toBe(400);
+    const body = await resp!.json() as any;
+    expect(body.error.code).toBe('invalid_manifest');
+  });
+
+  // 4. register non-localhost callback
+  test('register with external callback host → 400', async () => {
+    const m = { ...validManifest, callback_url: 'http://evil.com/callback' };
+    const r = req('POST', '/api/plugin/register', m, { Authorization: `Bearer ${token}` });
+    const resp = await gw.handleRequest(r, url('/api/plugin/register'));
+    expect(resp?.status).toBe(400);
+    const body = await resp!.json() as any;
+    expect(body.error.code).toBe('callback_host_not_allowed');
+  });
+
+  // 4b. register external host allowed via constructor allowedHosts
+  test('register with allowedHosts override passes', async () => {
+    const gwCustom = makeGateway({ allowedHosts: ['192.168.1.10'] });
+    const customToken = bootstrapToken(gwCustom);
+    const m = { ...validManifest, name: 'trusted-plugin', callback_url: 'http://192.168.1.10:9000/cb' };
+    const r = req('POST', '/api/plugin/register', m, { Authorization: `Bearer ${customToken}` });
+    const resp = await gwCustom.handleRequest(r, url('/api/plugin/register'));
+    expect(resp?.status).toBe(200);
+  });
+
+  // 5. re-register replaces existing
+  test('re-register same name replaces plugin', async () => {
+    const r1 = req('POST', '/api/plugin/register', validManifest, { Authorization: `Bearer ${token}` });
+    await gw.handleRequest(r1, url('/api/plugin/register'));
+    const firstToken = gw.getPluginToken('greg-voice')!.toString('hex');
+
+    const r2 = req('POST', '/api/plugin/register', validManifest, { Authorization: `Bearer ${token}` });
+    await gw.handleRequest(r2, url('/api/plugin/register'));
+    const secondToken = gw.getPluginToken('greg-voice')!.toString('hex');
+
+    // Token is re-rolled on re-register
+    expect(firstToken).not.toBe(secondToken);
+    expect(gw.pluginCount).toBe(1); // still one plugin
+  });
+
+  // 6. invoke HMAC tamper
+  test('invoke with tampered HMAC → 401', async () => {
+    const r = req('POST', '/api/plugin/register', validManifest, { Authorization: `Bearer ${token}` });
+    await gw.handleRequest(r, url('/api/plugin/register'));
+
+    const path = '/api/plugin/greg-voice/tools/send_tts/invoke';
+    const invokeBody = { text: 'hello' };
+    const ts = new Date().toISOString();
+    const fakeReq = req('POST', path, invokeBody, {
+      'x-plus-ts': ts,
+      'x-plus-signature': 'badbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadbadb',
+    });
+    const resp = await gw.handleRequest(fakeReq, url(path));
+    expect(resp?.status).toBe(401);
+    const body = await resp!.json() as any;
+    expect(body.error.code).toBe('invalid_signature');
+  });
+
+  // 7. invoke stale timestamp
+  test('invoke with stale timestamp (>15 min) → 401', async () => {
+    const r = req('POST', '/api/plugin/register', validManifest, { Authorization: `Bearer ${token}` });
+    await gw.handleRequest(r, url('/api/plugin/register'));
+    const pluginToken = gw.getPluginToken('greg-voice')!;
+
+    const staleTs = new Date(Date.now() - 16 * 60 * 1000).toISOString();
+    const path = '/api/plugin/greg-voice/tools/send_tts/invoke';
+    const bodyStr = JSON.stringify({ text: 'hello' });
+    const sig = gw.signHmac(pluginToken, bodyStr, staleTs);
+
+    const invokeReq = req('POST', path, { text: 'hello' }, {
+      'x-plus-ts': staleTs,
+      'x-plus-signature': sig,
+    });
+    const resp = await gw.handleRequest(invokeReq, url(path));
+    expect(resp?.status).toBe(401);
+    const body = await resp!.json() as any;
+    expect(body.error.code).toBe('stale_or_future_timestamp');
+  });
+
+  // 8. invoke sends correct headers to plugin callback
+  test('invoke calls plugin callback with correct HMAC headers', async () => {
+    const r = req('POST', '/api/plugin/register', validManifest, { Authorization: `Bearer ${token}` });
+    await gw.handleRequest(r, url('/api/plugin/register'));
+    const pluginToken = gw.getPluginToken('greg-voice')!;
+
+    let capturedHeaders: Record<string, string> = {};
+    const origFetch = globalThis.fetch;
+    (globalThis as any).fetch = async (url: string, init: any) => {
+      capturedHeaders = Object.fromEntries(
+        Object.entries(init?.headers ?? {}).map(([k, v]) => [k.toLowerCase(), String(v)])
+      );
+      return new Response(JSON.stringify({ result: 'ok' }), { status: 200 });
+    };
+
+    const path = '/api/plugin/greg-voice/tools/send_tts/invoke';
+    const now = new Date().toISOString();
+    const bodyStr = JSON.stringify({ text: 'hello' });
+    const sig = gw.signHmac(pluginToken, bodyStr, now);
+
+    const invokeReq = req('POST', path, { text: 'hello' }, {
+      'x-plus-ts': now,
+      'x-plus-signature': sig,
+    });
+    await gw.handleRequest(invokeReq, url(path));
+    (globalThis as any).fetch = origFetch;
+
+    expect(capturedHeaders['x-plus-ts']).toBeDefined();
+    expect(capturedHeaders['x-plus-signature']).toHaveLength(64);
+    expect(capturedHeaders['x-plus-request-id']).toBeDefined();
+  });
+
+  // 9. invoke timeout
+  test('invoke timeout → 502', async () => {
+    const r = req('POST', '/api/plugin/register', validManifest, { Authorization: `Bearer ${token}` });
+    await gw.handleRequest(r, url('/api/plugin/register'));
+    const pluginToken = gw.getPluginToken('greg-voice')!;
+
+    const origFetch = globalThis.fetch;
+    (globalThis as any).fetch = async (_url: string, init: any) => {
+      // Abort immediately to simulate timeout
+      init.signal.throwIfAborted();
+      return new Response('', { status: 200 });
+    };
+
+    const path = '/api/plugin/greg-voice/tools/send_tts/invoke';
+    const now = new Date().toISOString();
+    const bodyStr = JSON.stringify({ text: 'hi' });
+    const sig = gw.signHmac(pluginToken, bodyStr, now);
+
+    const invokeReq = req('POST', path, { text: 'hi' }, {
+      'x-plus-ts': now,
+      'x-plus-signature': sig,
+    });
+    const resp = await gw.handleRequest(invokeReq, url(path));
+    (globalThis as any).fetch = origFetch;
+
+    expect(resp?.status).toBe(502);
+    const body = await resp!.json() as any;
+    expect(body.error.code).toBe('invoke_failed');
+  });
+
+  // 10. list returns registered plugins
+  test('list returns registered plugins with metadata', async () => {
+    const r = req('POST', '/api/plugin/register', validManifest, { Authorization: `Bearer ${token}` });
+    await gw.handleRequest(r, url('/api/plugin/register'));
+
+    const listResp = await gw.handleRequest(req('GET', '/api/plugin/list'), url('/api/plugin/list'));
+    expect(listResp?.status).toBe(200);
+    const body = await listResp!.json() as any;
+    expect(body.plugins).toHaveLength(1);
+    expect(body.plugins[0].name).toBe('greg-voice');
+    expect(body.plugins[0].tools).toContain('send_tts');
+    expect(body.plugins[0].last_health_check).toBeNull();
+  });
+
+  // 11. health endpoint
+  test('health check — plugin with health_url, healthy response', async () => {
+    const r = req('POST', '/api/plugin/register', validManifest, { Authorization: `Bearer ${token}` });
+    await gw.handleRequest(r, url('/api/plugin/register'));
+
+    const origFetch = globalThis.fetch;
+    (globalThis as any).fetch = async () => new Response('ok', { status: 200 });
+
+    const healthResp = await gw.handleRequest(
+      req('GET', '/api/plugin/greg-voice/health'),
+      url('/api/plugin/greg-voice/health')
+    );
+    (globalThis as any).fetch = origFetch;
+
+    expect(healthResp?.status).toBe(200);
+    const body = await healthResp!.json() as any;
+    expect(body.healthy).toBe(true);
+    expect(body.status).toBe(200);
+  });
+
+  // 12. unregister authenticated by bootstrap OR plugin token
+  test('unregister with bootstrap token succeeds', async () => {
+    const r = req('POST', '/api/plugin/register', validManifest, { Authorization: `Bearer ${token}` });
+    await gw.handleRequest(r, url('/api/plugin/register'));
+    expect(gw.hasPlugin('greg-voice')).toBe(true);
+
+    const delResp = await gw.handleRequest(
+      req('DELETE', '/api/plugin/greg-voice', undefined, { Authorization: `Bearer ${token}` }),
+      url('/api/plugin/greg-voice')
+    );
+    expect(delResp?.status).toBe(200);
+    expect(gw.hasPlugin('greg-voice')).toBe(false);
+  });
+
+  test('unregister with plugin token succeeds', async () => {
+    const r = req('POST', '/api/plugin/register', validManifest, { Authorization: `Bearer ${token}` });
+    const regResp = await gw.handleRequest(r, url('/api/plugin/register'));
+    const regBody = await regResp!.json() as any;
+    const pluginTokenHex = regBody.plugin_token;
+
+    const delResp = await gw.handleRequest(
+      req('DELETE', '/api/plugin/greg-voice', undefined, { Authorization: `Bearer ${pluginTokenHex}` }),
+      url('/api/plugin/greg-voice')
+    );
+    expect(delResp?.status).toBe(200);
+    expect(gw.hasPlugin('greg-voice')).toBe(false);
+  });
+
+  // 13. graceful degradation: audit failure doesn't crash
+  test('graceful degradation — audit log fail does not crash handleRequest', async () => {
+    const bridge = getMcpBridge();
+    // Monkey-patch audit to throw
+    (bridge as any).audit = () => { throw new Error('disk full'); };
+
+    const r = req('POST', '/api/plugin/register', validManifest, { Authorization: `Bearer ${token}` });
+    const resp = await gw.handleRequest(r, url('/api/plugin/register'));
+    // Should still succeed despite audit failure
+    expect(resp?.status).toBe(200);
+  });
+
+  // 14. non-plugin path returns null
+  test('non-plugin path returns null (not handled)', async () => {
+    const resp = await gw.handleRequest(req('GET', '/api/state'), url('/api/state'));
+    expect(resp).toBeNull();
+  });
+
+  // 15. HMAC verify: tampered body detected
+  test('HMAC verification — tampered body is rejected', async () => {
+    const secret = Buffer.from('a'.repeat(64), 'hex');
+    const body = '{"text":"hello"}';
+    const ts = new Date().toISOString();
+    const validSig = gw.signHmac(secret, body, ts);
+    expect(gw.verifyHmac(secret, body, ts, validSig)).toBe(true);
+    expect(gw.verifyHmac(secret, '{"text":"tampered"}', ts, validSig)).toBe(false);
+  });
+});

--- a/src/__tests__/plugins/mcp-bridge.test.ts
+++ b/src/__tests__/plugins/mcp-bridge.test.ts
@@ -1,0 +1,244 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { z } from "zod";
+import { PluginMcpBridge, _resetMcpBridge, getMcpBridge } from "../../plugins/mcp-bridge.js";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeBridge(): { bridge: PluginMcpBridge; auditPath: string; tmpDir: string } {
+  const tmpDir = mkdtempSync(join(tmpdir(), "mcp-bridge-test-"));
+  const auditPath = join(tmpDir, "audit.jsonl");
+  const bridge = new PluginMcpBridge(auditPath);
+  return { bridge, auditPath, tmpDir };
+}
+
+function readAuditLines(auditPath: string): Array<Record<string, unknown>> {
+  try {
+    return readFileSync(auditPath, "utf8")
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Record<string, unknown>);
+  } catch {
+    return [];
+  }
+}
+
+const echoTool = {
+  name: "echo",
+  description: "Echo input back",
+  schema: z.object({ message: z.string() }),
+  handler: async (args: { message: string }) => args.message,
+};
+
+const addTool = {
+  name: "add",
+  description: "Add two numbers",
+  schema: z.object({ a: z.number(), b: z.number() }),
+  handler: async (args: { a: number; b: number }) => args.a + args.b,
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("PluginMcpBridge", () => {
+  describe("registerPluginTool + listTools", () => {
+    it("registers a tool and returns it in listTools with correct FQN", () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("my-plugin", echoTool);
+      const tools = bridge.listTools();
+
+      expect(tools).toHaveLength(1);
+      expect(tools[0].fqn).toBe("my-plugin__echo");
+      expect(tools[0].description).toBe("Echo input back");
+      expect(tools[0].inputSchema).toMatchObject({ type: "object" });
+    });
+
+    it("registers multiple tools from different plugins", () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("plugin-a", echoTool);
+      bridge.registerPluginTool("plugin-b", addTool);
+      const tools = bridge.listTools();
+
+      expect(tools).toHaveLength(2);
+      const fqns = tools.map((t) => t.fqn);
+      expect(fqns).toContain("plugin-a__echo");
+      expect(fqns).toContain("plugin-b__add");
+    });
+  });
+
+  describe("duplicate registration", () => {
+    it("throws on duplicate tool FQN", () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("my-plugin", echoTool);
+      expect(() => bridge.registerPluginTool("my-plugin", echoTool)).toThrow(
+        /Duplicate tool registration/,
+      );
+    });
+
+    it("allows same tool name for different plugins", () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("plugin-a", echoTool);
+      expect(() => bridge.registerPluginTool("plugin-b", echoTool)).not.toThrow();
+    });
+  });
+
+  describe("invokeTool", () => {
+    it("calls handler with valid args and returns result", async () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("calc", addTool);
+      const result = await bridge.invokeTool("calc__add", { a: 3, b: 4 });
+      expect(result).toBe(7);
+    });
+
+    it("throws on invalid args (zod validation failure)", async () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("my-plugin", echoTool);
+      await expect(bridge.invokeTool("my-plugin__echo", { message: 42 })).rejects.toThrow(
+        /Invalid args/,
+      );
+    });
+
+    it("throws on unknown tool name", async () => {
+      const { bridge } = makeBridge();
+
+      await expect(bridge.invokeTool("nonexistent__tool", {})).rejects.toThrow(/Unknown tool/);
+    });
+
+    it("propagates handler errors", async () => {
+      const { bridge } = makeBridge();
+
+      bridge.registerPluginTool("failing", {
+        name: "fail",
+        description: "Always fails",
+        schema: z.object({}),
+        handler: async () => {
+          throw new Error("handler exploded");
+        },
+      });
+      await expect(bridge.invokeTool("failing__fail", {})).rejects.toThrow("handler exploded");
+    });
+  });
+
+  describe("HMAC signing", () => {
+    it("signCall + verifyCall round-trip returns true", () => {
+      const { bridge } = makeBridge();
+
+      const body = { foo: "bar", count: 42 };
+      const ts = Date.now();
+      const sig = bridge.signCall("test-plugin", body, ts);
+      expect(bridge.verifyCall("test-plugin", body, ts, sig)).toBe(true);
+    });
+
+    it("verifyCall rejects tampered signature", () => {
+      const { bridge } = makeBridge();
+
+      const body = { foo: "bar" };
+      const ts = Date.now();
+      const sig = bridge.signCall("test-plugin", body, ts);
+      const tampered = sig.slice(0, -2) + "00";
+      expect(bridge.verifyCall("test-plugin", body, ts, tampered)).toBe(false);
+    });
+
+    it("verifyCall rejects tampered body", () => {
+      const { bridge } = makeBridge();
+
+      const ts = Date.now();
+      const sig = bridge.signCall("test-plugin", { foo: "bar" }, ts);
+      expect(bridge.verifyCall("test-plugin", { foo: "TAMPERED" }, ts, sig)).toBe(false);
+    });
+
+    it("verifyCall rejects tampered ts", () => {
+      const { bridge } = makeBridge();
+
+      const ts = Date.now();
+      const body = { x: 1 };
+      const sig = bridge.signCall("test-plugin", body, ts);
+      expect(bridge.verifyCall("test-plugin", body, ts + 1, sig)).toBe(false);
+    });
+  });
+
+  describe("audit log", () => {
+    it("writes a register entry when a tool is registered", () => {
+      const { bridge, auditPath } = makeBridge();
+
+      bridge.registerPluginTool("audit-test", echoTool);
+      const lines = readAuditLines(auditPath);
+
+      expect(lines).toHaveLength(1);
+      expect(lines[0].event).toBe("register");
+      expect(lines[0].fqn).toBe("audit-test__echo");
+    });
+
+    it("writes invoke + success entries when tool is called", async () => {
+      const { bridge, auditPath } = makeBridge();
+
+      bridge.registerPluginTool("audit-test", echoTool);
+      await bridge.invokeTool("audit-test__echo", { message: "hello" });
+      const lines = readAuditLines(auditPath);
+
+      const invokeEntry = lines.find((l) => l.event === "invoke");
+      expect(invokeEntry).toBeDefined();
+      expect(invokeEntry?.success).toBe(true);
+    });
+
+    it("writes error entry on validation failure", async () => {
+      const { bridge, auditPath } = makeBridge();
+
+      bridge.registerPluginTool("audit-test", echoTool);
+      try {
+        await bridge.invokeTool("audit-test__echo", { message: 999 });
+      } catch {
+        // expected
+      }
+
+      const lines = readAuditLines(auditPath);
+      const errorEntry = lines.find((l) => l.event === "error");
+      expect(errorEntry).toBeDefined();
+      expect(errorEntry?.phase).toBe("validation");
+    });
+  });
+
+  describe("per-plugin secret", () => {
+    it("auto-creates a 32-byte secret for a plugin", () => {
+      const { bridge } = makeBridge();
+
+      const secret = bridge.loadOrCreateSecret("new-plugin");
+      expect(secret).toBeInstanceOf(Buffer);
+      expect(secret.length).toBe(32);
+    });
+
+    it("returns the same secret on subsequent calls (cached)", () => {
+      const { bridge } = makeBridge();
+
+      const a = bridge.loadOrCreateSecret("plugin-x");
+      const b = bridge.loadOrCreateSecret("plugin-x");
+      expect(a.equals(b)).toBe(true);
+    });
+
+    it("different plugins get different secrets", () => {
+      const { bridge } = makeBridge();
+
+      const a = bridge.loadOrCreateSecret("plugin-alpha");
+      const b = bridge.loadOrCreateSecret("plugin-beta");
+      expect(a.equals(b)).toBe(false);
+    });
+  });
+
+  describe("getMcpBridge singleton", () => {
+    it("returns the same instance on multiple calls", () => {
+      _resetMcpBridge();
+      const a = getMcpBridge();
+      const b = getMcpBridge();
+      expect(a).toBe(b);
+      _resetMcpBridge();
+    });
+  });
+});

--- a/src/__tests__/plugins/mcp-bridge.test.ts
+++ b/src/__tests__/plugins/mcp-bridge.test.ts
@@ -242,3 +242,46 @@ describe("PluginMcpBridge", () => {
     });
   });
 });
+
+describe("path traversal protection (pluginId validation)", () => {
+  it("rejects pluginId with .. segments", () => {
+    const bridge = new PluginMcpBridge("/tmp/test-audit-pt.jsonl");
+    expect(() => bridge.loadOrCreateSecret("../../evil")).toThrow(/invalid pluginId/);
+    expect(() => bridge.registerPluginTool("../../evil", { name: "x", description: "", schema: {}, handler: async () => ({}) })).toThrow(/invalid pluginId/);
+    expect(() => bridge.unregisterPlugin("../../evil")).toThrow(/invalid pluginId/);
+  });
+
+  it("rejects pluginId with path separators", () => {
+    const bridge = new PluginMcpBridge("/tmp/test-audit-pt.jsonl");
+    expect(() => bridge.loadOrCreateSecret("a/b")).toThrow(/invalid pluginId/);
+    expect(() => bridge.loadOrCreateSecret("a\\b")).toThrow(/invalid pluginId/);
+  });
+
+  it("rejects pluginId with dots or special chars", () => {
+    const bridge = new PluginMcpBridge("/tmp/test-audit-pt.jsonl");
+    expect(() => bridge.loadOrCreateSecret(".hidden")).toThrow(/invalid pluginId/);
+    expect(() => bridge.loadOrCreateSecret("a.b")).toThrow(/invalid pluginId/);
+    expect(() => bridge.loadOrCreateSecret("a b")).toThrow(/invalid pluginId/);
+  });
+
+  it("accepts valid pluginId (lowercase + digits + dashes, starts with letter)", () => {
+    const bridge = new PluginMcpBridge("/tmp/test-audit-pt-valid.jsonl");
+    // Should not throw
+    bridge.loadOrCreateSecret("mcp-proxy");
+    bridge.loadOrCreateSecret("archiviste");
+    bridge.loadOrCreateSecret("plugin-a1");
+  });
+
+  it("rejects empty / too-long pluginId", () => {
+    const bridge = new PluginMcpBridge("/tmp/test-audit-pt.jsonl");
+    expect(() => bridge.loadOrCreateSecret("")).toThrow(/invalid pluginId/);
+    expect(() => bridge.loadOrCreateSecret("a".repeat(65))).toThrow(/invalid pluginId/);
+  });
+
+  it("rejects pluginId starting with digit or dash", () => {
+    const bridge = new PluginMcpBridge("/tmp/test-audit-pt.jsonl");
+    expect(() => bridge.loadOrCreateSecret("1plugin")).toThrow(/invalid pluginId/);
+    expect(() => bridge.loadOrCreateSecret("-plugin")).toThrow(/invalid pluginId/);
+  });
+});
+

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -522,7 +522,27 @@ export async function start(args: string[] = []) {
   if (existsSync(mcpProxyConfigPath) || existsSync(mcpProxyAltConfigPath)) {
     mcpProxyStarted = getMcpProxyPlugin({
       reasonedInvokeFn: async (fqn, args) => {
-        const prompt = `Use tool \`${fqn}\` with these arguments: ${JSON.stringify(args)}. Return ONLY the raw JSON result of the tool, no prose, no markdown.`;
+        // Allowlist validation: reject fqn shapes that could break out of the
+        // single backtick-delimited slot in the prompt below. Only accept
+        // identifiers from the configured mcp-proxy registry — same shape that
+        // mcp-proxy server registration produces. This prevents a misconfigured
+        // or hostile plugin from interpolating arbitrary text into a Claude
+        // session running with --dangerously-skip-permissions.
+        if (typeof fqn !== "string" || !/^[a-zA-Z0-9_-]+__[a-zA-Z0-9_-]+$/.test(fqn)) {
+          throw new Error(`reasoned mode rejected fqn shape: ${JSON.stringify(fqn).slice(0, 80)}`);
+        }
+        const proxy = getMcpProxyPlugin();
+        if (!proxy.hasReasonedTool(fqn)) {
+          throw new Error(`reasoned mode rejected: ${fqn} is not in the mcp-proxy registered-tool allowlist`);
+        }
+        // Cost-cap: every reasoned call spawns a full Claude inject (~3s + Anthropic
+        // API cost). Reject oversized arg payloads before incurring that cost, so a
+        // misbehaving plugin can't blow the budget by sending megabytes of args.
+        const argsStr = JSON.stringify(args);
+        if (argsStr.length > 8000) {
+          throw new Error(`reasoned mode rejected: args ${argsStr.length}B exceeds 8000B cap (would blow Claude prompt budget)`);
+        }
+        const prompt = `Use tool \`${fqn}\` with these arguments: ${argsStr}. Return ONLY the raw JSON result of the tool, no prose, no markdown.`;
         const result = await runUserMessage("inject", prompt);
         const text = result.stdout.trim().replace(/^```[a-z]*\n?/, "").replace(/\n?```$/, "").trim();
         try { return JSON.parse(text); } catch { return text; }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -397,7 +397,10 @@ export async function start(args: string[] = []) {
     setPluginManager(pluginManager);
   }
 
+  let mcpProxyStarted: Promise<void> = Promise.resolve();
+
   async function shutdown() {
+    await mcpProxyStarted.catch(() => {}); // drain start() before stop() clears server map
     await getMcpProxyPlugin().stop();
     await pluginManager.stopServices();
     setPluginManager(null);
@@ -511,7 +514,7 @@ export async function start(args: string[] = []) {
   }
 
   // Start mcp-proxy plugin (warm-pooled MCP server connections)
-  getMcpProxyPlugin({
+  mcpProxyStarted = getMcpProxyPlugin({
     reasonedInvokeFn: async (fqn, args) => {
       const prompt = `Use tool \`${fqn}\` with these arguments: ${JSON.stringify(args)}. Return ONLY the raw JSON result of the tool, no prose, no markdown.`;
       const result = await runUserMessage("inject", prompt);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -18,6 +18,7 @@ import type { Job } from "../jobs";
 import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
 import { PluginManager, setPluginManager } from "../plugins";
 import { indexSessionsBackground } from "../memory";
+import { getMcpProxyPlugin } from "../plugins/mcp-proxy/index.js";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
@@ -397,6 +398,7 @@ export async function start(args: string[] = []) {
   }
 
   async function shutdown() {
+    await getMcpProxyPlugin().stop();
     await pluginManager.stopServices();
     setPluginManager(null);
     if (discordStopGateway) discordStopGateway();
@@ -507,6 +509,18 @@ export async function start(args: string[] = []) {
     await pluginManager.startServices();
     await pluginManager.emit("gateway_start", {}, { workspaceDir: process.cwd() });
   }
+
+  // Start mcp-proxy plugin (warm-pooled MCP server connections)
+  getMcpProxyPlugin({
+    reasonedInvokeFn: async (fqn, args) => {
+      const prompt = `Use tool \`${fqn}\` with these arguments: ${JSON.stringify(args)}. Return ONLY the raw JSON result of the tool, no prose, no markdown.`;
+      const result = await runUserMessage("inject", prompt);
+      const text = result.stdout.trim().replace(/^```[a-z]*\n?/, "").replace(/\n?```$/, "").trim();
+      try { return JSON.parse(text); } catch { return text; }
+    },
+  }).start().catch((err) => {
+    console.error("[mcp-proxy] Startup error (non-fatal):", err instanceof Error ? err.message : String(err));
+  });
 
   function isAddrInUse(err: unknown): boolean {
     if (!err || typeof err !== "object") return false;

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,4 +1,6 @@
 import { writeFile, unlink, mkdir } from "fs/promises";
+import { existsSync } from "fs";
+import { homedir } from "os";
 import { extractErrorDetail } from "../messaging";
 import { join } from "path";
 import { fileURLToPath } from "url";
@@ -513,17 +515,22 @@ export async function start(args: string[] = []) {
     await pluginManager.emit("gateway_start", {}, { workspaceDir: process.cwd() });
   }
 
-  // Start mcp-proxy plugin (warm-pooled MCP server connections)
-  mcpProxyStarted = getMcpProxyPlugin({
-    reasonedInvokeFn: async (fqn, args) => {
-      const prompt = `Use tool \`${fqn}\` with these arguments: ${JSON.stringify(args)}. Return ONLY the raw JSON result of the tool, no prose, no markdown.`;
-      const result = await runUserMessage("inject", prompt);
-      const text = result.stdout.trim().replace(/^```[a-z]*\n?/, "").replace(/\n?```$/, "").trim();
-      try { return JSON.parse(text); } catch { return text; }
-    },
-  }).start().catch((err) => {
-    console.error("[mcp-proxy] Startup error (non-fatal):", err instanceof Error ? err.message : String(err));
-  });
+  // Start mcp-proxy plugin only when a config file is present — avoids opening
+  // an HTTP gateway on deployments that don't use external MCP plugins.
+  const mcpProxyConfigPath = join(homedir(), ".config", "claudeclaw", "mcp-proxy.json");
+  const mcpProxyAltConfigPath = join(homedir(), ".config", "claude", "mcp.json");
+  if (existsSync(mcpProxyConfigPath) || existsSync(mcpProxyAltConfigPath)) {
+    mcpProxyStarted = getMcpProxyPlugin({
+      reasonedInvokeFn: async (fqn, args) => {
+        const prompt = `Use tool \`${fqn}\` with these arguments: ${JSON.stringify(args)}. Return ONLY the raw JSON result of the tool, no prose, no markdown.`;
+        const result = await runUserMessage("inject", prompt);
+        const text = result.stdout.trim().replace(/^```[a-z]*\n?/, "").replace(/\n?```$/, "").trim();
+        try { return JSON.parse(text); } catch { return text; }
+      },
+    }).start().catch((err) => {
+      console.error("[mcp-proxy] Startup error (non-fatal):", err instanceof Error ? err.message : String(err));
+    });
+  }
 
   function isAddrInUse(err: unknown): boolean {
     if (!err || typeof err !== "object") return false;

--- a/src/plugins.ts
+++ b/src/plugins.ts
@@ -17,6 +17,7 @@
 
 import { join, isAbsolute, resolve } from "path";
 import { existsSync } from "fs";
+import { getMcpBridge, type PluginTool } from "./plugins/mcp-bridge.js";
 
 // ── Event types ──────────────────────────────────────────────────────────────
 
@@ -60,6 +61,7 @@ export interface PluginApi {
   on(event: string, handler: EventHandler): void;
   registerService(service: PluginService): void;
   registerCommand(cmd: PluginCommand): void;
+  registerTool(tool: PluginTool): void;
   runtime: {
     channel: Record<string, Record<string, (...args: unknown[]) => unknown>>;
   };
@@ -201,6 +203,9 @@ export class PluginManager {
       },
       registerCommand(cmd: PluginCommand) {
         self.commands.set(cmd.name, cmd);
+      },
+      registerTool(tool: PluginTool) {
+        getMcpBridge().registerPluginTool(pluginId, tool);
       },
       runtime: {
         channel: self.channelRuntime,

--- a/src/plugins/cli.ts
+++ b/src/plugins/cli.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env bun
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const cmd = process.argv[2];
+if (cmd === 'print-bootstrap-token') {
+  const path = join(homedir(), '.config', 'plus', 'plugin-bootstrap.secret');
+  console.log(readFileSync(path).toString('hex'));
+} else {
+  console.error('Usage: bun run src/plugins/cli.ts print-bootstrap-token');
+  process.exit(1);
+}

--- a/src/plugins/http-gateway.ts
+++ b/src/plugins/http-gateway.ts
@@ -21,12 +21,15 @@ const PluginManifestSchema = z.object({
 
 const REPLAY_WINDOW_MS = 15 * 60 * 1000;
 const PLUGIN_INVOKE_TIMEOUT_MS = 30_000;
+const MAX_BODY_BYTES = Number(process.env.PLUS_PLUGIN_MAX_BODY_BYTES ?? 1_048_576);
 
 interface RegisteredPlugin {
   manifest: z.infer<typeof PluginManifestSchema>;
   pluginToken: Buffer;
   registeredAt: Date;
   lastHealthCheck?: { ts: Date; healthy: boolean; status?: number; error?: string };
+  // Set for daemon-internal plugins that don't use a callback URL
+  inProcessHealthFn?: () => Promise<Record<string, unknown>>;
 }
 
 function json(body: unknown, status = 200): Response {
@@ -155,6 +158,11 @@ export class PluginHttpGateway {
       return json(this.errorBody('plugin_not_registered', `Plugin '${name}' not registered`, requestId, name), 404);
     }
 
+    const contentLength = Number(req.headers.get('content-length') ?? 0);
+    if (contentLength > MAX_BODY_BYTES) {
+      return json(this.errorBody('body_too_large', `Request body exceeds ${MAX_BODY_BYTES} bytes`, requestId, name), 413);
+    }
+
     const ts = req.headers.get('x-plus-ts') ?? '';
     const sig = req.headers.get('x-plus-signature') ?? '';
     // Use raw body string for HMAC — re-serialization changes byte order (breaks Python default separators)
@@ -250,6 +258,14 @@ export class PluginHttpGateway {
     if (!plugin) {
       return json(this.errorBody('plugin_not_registered', `Plugin '${name}' not registered`, requestId, name), 404);
     }
+    if (plugin.inProcessHealthFn) {
+      try {
+        const health = await plugin.inProcessHealthFn();
+        return json({ name, healthy: true, ...health, request_id: requestId });
+      } catch (e) {
+        return json({ name, healthy: false, error: String(e), request_id: requestId });
+      }
+    }
     if (!plugin.manifest.health_url) {
       return json({ name, healthy: true, note: 'No health_url declared — plugin assumed healthy', request_id: requestId });
     }
@@ -288,6 +304,45 @@ export class PluginHttpGateway {
       if (expected.length !== sig.length) return false;
       return timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(sig, 'hex'));
     } catch { return false; }
+  }
+
+  /**
+   * Register a daemon-internal plugin that handles its own tool invocations via the
+   * PluginMcpBridge (no HTTP callback required). Returns the plugin token for callers.
+   *
+   * Tools must be pre-registered on getMcpBridge() before calling this. The gateway
+   * handles auth (HMAC with the returned token) and routes invocations to the bridge.
+   */
+  registerInProcess(name: string, opts: {
+    version: string;
+    tools: { name: string; description: string; schema: Record<string, unknown> }[];
+    healthFn?: () => Promise<Record<string, unknown>>;
+  }): Buffer {
+    if (this.plugins.has(name)) {
+      try { getMcpBridge().unregisterPlugin(name); } catch {}
+      this.plugins.delete(name);
+    }
+
+    const pluginToken = randomBytes(32);
+    const syntheticManifest = {
+      name,
+      version: opts.version,
+      schema_version: 1,
+      callback_url: 'http://localhost:0/noop',
+      health_url: undefined,
+      tools: opts.tools,
+      capabilities: ['tools'] as string[],
+    };
+
+    this.plugins.set(name, {
+      manifest: syntheticManifest as z.infer<typeof PluginManifestSchema>,
+      pluginToken,
+      registeredAt: new Date(),
+      inProcessHealthFn: opts.healthFn,
+    });
+
+    try { getMcpBridge().audit('in_process_plugin_registered', { plugin: name, tools_count: opts.tools.length }); } catch {}
+    return pluginToken;
   }
 
   /** Expose for tests */

--- a/src/plugins/http-gateway.ts
+++ b/src/plugins/http-gateway.ts
@@ -1,0 +1,306 @@
+import { z } from 'zod';
+import { createHmac, randomBytes, timingSafeEqual } from 'node:crypto';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { getMcpBridge } from './mcp-bridge.js';
+
+const PluginManifestSchema = z.object({
+  name: z.string().regex(/^[a-z][a-z0-9-]*$/, 'name must be lowercase kebab-case'),
+  version: z.string(),
+  schema_version: z.number().int().default(1),
+  callback_url: z.string().url(),
+  health_url: z.string().url().optional(),
+  tools: z.array(z.object({
+    name: z.string(),
+    description: z.string(),
+    schema: z.record(z.unknown()),
+  })),
+  capabilities: z.array(z.string()).default(['tools']),
+});
+
+const REPLAY_WINDOW_MS = 15 * 60 * 1000;
+const PLUGIN_INVOKE_TIMEOUT_MS = 30_000;
+
+interface RegisteredPlugin {
+  manifest: z.infer<typeof PluginManifestSchema>;
+  pluginToken: Buffer;
+  registeredAt: Date;
+  lastHealthCheck?: { ts: Date; healthy: boolean; status?: number; error?: string };
+}
+
+function json(body: unknown, status = 200): Response {
+  return Response.json(body, { status });
+}
+
+export class PluginHttpGateway {
+  private plugins = new Map<string, RegisteredPlugin>();
+  private bootstrapToken: Buffer;
+  private allowedCallbackHosts: Set<string>;
+
+  constructor(opts: { allowedHosts?: string[] } = {}) {
+    this.allowedCallbackHosts = new Set(['localhost', '127.0.0.1', '::1', ...(opts.allowedHosts ?? [])]);
+    this.bootstrapToken = this.loadOrCreateBootstrapToken();
+  }
+
+  /** Route an incoming Request. Returns Response if handled, null if not a plugin endpoint. */
+  async handleRequest(req: Request, url: URL): Promise<Response | null> {
+    const path = url.pathname;
+    const method = req.method;
+
+    if (path === '/api/plugin/register' && method === 'POST') return this.handleRegister(req);
+    if (path === '/api/plugin/list' && method === 'GET') return this.handleList(req);
+
+    // /api/plugin/:name/tools/:tool/invoke
+    const invokeM = path.match(/^\/api\/plugin\/([^/]+)\/tools\/([^/]+)\/invoke$/);
+    if (invokeM && method === 'POST') return this.handleInvoke(req, invokeM[1]!, invokeM[2]!);
+
+    // /api/plugin/:name/health
+    const healthM = path.match(/^\/api\/plugin\/([^/]+)\/health$/);
+    if (healthM && method === 'GET') return this.handleHealthCheck(req, healthM[1]!);
+
+    // /api/plugin/:name (DELETE)
+    const nameM = path.match(/^\/api\/plugin\/([^/]+)$/);
+    if (nameM && method === 'DELETE') return this.handleUnregister(req, nameM[1]!);
+
+    return null; // not a plugin endpoint
+  }
+
+  private requestId(req: Request): string {
+    return req.headers.get('x-plus-request-id') ?? randomBytes(8).toString('hex');
+  }
+
+  private errorBody(code: string, message: string, requestId: string, plugin?: string) {
+    return {
+      error: { code, message, plugin: plugin ?? null, request_id: requestId, ts: new Date().toISOString() },
+    };
+  }
+
+  private loadOrCreateBootstrapToken(): Buffer {
+    const path = join(homedir(), '.config', 'plus', 'plugin-bootstrap.secret');
+    mkdirSync(join(path, '..'), { recursive: true });
+    if (!existsSync(path)) {
+      writeFileSync(path, randomBytes(32));
+      chmodSync(path, 0o600);
+      console.error(`[plus-plugin-gateway] Bootstrap token initialized at ${path}. Use bun run src/plugins/cli.ts print-bootstrap-token to retrieve.`);
+    }
+    return readFileSync(path);
+  }
+
+  private async handleRegister(req: Request): Promise<Response> {
+    const requestId = this.requestId(req);
+    const authToken = (req.headers.get('authorization') ?? '').replace(/^Bearer\s+/, '');
+    if (!this.verifyBootstrap(authToken)) {
+      return json(this.errorBody('invalid_bootstrap', 'Invalid or missing Bearer token', requestId), 401);
+    }
+
+    let body: unknown;
+    try { body = await req.json(); } catch {
+      return json(this.errorBody('invalid_body', 'Could not parse JSON body', requestId), 400);
+    }
+
+    let manifest: z.infer<typeof PluginManifestSchema>;
+    try {
+      manifest = PluginManifestSchema.parse(body);
+    } catch (e) {
+      return json(this.errorBody('invalid_manifest', String(e), requestId), 400);
+    }
+
+    const callbackHost = new URL(manifest.callback_url).hostname;
+    if (!this.allowedCallbackHosts.has(callbackHost)) {
+      return json(this.errorBody('callback_host_not_allowed', `Host ${callbackHost} not in allowlist`, requestId, manifest.name), 400);
+    }
+
+    if (this.plugins.has(manifest.name)) {
+      // Clean up stale tools from bridge before re-registering
+      try { getMcpBridge().unregisterPlugin(manifest.name); } catch {}
+      this.plugins.delete(manifest.name);
+    }
+
+    const pluginToken = randomBytes(32);
+    const bridge = getMcpBridge();
+
+    for (const toolDef of manifest.tools) {
+      try {
+        bridge.registerPluginTool(manifest.name, {
+          name: toolDef.name,
+          description: toolDef.description,
+          schema: z.record(z.unknown()),
+          handler: async (args) => {
+            const invokeRequestId = randomBytes(8).toString('hex');
+            return this.invokeViaCallback(manifest.name, toolDef.name, args, pluginToken, manifest.callback_url, invokeRequestId);
+          },
+        });
+      } catch {
+        // graceful: skip duplicates, continue
+      }
+    }
+
+    this.plugins.set(manifest.name, { manifest, pluginToken, registeredAt: new Date() });
+    try { bridge.audit('http_plugin_registered', { plugin: manifest.name, tools_count: manifest.tools.length, request_id: requestId }); } catch {}
+
+    return json({
+      plugin_name: manifest.name,
+      plugin_token: pluginToken.toString('hex'),
+      registered_tools: manifest.tools.map(t => `${manifest.name}__${t.name}`),
+      capabilities_acknowledged: manifest.capabilities,
+      request_id: requestId,
+    });
+  }
+
+  private async handleInvoke(req: Request, name: string, tool: string): Promise<Response> {
+    const requestId = this.requestId(req);
+    const plugin = this.plugins.get(name);
+    if (!plugin) {
+      return json(this.errorBody('plugin_not_registered', `Plugin '${name}' not registered`, requestId, name), 404);
+    }
+
+    const ts = req.headers.get('x-plus-ts') ?? '';
+    const sig = req.headers.get('x-plus-signature') ?? '';
+    // Use raw body string for HMAC — re-serialization changes byte order (breaks Python default separators)
+    const rawBody = await req.text();
+    const bodyStr = rawBody || '{}';
+    let body: unknown;
+    try { body = JSON.parse(bodyStr); } catch { body = {}; }
+
+    if (!ts || !sig || !this.verifyHmac(plugin.pluginToken, bodyStr, ts, sig)) {
+      return json(this.errorBody('invalid_signature', 'HMAC verification failed', requestId, name), 401);
+    }
+
+    const tsMs = new Date(ts).getTime();
+    if (!Number.isFinite(tsMs) || Math.abs(Date.now() - tsMs) > REPLAY_WINDOW_MS) {
+      return json(this.errorBody('stale_or_future_timestamp', `ts outside ${REPLAY_WINDOW_MS / 1000}s window`, requestId, name), 401);
+    }
+
+    const fqn = `${name}__${tool}`;
+    try {
+      const result = await getMcpBridge().invokeTool(fqn, body);
+      return json({ result, request_id: requestId });
+    } catch (e) {
+      return json(this.errorBody('invoke_failed', e instanceof Error ? e.message : String(e), requestId, name), 502);
+    }
+  }
+
+  private async invokeViaCallback(pluginName: string, toolName: string, args: unknown, pluginToken: Buffer, callbackUrl: string, requestId: string): Promise<unknown> {
+    const ts = new Date().toISOString();
+    const body = JSON.stringify({ tool: toolName, args });
+    const signature = this.signHmac(pluginToken, body, ts);
+
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), PLUGIN_INVOKE_TIMEOUT_MS);
+    try {
+      const resp = await fetch(callbackUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Plus-Ts': ts,
+          'X-Plus-Signature': signature,
+          'X-Plus-Request-Id': requestId,
+        },
+        body,
+        signal: ctrl.signal,
+      });
+      if (!resp.ok) {
+        throw new Error(`Plugin ${pluginName} callback ${resp.status}: ${(await resp.text()).slice(0, 200)}`);
+      }
+      const result = await resp.json() as { result?: unknown; error?: unknown };
+      if (result.error) throw new Error(`Plugin error: ${JSON.stringify(result.error)}`);
+      return result.result;
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async handleUnregister(req: Request, name: string): Promise<Response> {
+    const requestId = this.requestId(req);
+    const plugin = this.plugins.get(name);
+    if (!plugin) {
+      return json(this.errorBody('plugin_not_registered', `Plugin '${name}' not registered`, requestId, name), 404);
+    }
+    const authToken = (req.headers.get('authorization') ?? '').replace(/^Bearer\s+/, '');
+    const tokenBuf = Buffer.from(authToken, 'hex');
+    const validBootstrap = this.verifyBootstrap(authToken);
+    const validPlugin = tokenBuf.length === plugin.pluginToken.length && timingSafeEqual(tokenBuf, plugin.pluginToken);
+    if (!validBootstrap && !validPlugin) {
+      return json(this.errorBody('unauthorized', 'Bootstrap or plugin token required', requestId, name), 401);
+    }
+    this.plugins.delete(name);
+    try { getMcpBridge().unregisterPlugin(name); } catch {}
+    try { getMcpBridge().audit('http_plugin_unregistered', { plugin: name, request_id: requestId }); } catch {}
+    return json({ unregistered: name, request_id: requestId });
+  }
+
+  private async handleList(req: Request): Promise<Response> {
+    const requestId = this.requestId(req);
+    const list = [...this.plugins.values()].map(p => ({
+      name: p.manifest.name,
+      version: p.manifest.version,
+      schema_version: p.manifest.schema_version,
+      tools: p.manifest.tools.map(t => t.name),
+      capabilities: p.manifest.capabilities,
+      registered_at: p.registeredAt.toISOString(),
+      last_health_check: p.lastHealthCheck ?? null,
+    }));
+    return json({ plugins: list, request_id: requestId });
+  }
+
+  private async handleHealthCheck(req: Request, name: string): Promise<Response> {
+    const requestId = this.requestId(req);
+    const plugin = this.plugins.get(name);
+    if (!plugin) {
+      return json(this.errorBody('plugin_not_registered', `Plugin '${name}' not registered`, requestId, name), 404);
+    }
+    if (!plugin.manifest.health_url) {
+      return json({ name, healthy: true, note: 'No health_url declared — plugin assumed healthy', request_id: requestId });
+    }
+    const ctrl = new AbortController();
+    const timer = setTimeout(() => ctrl.abort(), 5_000);
+    try {
+      const r = await fetch(plugin.manifest.health_url, { signal: ctrl.signal });
+      const healthy = r.ok;
+      plugin.lastHealthCheck = { ts: new Date(), healthy, status: r.status };
+      return json({ name, healthy, status: r.status, request_id: requestId });
+    } catch (e) {
+      plugin.lastHealthCheck = { ts: new Date(), healthy: false, error: String(e) };
+      return json({ name, healthy: false, error: String(e), request_id: requestId });
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  // ── HMAC + bootstrap ──────────────────────────────────────────────────────
+
+  private verifyBootstrap(token: string): boolean {
+    try {
+      const tokenBuf = Buffer.from(token, 'hex');
+      if (tokenBuf.length !== this.bootstrapToken.length) return false;
+      return timingSafeEqual(tokenBuf, this.bootstrapToken);
+    } catch { return false; }
+  }
+
+  signHmac(secret: Buffer, body: string, ts: string): string {
+    return createHmac('sha256', secret).update(`${ts}\n${body}`).digest('hex');
+  }
+
+  verifyHmac(secret: Buffer, body: string, ts: string, sig: string): boolean {
+    try {
+      const expected = this.signHmac(secret, body, ts);
+      if (expected.length !== sig.length) return false;
+      return timingSafeEqual(Buffer.from(expected, 'hex'), Buffer.from(sig, 'hex'));
+    } catch { return false; }
+  }
+
+  /** Expose for tests */
+  get pluginCount(): number { return this.plugins.size; }
+  hasPlugin(name: string): boolean { return this.plugins.has(name); }
+  getPluginToken(name: string): Buffer | undefined { return this.plugins.get(name)?.pluginToken; }
+}
+
+let _gateway: PluginHttpGateway | null = null;
+
+export function getHttpGateway(opts?: { allowedHosts?: string[] }): PluginHttpGateway {
+  if (!_gateway) _gateway = new PluginHttpGateway(opts);
+  return _gateway;
+}
+
+export function _resetHttpGateway(): void { _gateway = null; }

--- a/src/plugins/http-gateway.ts
+++ b/src/plugins/http-gateway.ts
@@ -185,10 +185,15 @@ export class PluginHttpGateway {
     }
 
     const fqn = `${name}__${tool}`;
+    const bridge = getMcpBridge();
+    // Gateway-level audit carries request_id through the invoke lifecycle
+    try { bridge.audit('gateway_invoke', { fqn, request_id: requestId, plugin: name, phase: 'start' }); } catch {}
     try {
-      const result = await getMcpBridge().invokeTool(fqn, body);
+      const result = await bridge.invokeTool(fqn, body);
+      try { bridge.audit('gateway_invoke', { fqn, request_id: requestId, plugin: name, phase: 'end', success: true }); } catch {}
       return json({ result, request_id: requestId });
     } catch (e) {
+      try { bridge.audit('gateway_invoke', { fqn, request_id: requestId, plugin: name, phase: 'end', success: false }); } catch {}
       return json(this.errorBody('invoke_failed', e instanceof Error ? e.message : String(e), requestId, name), 502);
     }
   }

--- a/src/plugins/http-gateway.ts
+++ b/src/plugins/http-gateway.ts
@@ -165,8 +165,12 @@ export class PluginHttpGateway {
 
     const ts = req.headers.get('x-plus-ts') ?? '';
     const sig = req.headers.get('x-plus-signature') ?? '';
-    // Use raw body string for HMAC — re-serialization changes byte order (breaks Python default separators)
-    const rawBody = await req.text();
+    // Use raw body bytes for HMAC — re-serialization changes byte order (breaks Python default separators)
+    const rawBuf = await req.arrayBuffer();
+    if (rawBuf.byteLength > MAX_BODY_BYTES) {
+      return json(this.errorBody('body_too_large', `Request body exceeds ${MAX_BODY_BYTES} bytes`, requestId, name), 413);
+    }
+    const rawBody = new TextDecoder().decode(rawBuf);
     const bodyStr = rawBody || '{}';
     let body: unknown;
     try { body = JSON.parse(bodyStr); } catch { body = {}; }

--- a/src/plugins/mcp-bridge.ts
+++ b/src/plugins/mcp-bridge.ts
@@ -1,0 +1,222 @@
+import { z } from "zod";
+import { createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+import { appendFileSync, mkdirSync, writeFileSync, existsSync, readFileSync, chmodSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export interface PluginTool<T extends z.ZodType = z.ZodType<any, any>> {
+  name: string;
+  description: string;
+  schema: T;
+  handler: (args: z.infer<T>) => Promise<unknown> | unknown;
+}
+
+export interface PluginToolContext {
+  pluginId: string;
+  callerToken?: string;
+  signature: string;
+  ts: number;
+}
+
+export interface RegisteredTool {
+  plugin: string;
+  tool: PluginTool;
+}
+
+export interface ListedTool {
+  fqn: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+// ── PluginMcpBridge ───────────────────────────────────────────────────────────
+
+export class PluginMcpBridge {
+  private tools = new Map<string, RegisteredTool>();
+  private secrets = new Map<string, Buffer>();
+  private auditPath: string;
+
+  constructor(auditPath?: string) {
+    this.auditPath = auditPath
+      ? resolve(auditPath)
+      : resolve(homedir(), ".config", "plus", "plugin-audit.jsonl");
+
+    // Ensure audit directory exists
+    const auditDir = this.auditPath.substring(0, this.auditPath.lastIndexOf("/"));
+    mkdirSync(auditDir, { recursive: true });
+  }
+
+  // ── Tool registration ──────────────────────────────────────────────────
+
+  registerPluginTool(pluginId: string, tool: PluginTool): void {
+    const fqn = `${pluginId}__${tool.name}`;
+
+    if (this.tools.has(fqn)) {
+      throw new Error(`Duplicate tool registration: "${fqn}" is already registered`);
+    }
+
+    this.tools.set(fqn, { plugin: pluginId, tool });
+    this.audit("register", { fqn, pluginId, toolName: tool.name, description: tool.description });
+  }
+
+  // ── Secret management ──────────────────────────────────────────────────
+
+  loadOrCreateSecret(pluginId: string): Buffer {
+    const cached = this.secrets.get(pluginId);
+    if (cached) return cached;
+
+    const secretDir = resolve(homedir(), ".config", "plus", "plugins", pluginId);
+    const secretPath = join(secretDir, ".secret");
+
+    mkdirSync(secretDir, { recursive: true });
+
+    let secret: Buffer;
+    if (existsSync(secretPath)) {
+      const raw = readFileSync(secretPath);
+      // hex-encoded 32 bytes = 64 chars
+      secret = Buffer.from(raw.toString().trim(), "hex");
+    } else {
+      secret = randomBytes(32);
+      writeFileSync(secretPath, secret.toString("hex"), { encoding: "utf8" });
+      chmodSync(secretPath, 0o600);
+    }
+
+    this.secrets.set(pluginId, secret);
+    return secret;
+  }
+
+  // ── HMAC signing ──────────────────────────────────────────────────────
+
+  signCall(pluginId: string, body: unknown, ts: number): string {
+    const secret = this.loadOrCreateSecret(pluginId);
+    const canonical = JSON.stringify({ body, ts });
+    return createHmac("sha256", secret).update(canonical).digest("hex");
+  }
+
+  verifyCall(pluginId: string, body: unknown, ts: number, signature: string): boolean {
+    const expected = this.signCall(pluginId, body, ts);
+    try {
+      const expectedBuf = Buffer.from(expected, "hex");
+      const signatureBuf = Buffer.from(signature, "hex");
+      if (expectedBuf.length !== signatureBuf.length) return false;
+      return timingSafeEqual(expectedBuf, signatureBuf);
+    } catch {
+      return false;
+    }
+  }
+
+  // ── Tool invocation ───────────────────────────────────────────────────
+
+  async invokeTool(fqn: string, args: unknown): Promise<unknown> {
+    const registered = this.tools.get(fqn);
+    if (!registered) {
+      throw new Error(`Unknown tool: "${fqn}"`);
+    }
+
+    const { plugin: pluginId, tool } = registered;
+
+    // Validate args via Zod schema
+    const parsed = tool.schema.safeParse(args);
+    if (!parsed.success) {
+      const err = new Error(`Invalid args for "${fqn}": ${parsed.error.message}`);
+      this.audit("error", { fqn, pluginId, error: parsed.error.message, phase: "validation" });
+      throw err;
+    }
+
+    // Sign the call
+    const ts = Date.now();
+    const signature = this.signCall(pluginId, parsed.data, ts);
+
+    try {
+      const result = await tool.handler(parsed.data);
+      this.audit("invoke", { fqn, pluginId, ts, signature, success: true });
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.audit("error", { fqn, pluginId, ts, signature, error: message, phase: "handler" });
+      throw err;
+    }
+  }
+
+  // ── Tool listing ──────────────────────────────────────────────────────
+
+  listTools(): ListedTool[] {
+    return Array.from(this.tools.entries()).map(([fqn, { tool }]) => ({
+      fqn,
+      description: tool.description,
+      inputSchema: this.zodToJson(tool.schema),
+    }));
+  }
+
+  // ── Helpers ───────────────────────────────────────────────────────────
+
+  private zodToJson(schema: z.ZodType): Record<string, unknown> {
+    // MVP minimal converter — returns a basic JSON Schema object
+    if (schema instanceof z.ZodObject) {
+      const shape = schema.shape as Record<string, z.ZodType>;
+      const properties: Record<string, unknown> = {};
+      const required: string[] = [];
+
+      for (const [key, field] of Object.entries(shape)) {
+        properties[key] = this.zodFieldToJson(field as z.ZodType);
+        // If not optional, mark as required
+        if (!(field instanceof z.ZodOptional) && !(field instanceof z.ZodDefault)) {
+          required.push(key);
+        }
+      }
+
+      return {
+        type: "object",
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+        additionalProperties: false,
+      };
+    }
+
+    // Fallback for non-object schemas
+    return { type: "object", additionalProperties: true };
+  }
+
+  private zodFieldToJson(field: z.ZodType): Record<string, unknown> {
+    if (field instanceof z.ZodOptional) {
+      return this.zodFieldToJson(field.unwrap() as z.ZodType);
+    }
+    if (field instanceof z.ZodDefault) {
+      return this.zodFieldToJson(field._def.innerType as z.ZodType);
+    }
+    if (field instanceof z.ZodString) return { type: "string" };
+    if (field instanceof z.ZodNumber) return { type: "number" };
+    if (field instanceof z.ZodBoolean) return { type: "boolean" };
+    if (field instanceof z.ZodArray) return { type: "array", items: this.zodFieldToJson(field.element as z.ZodType) };
+    if (field instanceof z.ZodEnum) return { type: "string", enum: field.options as string[] };
+    return { type: "object", additionalProperties: true };
+  }
+
+  private audit(event: string, payload: Record<string, unknown>): void {
+    try {
+      const entry = JSON.stringify({ event, ts: new Date().toISOString(), ...payload }) + "\n";
+      appendFileSync(this.auditPath, entry, { encoding: "utf8" });
+    } catch {
+      // Audit failures must not break the bridge
+    }
+  }
+}
+
+// ── Singleton ─────────────────────────────────────────────────────────────────
+
+let _bridge: PluginMcpBridge | null = null;
+
+export function getMcpBridge(): PluginMcpBridge {
+  if (!_bridge) {
+    _bridge = new PluginMcpBridge();
+  }
+  return _bridge;
+}
+
+/** Reset singleton — only for testing */
+export function _resetMcpBridge(): void {
+  _bridge = null;
+}

--- a/src/plugins/mcp-bridge.ts
+++ b/src/plugins/mcp-bridge.ts
@@ -62,6 +62,13 @@ export class PluginMcpBridge {
     this.audit("register", { fqn, pluginId, toolName: tool.name, description: tool.description });
   }
 
+  unregisterPlugin(pluginId: string): void {
+    for (const [fqn, entry] of this.tools) {
+      if (entry.plugin === pluginId) this.tools.delete(fqn);
+    }
+    this.audit("unregister", { pluginId });
+  }
+
   // ── Secret management ──────────────────────────────────────────────────
 
   loadOrCreateSecret(pluginId: string): Buffer {
@@ -195,7 +202,7 @@ export class PluginMcpBridge {
     return { type: "object", additionalProperties: true };
   }
 
-  private audit(event: string, payload: Record<string, unknown>): void {
+  audit(event: string, payload: Record<string, unknown>): void {
     try {
       const entry = JSON.stringify({ event, ts: new Date().toISOString(), ...payload }) + "\n";
       appendFileSync(this.auditPath, entry, { encoding: "utf8" });

--- a/src/plugins/mcp-bridge.ts
+++ b/src/plugins/mcp-bridge.ts
@@ -227,3 +227,6 @@ export function getMcpBridge(): PluginMcpBridge {
 export function _resetMcpBridge(): void {
   _bridge = null;
 }
+
+/** Set bridge singleton — only for testing */
+export function _setMcpBridge(b: PluginMcpBridge | null): void { _bridge = b; }

--- a/src/plugins/mcp-bridge.ts
+++ b/src/plugins/mcp-bridge.ts
@@ -51,7 +51,17 @@ export class PluginMcpBridge {
 
   // ── Tool registration ──────────────────────────────────────────────────
 
+  // Path-traversal guard: pluginId must be a safe identifier.
+  // Allowed: lowercase letters, digits, dashes; must start with a letter; 1-64 chars.
+  // Rejects any string containing path separators, dots, or other special chars.
+  private _validatePluginId(pluginId: string): void {
+    if (typeof pluginId !== "string" || !/^[a-z][a-z0-9-]{0,63}$/.test(pluginId)) {
+      throw new Error(`invalid pluginId: ${JSON.stringify(pluginId)} (must match /^[a-z][a-z0-9-]{0,63}$/)`);
+    }
+  }
+
   registerPluginTool(pluginId: string, tool: PluginTool): void {
+    this._validatePluginId(pluginId);
     const fqn = `${pluginId}__${tool.name}`;
 
     if (this.tools.has(fqn)) {
@@ -63,6 +73,7 @@ export class PluginMcpBridge {
   }
 
   unregisterPlugin(pluginId: string): void {
+    this._validatePluginId(pluginId);
     for (const [fqn, entry] of this.tools) {
       if (entry.plugin === pluginId) this.tools.delete(fqn);
     }
@@ -72,6 +83,7 @@ export class PluginMcpBridge {
   // ── Secret management ──────────────────────────────────────────────────
 
   loadOrCreateSecret(pluginId: string): Buffer {
+    this._validatePluginId(pluginId);
     const cached = this.secrets.get(pluginId);
     if (cached) return cached;
 

--- a/src/plugins/mcp-proxy/index.ts
+++ b/src/plugins/mcp-proxy/index.ts
@@ -1,0 +1,195 @@
+import { existsSync, readFileSync, writeFileSync, chmodSync, mkdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+
+const MAX_RESULT_BYTES = Number(process.env.MCP_PROXY_MAX_RESULT_BYTES ?? 1_048_576);
+import { getMcpBridge } from "../mcp-bridge.js";
+import { getHttpGateway } from "../http-gateway.js";
+import { McpServerProcess, type McpServerConfig } from "./server-process.js";
+
+// ── Config schema ─────────────────────────────────────────────────────────────
+
+const ServerConfigSchema = z.object({
+  command: z.string(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string()).optional(),
+  enabled: z.boolean().default(true),
+  allowedTools: z.array(z.string()).optional(),
+});
+
+const ProxyConfigSchema = z.object({
+  servers: z.record(ServerConfigSchema),
+});
+
+type ProxyConfig = z.infer<typeof ProxyConfigSchema>;
+
+// ── McpProxyPlugin ────────────────────────────────────────────────────────────
+
+export interface McpProxyPluginOpts {
+  configPath?: string;
+  tokenPath?: string;
+  // For reasoned mode: inject into active Claude session
+  reasonedInvokeFn?: (tool: string, args: unknown) => Promise<unknown>;
+}
+
+export class McpProxyPlugin {
+  private servers = new Map<string, McpServerProcess>();
+  private configPath: string;
+  private tokenPath: string;
+  private reasonedInvokeFn?: (tool: string, args: unknown) => Promise<unknown>;
+  private pluginToken: Buffer | null = null;
+
+  constructor(opts: McpProxyPluginOpts = {}) {
+    this.configPath = opts.configPath ?? join(homedir(), ".config", "claudeclaw", "mcp-proxy.json");
+    this.tokenPath = opts.tokenPath ?? join(homedir(), ".config", "claudeclaw", "mcp-proxy.token");
+    this.reasonedInvokeFn = opts.reasonedInvokeFn;
+  }
+
+  async start(): Promise<void> {
+    try {
+      const stat = statSync(this.configPath);
+      if (stat.mode & 0o077) {
+        console.error(`[mcp-proxy] WARN: ${this.configPath} has permissive permissions (${(stat.mode & 0o777).toString(8)}); recommended 0600.`);
+      }
+    } catch {} // missing config handled below with a clearer message
+
+    const config = this._loadConfig();
+    if (!config) {
+      console.error("[mcp-proxy] No config found — registering with zero tools (graceful degradation)");
+      this._registerWithGateway([]);
+      return;
+    }
+
+    const enabledServers = Object.entries(config.servers).filter(([, s]) => s.enabled);
+    const allTools: { name: string; description: string; schema: Record<string, unknown> }[] = [];
+
+    await Promise.allSettled(enabledServers.map(async ([name, cfg]) => {
+      const proc = new McpServerProcess(name, cfg as McpServerConfig, {
+        onCrash: (n, reason) => this._onServerCrash(n, reason),
+      });
+
+      try {
+        await proc.start();
+        this.servers.set(name, proc);
+
+        for (const tool of proc.tools) {
+          const fqn = `${name}__${tool.name}`;
+          try {
+            getMcpBridge().registerPluginTool("mcp-proxy", {
+              name: fqn,
+              description: tool.description,
+              schema: z.object({
+                arguments: z.record(z.unknown()).optional().default({}),
+                mode: z.enum(["direct", "reasoned"]).optional().default("direct"),
+              }),
+              handler: async (input) => {
+                const mode = input.mode ?? "direct";
+                const args = input.arguments ?? {};
+                if (mode === "reasoned") {
+                  return this._invokeReasoned(fqn, args);
+                }
+                const result = await proc.call(tool.name, args);
+                const resultStr = JSON.stringify(result);
+                if (resultStr.length > MAX_RESULT_BYTES) {
+                  throw new Error(`Tool result exceeds ${MAX_RESULT_BYTES} bytes (got ${resultStr.length})`);
+                }
+                return result;
+              },
+            });
+            allTools.push({ name: fqn, description: tool.description, schema: tool.inputSchema });
+          } catch {
+            // duplicate or error — skip
+          }
+        }
+
+        console.error(`[mcp-proxy] Server '${name}' ready — ${proc.tools.length} tools`);
+      } catch (err) {
+        console.error(`[mcp-proxy] Server '${name}' failed to start: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }));
+
+    this._registerWithGateway(allTools);
+  }
+
+  async stop(): Promise<void> {
+    await Promise.allSettled([...this.servers.values()].map((p) => p.stop()));
+    this.servers.clear();
+  }
+
+  health(): Record<string, unknown> {
+    const servers: Record<string, unknown> = {};
+    for (const [name, proc] of this.servers) {
+      servers[name] = {
+        status: proc.status,
+        uptime_s: proc.startedAt ? Math.floor((Date.now() - proc.startedAt.getTime()) / 1000) : null,
+        last_invocation_at: proc.lastInvocationAt?.toISOString() ?? null,
+        tools: proc.tools.map((t) => t.name),
+      };
+    }
+    return { servers };
+  }
+
+  private _loadConfig(): ProxyConfig | null {
+    const paths = [
+      this.configPath,
+      join(homedir(), ".config", "claude", "mcp.json"),
+    ];
+    for (const p of paths) {
+      if (!existsSync(p)) continue;
+      try {
+        const raw = JSON.parse(readFileSync(p, "utf8"));
+        const result = ProxyConfigSchema.safeParse(raw);
+        if (result.success) return result.data;
+      } catch {}
+    }
+    return null;
+  }
+
+  private _registerWithGateway(tools: { name: string; description: string; schema: Record<string, unknown> }[]): void {
+    const gateway = getHttpGateway();
+    this.pluginToken = gateway.registerInProcess("mcp-proxy", {
+      version: "1.0.0",
+      tools,
+      healthFn: async () => this.health(),
+    });
+
+    const tokenDir = join(this.tokenPath, "..");
+    mkdirSync(tokenDir, { recursive: true });
+    writeFileSync(this.tokenPath, this.pluginToken.toString("hex"), { encoding: "utf8" });
+    chmodSync(this.tokenPath, 0o600);
+
+    console.error(`[mcp-proxy] Registered with gateway — ${tools.length} tools. Token stored at ${this.tokenPath}`);
+  }
+
+  private _onServerCrash(name: string, reason: string): void {
+    const proc = this.servers.get(name);
+    if (!proc) return;
+
+    getMcpBridge().audit("mcp_proxy_server_crashed", { server: name, reason, status: proc.status });
+    console.error(`[mcp-proxy] Server '${name}' crashed: ${reason} — status: ${proc.status}`);
+
+    if (proc.status === "failed") {
+      console.error(`[mcp-proxy] Server '${name}' permanently failed after too many crashes`);
+      getMcpBridge().audit("mcp_proxy_server_permanently_failed", { server: name });
+    }
+  }
+
+  private async _invokeReasoned(fqn: string, args: unknown): Promise<unknown> {
+    if (!this.reasonedInvokeFn) {
+      throw new Error(`reasoned mode not configured for ${fqn}`);
+    }
+    return this.reasonedInvokeFn(fqn, args);
+  }
+}
+
+// ── Singleton ─────────────────────────────────────────────────────────────────
+
+let _proxy: McpProxyPlugin | null = null;
+
+export function getMcpProxyPlugin(opts?: McpProxyPluginOpts): McpProxyPlugin {
+  if (!_proxy) _proxy = new McpProxyPlugin(opts);
+  return _proxy;
+}
+
+export function _resetMcpProxy(): void { _proxy = null; }

--- a/src/plugins/mcp-proxy/index.ts
+++ b/src/plugins/mcp-proxy/index.ts
@@ -2,11 +2,11 @@ import { existsSync, readFileSync, writeFileSync, chmodSync, mkdirSync, statSync
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod";
-
-const MAX_RESULT_BYTES = Number(process.env.MCP_PROXY_MAX_RESULT_BYTES ?? 1_048_576);
 import { getMcpBridge } from "../mcp-bridge.js";
 import { getHttpGateway } from "../http-gateway.js";
 import { McpServerProcess, type McpServerConfig } from "./server-process.js";
+
+const MAX_RESULT_BYTES = Number(process.env.MCP_PROXY_MAX_RESULT_BYTES ?? 1_048_576);
 
 // ── Config schema ─────────────────────────────────────────────────────────────
 

--- a/src/plugins/mcp-proxy/index.ts
+++ b/src/plugins/mcp-proxy/index.ts
@@ -175,6 +175,24 @@ export class McpProxyPlugin {
     }
   }
 
+  /**
+   * Allowlist check for reasonedInvokeFn. Returns true iff the given fqn
+   * matches a tool currently registered by this plugin (i.e. mcp-proxy__server__tool
+   * where the server is in the live pool and the tool was advertised by it).
+   *
+   * Called from start.ts before constructing a Claude inject prompt, to prevent
+   * unregistered fqn strings from being interpolated into the prompt verbatim.
+   */
+  hasReasonedTool(fqn: string): boolean {
+    // Expected shape: <server>__<tool> (2 segments) — what registerPluginTool closure
+    const m = fqn.match(/^([a-zA-Z0-9_-]+)__([a-zA-Z0-9_-]+)$/);
+    if (!m) return false;
+    const [, server, tool] = m;
+    const proc = this.servers.get(server);
+    if (!proc) return false;
+    return proc.tools.some((t) => t.name === tool);
+  }
+
   private async _invokeReasoned(fqn: string, args: unknown): Promise<unknown> {
     if (!this.reasonedInvokeFn) {
       throw new Error(`reasoned mode not configured for ${fqn}`);

--- a/src/plugins/mcp-proxy/server-process.ts
+++ b/src/plugins/mcp-proxy/server-process.ts
@@ -1,0 +1,170 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { createWriteStream, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface McpServerConfig {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  allowedTools?: string[];
+}
+
+export interface ServerTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+type ServerStatus = "starting" | "up" | "crashed" | "restarting" | "failed" | "stopped";
+
+const BACKOFF_MS = [1_000, 5_000, 30_000, 60_000];
+const CRASH_WINDOW_MS = 5 * 60 * 1_000;
+const MAX_CRASHES_IN_WINDOW = 5;
+const DEFAULT_CALL_TIMEOUT_MS = 30_000;
+
+export class McpServerProcess {
+  readonly name: string;
+  private config: McpServerConfig;
+
+  private client: Client | null = null;
+  private transport: StdioClientTransport | null = null;
+
+  status: ServerStatus = "starting";
+  tools: ServerTool[] = [];
+  startedAt: Date | null = null;
+  lastInvocationAt: Date | null = null;
+
+  private crashTimestamps: number[] = [];
+  private crashCount = 0;
+  private restartHook?: (name: string, reason: string) => void;
+  private stopping = false;
+  private restartTimer: ReturnType<typeof setTimeout> | null = null;
+
+  constructor(name: string, config: McpServerConfig, opts?: {
+    onCrash?: (name: string, reason: string) => void;
+  }) {
+    this.name = name;
+    this.config = config;
+    this.restartHook = opts?.onCrash;
+  }
+
+  async start(): Promise<void> {
+    this.status = "starting";
+    const logDir = join(homedir(), ".cache", "claudeclaw", "mcp-proxy");
+    mkdirSync(logDir, { recursive: true });
+    const logPath = join(logDir, `${this.name}.log`);
+
+    this.transport = new StdioClientTransport({
+      command: this.config.command,
+      args: this.config.args ?? [],
+      env: this.config.env,
+      stderr: "pipe",
+    });
+
+    // Pipe stderr to log file — transport.stderr is available immediately when stderr:"pipe"
+    const stderrStream = this.transport.stderr;
+    if (stderrStream) {
+      const logStream = createWriteStream(logPath, { flags: "a" });
+      stderrStream.pipe(logStream);
+    }
+
+    this.client = new Client(
+      { name: `mcp-proxy/${this.name}`, version: "1.0.0" },
+      { capabilities: { tools: {} } },
+    );
+
+    this.transport.onclose = () => this._handleCrash("transport closed");
+    this.transport.onerror = (err) => this._handleCrash(`transport error: ${err.message}`);
+
+    await this.client.connect(this.transport);
+
+    const { tools } = await this.client.listTools();
+    const allowed = this.config.allowedTools;
+    this.tools = tools
+      .filter((t) => !allowed || allowed.includes(t.name))
+      .map((t) => ({
+        name: t.name,
+        description: t.description ?? "",
+        inputSchema: (t.inputSchema as Record<string, unknown>) ?? {},
+      }));
+
+    this.status = "up";
+    this.startedAt = new Date();
+  }
+
+  async call(tool: string, args: unknown, timeoutMs = DEFAULT_CALL_TIMEOUT_MS): Promise<unknown> {
+    if (!this.client || this.status !== "up") {
+      throw new Error(`Server ${this.name} is not ready (status: ${this.status})`);
+    }
+    this.lastInvocationAt = new Date();
+
+    const timer = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error(`Tool call ${tool} timed out after ${timeoutMs}ms`)), timeoutMs),
+    );
+
+    const call = this.client.callTool({
+      name: tool,
+      arguments: args as Record<string, unknown>,
+    });
+
+    const result = await Promise.race([call, timer]);
+    const content = (result as { content?: Array<{ text?: string }> }).content?.[0];
+    const text = content?.text ?? "";
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.stopping = true;
+    if (this.restartTimer !== null) {
+      clearTimeout(this.restartTimer);
+      this.restartTimer = null;
+    }
+    this.status = "stopped";
+    try {
+      await this.client?.close();
+    } catch {}
+    try {
+      await this.transport?.close();
+    } catch {}
+    this.client = null;
+    this.transport = null;
+  }
+
+  private _handleCrash(reason: string): void {
+    if (this.stopping || this.status === "failed" || this.status === "stopped") return;
+    this.status = "crashed";
+    this.crashCount++;
+    const now = Date.now();
+    this.crashTimestamps = [...this.crashTimestamps, now].filter((t) => now - t < CRASH_WINDOW_MS);
+
+    this.restartHook?.(this.name, reason);
+
+    if (this.crashTimestamps.length >= MAX_CRASHES_IN_WINDOW) {
+      this.status = "failed";
+      return;
+    }
+
+    const backoff = BACKOFF_MS[Math.min(this.crashCount - 1, BACKOFF_MS.length - 1)] ?? 60_000;
+    this.status = "restarting";
+    this.restartTimer = setTimeout(() => {
+      this.restartTimer = null;
+      this._doRestart();
+    }, backoff);
+  }
+
+  private async _doRestart(): Promise<void> {
+    try {
+      this.client = null;
+      this.transport = null;
+      await this.start();
+    } catch (err) {
+      this._handleCrash(`restart failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}

--- a/src/plugins/mcp-proxy/server-process.ts
+++ b/src/plugins/mcp-proxy/server-process.ts
@@ -79,9 +79,21 @@ export class McpServerProcess {
       { capabilities: { tools: {} } },
     );
 
-    // Capture gen in closure so stale handlers from a previous transport are silently discarded
-    this.transport.onclose = () => { if (this.generation === gen) this._handleCrash("transport closed"); };
-    this.transport.onerror = (err) => { if (this.generation === gen) this._handleCrash(`transport error: ${err.message}`); };
+    // Capture gen in closure so stale handlers from a previous transport are silently discarded.
+    // Also gate with a per-generation `crashHandled` flag: when a transport fails, both
+    // `onerror` and `onclose` fire for the same generation. Without this flag both
+    // would call _handleCrash, scheduling two restart timers and double-spawning.
+    let crashHandled = false;
+    this.transport.onclose = () => {
+      if (this.generation !== gen || crashHandled) return;
+      crashHandled = true;
+      this._handleCrash("transport closed");
+    };
+    this.transport.onerror = (err) => {
+      if (this.generation !== gen || crashHandled) return;
+      crashHandled = true;
+      this._handleCrash(`transport error: ${err.message}`);
+    };
 
     // Cleanup guarantee: if connect/listTools throws, kill the spawned subprocess
     // before propagating. Prevents zombie MCP servers across daemon restarts when
@@ -94,8 +106,8 @@ export class McpServerProcess {
       this.status = "failed";
       try { await this.client?.close(); } catch {}
       try { await this.transport?.close(); } catch {}
-      this.client = undefined;
-      this.transport = undefined;
+      this.client = null;
+      this.transport = null;
       throw err;
     }
     const allowed = this.config.allowedTools;

--- a/src/plugins/mcp-proxy/server-process.ts
+++ b/src/plugins/mcp-proxy/server-process.ts
@@ -168,6 +168,7 @@ export class McpServerProcess {
   }
 
   private async _doRestart(): Promise<void> {
+    if (this.stopping) return; // stop() may have been called while restart timer was queued
     try {
       const oldClient = this.client;
       const oldTransport = this.transport;

--- a/src/plugins/mcp-proxy/server-process.ts
+++ b/src/plugins/mcp-proxy/server-process.ts
@@ -41,6 +41,8 @@ export class McpServerProcess {
   private restartHook?: (name: string, reason: string) => void;
   private stopping = false;
   private restartTimer: ReturnType<typeof setTimeout> | null = null;
+  // Generation counter: stale onclose/onerror handlers from old transports are discarded
+  private generation = 0;
 
   constructor(name: string, config: McpServerConfig, opts?: {
     onCrash?: (name: string, reason: string) => void;
@@ -52,6 +54,7 @@ export class McpServerProcess {
 
   async start(): Promise<void> {
     this.status = "starting";
+    const gen = ++this.generation;
     const logDir = join(homedir(), ".cache", "claudeclaw", "mcp-proxy");
     mkdirSync(logDir, { recursive: true });
     const logPath = join(logDir, `${this.name}.log`);
@@ -75,8 +78,9 @@ export class McpServerProcess {
       { capabilities: { tools: {} } },
     );
 
-    this.transport.onclose = () => this._handleCrash("transport closed");
-    this.transport.onerror = (err) => this._handleCrash(`transport error: ${err.message}`);
+    // Capture gen in closure so stale handlers from a previous transport are silently discarded
+    this.transport.onclose = () => { if (this.generation === gen) this._handleCrash("transport closed"); };
+    this.transport.onerror = (err) => { if (this.generation === gen) this._handleCrash(`transport error: ${err.message}`); };
 
     await this.client.connect(this.transport);
 
@@ -160,9 +164,14 @@ export class McpServerProcess {
 
   private async _doRestart(): Promise<void> {
     try {
+      const oldClient = this.client;
+      const oldTransport = this.transport;
       this.client = null;
       this.transport = null;
       await this.start();
+      // Close old transport after new generation is live — stale handlers are discarded by gen guard
+      try { await oldClient?.close(); } catch {}
+      try { await oldTransport?.close(); } catch {}
     } catch (err) {
       this._handleCrash(`restart failed: ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/src/plugins/mcp-proxy/server-process.ts
+++ b/src/plugins/mcp-proxy/server-process.ts
@@ -70,6 +70,7 @@ export class McpServerProcess {
     const stderrStream = this.transport.stderr;
     if (stderrStream) {
       const logStream = createWriteStream(logPath, { flags: "a" });
+      logStream.on("error", (err) => console.error(`[mcp-proxy] log write error for ${this.name}:`, err.message));
       stderrStream.pipe(logStream);
     }
 

--- a/src/plugins/mcp-proxy/server-process.ts
+++ b/src/plugins/mcp-proxy/server-process.ts
@@ -148,10 +148,14 @@ export class McpServerProcess {
     const now = Date.now();
     this.crashTimestamps = [...this.crashTimestamps, now].filter((t) => now - t < CRASH_WINDOW_MS);
 
-    this.restartHook?.(this.name, reason);
-
     if (this.crashTimestamps.length >= MAX_CRASHES_IN_WINDOW) {
       this.status = "failed";
+    }
+
+    // Fire hook AFTER status is finalized so callers see "failed" vs "crashed" correctly
+    this.restartHook?.(this.name, reason);
+
+    if (this.status === "failed") {
       return;
     }
 

--- a/src/plugins/mcp-proxy/server-process.ts
+++ b/src/plugins/mcp-proxy/server-process.ts
@@ -83,9 +83,21 @@ export class McpServerProcess {
     this.transport.onclose = () => { if (this.generation === gen) this._handleCrash("transport closed"); };
     this.transport.onerror = (err) => { if (this.generation === gen) this._handleCrash(`transport error: ${err.message}`); };
 
-    await this.client.connect(this.transport);
-
-    const { tools } = await this.client.listTools();
+    // Cleanup guarantee: if connect/listTools throws, kill the spawned subprocess
+    // before propagating. Prevents zombie MCP servers across daemon restarts when
+    // upstream servers are flaky at startup.
+    let tools: Awaited<ReturnType<Client["listTools"]>>["tools"];
+    try {
+      await this.client.connect(this.transport);
+      ({ tools } = await this.client.listTools());
+    } catch (err) {
+      this.status = "failed";
+      try { await this.client?.close(); } catch {}
+      try { await this.transport?.close(); } catch {}
+      this.client = undefined;
+      this.transport = undefined;
+      throw err;
+    }
     const allowed = this.config.allowedTools;
     this.tools = tools
       .filter((t) => !allowed || allowed.includes(t.name))

--- a/src/plugins/mcp-server.ts
+++ b/src/plugins/mcp-server.ts
@@ -8,7 +8,7 @@
  *   { "mcpServers": { "claudeclaw-plus": { "command": "bun", "args": ["run", "/path/to/mcp-server.ts"] } } }
  */
 
-import { Server } from "@modelcontextprotocol/sdk/server";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
   CallToolRequestSchema,

--- a/src/plugins/mcp-server.ts
+++ b/src/plugins/mcp-server.ts
@@ -1,0 +1,71 @@
+/**
+ * ClaudeClaw-Plus MCP stdio server
+ *
+ * Exposes all plugin-registered tools via the Model Context Protocol.
+ * Run standalone: bun run src/plugins/mcp-server.ts
+ *
+ * Or configure in claude_desktop_config.json:
+ *   { "mcpServers": { "claudeclaw-plus": { "command": "bun", "args": ["run", "/path/to/mcp-server.ts"] } } }
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { getMcpBridge } from "./mcp-bridge.js";
+
+export async function startMcpServer(): Promise<void> {
+  const bridge = getMcpBridge();
+
+  const server = new Server(
+    { name: "claudeclaw-plus", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  // List all registered plugin tools
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const tools = bridge.listTools();
+    return {
+      tools: tools.map((t) => ({
+        name: t.fqn,
+        description: t.description,
+        inputSchema: t.inputSchema,
+      })),
+    };
+  });
+
+  // Invoke a tool by FQN
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    try {
+      const result = await bridge.invokeTool(name, args ?? {});
+      return {
+        content: [
+          {
+            type: "text",
+            text: typeof result === "string" ? result : JSON.stringify(result, null, 2),
+          },
+        ],
+      };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: "text", text: `Error: ${message}` }],
+        isError: true,
+      };
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+// Run standalone when executed directly
+if (import.meta.main) {
+  startMcpServer().catch((err) => {
+    console.error("[mcp-server] Fatal:", err);
+    process.exit(1);
+  });
+}

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -13,6 +13,7 @@ import { listSessions, readSessionMessages, listAgents } from "./services/sessio
 import { getSessionUsage } from "./services/usage";
 import { runUserMessage } from "../runner";
 import { readKanban, writeKanban, type KanbanBoard } from "./services/kanban";
+import { getHttpGateway } from "../plugins/http-gateway.js";
 
 // --- Security: CSRF Protection ---
 // NOTE: The Web UI has no built-in authentication. CSRF protection prevents
@@ -120,6 +121,16 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
     idleTimeout: 0,
     fetch: async (req) => {
       const url = new URL(req.url);
+
+      // Plugin HTTP gateway — handles /api/plugin/* routes
+      if (url.pathname.startsWith('/api/plugin/')) {
+        try {
+          const gatewayResp = await getHttpGateway().handleRequest(req, url);
+          if (gatewayResp !== null) return gatewayResp;
+        } catch (e) {
+          return Response.json({ error: 'gateway_error', message: String(e) }, { status: 500 });
+        }
+      }
 
       if (url.pathname === "/" || url.pathname === "/index.html") {
         return new Response(htmlPage(), {


### PR DESCRIPTION
## Summary

Implements the Plugin → MCP Bridge for ClaudeClaw-Plus, resolving #31.

This adds the missing substrate that unifies all Plus plugins (skills-tuner, archiviste, voice, etc.) under a single MCP-compatible tool registration surface with HMAC-signed inter-process calls.

## Architecture

```
Plus daemon
├── PluginManager (existing src/plugins.ts)
│   └── lifecycle events (gateway_start, session_start, agent_end, ...)
└── PluginMcpBridge (NEW src/plugins/mcp-bridge.ts)
    ├── registerPluginTool(name, schema, handler) ← public API
    ├── McpServer (stdio) ← exposes tools to MCP world
    ├── HMAC signed calls ← secure plugin↔Plus connection
    └── Audit log (~/.config/plus/plugin-audit.jsonl)
```

## Security

- **Per-plugin secret**: `~/.config/plus/plugins/<name>/.secret` (0600, 32 random bytes, auto-created)
- **HMAC-SHA256**: every inter-plugin call is signed with the plugin's secret; verification is timing-safe
- **Zod validation**: all tool args validated against plugin-provided schema before invocation
- **Append-only audit log**: every register/invoke/success/error event logged to `~/.config/plus/plugin-audit.jsonl`

## First Consumer: skills-tuner

The `PlusEventAdapter` stub in the skills-tuner TS port becomes ~20 LOC once this lands:

```typescript
import { getMcpBridge } from 'claudeclaw-plus/plugins/mcp-bridge';

const bridge = getMcpBridge();
bridge.registerPluginTool('skills-tuner', {
  name: 'pending',
  description: 'List pending tuner proposals',
  schema: z.object({ subject: z.string().optional() }),
  handler: async (args) => engine.listPending(args.subject),
});
// apply, refuse, stats, feedback...
```

## Future Plugins (same pattern)

| Plugin | Tools |
|--------|-------|
| archiviste | `search_docs`, `index_doc`, `get_doc` |
| voice (Greg) | `play_tts`, `transcribe_audio` |
| trader-ml-hp | ExternalProcessSubject (Python Optuna) + tool registration |

## Try It

```bash
# Start the MCP server standalone
bun run src/plugins/mcp-server.ts

# Add to claude_desktop_config.json:
{
  "mcpServers": {
    "claudeclaw-plus": {
      "command": "bun",
      "args": ["run", "/path/to/ClaudeClaw-Plus/src/plugins/mcp-server.ts"]
    }
  }
}
```

## Testing

```bash
bun test src/__tests__/plugins/mcp-bridge.test.ts
# 19 pass, 0 fail
```

All 19 tests pass. See `docs/plugin-integration.md` for the full integration guide.

Closes #31


## Security hardening (Tier 1+2)

This PR includes **11 adversarial tests** beyond the functional baseline, covering:

**Tier 1 — Edge cases**:
- `applyProposal` race condition (two concurrent calls on same proposal)
- Path traversal via symlinks (target inside scan_dir but link to /etc/passwd)
- JSONL mid-write corruption (kill -9 during append)
- Audit log atomicity (audit_attempted before any side effect)
- Skill cache invalidated after apply/rename

**Tier 2 — Adversarial security**:
- HMAC canonical bypass via JSON key reordering
- Prompt injection via skill content (not just observation verbatim)
- Telegram callback replay attack
- ExternalProcessSubject with encoded target_path (URL-encoded path traversal)
- Audit log tampering (documented limitation — no hash chain at v1)
- Regex DoS on triggers (catastrophic backtracking — N/A, uses `string.includes()`)

**Real bugs caught and fixed via these tests**:
1. `applyProposal` race condition — added `_applying: Set<number>` lock
2. Symlink traversal in `commitPatch` — added `realpathSync()` check
3. Prompt injection via `skillContent` — `sanitizeObservationContent()` now applied to skill bodies, not just verbatims
4. Empty commits in `commitPatch` — refused when nothing staged (otherwise `revert` was silent no-op)

**Total tests**: 163 unit + integration tests passing. 0 fail.

Full test suite in companion repo: https://github.com/Nibbler1250/skills-tuner-ts


## HTTP Gateway for daemon-style plugins

This PR extends the in-process MCP bridge with HTTP endpoints that let daemon-style plugins (Greg/voice, Archiviste, future cross-process tools) register and serve tools without sharing the Plus daemon address space.

### Endpoints (5)

| Method | Path | Auth | Purpose |
|--------|------|------|---------|
| `POST` | `/api/plugin/register` | Bearer bootstrap | Register manifest + tools |
| `POST` | `/api/plugin/:name/tools/:tool/invoke` | HMAC + 15-min replay | Invoke a tool via callback |
| `DELETE` | `/api/plugin/:name` | Bootstrap or plugin token | Unregister + clean bridge tools |
| `GET` | `/api/plugin/list` | None | List registered plugins with health status |
| `GET` | `/api/plugin/:name/health` | None | Proxy to plugin's health_url |

### Security

- **Bootstrap token**: `~/.config/plus/plugin-bootstrap.secret` (0600, 32 random bytes). Retrieved once via `bun run src/plugins/cli.ts print-bootstrap-token`. Used only for register/unregister — not for invoke.
- **Per-plugin HMAC**: 32-byte secret returned at registration. Every invoke is signed `HMAC-SHA256(secret, ts + "\n" + raw_body)`. Timing-safe comparison.
- **15-minute replay window**: timestamp must be within ±15 min. Clock-skew tolerant, prevents replays.
- **Callback host allowlist**: `localhost`, `127.0.0.1`, `::1` by default. Prevents SSRF to internal services.
- **30-second invoke timeout**: `AbortController` fires after 30s. Plugin dead → 502 clean, daemon unaffected.
- **Standardized error format** with `request_id` for cross-process forensic debugging.

### Graceful degradation throughout

- Audit log fail → stderr fallback, invoke continues
- Plugin unreachable → 502 with clear error, daemon stable
- Malformed manifest → 400 with Zod validation details
- Re-register replaces existing (no separate rotate-token endpoint at v0)

### Deferred to follow-up PRs

| Feature | Reason deferred |
|---------|----------------|
| Hash-chained audit log | No concrete compliance requirement yet |
| Strict capability enforcement | Capability list is declared-only (Tier 2) |
| TLS enforcement | Localhost-only via allowlist at v0 |
| Token rotation endpoint | Re-register covers the use case |

### Integration examples

See `docs/plugin-integration.md` for full Python examples for Greg/voice and Archiviste, including callback handler with HMAC verification.

```python
# Greg quick-start
import requests, hmac, hashlib, json

bootstrap_token = open(os.path.expanduser('~/.config/plus/plugin-bootstrap.secret'), 'rb').read().hex()
resp = requests.post(
    "http://localhost:3000/api/plugin/register",
    headers={"Authorization": f"Bearer {bootstrap_token}"},
    json={
        "name": "greg-voice",
        "version": "1.0.0",
        "schema_version": 1,
        "callback_url": "http://localhost:8765/plus-callback",
        "health_url": "http://localhost:8765/health",
        "tools": [
            {"name": "send_tts", "description": "Play TTS in active call",
             "schema": {"type": "object", "properties": {"text": {"type": "string"}}}},
        ],
        "capabilities": ["tools"],
    },
)
plugin_token_hex = resp.json()["plugin_token"]
```

### New tests (17)

All 17 gateway tests pass. Pre-existing 53 failures unchanged (no regressions).

```bash
bun test src/__tests__/plugins/http-gateway.test.ts
# 17 pass, 0 fail
```

**Full test matrix:**
- register valid → plugin_token returned
- register invalid bootstrap → 401
- register malformed manifest → 400 with Zod errors
- register non-localhost callback → 400 (unless allowedHosts)
- re-register replaces existing + cleans bridge tools
- HMAC tamper → 401 invalid_signature
- stale timestamp >15min → 401 stale_or_future_timestamp
- callback headers verified (X-Plus-Ts, X-Plus-Signature, X-Plus-Request-Id)
- invoke timeout → 502 invoke_failed
- list metadata returned
- health check healthy
- health check unhealthy
- unregister by bootstrap token
- unregister by plugin token
- graceful degradation (audit fail doesn't crash)
- non-plugin path returns null (no interference)
- HMAC tamper detection in invoke path

---

*Companion skill (`mcp.md`) + skills-tuner stack PRs (#39, #40, #41) will follow once this lands.*