### PR TITLE
fix: stop crash + suppress memory-search startup noise

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.22",
+      "version": "2.0.23",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/commands/stop.ts
+++ b/src/commands/stop.ts
@@ -3,7 +3,7 @@ import { join } from "path";
 import { homedir } from "os";
 import { getPidPath, cleanupPidFile } from "../pid";
 import { getSession } from "../sessions";
-import { getSettings, type SecurityConfig } from "../config";
+import { loadSettings, type SecurityConfig } from "../config";
 import { getMemoryPath } from "../memory";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
@@ -31,7 +31,7 @@ async function preShutdownMemorySave(): Promise<void> {
   const session = await getSession();
   if (!session) return;
 
-  const settings = getSettings();
+  const settings = await loadSettings();
   const memPath = getMemoryPath();
   console.log(`[shutdown] Saving memory to ${memPath}...`);
 

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -265,7 +265,7 @@ export function indexSessionsBackground(opts?: MemorySearchSettings): void {
   if (opts?.enabled === false) return;
   const check = checkMemorySearchBin(opts);
   if (!check.ok) {
-    console.log(`[memory-search] ${check.reason}`);
+    console.debug(`[memory-search] ${check.reason}`);
     return;
   }
   const proc = spawn(check.bin, ["index"], {


### PR DESCRIPTION
Two small bug fixes found during a fresh install on Linux (Fedora).

**Fix 1 — `stop` command crashes with "Settings not loaded"**

`preShutdownMemorySave()` in `commands/stop.ts` calls `getSettings()` which requires the settings cache to be populated first. When invoked via `claudeclaw stop`, `loadSettings()` has never been called, so it always throws.

Changed `getSettings()` → `await loadSettings()` which loads and returns in one call.

- `src/commands/stop.ts:6` — import `loadSettings` instead of `getSettings`
- `src/commands/stop.ts:34` — `const settings = await loadSettings()`

**Fix 2 — memory-search "binary not installed" logs on every boot**

`indexSessionsBackground()` in `memory.ts` uses `console.log` when the optional `memory-search` binary isn't installed. This prints a noisy setup hint on every daemon start for users who haven't installed the optional Python tooling.

Changed to `console.debug` — still accessible with debug logging, invisible in normal output.

- `src/memory.ts:268` — `console.log` → `console.debug`

Both changes are one-liners, no behavior change beyond the fix. Tested locally on Linux (Fedora, kernel 6.19).