### PR TITLE
chore: bump plugin + marketplace to 2.1.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.0.23",
+      "version": "2.1.0",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.0.23",
+  "version": "2.1.0",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }


### PR DESCRIPTION
Single bump commit to mark yesterday's 5-PR batch (#46 #47 #53 #45 #56) as a distinct release. Version stayed at 2.0.23 across those merges because the GitHub UI conflict resolution kept main's value on each step rather than incrementing further.

Minor bump (2.0.23 → 2.1.0) reflects that the batch included features (#45 gateway outbound delivery, #53 skills-tuner standard paths) on top of bug fixes.