### PR TITLE
feat(skills-tuner): align defaults with standard discovery paths

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.22",
+      "version": "2.0.25",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.22",
+  "version": "2.0.25",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/skills-tuner-config.test.ts
+++ b/src/__tests__/skills-tuner-config.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
+import {
+  DEFAULT_SKILLS_DIR,
+  DEFAULT_SYSTEMD_USER_DIR,
+  DEFAULT_CRONTAB_DIR,
+  SUBJECT_STANDARD_PATHS,
+  subjectConfig,
+  isStandardPath,
+  loadConfig,
+} from "../skills-tuner/core/config";
+
+describe("skills-tuner config — standard discovery paths (issue #52)", () => {
+  describe("DEFAULT_* constants", () => {
+    it("skills points at Anthropic Skills global path", () => {
+      expect(DEFAULT_SKILLS_DIR).toBe(join(homedir(), ".claude", "skills"));
+    });
+
+    it("systemd points at XDG user units path", () => {
+      expect(DEFAULT_SYSTEMD_USER_DIR).toBe(join(homedir(), ".config", "systemd", "user"));
+    });
+
+    it("crontab points at XDG-config sidecar", () => {
+      expect(DEFAULT_CRONTAB_DIR).toBe(join(homedir(), ".config", "cron"));
+    });
+  });
+
+  describe("SUBJECT_STANDARD_PATHS mapping", () => {
+    it("maps skills subject to anthropic global path", () => {
+      expect(SUBJECT_STANDARD_PATHS["skills"]?.git_repo).toBe(DEFAULT_SKILLS_DIR);
+      expect(SUBJECT_STANDARD_PATHS["skills"]?.scan_dirs).toContain(DEFAULT_SKILLS_DIR);
+    });
+
+    it("maps wisecron to systemd user dir", () => {
+      expect(SUBJECT_STANDARD_PATHS["wisecron"]?.git_repo).toBe(DEFAULT_SYSTEMD_USER_DIR);
+    });
+
+    it("maps cron to XDG-config sidecar", () => {
+      expect(SUBJECT_STANDARD_PATHS["cron"]?.git_repo).toBe(DEFAULT_CRONTAB_DIR);
+    });
+  });
+
+  describe("subjectConfig — default injection", () => {
+    const emptyConfig = {
+      models: {} as any,
+      llm: {} as any,
+      detection: {} as any,
+      proposer: {} as any,
+      subjects: {},
+      ui: {} as any,
+      storage: { schema_version: 1, proposals_jsonl: "", refused_jsonl: "", backup_keep: 7 } as any,
+    } as any;
+
+    it("returns standard git_repo for skills when not configured", () => {
+      const cfg = subjectConfig(emptyConfig, "skills");
+      expect(cfg.git_repo).toBe(DEFAULT_SKILLS_DIR);
+    });
+
+    it("returns standard git_repo for wisecron when not configured", () => {
+      const cfg = subjectConfig(emptyConfig, "wisecron");
+      expect(cfg.git_repo).toBe(DEFAULT_SYSTEMD_USER_DIR);
+    });
+
+    it("returns standard scan_dirs for skills when empty", () => {
+      const cfg = subjectConfig(emptyConfig, "skills");
+      expect(cfg.scan_dirs).toEqual([DEFAULT_SKILLS_DIR]);
+    });
+
+    it("user override wins over default git_repo", () => {
+      const userCfg = {
+        ...emptyConfig,
+        subjects: {
+          skills: { enabled: true, auto_merge: false, scan_dirs: [], git_repo: "/custom/path" },
+        },
+      };
+      const cfg = subjectConfig(userCfg, "skills");
+      expect(cfg.git_repo).toBe("/custom/path");
+    });
+
+    it("user scan_dirs win when non-empty", () => {
+      const userCfg = {
+        ...emptyConfig,
+        subjects: {
+          skills: { enabled: true, auto_merge: false, scan_dirs: ["/a", "/b"] },
+        },
+      };
+      const cfg = subjectConfig(userCfg, "skills");
+      expect(cfg.scan_dirs).toEqual(["/a", "/b"]);
+    });
+
+    it("unknown subject without standard returns user config unmodified", () => {
+      const userCfg = {
+        ...emptyConfig,
+        subjects: {
+          custom: { enabled: true, auto_merge: false, scan_dirs: [], git_repo: "/x" },
+        },
+      };
+      const cfg = subjectConfig(userCfg, "custom");
+      expect(cfg.git_repo).toBe("/x");
+    });
+
+    it("TUNER_DISABLE_STANDARD_DEFAULTS=1 bypasses default injection", () => {
+      const prev = process.env.TUNER_DISABLE_STANDARD_DEFAULTS;
+      process.env.TUNER_DISABLE_STANDARD_DEFAULTS = "1";
+      try {
+        const cfg = subjectConfig(emptyConfig, "skills");
+        expect(cfg.git_repo).toBeUndefined();
+        expect(cfg.scan_dirs).toEqual([]);
+      } finally {
+        if (prev === undefined) delete process.env.TUNER_DISABLE_STANDARD_DEFAULTS;
+        else process.env.TUNER_DISABLE_STANDARD_DEFAULTS = prev;
+      }
+    });
+  });
+
+  describe("isStandardPath", () => {
+    it("returns true for canonical skills path", () => {
+      expect(isStandardPath("skills", DEFAULT_SKILLS_DIR)).toBe(true);
+    });
+
+    it("returns false for non-canonical skills path", () => {
+      expect(isStandardPath("skills", "/home/user/agent/skills")).toBe(false);
+    });
+
+    it("returns false for unknown subject", () => {
+      expect(isStandardPath("unknown", DEFAULT_SKILLS_DIR)).toBe(false);
+    });
+
+    it("returns false for undefined path", () => {
+      expect(isStandardPath("skills", undefined)).toBe(false);
+    });
+  });
+
+  describe("loadConfig — tilde expansion + scan_dirs", () => {
+    let tmp: string;
+
+    beforeEach(() => {
+      tmp = mkdtempSync(join(tmpdir(), "tuner-test-"));
+    });
+
+    afterEach(() => {
+      rmSync(tmp, { recursive: true, force: true });
+    });
+
+    it("expands ~ in scan_dirs entries (was missing in previous version)", () => {
+      const cfgPath = join(tmp, "config.yaml");
+      writeFileSync(
+        cfgPath,
+        `subjects:
+  skills:
+    scan_dirs:
+      - ~/some-skill-dir
+      - /absolute/path
+`,
+        "utf8",
+      );
+      const c = loadConfig(cfgPath);
+      const skills = c.subjects["skills"]!;
+      expect(skills.scan_dirs).toContain(join(homedir(), "some-skill-dir"));
+      expect(skills.scan_dirs).toContain("/absolute/path");
+    });
+
+    it("returns empty parsed config when file missing", () => {
+      const c = loadConfig(join(tmp, "absent.yaml"));
+      expect(c.subjects).toEqual({});
+    });
+  });
+});

