### PR TITLE
ci(deploy): run bun install after git reset

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,6 +41,9 @@ jobs:
             echo "==> Updating to latest main"
             sudo git -C /opt/claudeclaw reset --hard povai/main
 
+            echo "==> Installing dependencies"
+            sudo bash -c "cd /opt/claudeclaw && /usr/local/bin/bun install --frozen-lockfile"
+
             echo "==> Restarting service"
             sudo systemctl restart claudeclaw
 


### PR DESCRIPTION
Missing `bun install` step caused the deploy to fail with `Cannot find package 'zod'` after #49 landed. The MCP bridge + skills-tuner stack added new dependencies (zod, @modelcontextprotocol/sdk, @anthropic-ai/sdk, commander, js-yaml, simple-git) that weren't installed on the server before service restart. Fixes the failed run at [#25694800040](https://github.com/TerrysPOV/ClaudeClaw-Plus/actions/runs/25694800040).