### PR TITLE
fix(runner): honor settings.timeouts.discord (was always 5 min)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -87,7 +87,7 @@ const DEFAULT_SETTINGS: Settings = {
   web: { enabled: false, host: "127.0.0.1", port: 4632 },
   stt: { baseUrl: "", model: "" },
   sessionTimeoutMs: DEFAULT_SESSION_TIMEOUT_MS,
-  timeouts: { telegram: 5, heartbeat: 15, job: 30, default: 5 },
+  timeouts: { telegram: 5, discord: 5, heartbeat: 15, job: 30, default: 5 },
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
   session: { autoRotate: false, maxMessages: 50, maxAgeHours: 24, summaryPath: "" },
   plugins: {},
@@ -159,6 +159,8 @@ export interface SecurityConfig {
 export interface TimeoutsConfig {
   /** Max minutes for a telegram message subprocess. Default: 5 min. */
   telegram: number;
+  /** Max minutes for a discord message subprocess. Default: 5 min. */
+  discord: number;
   /** Max minutes for a heartbeat subprocess. Default: 15 min. */
   heartbeat: number;
   /** Max minutes for a scheduled job subprocess. Default: 30 min. */
@@ -404,6 +406,7 @@ function parseSettings(
       : DEFAULT_SESSION_TIMEOUT_MS,
     timeouts: {
       telegram: Number.isFinite(raw.timeouts?.telegram) && Number(raw.timeouts.telegram) > 0 ? Number(raw.timeouts.telegram) : 5,
+      discord: Number.isFinite(raw.timeouts?.discord) && Number(raw.timeouts.discord) > 0 ? Number(raw.timeouts.discord) : 5,
       heartbeat: Number.isFinite(raw.timeouts?.heartbeat) && Number(raw.timeouts.heartbeat) > 0 ? Number(raw.timeouts.heartbeat) : 15,
       job: Number.isFinite(raw.timeouts?.job) && Number(raw.timeouts.job) > 0 ? Number(raw.timeouts.job) : 30,
       default: Number.isFinite(raw.timeouts?.default) && Number(raw.timeouts.default) > 0 ? Number(raw.timeouts.default) : 5,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -372,6 +372,7 @@ function buildChildEnv(baseEnv: Record<string, string>, model: string, api: stri
  *
  * Category mapping:
  *   "telegram"  → settings.timeouts.telegram  (default 5 min)
+ *   "discord"   → settings.timeouts.discord   (default 5 min)
  *   "heartbeat" → settings.timeouts.heartbeat (default 15 min)
  *   "job"       → settings.timeouts.job       (default 30 min)
  *   anything else (bootstrap, trigger, chat…) → settings.timeouts.default (default 5 min)
@@ -385,6 +386,8 @@ function resolveTimeoutMs(name: string): number {
   let minutes: number;
   if (name === "telegram") {
     minutes = t.telegram;
+  } else if (name === "discord") {
+    minutes = t.discord;
   } else if (name === "heartbeat") {
     minutes = t.heartbeat;
   } else if (name === "job") {


### PR DESCRIPTION
## Problem

Discord chat sessions time out after **5 minutes** regardless of any value set under \`timeouts.discord\` in \`settings.json\`. Setting \`timeouts.discord: 60\` (or any other value) had no effect — the setting was silently dropped.

## Root cause

\`resolveTimeoutMs()\` in \`src/runner.ts:383\` had no branch for \`discord\`:

\`\`\`typescript
function resolveTimeoutMs(name: string): number {
  const t = getSettings().timeouts;
  if (name === \"telegram\") return t.telegram * 60_000;
  if (name === \"heartbeat\") return t.heartbeat * 60_000;
  if (name === \"job\") return t.job * 60_000;
  return t.default * 60_000;   // <-- discord falls through here, default = 5 min
}
\`\`\`

The \`TimeoutsConfig\` interface and \`DEFAULT_SETTINGS.timeouts\` in \`src/config.ts\` also didn't include a \`discord\` field, so even at parse time any \`raw.timeouts.discord\` was thrown away.

Git history confirms there's never been a commit that wired discord through this code path — this is a missing-feature bug from when per-category timeouts were introduced (\`5751271 feat: add per-context timeouts\`), not a regression.

## Fix

Adds \`discord\` as a first-class timeout category, matching the pattern used for \`telegram\`:

- \`TimeoutsConfig.discord: number\`
- \`DEFAULT_SETTINGS.timeouts.discord = 5\` (parity with telegram default — no behavioral change for fresh installs)
- \`parseSettings\` reads \`raw.timeouts?.discord\` with the same \`> 0\` validation as the other fields
- \`resolveTimeoutMs\` adds an explicit \`discord\` branch before the fallthrough

## Use

After deploy, set in production \`settings.json\`:

\`\`\`json
\"timeouts\": {
  \"telegram\": 5,
  \"discord\": 60,
  \"heartbeat\": 15,
  \"job\": 30,
  \"default\": 5
}
\`\`\`

Daemon picks it up on next subprocess spawn (no restart needed — \`resolveTimeoutMs\` reads from \`getSettings()\` on every call).

## Files

- \`src/config.ts\` — interface + defaults + parser
- \`src/runner.ts\` — \`resolveTimeoutMs\` branch + jsdoc
- \`.claude-plugin/plugin.json\`, \`.claude-plugin/marketplace.json\` — version bump to 2.1.1