--- a/src/__tests__/skills-tuner-config.test.ts
+++ b/src/__tests__/skills-tuner-config.test.ts
@@ -168,3 +168,16 @@ describe("skills-tuner config — standard discovery paths (issue #52)", () => {
     });
   });
 });
+
+import { SkillsSubject } from '../skills-tuner/subjects/skills';
+
+describe('SkillsSubject constructor — uses standard default', () => {
+  it('falls back to DEFAULT_SKILLS_DIR when scanDirs omitted', () => {
+    const subject = new SkillsSubject({});
+    // Reach into the instance via type assertion — constructor default is the
+    // observable contract here. If the field is renamed or made private+inaccessible,
+    // expose a getter rather than reverting the assertion.
+    const scanDirs = (subject as unknown as { scanDirs: string[] }).scanDirs;
+    expect(scanDirs).toEqual([DEFAULT_SKILLS_DIR]);
+  });
+});

--- a/src/skills-tuner-templates/tuner.md
+++ b/src/skills-tuner-templates/tuner.md
@@ -74,11 +74,19 @@ Ask if they want to proceed (yes/no). If no, exit gracefully.
 
 ### Step 2 — Detect the git repo
 
-Scan candidate locations:
-- `~/agent/skills`
-- `~/.claude/skills`
-- `~/skills`
-- `~/.config/claude/skills`
+The **standard skills path** is `~/.claude/skills/` — the canonical Anthropic Skills
+discovery directory read by Claude Code and the ClaudeClaw-Plus daemon. If you ran
+`tuner setup` from the CLI, this directory already exists and is git-initialized.
+
+**Preferred flow** (zero config): use `~/.claude/skills/` and skip to Step 3.
+
+**Legacy installs**: scan for older custom directories and offer to migrate. Candidate
+locations to check (priority order):
+
+- `~/.claude/skills`         ← standard, default
+- `~/agent/skills`           ← legacy
+- `~/skills`                 ← legacy
+- `~/.config/claude/skills`  ← legacy
 
 For each existing path, run:
 - `test -d "$path/.git" && echo "git: yes" || echo "git: no"`
