### PR TITLE
fix(agents): wizard captures recurring flag so jobs don't silently become one-shots

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/skills/create-agent/SKILL.md
+++ b/skills/create-agent/SKILL.md
@@ -101,8 +101,12 @@ For each task:
    bun -e 'const {parseScheduleToCron} = await import(`${process.env.CLAUDECLAW_ROOT || "."}/src/agents.ts`); console.log(parseScheduleToCron("USER_INPUT"));'
    ```
    If `null`, re-ask with examples.
-3. **Trigger prompt** — "What should the agent do when this fires? (multi-line ok — write to a temp file if helpful)"
-4. **Model** — "Which model? (`default` / `opus` / `haiku` — press enter for default)"
+3. **Recurring or one-shot** — "Should this fire on every schedule tick, or just once?"
+   - Use **AskUserQuestion** with options: `Recurring (cron)` (default) and `One-shot (fire once, then clear schedule)`.
+   - Set `recurring: true` for `Recurring`, `recurring: false` for `One-shot`.
+   - **Why this matters:** `src/jobs.ts:clearJobSchedule()` strips the `schedule:` line on the first fire of any job without `recurring: true`, converting it to a one-shot. A wizard job that the user expects to recur (the common case) MUST be written with `recurring: true` or it silently becomes a one-shot after the first run. Setting this explicitly is the fix for the silent-strip footgun.
+4. **Trigger prompt** — "What should the agent do when this fires? (multi-line ok — write to a temp file if helpful)"
+5. **Model** — "Which model? (`default` / `opus` / `haiku` — press enter for default)"
 
 Then: "Add another task? (y/n)" — loop or break out.
 
@@ -126,7 +130,7 @@ Once all answers are in and the user confirmed the review block, **write them to
 #      "dataSources": "...",
 #      "defaultModel": "opus",   // optional — omit for daemon default
 #      "jobs": [
-#        { "label": "digest-scan", "cron": "0 9 * * *", "trigger": "...", "model": "opus" },
+#        { "label": "digest-scan", "cron": "0 9 * * *", "recurring": true, "trigger": "...", "model": "opus" },
 #        ...
 #      ]
 #    }
@@ -146,7 +150,10 @@ const ctx = await createAgent({
   defaultModel: cfg.defaultModel,
 });
 for (const job of cfg.jobs) {
-  await addJob(ctx.name, job.label, job.cron, job.trigger, job.model);
+  // Pass recurring through so the wizard does not silently produce one-shot jobs.
+  // addJob defaults to recurring=true if omitted, but the wizard must capture the
+  // user choice explicitly per the Q3 step above.
+  await addJob(ctx.name, job.label, job.cron, job.trigger, job.model, job.recurring ?? true);
 }
 console.log(JSON.stringify({ agent: ctx.name, jobs: cfg.jobs.map(j => j.label) }, null, 2));
 '
@@ -154,7 +161,7 @@ console.log(JSON.stringify({ agent: ctx.name, jobs: cfg.jobs.map(j => j.label) }
 
 Notes:
 - `createAgent()` handles IDENTITY.md, SOUL.md (Personality + Workflow markers), CLAUDE.md, MEMORY.md, session.json, .gitignore.
-- `addJob()` writes each scheduled task to `agents/<name>/jobs/<label>.md` with frontmatter (label, cron, enabled, model).
+- `addJob()` writes each scheduled task to `agents/<name>/jobs/<label>.md` with frontmatter (label, cron, recurring, enabled, model). When `recurring: true` (the wizard default), the daemon preserves the schedule across fires. When `recurring: false`, the daemon clears the schedule on first fire (one-shot).
 - **Do not use the Write tool to write any of the agent files** — let the helpers do it. The only file you write is the temp JSON.
 - If there are zero jobs, the loop just doesn't execute and the agent is ad-hoc only.
 

--- a/skills/update-agent/SKILL.md
+++ b/skills/update-agent/SKILL.md
@@ -133,14 +133,17 @@ console.log("personality updated (" + mode + ")");
 
 #### Option 3 — Add job
 
-Collect: label (validate via `validateJobLabel`), cron (validate via `parseScheduleToCron`), trigger prompt, model (`default`/`opus`/`haiku` — empty for default).
+Collect: label (validate via `validateJobLabel`), cron (validate via `parseScheduleToCron`), **recurring vs one-shot** (use AskUserQuestion — default `Recurring (cron)`; pick `One-shot` only when the user is clear they want a single fire), trigger prompt, model (`default`/`opus`/`haiku` — empty for default).
+
+The recurring step is non-optional: jobs without `recurring: true` are silently converted to one-shots by `src/jobs.ts:clearJobSchedule()` on first fire. Default to `recurring: true` if the user expresses any uncertainty.
 
 ```bash
 bun -e '
 import { readFileSync } from "fs";
 const { addJob } = await import(`${process.env.CLAUDECLAW_ROOT || "."}/src/agents.ts`);
 const j = JSON.parse(readFileSync("/tmp/claudeclaw-update.json", "utf8"));
