### PR TITLE
fix(gateway): deliver agent reply for gateway-routed inbound events

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.22",
+      "version": "2.0.23",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -14,6 +14,8 @@ import { mkdir } from "node:fs/promises";
 import { extname, join, basename, sep } from "node:path";
 import { processEventWithFallback, setGatewayEnabled } from "../gateway";
 import { normalizeDiscordMessage, type NormalizedEvent } from "../gateway/normalizer";
+import type { EventRecord } from "../event-log";
+import type { GatewayRunResult } from "../event-processor";
 import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
 
 // --- Discord API constants ---
@@ -1145,13 +1147,12 @@ async function handleMessageCreate(token: string, message: DiscordMessage, skipC
         return;
       }
 
-      // Deliver response back to Discord
+      // Legacy fallback case: gateway was disabled, the inline legacyHandler ran.
+      // Deliver its stdout immediately. When the gateway is enabled, the response
+      // is delivered asynchronously by deliverGatewayReply via the event processor.
       if (gatewayResult.legacyResult?.stdout) {
         const responseText = gatewayResult.legacyResult.stdout || "Done.";
         await sendMessage(config.token, channelId, responseText);
-      } else {
-        // Gateway path - response will be delivered asynchronously via the event processor
-        await sendMessage(config.token, channelId, "Processing your request...");
       }
       return;
     }
@@ -1751,6 +1752,71 @@ function connectGateway(token: string, url?: string): void {
   ws.onerror = () => {
     // onclose will fire after onerror, reconnection handled there
   };
+}
+
+// --- Gateway delivery ---
+
+/**
+ * Deliver the agent's reply for a gateway-routed inbound Discord event.
+ *
+ * Registered as the Discord gateway delivery hook in start.ts:initDiscord and
+ * invoked by event-processor.ts's gateway onEvent after the agent finishes.
+ * Mirrors the legacy non-gateway delivery path's directive handling (reaction,
+ * image attachments) but without streaming, since the gateway runs the agent
+ * synchronously and only the final stdout is available.
+ */
+export async function deliverGatewayReply(
+  token: string,
+  event: EventRecord,
+  result: GatewayRunResult
+): Promise<void> {
+  const normalizedEvent = (event.payload as any)?.normalizedEvent;
+  if (!normalizedEvent) {
+    console.error(`[gateway-delivery:discord] event ${event.id} has no normalizedEvent`);
+    return;
+  }
+
+  const rawChannelId = String(normalizedEvent.channelId ?? "");
+  // Discord channelId format: "discord:dm:<channelId>" or "discord:guild:<guildId>:<channelId>"
+  const match = rawChannelId.match(/^discord:(?:dm:(\d+)|guild:\d+:(\d+))$/);
+  if (!match) {
+    console.error(`[gateway-delivery:discord] cannot parse channelId from "${rawChannelId}"`);
+    return;
+  }
+  const channelId = match[1] || match[2];
+
+  const sourceMessageId = normalizedEvent.sourceEventId ? String(normalizedEvent.sourceEventId) : null;
+  const label = `channel ${channelId}`;
+
+  if (result.exitCode !== 0) {
+    const errorMsg = `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`;
+    await sendMessage(token, channelId, errorMsg);
+    return;
+  }
+
+  const { cleanedText, reactionEmoji } = extractReactionDirective(result.stdout || "");
+
+  if (reactionEmoji && sourceMessageId) {
+    await sendReaction(token, channelId, sourceMessageId, reactionEmoji).catch((err) => {
+      console.error(`[gateway-delivery:discord] reaction failed for ${label}: ${err instanceof Error ? err.message : err}`);
+    });
+  }
+
+  const settings = getSettings();
+  // Use the inbound event's timestamp as the lower bound for "images generated during this request" —
+  // ingest time is strictly before the agent ran, so any image created during the run will pass.
+  const requestStartedAt = new Date(event.timestamp).getTime();
+  const { paths: imagePaths, cleanedText: finalText } = extractImagePaths(
+    cleanedText || "",
+    settings.discord.imageOutputRoots,
+    requestStartedAt,
+  );
+
+  if (imagePaths.length > 0) {
+    await sendMessageWithImages(token, channelId, finalText || "(empty response)", imagePaths);
+  } else {
+    await sendMessage(token, channelId, finalText || "(empty response)");
+  }
 }
 
 // --- Exports ---

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -5,7 +5,7 @@ import { extractErrorDetail } from "../messaging";
 import { join } from "path";
 import { fileURLToPath } from "url";
 import { run, runUserMessage, streamUserMessage, bootstrap, ensureProjectClaudeMd, loadHeartbeatPromptTemplate, isRateLimited, getRateLimitResetAt, wasRateLimitNotified, markRateLimitNotified } from "../runner";