@@ -88,18 +96,21 @@ For each existing path, run:
 Show the user a table:
 
 ```
-Found candidate directories:
-  1. ~/agent/skills          12 skills, git: yes, lang: english
-  2. ~/.claude/skills          3 skills, git: no,  lang: french
-  3. ~/skills                  not found
+Found skill directories:
+  1. ~/.claude/skills    50 skills, git: yes, lang: english   ← standard
+  2. ~/agent/skills      48 skills, git: yes, lang: english   ← legacy
 
-Which one should be your tunable surface? [1/2/3/other]
+Use ~/.claude/skills as your tunable surface? [Y/n]
 ```
 
-If user picks one without git → run `git init -b main` + initial commit.
-If user picks `other` → ask path → init if needed.
+If user picks a non-standard directory → warn that it bypasses Claude Code's
+discovery path and may require manual symlinks. Offer to skip.
 
-Save the choice as `storage.git_repo` in config.
+If user picks the standard but it has no git → run `git init -b main` + initial commit.
+
+Save the choice as `storage.git_repo` in config. Per-subject `git_repo` defaults to
+the standard path automatically when omitted — see "Where artifacts land" in the
+skills-tuner README.
 
 ### Step 2.5 — Scan for legacy flat skills and offer migration
 

--- a/src/skills-tuner/README.md
+++ b/src/skills-tuner/README.md
@@ -106,7 +106,7 @@ tuner skip 2
 | `revert` | `<id>` | Revert an applied proposal via `git revert` |
 | `feedback` | `<id> <yes\|yes-but\|no>` | Record preference feedback |
 | `stats` | — | Show created / applied / refused counts |
-| `setup` | — | First-run wizard: copy skill template + generate config |
+| `setup` | — | First-run wizard: init standard paths (~/.claude/skills, etc.) + copy skill + generate config |
 
 Duration format: `30s`, `10m`, `24h`, `7d`.
 
@@ -119,6 +119,33 @@ Duration format: `30s`, `10m`, `24h`, `7d`.
 | `skills` | Parses `.md` skill files, detects stale triggers, missing examples, weak descriptions |
 | `voice` | Detects repeated phrasing patterns in voice transcripts |
 | `external_process` | Spawns any Python/binary over stdio JSON-RPC — plug in Optuna, custom ML, etc. |
+
+---
+
+
+---
+
+## Where artifacts land
+
+Per-subject defaults resolve to the **standard discovery paths** read by the consuming
+runtime — no custom directories, no symlinks. Skills produced by the tuner are visible
+to Claude Code and the ClaudeClaw-Plus daemon out of the box.
+
+| Subject | Default `git_repo` | Standard |
+|---|---|---|
+| `skills` | `~/.claude/skills/` | Anthropic Skills discovery path |
+| `wisecron` | `~/.config/systemd/user/` | XDG path for systemd user units |
+| `cron` | `~/.config/cron/` | XDG-config sidecar for `crontab -l` snapshot |
+| _tuner state_ | `~/.config/tuner/` | proposals.jsonl, refused.jsonl, .secret |
+
+`tuner setup` creates each path, runs `git init`, snapshots `crontab -l` if non-empty,
+and installs the `/tuner` skill in Anthropic dir-format (`<name>/SKILL.md`).
+
+`tuner doctor` verifies the configured `git_repo` for each enabled subject matches the
+standard path, and warns if it diverges (set `git_repo:` explicitly in `config.yaml` to
+opt out of the warning if you have a deliberate non-standard target).
+
+Override any default by setting `subjects.<name>.git_repo` in `~/.config/tuner/config.yaml`.
 
 ---
 