-await addJob("AGENT_NAME", j.label, j.cron, j.trigger, j.model);
+// Pass recurring explicitly (default true) so the wizard never produces silent one-shots.
+await addJob("AGENT_NAME", j.label, j.cron, j.trigger, j.model, j.recurring ?? true);
 console.log("added " + j.label);
 '
 ```
@@ -159,7 +162,7 @@ console.log("updated " + label);
 '
 ```
 
-`patch` may contain any subset of `{ cron, trigger, enabled, model }`.
+`patch` may contain any subset of `{ cron, trigger, enabled, recurring, model }`. Flipping `recurring` from `false` to `true` re-arms a previously-cleared schedule; the daemon picks it up on the next hot-reload tick.
 
 #### Option 5 — Remove job
 

--- a/src/__tests__/agents.test.ts
+++ b/src/__tests__/agents.test.ts
@@ -319,6 +319,7 @@ describe("Phase 17: multi-job agents", () => {
       expect(job.label).toBe("digest-scan");
       expect(job.cron).toBe("0 9 * * 1-5");
       expect(job.enabled).toBe(true);
+      expect(job.recurring).toBe(true);
       expect(job.model).toBe("opus");
 
       const path = join(AGENTS_DIR, name, "jobs", "digest-scan.md");
@@ -326,9 +327,28 @@ describe("Phase 17: multi-job agents", () => {
       const content = await readFile(path, "utf8");
       expect(content).toContain("label: digest-scan");
       expect(content).toContain("schedule: 0 9 * * 1-5");
+      expect(content).toContain("recurring: true");
       expect(content).toContain("enabled: true");
       expect(content).toContain("model: opus");
       expect(content).toContain("Run the daily digest");
+    });
+
+    it("defaults to recurring: true when caller omits the flag", async () => {
+      const name = uniq("recur-default");
+      await createAgent({ name, role: "x", personality: "y" });
+      const job = await addJob(name, "daily", "0 9 * * *", "fire");
+      expect(job.recurring).toBe(true);
+      const content = await readFile(join(AGENTS_DIR, name, "jobs", "daily.md"), "utf8");
+      expect(content).toContain("recurring: true");
+    });
+
+    it("emits recurring: false for explicit one-shot jobs", async () => {
+      const name = uniq("oneshot");
+      await createAgent({ name, role: "x", personality: "y" });
+      const job = await addJob(name, "once", "0 9 * * *", "fire once", undefined, false);
+      expect(job.recurring).toBe(false);
+      const content = await readFile(join(AGENTS_DIR, name, "jobs", "once.md"), "utf8");
+      expect(content).toContain("recurring: false");
     });
 
     it("throws on duplicate label", async () => {
@@ -393,6 +413,26 @@ describe("Phase 17: multi-job agents", () => {
       const name = uniq("missing");
       await createAgent({ name, role: "x", personality: "y" });
       await expect(updateJob(name, "ghost", { enabled: false })).rejects.toThrow();
+    });
+
+    it("preserves recurring across unrelated patches", async () => {
+      const name = uniq("recur-preserve");
+      await createAgent({ name, role: "x", personality: "y" });
+      await addJob(name, "task", "0 9 * * *", "body", undefined, true);
+      const updated = await updateJob(name, "task", { cron: "0 10 * * *" });
+      expect(updated.recurring).toBe(true);
+      const content = await readFile(join(AGENTS_DIR, name, "jobs", "task.md"), "utf8");
+      expect(content).toContain("recurring: true");
+    });
+
+    it("flips recurring when patched", async () => {
+      const name = uniq("recur-flip");
+      await createAgent({ name, role: "x", personality: "y" });
+      await addJob(name, "task", "0 9 * * *", "body", undefined, false);
+      const updated = await updateJob(name, "task", { recurring: true });
+      expect(updated.recurring).toBe(true);
+      const content = await readFile(join(AGENTS_DIR, name, "jobs", "task.md"), "utf8");
+      expect(content).toContain("recurring: true");
     });
   });
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -211,6 +211,9 @@ export interface AgentJob {
   label: string;
   cron: string;
   enabled: boolean;
+  /** When true, the daemon keeps the cron schedule after each fire. When false,
+   *  jobs.ts:clearJobSchedule() strips the schedule line on first run (one-shot). */
+  recurring: boolean;
   model?: string;
   trigger: string;
   path: string;
@@ -473,11 +476,18 @@ function renderClaudeMd(opts: AgentCreateOpts): string {
   return lines.join("\n");
 }
 
-function renderJobFile(label: string, cron: string, trigger: string, model?: string): string {
+function renderJobFile(
+  label: string,
+  cron: string,
+  trigger: string,
+  model?: string,
+  recurring: boolean = true,
+): string {
   const lines = [
     `---`,
     `label: ${label}`,
     `schedule: ${cron}`,
+    `recurring: ${recurring}`,
     `enabled: true`,
   ];
   if (model) lines.push(`model: ${model}`);
@@ -491,7 +501,7 @@ function parseFrontmatterValue(raw: string): string {
 
 function parseJobFileContent(
   content: string
-): { label: string; cron: string; enabled: boolean; model?: string; trigger: string } | null {
+): { label: string; cron: string; enabled: boolean; recurring: boolean; model?: string; trigger: string } | null {
   const match = content.match(/^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/);
   if (!match) return null;
   const fm = match[1];
@@ -518,10 +528,19 @@ function parseJobFileContent(
     if (v === "false" || v === "no" || v === "0") enabled = false;
   }
 
+  // Default false for legacy jobs without the field — preserves prior behaviour
+  // where jobs.ts:clearJobSchedule() strips schedule: on first fire.
+  const recurringLine = lines.find((l) => l.startsWith("recurring:"));
+  let recurring = false;
+  if (recurringLine) {
+    const v = parseFrontmatterValue(recurringLine.replace("recurring:", "")).toLowerCase();
+    recurring = v === "true" || v === "yes" || v === "1";
+  }
+
   const modelLine = lines.find((l) => l.startsWith("model:"));
   const model = modelLine ? parseFrontmatterValue(modelLine.replace("model:", "")) || undefined : undefined;
 
-  return { label, cron, enabled, model, trigger };
+  return { label, cron, enabled, recurring, model, trigger };
 }
 
 function validateCronOrThrow(cron: string): void {
@@ -551,7 +570,8 @@ export async function addJob(
   label: string,
   cron: string,
   trigger: string,
-  model?: string
+  model?: string,
+  recurring: boolean = true,
 ): Promise<AgentJob> {
   // Verify agent exists
   await loadAgent(agentName);
@@ -567,15 +587,15 @@ export async function addJob(
     throw new Error(`job ${label} already exists for agent ${agentName}`);
   }
 
-  await writeFile(path, renderJobFile(label, cron, trigger, model), "utf8");
+  await writeFile(path, renderJobFile(label, cron, trigger, model, recurring), "utf8");
 
-  return { label, cron, enabled: true, model, trigger, path };
+  return { label, cron, enabled: true, recurring, model, trigger, path };
 }
 
 export async function updateJob(
   agentName: string,
   label: string,
-  patch: { cron?: string; trigger?: string; enabled?: boolean; model?: string }
+  patch: { cron?: string; trigger?: string; enabled?: boolean; recurring?: boolean; model?: string }
 ): Promise<AgentJob> {
   const path = jobFilePath(agentName, label);
   if (!existsSync(path)) {
@@ -589,17 +609,19 @@ export async function updateJob(
     label: parsed.label,
     cron: patch.cron ?? parsed.cron,
     enabled: patch.enabled ?? parsed.enabled,
+    recurring: patch.recurring ?? parsed.recurring,
     model: patch.model !== undefined ? patch.model : parsed.model,
     trigger: patch.trigger ?? parsed.trigger,
   };
 
   if (patch.cron !== undefined) validateCronOrThrow(merged.cron);
 
-  // Render preserving enabled flag
+  // Render preserving recurring + enabled flags
   const lines = [
     `---`,
     `label: ${merged.label}`,
     `schedule: ${merged.cron}`,
+    `recurring: ${merged.recurring}`,
     `enabled: ${merged.enabled}`,
   ];
   if (merged.model) lines.push(`model: ${merged.model}`);


### PR DESCRIPTION
## Problem

Operator-reported bug downstream: 7 scheduled jobs across 3 agents (Suzy ×3, Reg ×3, Peggy) all stopped firing after their first run. Looked like a daemon bug; turned out to be a wizard bug.

Root cause: `src/jobs.ts:clearJobSchedule()` deliberately strips the `schedule:` frontmatter line from any job whose `recurring:` field is not `true` once the job fires. That's the documented one-shot path. But the create-agent / update-agent wizards never asked the operator about `recurring`, and `addJob()` never emitted a `recurring:` line at all. So every cron job scaffolded via the wizard was a latent one-shot — fired on the first tick, then silently lost its schedule.

Confirmed by inspecting `renderJobFile()` in `src/agents.ts` (no `recurring` written) and `clearJobSchedule()` in `src/jobs.ts` (strips on missing/false).

## Changes

### `src/agents.ts`
- `AgentJob` gains `recurring: boolean` field.
- `renderJobFile()` now emits `recurring: <bool>` (default `true`).
- `addJob()` accepts optional `recurring` arg (default `true`).
- `updateJob()` patch accepts `recurring`; preserves the field on unrelated patches; correctly emits it in the rewritten frontmatter.
- `parseJobFileContent()` reads `recurring:` from frontmatter. **Legacy jobs without the field default to `false`** to preserve prior behaviour (the daemon's own loader has always treated absence as one-shot — see `jobs.ts:81-84`).

### `skills/create-agent/SKILL.md`
- New per-job wizard step using `AskUserQuestion`: `Recurring (cron)` (default) vs `One-shot (fire once, then clear schedule)`.
- The step explicitly explains the silent-strip footgun so the operator understands what they're choosing, not just clicking through.
- Temp JSON shape gains `job.recurring`; scaffold loop passes it to `addJob()` with a safe `?? true` fallback.

### `skills/update-agent/SKILL.md`
- 'Add job' option mirrors the recurring step.
- 'Edit job' patch shape gains `recurring`, with a note that flipping `false → true` re-arms a previously-cleared schedule on the next daemon hot-reload tick.

### Tests — `src/__tests__/agents.test.ts` (+40)
- `addJob` writes `recurring: true` when explicit
- `addJob` writes `recurring: true` by default (no flag passed)
- `addJob` writes `recurring: false` on explicit one-shot
- `updateJob` preserves `recurring` across unrelated patches (the silent-loss case)
- `updateJob` flips `recurring` when patched

```
116 pass / 0 fail / 277 expect() calls
```

## Scope notes

This is a wizard UX fix. The daemon's `clearJobSchedule()` behaviour is unchanged — one-shot semantics still work for operators who genuinely want them. Operators who already manually edited their job files to add `recurring: true` are unaffected. The migration story for existing wizard-scaffolded jobs missing the field: they continue to be one-shots until rescaffolded or edited via `/claudeclaw:update-agent`.

Plus-only (no upstream PR needed): the create-agent wizard is Plus-specific; upstream doesn't have it.

## Files

- `src/agents.ts` (+25 / -8)
- `skills/create-agent/SKILL.md` (+11 / -3)
- `skills/update-agent/SKILL.md` (+6 / -3)
- `src/__tests__/agents.test.ts` (+40)
- Version bump to 2.1.2