-import { initGatewayProcessor } from "../event-processor";
+import { initGatewayProcessor, registerGatewayDelivery, unregisterGatewayDelivery } from "../event-processor";
 import { writeState, type StateData } from "../statusline";
 import { cronMatches, nextCronMatch } from "../cron";
 import { clearJobSchedule, loadJobs, resolveJobModel, snapshotJobFrontmatter } from "../jobs";
@@ -451,11 +451,13 @@ export async function start(args: string[] = []) {
 
   async function initTelegram(token: string, receiveEnabled = true) {
     if (token && token !== telegramToken) {
-      const { startPolling, sendMessage } = await import("./telegram");
+      const { startPolling, sendMessage, deliverGatewayReply } = await import("./telegram");
       if (receiveEnabled) startPolling(debugFlag);
       telegramSend = (chatId, text) => sendMessage(token, chatId, text);
       telegramToken = token;
       telegramReceiveEnabled = receiveEnabled;
+      // Register the outbound delivery hook so gateway-routed events get a reply.
+      registerGatewayDelivery("telegram", (event, result) => deliverGatewayReply(token, event, result));
       console.log(`[${ts()}] Telegram: enabled${receiveEnabled ? "" : " (send-only)"}`);
     } else if (token && token === telegramToken && receiveEnabled !== telegramReceiveEnabled) {
       const { startPolling, stopPolling } = await import("./telegram");
@@ -470,6 +472,7 @@ export async function start(args: string[] = []) {
     } else if (!token && telegramToken) {
       telegramSend = null;
       telegramToken = "";
+      unregisterGatewayDelivery("telegram");
       console.log(`[${ts()}] Telegram: disabled`);
     }
   }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -490,18 +490,21 @@ export async function start(args: string[] = []) {
 
   async function initDiscord(token: string) {
     if (token && token !== discordToken) {
-      const { startGateway, sendMessageToUser, stopGateway } = await import("./discord");
+      const { startGateway, sendMessageToUser, stopGateway, deliverGatewayReply } = await import("./discord");
       if (discordToken) stopGateway();
       startGateway(debugFlag);
       discordStopGateway = stopGateway;
       discordSendToUser = (userId, text) => sendMessageToUser(token, userId, text);
       discordToken = token;
+      // Register the outbound delivery hook so gateway-routed events get a reply.
+      registerGatewayDelivery("discord", (event, result) => deliverGatewayReply(token, event, result));
       console.log(`[${ts()}] Discord: enabled`);
     } else if (!token && discordToken) {
       if (discordStopGateway) discordStopGateway();
       discordStopGateway = null;
       discordSendToUser = null;
       discordToken = "";
+      unregisterGatewayDelivery("discord");
       console.log(`[${ts()}] Discord: disabled`);
     }
   }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -14,6 +14,8 @@ import { fireJob, parseFireArgs } from "./fire";
 import { extname, join } from "node:path";
 import { submitTelegramToGateway } from "../gateway";
 import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
+import type { EventRecord } from "../event-log";
+import type { GatewayRunResult } from "../event-processor";
 
 // --- Outbox sandbox for send-file / voice directives ---
 
@@ -1817,6 +1819,96 @@ async function poll(generation: number): Promise<void> {
   }
 
   if (pollingGeneration === generation) isPolling = false;
+}
+
+// --- Gateway delivery ---
+
+/**
+ * Deliver the agent's reply for a gateway-routed inbound Telegram event.
+ *
+ * Registered as the Telegram gateway delivery hook in start.ts:initTelegram and
+ * invoked by event-processor.ts's gateway onEvent after the agent finishes.
+ * Mirrors the legacy non-gateway delivery path's directive pipeline
+ * (reaction → voice → file → buttons), minus streaming concerns — the gateway
+ * runs the agent synchronously and only the final stdout is available.
+ */
+export async function deliverGatewayReply(
+  token: string,
+  event: EventRecord,
+  result: GatewayRunResult
+): Promise<void> {
+  const normalizedEvent = (event.payload as any)?.normalizedEvent;
+  if (!normalizedEvent) {
+    console.error(`[gateway-delivery:telegram] event ${event.id} has no normalizedEvent`);
+    return;
+  }
+
+  const channelId = String(normalizedEvent.channelId ?? "");
+  const chatMatch = channelId.match(/^telegram:(-?\d+)$/);
+  if (!chatMatch) {
+    console.error(`[gateway-delivery:telegram] cannot parse chatId from "${channelId}"`);
+    return;
+  }
+  const chatId = Number(chatMatch[1]);
+
+  const threadIdRaw = normalizedEvent.threadId;
+  const threadId = threadIdRaw && threadIdRaw !== "default" && /^-?\d+$/.test(String(threadIdRaw))
+    ? Number(threadIdRaw)
+    : undefined;
+
+  const sourceMessageId = normalizedEvent.sourceEventId && /^-?\d+$/.test(String(normalizedEvent.sourceEventId))
+    ? Number(normalizedEvent.sourceEventId)
+    : null;
+
+  const label = `chat ${chatId}`;
+
+  if (result.exitCode !== 0) {
+    const isTimedOut = result.exitCode === 124;
+    const errorMsg = isTimedOut
+      ? `⏱ Request timed out — the subprocess took too long and was killed. Try again or split into smaller steps.`
+      : `Error (exit ${result.exitCode}): ${extractErrorDetail(result) || "Unknown error"}`;
+    await sendMessage(token, chatId, errorMsg, threadId);
+    return;
+  }
+
+  const { cleanedText: afterReact, reactionEmoji } = extractReactionDirective(result.stdout || "");
+  const hadVoiceDirective = /\[voice:\/[^\]\r\n]+\]/i.test(afterReact);
+  const { cleanedText: afterVoice, voicePaths } = extractVoiceDirectives(afterReact);
+  const { cleanedText: afterFile, filePaths } = extractSendFileDirectives(afterVoice);
+  const { cleanedText, buttonRows } = extractButtonsDirective(afterFile);
+
+  if (reactionEmoji && sourceMessageId !== null) {
+    await sendReaction(token, chatId, sourceMessageId, reactionEmoji).catch((err) => {
+      console.error(`[gateway-delivery:telegram] reaction failed for ${label}: ${err instanceof Error ? err.message : err}`);
+    });
+  }
+
+  for (const vp of voicePaths) {
+    try {
+      await sendVoiceMessage(token, chatId, vp, threadId);
+    } catch (err) {
+      console.error(`[gateway-delivery:telegram] voice send failed for ${label}: ${err instanceof Error ? err.message : err}`);
+    }
+  }
+
+  if (buttonRows) {
+    await sendMessageWithButtons(token, chatId, cleanedText, buttonRows, threadId);
+  } else if (cleanedText) {
+    await sendMessage(token, chatId, cleanedText, threadId);
+  }
+
+  for (const fp of filePaths) {
+    try {
+      await sendDocumentToChat(token, chatId, fp, threadId);
+    } catch (err) {
+      console.error(`[gateway-delivery:telegram] document send failed for ${label}: ${err instanceof Error ? err.message : err}`);
+      await sendMessage(token, chatId, `Failed to send file: ${fp.split("/").pop()}`, threadId);
+    }
+  }
+
+  if (!cleanedText && !buttonRows && filePaths.length === 0 && voicePaths.length === 0 && !hadVoiceDirective) {
+    await sendMessage(token, chatId, "(empty response)", threadId);
+  }
 }
 
 // --- Exports ---

--- a/src/event-processor.ts
+++ b/src/event-processor.ts
@@ -69,6 +69,33 @@ let processorConfig: ProcessorConfig | null = null;
 let isProcessing = false;
 let lastProcessedSeq = 0;
 
+// Gateway outbound delivery.
+//
+// The gateway path serializes inbound platform messages against a single persistent
+// session — in-order processing with dedup via the durable event log, opposed to the
+// legacy fork-per-message path that races concurrent messages from the same user.
+// When a per-adapter gateway flag (e.g. USE_GATEWAY_TELEGRAM) is set, the adapter
+// hands the inbound to its submit*ToGateway helper and returns; this processor's
+// onEvent runs the agent.
+//
+// Adapters register an outbound delivery callback here so the agent's reply reaches
+// the chat. Invocation happens inside the serial onEvent, preserving inbound order.
+//
+// Delivery failures log but do NOT fail/retry the event: a retry would re-run the
+// agent (expensive) and would either block the queue head or risk double-send if a
+// first delivery partially landed. Delivery health needs separate monitoring.
+export type GatewayRunResult = { exitCode: number; stdout: string; stderr: string };
+export type GatewayDeliveryFn = (event: EventRecord, result: GatewayRunResult) => Promise<void>;
+const gatewayDeliveryHooks = new Map<string, GatewayDeliveryFn>();
+
+export function registerGatewayDelivery(source: string, fn: GatewayDeliveryFn): void {
+  gatewayDeliveryHooks.set(source, fn);
+}
+
+export function unregisterGatewayDelivery(source: string): void {
+  gatewayDeliveryHooks.delete(source);
+}
+
 /**
  * Initialize the event processor.
  * Loads or creates dedupe state.
@@ -469,6 +496,17 @@ export async function initGatewayProcessor(
 
         const source = event.source || normalizedEvent.channel;
         const result = await processFn(source, prompt);
+
+        // Dispatch outbound delivery for this source. See the block comment above
+        // gatewayDeliveryHooks for queue-ordering and no-retry rationale.
+        const deliveryHook = gatewayDeliveryHooks.get(source);
+        if (deliveryHook) {
+          try {
+            await deliveryHook(event, result);
+          } catch (err) {
+            console.error(`[gateway-delivery] ${source} delivery failed: ${err instanceof Error ? err.message : String(err)}`);
+          }
+        }
 
         return {
           success: result.exitCode === 0,


### PR DESCRIPTION
Fixes #44.

## Summary

When a per-adapter gateway flag (`USE_GATEWAY_TELEGRAM=true` or `USE_GATEWAY_DISCORD=true`) is set, inbound messages are received, normalized, policy-allowed, the agent runs, and the event is marked `done` — but the reply is never sent back to the chat. The directive-parsing + `sendMessage` block in the legacy branch is bypassed, and the gateway's `onEvent` only checks `exitCode` without reading `stdout`. For Discord, the gateway branch instead sends a stub "Processing your request..." and relies on async delivery that never happens. From the user's side, the bot silently stops replying once the gateway is enabled, which is the documented way to opt into queued single-session semantics.

## Approach

Add a per-source outbound delivery hook registry in `event-processor.ts`:

- `registerGatewayDelivery(source, fn)` / `unregisterGatewayDelivery(source)` — adapters register a callback.
- `initGatewayProcessor`'s `onEvent` invokes the registered hook after each agent run, **inside the serial `onEvent`**, so deliveries preserve inbound order against the queue.
- Delivery failures log but do **not** fail/retry the event. A retry would re-run the agent (expensive) and would either block the queue head or risk double-send if a first delivery partially landed. Delivery health needs separate monitoring — same trade-off pattern as other at-least-once delivery seams.

Telegram delivery (`commands/telegram.ts`):

- `deliverGatewayReply(token, event, result)` mirrors the legacy path's directive pipeline (reaction → voice → file → buttons), minus streaming concerns since the gateway runs the agent synchronously and only the final stdout is available.
- `commands/start.ts:initTelegram` registers the hook when the token is set; unregisters on teardown.

Discord delivery (`commands/discord.ts`):

- `deliverGatewayReply(token, event, result)` parses both DM (`discord:dm:<id>`) and guild (`discord:guild:<g>:<c>`) channelId forms, then runs the legacy path's directive handling (reaction + image attachments).
- Uses `event.timestamp` (inbound ingest time, strictly before the agent ran) as the lower bound for `extractImagePaths` to decide which generated files are valid for this request.
- `commands/start.ts:initDiscord` registers / unregisters the hook with the same shape as Telegram.
- The "Processing your request..." stub in the Discord gateway branch is removed — it was a placeholder for the async delivery that didn't exist; with the hook in place it would just be UX noise above the real reply. The legacy-fallback delivery line is kept; its incomplete directive handling is a separate concern not in scope here.

Slack / Teams adapters can plug into the same registry — left for follow-up since I don't have a deployment of either to test against.

## Testing

Manual end-to-end against a live Telegram bot with `USE_GATEWAY=true USE_GATEWAY_TELEGRAM=true`:

- Plain-text reply: delivered ✓
- Reaction directive (`[react:🐾]` via the `claudeclaw-plus:telegram-react` skill): emoji reaction lands on the source message, text reply lands without the directive tag ✓
- Error path (forced non-zero exit): error message lands in chat ✓
- In-order delivery for rapid-fire messages from the same chat: preserved (verified via serial `onEvent` invocation) ✓

Voice / file / buttons paths (Telegram) and image paths (Discord) share code with the legacy branch and pass `tsc --noEmit`; not exercised end-to-end in this round. Discord end-to-end not exercised — review focus appreciated there.

## Files

- `src/event-processor.ts` — delivery hook registry + invocation in `initGatewayProcessor`'s `onEvent`
- `src/commands/telegram.ts` — `deliverGatewayReply()` + export
- `src/commands/discord.ts` — `deliverGatewayReply()` + export, "Processing..." stub removed
- `src/commands/start.ts` — register / unregister the hook in `initTelegram` and `initDiscord`

## Note on scope

Per CONTRIBUTING.md, small bug fixes typically belong at `moazbuilds/claudeclaw`. This one touches Plus-specific infrastructure (`event-processor.ts`, the durable event log, policy-gated gateway), and #44 was opened here — happy to redirect if you'd prefer it land upstream and be merged down.