--- a/src/skills-tuner/README.md
+++ b/src/skills-tuner/README.md
@@ -216,20 +216,25 @@ The script backs up the original file to `proposals.jsonl.python-backup-<timesta
 Each subject can declare its own git repository in `~/.config/tuner/config.yaml`:
 
 ```yaml
+# 'skills' subject defaults resolve to the standard Anthropic discovery path
+# (~/.claude/skills/) when omitted. Override only for non-standard layouts.
+
 storage:
-  git_repo: ~/agent/skills        # default fallback
+  # Top-level fallback for any subject without its own git_repo.
+  # Subjects with a SUBJECT_STANDARD_PATHS entry resolve to that instead.
+  git_repo: ~/.claude/skills
 
 subjects:
   skills:
     enabled: true
-    git_repo: ~/agent/skills      # explicit (matches default here)
+    # git_repo defaults to ~/.claude/skills (Anthropic Skills discovery path)
+    # scan_dirs defaults to [~/.claude/skills]
     auto_merge: [patch, frontmatter]
-    scan_dirs: [~/agent/skills]
   voice:
     enabled: true
-    git_repo: ~/agent/voice-config  # different repo for voice
+    git_repo: ~/.config/voice-config  # explicit, no standard mapping for 'voice' yet
     auto_merge: false
-    scan_dirs: [~/agent/voice-config/lexicons]
+    scan_dirs: [~/.config/voice-config/lexicons]
   trader-ml-hp:
     enabled: true
     git_repo: ~/Projects/momentum_trader_v7  # trader's own repo

--- a/src/skills-tuner/cli/index.ts
+++ b/src/skills-tuner/cli/index.ts
@@ -54,6 +54,29 @@ program
       check('storage.git_repo configured', false, 'not set in config');
     }
 
+    // 2b. Per-subject git_repo alignment with standard discovery paths (issue #52)
+    if (config) {
+      const { subjectConfig, isStandardPath, SUBJECT_STANDARD_PATHS } =
+        await import('../core/config.js');
+      for (const name of Object.keys(SUBJECT_STANDARD_PATHS)) {
+        const sub = subjectConfig(config, name);
+        if (!sub.enabled) continue;
+        const standard = SUBJECT_STANDARD_PATHS[name]?.git_repo;
+        if (sub.git_repo && standard) {
+          const aligned = isStandardPath(name, sub.git_repo);
+          if (aligned) {
+            check(`Subject ${name} git_repo on standard path`, true, sub.git_repo);
+          } else {
+            check(
+              `Subject ${name} git_repo on standard path`,
+              false,
+              `${sub.git_repo} ≠ ${standard} — run 'tuner setup' to align or override intentionally`,
+            );
+          }
+        }
+      }
+    }
+
     // 3. .secret exists + 32 bytes + 0600 perms
     const secretExists = existsSync(secretPath);
     check('Secret file exists', secretExists, secretPath);
@@ -280,17 +303,85 @@ program
 // ── setup ─────────────────────────────────────────────────────────────────────────────
 program
   .command('setup')
-  .description('First-run wizard — copies /tuner skill, generates config')
+  .description('First-run wizard — initializes standard discovery paths, copies /tuner skill, generates config')
   .action(async () => {
     const home = homedir();
-    const skillsDir = join(home, '.claude', 'skills');
-    const targetSkill = join(skillsDir, 'tuner.md');
+    const { mkdirSync, copyFileSync, writeFileSync } = await import('node:fs');
+    const { execSync } = await import('node:child_process');
+    const {
+      DEFAULT_SKILLS_DIR,
+      DEFAULT_SYSTEMD_USER_DIR,
+      DEFAULT_CRONTAB_DIR,
+    } = await import('../core/config.js');
 
+    function ensureGitRepo(dir: string, label: string, initFn?: () => void): void {
+      mkdirSync(dir, { recursive: true });
+      if (initFn) initFn();
+      if (!existsSync(join(dir, '.git'))) {
+        try {
+          execSync('git init', { cwd: dir, stdio: 'pipe' });
+          // Commit only if there is content to track (avoids empty-repo first commit).
+          const entries = readdirSync(dir).filter(f => f !== '.git');
+          if (entries.length > 0) {
+            execSync('git add -A', { cwd: dir, stdio: 'pipe' });
+            execSync(
+              `git -c user.name=tuner -c user.email=tuner@localhost commit -m "init: ${label} tracker"`,
+              { cwd: dir, stdio: 'pipe' },
+            );
+          }
+          console.log(`✅ Initialized git repo: ${dir}`);
+        } catch (e: unknown) {
+          console.warn(
+            `⚠️  Could not init git repo at ${dir}: ${e instanceof Error ? e.message : String(e)}`,
+          );
+        }
+      } else {
+        console.log(`ℹ️  Already a git repo: ${dir}`);
+      }
+    }
+
+    // 1. Skills standard dir (~/.claude/skills/) — Anthropic Skills discovery path.
+    ensureGitRepo(DEFAULT_SKILLS_DIR, 'tuned skills');
+
+    // 2. systemd user units (~/.config/systemd/user/) — only if dir already populated,
+    //    otherwise skip silently (systems without systemd or empty installs).
+    if (existsSync(DEFAULT_SYSTEMD_USER_DIR)) {
+      const units = readdirSync(DEFAULT_SYSTEMD_USER_DIR).filter(f =>
+        f.endsWith('.service') || f.endsWith('.timer'),
+      );
+      if (units.length > 0) {
+        ensureGitRepo(DEFAULT_SYSTEMD_USER_DIR, 'systemd user units (wisecron target)');
+      } else {
+        console.log(`ℹ️  Skipping ${DEFAULT_SYSTEMD_USER_DIR} — no unit files`);
+      }
+    } else {
+      console.log(`ℹ️  Skipping ${DEFAULT_SYSTEMD_USER_DIR} — directory absent`);
+    }
+
+    // 3. POSIX crontab sidecar (~/.config/cron/) — snapshot only if user has a crontab.
+    ensureGitRepo(DEFAULT_CRONTAB_DIR, 'user crontab snapshot', () => {
+      const snapshotPath = join(DEFAULT_CRONTAB_DIR, 'crontab.snapshot');
+      if (existsSync(snapshotPath)) return;
+      try {
+        const out = execSync('crontab -l', { stdio: ['pipe', 'pipe', 'pipe'] }).toString();
+        writeFileSync(snapshotPath, out, 'utf8');
+        console.log(`✅ Snapshotted crontab → ${snapshotPath}`);
+      } catch {
+        // No crontab or crontab not installed — write empty placeholder so git repo has content.
+        writeFileSync(
+          snapshotPath,
+          '# No active crontab when this snapshot was created.\n# Re-run `tuner setup` after adding entries.\n',
+          'utf8',
+        );
+      }
+    });
+
+    // 4. Tuner skill — install as Anthropic dir-format (<name>/SKILL.md), not flat .md.
+    const skillDir = join(DEFAULT_SKILLS_DIR, 'tuner');
+    const targetSkill = join(skillDir, 'SKILL.md');
     if (!existsSync(targetSkill)) {
       const { fileURLToPath } = await import('node:url');
       const __dirname = resolve(fileURLToPath(import.meta.url), '..');
-      // Resolve template across contexts: skills-tuner-ts standalone (templates/skills/) OR
-      // Plus integration context (src/skills-tuner-templates/)
       const candidates = [
         join(__dirname, '..', '..', 'templates', 'skills', 'tuner.md'),
         join(__dirname, '..', '..', '..', 'templates', 'skills', 'tuner.md'),
@@ -299,28 +390,34 @@ program
       ];
       const templateSrc = candidates.find(p => existsSync(p)) ?? candidates[0]!;
       if (existsSync(templateSrc)) {
-        const { mkdirSync, copyFileSync } = await import('node:fs');
-        mkdirSync(skillsDir, { recursive: true });
+        mkdirSync(skillDir, { recursive: true });
         copyFileSync(templateSrc, targetSkill);
-        console.log(`✅ Copied tuner skill to ${targetSkill}`);
+        console.log(`✅ Installed tuner skill → ${targetSkill}`);
       } else {
         console.warn(`⚠️  Template not found at ${templateSrc} — skipping skill copy`);
       }
     } else {
-      console.log(`ℹ️  Skill already exists: ${targetSkill}`);
+      console.log(`ℹ️  Tuner skill already installed: ${targetSkill}`);
     }
 
+    // 5. Tuner config (~/.config/tuner/config.yaml).
     const configDir = join(home, '.config', 'tuner');
     const configPath = join(configDir, 'config.yaml');
     if (!existsSync(configPath)) {
       const { writeDefaultConfig } = await import('../core/config.js');
       writeDefaultConfig(configPath);
-      console.log(`✅ Created default config at ${configPath}`);
+      console.log(`✅ Created default config: ${configPath}`);
     } else {
       console.log(`ℹ️  Config already exists: ${configPath}`);
     }
 
-    console.log('\nRun /tuner inside Claude Code to start the wizard');
+    // 6. Final summary — show where things live.
+    console.log('\n📍 Tracked paths:');
+    console.log(`   skills    → ${DEFAULT_SKILLS_DIR}`);
+    console.log(`   wisecron  → ${DEFAULT_SYSTEMD_USER_DIR}`);
+    console.log(`   cron      → ${DEFAULT_CRONTAB_DIR}`);
+    console.log(`   config    → ${configPath}`);
+    console.log("\nRun 'tuner doctor' to verify, or invoke /tuner inside Claude Code.");
   });
 
 // ── helpers ───────────────────────────────────────────────────────────────────────────

--- a/src/skills-tuner/core/config.ts
+++ b/src/skills-tuner/core/config.ts
@@ -6,6 +6,33 @@ import { z } from 'zod';
 
 export const DEFAULT_CONFIG_PATH = join(homedir(), '.config', 'tuner', 'config.yaml');
 
+// ─── Standard discovery paths (per-subject defaults) ──────────────────────────────────
+// Each TunableSubject writes its artifacts to the canonical path the consuming runtime
+// already reads from. No custom directories, no symlink dance — see issue #52.
+
+/** Anthropic Skills global path. Read by Claude Code and ClaudeClaw-Plus daemon. */
+export const DEFAULT_SKILLS_DIR = join(homedir(), '.claude', 'skills');
+
+/** XDG-standard path for systemd user units. */
+export const DEFAULT_SYSTEMD_USER_DIR = join(homedir(), '.config', 'systemd', 'user');
+
+/** XDG-config sidecar for POSIX crontab snapshots (table itself is root-managed). */
+export const DEFAULT_CRONTAB_DIR = join(homedir(), '.config', 'cron');
+
+/** Subject-name → standard path mapping. Override via `subjects.<name>.git_repo` in config. */
+export const SUBJECT_STANDARD_PATHS: Record<string, { git_repo?: string; scan_dirs?: string[] }> = {
+  skills: {
+    git_repo: DEFAULT_SKILLS_DIR,
+    scan_dirs: [DEFAULT_SKILLS_DIR],
+  },
+  wisecron: {
+    git_repo: DEFAULT_SYSTEMD_USER_DIR,
+  },
+  cron: {
+    git_repo: DEFAULT_CRONTAB_DIR,
+  },
+};
+
 const ModelConfigSchema = z.object({
   intent_classifier: z.string().default('claude-haiku-4-5-20251001'),
   detector: z.string().default('claude-opus-4-7'),
@@ -67,8 +94,36 @@ const TunerConfigSchema = z.object({
 });
 export type TunerConfig = z.infer<typeof TunerConfigSchema>;
 
+/**
+ * Returns the effective config for a subject, merging user overrides with
+ * standard-path defaults. User values always win — defaults only fill gaps.
+ *
+ * - `git_repo` defaults to the canonical path read by the consuming runtime
+ *   (e.g. `~/.claude/skills/` for the `skills` subject).
+ * - `scan_dirs` defaults are appended if the user did not provide any.
+ *
+ * Override the env var `TUNER_DISABLE_STANDARD_DEFAULTS=1` to get raw user
+ * config without defaults (useful for tests / introspection).
+ */
 export function subjectConfig(config: TunerConfig, name: string): SubjectConfig {
-  return config.subjects[name] ?? SubjectConfigSchema.parse({});
+  const userCfg = config.subjects[name] ?? SubjectConfigSchema.parse({});
+  if (process.env.TUNER_DISABLE_STANDARD_DEFAULTS === '1') return userCfg;
+
+  const standard = SUBJECT_STANDARD_PATHS[name];
+  if (!standard) return userCfg;
+
+  return {
+    ...userCfg,
+    git_repo: userCfg.git_repo ?? standard.git_repo,
+    scan_dirs: userCfg.scan_dirs.length > 0 ? userCfg.scan_dirs : (standard.scan_dirs ?? []),
+  };
+}
+
+/** Returns true if the configured path matches the standard one for this subject. */
+export function isStandardPath(subjectName: string, path: string | undefined): boolean {
+  if (!path) return false;
+  const standard = SUBJECT_STANDARD_PATHS[subjectName]?.git_repo;
+  return !!standard && standard === path;
 }
 
 export function loadConfig(path = DEFAULT_CONFIG_PATH): TunerConfig {
@@ -93,6 +148,11 @@ export function loadConfig(path = DEFAULT_CONFIG_PATH): TunerConfig {
         if (typeof s['git_repo'] === 'string') {
           s['git_repo'] = (s['git_repo'] as string).replace(/^~/, homedir());
         }
+        if (Array.isArray(s['scan_dirs'])) {
+          s['scan_dirs'] = (s['scan_dirs'] as unknown[]).map(d =>
+            typeof d === 'string' ? d.replace(/^~/, homedir()) : d
+          );
+        }
       }
     }
   }
@@ -100,6 +160,15 @@ export function loadConfig(path = DEFAULT_CONFIG_PATH): TunerConfig {
 }
 
 const DEFAULT_YAML = `# Skills Tuner TS configuration
+#
+# Per-subject defaults (git_repo, scan_dirs) resolve to standard discovery paths
+# automatically — see SUBJECT_STANDARD_PATHS in core/config.ts. Override here only
+# when you need a non-standard location.
+#
+# Standard paths:
+#   skills    → ~/.claude/skills/              (Anthropic Skills, read by Claude Code)
+#   wisecron  → ~/.config/systemd/user/        (XDG systemd user units)
+#   cron      → ~/.config/cron/                (XDG sidecar for crontab snapshot)
 
 llm:
   backend: anthropic_api
@@ -126,6 +195,8 @@ subjects:
     auto_merge: [patch, frontmatter]
     proposer: claude-sonnet-4-6
     proposer_for_create: claude-opus-4-7
+    # git_repo defaults to ~/.claude/skills/
+    # scan_dirs defaults to [~/.claude/skills]
 
 ui:
   primary_adapter: cli

--- a/src/skills-tuner/subjects/skills.ts
+++ b/src/skills-tuner/subjects/skills.ts
@@ -3,6 +3,7 @@ import { existsSync, statSync, readdirSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join, dirname, basename, resolve, sep } from 'node:path';
 import { homedir } from 'node:os';
+import { DEFAULT_SKILLS_DIR } from '../core/config.js';
 import { createInterface } from 'node:readline';
 import { createReadStream } from 'node:fs';
 import { BaseSubject } from './base.js';
@@ -86,7 +87,7 @@ export class SkillsSubject extends BaseSubject {
   constructor(opts: SkillsSubjectConfig = {}) {
     super();
     this.llm = opts.llm;
-    this.scanDirs = opts.scanDirs ?? [join(homedir(), 'agent', 'skills')];
+    this.scanDirs = opts.scanDirs ?? [DEFAULT_SKILLS_DIR];
     this.negRe = combineRegex(opts.negativePatterns ?? DEFAULT_NEGATIVE_PATTERNS);
     this.posRe = combineRegex(opts.positivePatterns ?? DEFAULT_POSITIVE_PATTERNS);
     this.emotRe = combineRegex(opts.emotionalPatterns ?? DEFAULT_EMOTIONAL_PATTERNS);


### PR DESCRIPTION
Closes #52.

## Summary

The skills tuner used to write generated/edited skills (and other TunableSubject artifacts) to a directory that **wasn't part of the standard discovery paths** read by Claude Code or the ClaudeClaw-Plus daemon. Fresh installs needed manual symlinks to make the loop close. This PR makes the defaults align with the standard paths — zero-config-portable for new users, drop-in for existing ones.

## What changes

| Subject | Default `git_repo` | Standard it matches |
|---|---|---|
| `skills` | `~/.claude/skills/` | Anthropic Skills global discovery path |
| `wisecron` | `~/.config/systemd/user/` | XDG path for systemd user units |
| `cron` | `~/.config/cron/` | XDG-config sidecar for `crontab -l` snapshot |

Defaults are applied in `subjectConfig()` when the user hasn't overridden `git_repo` / `scan_dirs`. User config always wins. Set `TUNER_DISABLE_STANDARD_DEFAULTS=1` to opt out (tests + introspection).

### Code surface

- **`src/skills-tuner/core/config.ts`** — `SUBJECT_STANDARD_PATHS` map + `isStandardPath()` helper; `subjectConfig()` merges defaults; `loadConfig()` now applies tilde expansion to `scan_dirs` entries too (was missing).
- **`src/skills-tuner/cli/index.ts`**:
  - **`tuner doctor`** — new per-subject section that confirms the configured `git_repo` matches the standard discovery path, with an actionable hint when it diverges.
  - **`tuner setup`** — mkdir + `git init` each standard path; snapshots `crontab -l` if non-empty (writes a placeholder otherwise); **installs the tuner skill in Anthropic directory format** (`<name>/SKILL.md`) instead of the previous flat `<name>.md`; ends with a "Tracked paths" summary so the user knows where everything lives.
- **`src/skills-tuner-templates/tuner.md`** — `~/.claude/skills/` promoted to the top of the candidate scan list; legacy locations kept for migration detection only.
- **`src/skills-tuner/README.md`** — new "Where artifacts land" section documenting the canonical paths and override mechanism.

### Bug fixes along the way

- `setup` previously copied the skill template to `~/.claude/skills/tuner.md` (flat), which Claude Code didn't pick up as a skill. Now `~/.claude/skills/tuner/SKILL.md` (dir-format) — discoverable out of the box.
- `loadConfig` expanded `~` for `git_repo` but not for `scan_dirs` entries. Fixed.

## Tests

19 new unit tests in `src/__tests__/skills-tuner-config.test.ts`:
- `DEFAULT_*` constants point at expected canonical paths
- `SUBJECT_STANDARD_PATHS` mapping for every supported subject
- `subjectConfig` default injection (skills / wisecron / cron)
- `subjectConfig` user override precedence (git_repo, scan_dirs)
- `subjectConfig` unknown-subject pass-through
- `TUNER_DISABLE_STANDARD_DEFAULTS=1` opt-out
- `isStandardPath` (canonical / non-canonical / unknown / undefined)
- `loadConfig` tilde expansion in `scan_dirs` + missing-file behaviour

```
19 pass / 0 fail / 22 expect() calls
```

No regressions on the skills-tuner code path (`engine.ts` only reads `auto_merge`, preserved by spread). Pre-existing fails on unrelated subsystems (Pause Controller, Event Processor) are untouched.

## Why it matters

- **Portability**: a fresh install resolves to the right paths with zero manual config. The "register plugin and go" promise actually holds for new operators.
- **Compliance / audit**: regulated environments need predictable artifact locations. "Skills land where Claude Code reads them" is now a contract rather than a convention.
- **Backup-friendly**: `~/.claude/` and `~/.config/` are standard backup targets — no orphan directories under arbitrary project roots.
- **Forward-compatible**: same rule applies to every future TunableSubject — add the entry to `SUBJECT_STANDARD_PATHS` and the rest of the system inherits the default.

## Migration for existing installs

Operators with a non-standard `subjects.<name>.git_repo` configured today get:
- A `tuner doctor` warning pointing at the divergence (single line, actionable).
- Their override continues to work — no breaking change.
- `tuner setup` is idempotent — re-running it surfaces what's already initialized vs. what was missing.

To adopt the new default, set/remove the override in `~/.config/tuner/config.yaml` and run `tuner setup` once.

## Test plan

- [x] `bun test src/__tests__/skills-tuner-config.test.ts` → 19 pass, 22 expect()
- [x] Fresh-install end-to-end in tmpdir (`HOME=$(mktemp -d) bun run cli setup`) → paths created, git init done, snapshot taken, skill installed
- [x] Idempotent re-run on a populated install → reports "Already a git repo" for each path
- [x] `tuner doctor` against live config with all-aligned paths → all checks pass
- [x] `tuner doctor` against config with a deliberately-custom `git_repo` → warning appears with hint
- [x] `engine.ts` regression check → `subjectConfig().auto_merge` still reads correctly
- [x] Full `bun test` → no new tuner failures, pre-existing fails on unrelated subsystems untouched
