### PR TITLE
feat: MCP multiplexer — shared MCP processes across PTYs (#64)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.6",
+      "version": "2.2.7",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.5",
+      "version": "2.2.6",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.3",
+      "version": "2.2.5",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.3",
+  "version": "2.2.5",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.planning/mcp-multiplexer/CODE-REVIEW.md
+++ b/.planning/mcp-multiplexer/CODE-REVIEW.md
@@ -1,0 +1,305 @@
+# Phase D Code Review — MCP Multiplexer Integration (#64)
+
+**Branch:** `feat/mcp-multiplexer-integration` (HEAD `d89a956`)
+**Reviewer:** Talon (Phase D code-review pass, read-only)
+**Date:** 2026-05-15
+**Scope:** code quality, cross-file consistency, error paths, naming, dead
+code, TypeScript strictness, ESM hygiene, test quality. Security is excluded
+(parallel auditor). Architecture is frozen by SPEC.
+
+---
+
+## 1. Executive verdict
+
+**Approve with conditions.** The multiplexer wiring is internally consistent,
+its public contract matches W1-COORD.md, the cross-worktree handshake works
+both ways, and the dormant path is provably backward-compatible. The merge is
+fundamentally safe to land behind `settings.mcp.shared = []` (its default
+state). What stops it from being a clean approve is a small set of correctness
+papercuts in the supervisor's URL construction and lifecycle bookkeeping, plus
+a notable coverage gap in `pty-supervisor-mcp.test.ts` whose header advertises
+tests it doesn't ship.
+
+| Area | Verdict | Notes |
+|---|---|---|
+| Cross-file consistency | GREEN | W1↔W2 interfaces match in both directions; FQN namespacing partitions cleanly. |
+| Error paths | AMBER | `start()` guards on `started=true` even when bailing dormant; bridgeBaseUrl divergence between plugin and supervisor. |
+| Typing / ESM | AMBER | Inconsistent `.js` extension hygiene across the new files; a few `unknown` casts that look avoidable in production code. |
+| Tests | AMBER | Integration tests are excellent. Supervisor-mcp tests claim coverage they don't have. Test-only side-doors used heavily in integration tests. |
+| Hygiene | GREEN | No dead code of concern; perPtyOnly is documented as future surface; commits map cleanly to logical phases. |
+
+---
+
+## 2. Findings (grouped by severity)
+
+### Critical (90–100)
+_None._
+
+### Important (80–89)
+
+#### #1 supervisor hardcodes `127.0.0.1` for bridgeBaseUrl, plugin uses `settings.web.host` [IMPORTANT] [80]
+**File:** `src/runner/pty-supervisor.ts:843-844`
+**Description:** `synthesizeMcpConfigIfActive` builds the bridge URL as
+`http://127.0.0.1:${bridgePort}`, ignoring `settings.web.host`. The
+multiplexer plugin (`src/plugins/mcp-multiplexer/index.ts:201-202`) builds it
+from `settings.webHost`. If the operator sets `settings.web.host = "localhost"`,
+the plugin advertises `http://localhost:4632` (and the test passes with the
+allowed-host check at index.ts:168) but the supervisor synthesises a config
+pointed at `http://127.0.0.1:4632`. The two resolve to the same socket on every
+modern host, so the bug is latent — but the two URL builders are now
+de-synchronised and a future change to either will silently drift.
+**Recommendation:** Either (a) read `bridgeBaseUrl()` from
+`getMcpMultiplexerPlugin()` in the supervisor (preferred — single source of
+truth, plugin already exposes the accessor), or (b) thread the URL through the
+issuer interface (`McpIdentityIssuer` returns the URL alongside the identity).
+Don't recompute it from settings in two places.
+
+#### #2 `pty-supervisor-mcp.test.ts` header advertises coverage it doesn't ship [IMPORTANT] [82]
+**File:** `src/__tests__/pty-supervisor-mcp.test.ts:14-15`
+**Description:** The file header lists "Cleanup fires on shutdownSupervisor,
+killAllPtys, reapIdle, LRU evict" and "Respawn rotates the bearer token via
+re-synthesis on the same path." `rg reapIdle|LRU|evict|respawn` returns one
+match — the header comment itself. There are no tests for reapIdle cleanup,
+LRU eviction cleanup, or respawn re-synthesis. These are real code paths
+(`pty-supervisor.ts` L696, L1177, L1002-1017) and they have real cleanup
+semantics; an operator-visible regression here would only surface after a PTY
+runs hot for 30+ minutes.
+**Recommendation:** Either ship the three missing test cases (drive the
+supervisor's idle clock past the cutoff; force LRU by setting maxConcurrent=1
+and spawning a second entry; throw `PtyClosedError` from a fake PTY to drive
+`respawnEntry`) or scope the file header down to what's actually covered.
+Don't ship a header that lies about its own coverage.
+
+#### #3 `started` flag stays `true` after dormant bail-out [IMPORTANT] [80]
+**File:** `src/plugins/mcp-multiplexer/index.ts:162-196`
+**Description:** `start()` sets `this.started = true` on line 163 (first line
+inside the guard), then returns early on any of four dormant conditions
+(non-loopback, web disabled, empty shared, config missing). `stop()` (L287)
+checks `!this.started` and short-circuits — but since `started=true`, the full
+teardown executes against empty maps. That's harmless today, but it also means
+a caller can never `restart` the plugin: a dormant-then-reconfigured plugin
+sees `started === true` and bails on the next `start()` call.
+**Recommendation:** Only set `this.started = true` once the spawn loop has
+committed (i.e. just before `this._startHealthProbe(...)` on line 284), or set
+a distinct `this.active`-style flag for "really running". The current pattern
+conflates "we've been called" with "we're hosting servers."
+
+### Medium (70–79)
+
+#### #4 `_toFqn` is mis-named — it returns the bridge tool-name argument, not the FQN [MEDIUM] [78]
+**File:** `src/plugins/mcp-multiplexer/index.ts:56-58`
+**Description:** The function is called `_toFqn` and returns
+`${serverName}__${toolName}`. The actual fully-qualified name stored in the
+bridge is `mcp-multiplexer__${serverName}__${toolName}` (the bridge prefixes
+with pluginId, per `mcp-bridge.ts:65`). The function's job is to build the
+NAME argument; the FQN is built downstream. The comments at L48-55 are
+correct, but the function name is the inverse of what it returns. Anyone
+reading `_toFqn` will think the value is what gets stored.
+**Recommendation:** Rename to `_toBridgeToolName` (or inline — it's a
+two-liner). The current name is a future-trap.
+
+#### #5 multiplexer issues `mcp_health_degraded` AND `multiplexer_server_crashed` for the same event [MEDIUM] [75]
+**File:** `src/plugins/mcp-multiplexer/index.ts:341-366` + `465-477`
+**Description:** When the upstream child crashes, `_onServerCrash` audits
+`multiplexer_server_crashed` immediately. On the next probe tick (default 30s
+later), `_sampleHealth` sees the status transition and audits
+`mcp_health_degraded`. Both events carry the server name. The Phase C
+integration test (`mcp-multiplexer-integration.test.ts:647-651`) explicitly
+asserts both fire. That's an OK design choice (the probe is the
+"belt-and-braces" check for crashes that bypass `_onServerCrash`), but the
+duplication is undocumented and operators grepping for "alpha crashed" will
+get two hits per crash event.
+**Recommendation:** Document in the audit-events table (wherever that lives)
+that `multiplexer_server_crashed` is the immediate event and
+`mcp_health_degraded` is the next-probe confirmation. Or: have
+`_onServerCrash` update `lastObservedStatus` so the next probe doesn't
+re-audit. The latter is cleaner. (Note: line 364 sets the observed status
+after audit, but `_onServerCrash` doesn't.)
+
+#### #6 http-handler does not enforce `allowedTools` on `tools/call` [MEDIUM] [74]
+**File:** `src/plugins/mcp-multiplexer/http-handler.ts:246-268`
+**Description:** `tools/list` returns the filtered `proc.tools` (L235-243),
+which already honours `mcp-proxy.json`'s `allowedTools`. But the
+`CallToolRequestSchema` handler forwards any name straight to `proc.call`
+without validating it's in the allowed set. The upstream MCP child would
+presumably reject unknown tools, but the multiplexer's tool gate is purely
+advisory. The legacy bridge callback path (`index.ts:481`) has the same
+property — it registers only allowed tools, so a non-allowed name isn't a
+known FQN there.
+**Recommendation:** Add a guard before `proc.call`: build a `Set<string>` of
+allowed tool names at handler construction time and reject anything not in
+the set with `isError: true`. Cheap, defence-in-depth. Flagging here as code
+quality; security auditor will likely call this out too.
+
+#### #7 mcp-proxy skip-shared and `~/.claude/mcp.json` are not in sync [MEDIUM] [72]
+**File:** `src/plugins/mcp-proxy/index.ts:65-88` + `src/runner/pty-process.ts:244-251`
+**Description:** The skip-shared rule prevents the daemon's `mcp-proxy` from
+spawning servers claimed by the multiplexer — but Claude Code inside the PTY
+still consults `~/.claude/mcp.json` because the synthesised `--mcp-config` is
+additive (no `--strict-mcp-config`). If the operator has the same MCP server
+in `mcp-proxy.json` AND `~/.claude/mcp.json`, the multiplexer hosts it and
+the PTY's claude also stdio-spawns its own copy. The comment on L245-248
+acknowledges this, but there's no validation, no warning, and no operator
+guidance in the synthesised JSON itself.
+**Recommendation:** Either (a) pass `--strict-mcp-config` (breaks operators
+who rely on `~/.claude/mcp.json` merging), (b) emit a startup warning when the
+multiplexer detects a name in both `~/.config/claudeclaw/mcp-proxy.json` and
+`~/.claude/mcp.json`, or (c) document this in the README operator section
+with a "remove shared names from `~/.claude/mcp.json`" instruction. Don't
+leave the footgun unmarked.
+
+#### #8 Integration test uses `lastObservedStatus` private internals via cast [MEDIUM] [72]
+**File:** `src/__tests__/mcp-multiplexer-integration.test.ts:631-636`
+**Description:** Tests reach into `plugin.servers`, `plugin.lastObservedStatus`,
+and `_sampleHealthForTests` via `as unknown as { ... }` casts. The unit
+tests have the same pattern (`index.test.ts:347-354`, `395-401`). This works
+but it bakes test-only knowledge of private fields into the suite. A rename
+of `lastObservedStatus` breaks five tests.
+**Recommendation:** Either expose a tiny test-seam method on the plugin
+(e.g. `_seedHealthStatus(name: string, status: string): void`) or accept the
+fragility and consolidate the cast into a single helper function at the top
+of the integration test. The current ad-hoc casts will be the first thing to
+rot during follow-up work.
+
+### Low (51–71)
+
+#### #9 ESM `.js` extension usage is inconsistent across new files [LOW] [68]
+**File:** `src/runner/pty-supervisor.ts:52-62`, `src/runner/pty-mcp-config-writer.ts:28`
+**Description:** All new code in `src/plugins/mcp-multiplexer/*` uses
+explicit `.js` extensions on relative imports (matches the codebase's
+modern convention for ESM/Node interop). `pty-supervisor.ts` and
+`pty-mcp-config-writer.ts` keep bare specifiers (no `.js`). Both work under
+`moduleResolution: bundler` in `tsconfig.json`, so it's cosmetic — but the
+new code split across two conventions in the same PR is noisy.
+**Recommendation:** Pick one. Project-wide migration is out of scope; for
+THIS PR, normalise the new mcp-multiplexer-adjacent code (writer and
+supervisor's new section) to match the rest of the multiplexer code. Test
+file at `mcp-multiplexer-integration.test.ts` uses `.js`,
+`pty-supervisor-mcp.test.ts` uses bare — pick one.
+
+#### #10 `_validatePtyId` regex disallows `/` but allows `:` — undocumented contract [LOW] [62]
+**File:** `src/plugins/mcp-multiplexer/pty-identity.ts:74-81`
+**Description:** The regex `/^[A-Za-z0-9_.:-]+$/` allows colons (for
+session-key shapes like `agent:suzy`, `UUID:f47...`) and dots, but bans
+slashes. This is correct for the current sessionKey shape, but the contract
+isn't documented anywhere; W1-COORD doesn't restate it. If future code
+introduces a new sessionKey shape (e.g. `workspace/agent`), this will fail
+with a confusing error.
+**Recommendation:** Either (a) reference the supervisor's sessionKey grammar
+in the comment, or (b) document the allowed shapes in W1-COORD.md as the
+authoritative interface contract. The function comment says "named-agent
+names, thread IDs, or 'global'" but `agent:suzy` doesn't match any of those —
+it's the supervisor's actual sessionKey grammar that matters.
+
+#### #11 `_readBody` clones the request for audit observability [LOW] [60]
+**File:** `src/plugins/mcp-multiplexer/http-handler.ts:61-73`, called L152
+**Description:** Every multiplexer call clones the request body to extract
+the JSON-RPC method name for audit. For tool calls with large arguments
+(`large_result` fixture returns 2MB), this doubles peak memory per request.
+Not a real concern at MCP body sizes, but it's per-call overhead for
+metadata that could often be extracted lazily.
+**Recommendation:** Optional — skip the audit body peek when the request
+body is over some small threshold (4KB), or move the audit into the SDK
+transport's request handler so the body is parsed once. Defer to follow-up
+if not landing in this PR.
+
+#### #12 multiplexer doesn't proxy resources/prompts, only tools [LOW] [58]
+**File:** `src/plugins/mcp-multiplexer/http-handler.ts:235-268`
+**Description:** The handler only wires `ListToolsRequestSchema` and
+`CallToolRequestSchema`. MCP servers also expose resources, prompts, and
+completions. If a shared MCP server advertises any of these, the PTY's
+`claude` won't see them through the multiplexer (but would see them through
+`mcp-proxy`'s in-process bridge — which is also tools-only, so this matches
+the existing limitation). Not a regression, but it's a known constraint that
+should be in the README.
+**Recommendation:** Document in the operator-facing docs that shared
+multiplexed servers expose tools only. Resources / prompts require the
+operator to keep the server out of `settings.mcp.shared` and let Claude Code
+spawn it per-PTY.
+
+#### #13 `try { ... } catch {}` swallows all errors around audit calls [LOW] [55]
+**File:** `src/plugins/mcp-multiplexer/index.ts:172-176`, `184-186`, `192-194`, `208-211`, `253-258`, `292-294`, `406-411`, `420-424`, `465-477`
+**Description:** Twelve call sites wrap `getMcpBridge().audit(...)` in a
+bare `try {} catch {}`. The bridge is initialised at module load; the only
+realistic failure mode is `_resetMcpBridge()` running mid-flight in a test.
+Wrapping every audit in a silent swallow makes the production code look
+defensive against a failure mode that exists only in tests.
+**Recommendation:** Drop the audit-call try/catches in production paths and
+let the bridge guarantee its own contract (the `audit` method should never
+throw against an initialised bridge). If a test concern remains, wrap once at
+the bridge level. The current pattern is noise.
+
+### Info (≤50)
+
+#### #14 `_toPublic` rebuilds the bearer string on every `getIdentity` call [INFO] [40]
+**File:** `src/plugins/mcp-multiplexer/pty-identity.ts:83-95`
+**Description:** Each call to `getIdentity` allocates a fresh bearer string
+and headers object. The store could cache `_toPublic(record)` once on
+`issueIdentity`. Not a real concern (hex encoding is microsecond-fast,
+secrets rotate on respawn so the cache wouldn't live long), but worth
+noting as cleanup opportunity.
+
+#### #15 Test fixture name drift from spec [INFO] [35]
+**File:** `src/__tests__/mcp-multiplexer-integration.test.ts:43-45`
+**Description:** The review brief references
+`src/__tests__/fixtures/mcp-stdio-echo.ts`. The actual fixture is
+`fixtures/mock-mcp-server.ts` (reused from earlier mcp-proxy tests). The
+reuse is correct; the brief is the one out of date. Mention because it's
+indicative of the SPEC referring to filenames that diverged during
+implementation — minor doc drift, easy to miss in PR review.
+
+---
+
+## 3. Top-5 things to fix before PR opens
+
+1. **Fix #1 — unify `bridgeBaseUrl` construction.** Make the supervisor
+   read `getMcpMultiplexerPlugin().bridgeBaseUrl()` instead of recomputing.
+   `src/runner/pty-supervisor.ts:843-844`. 4 lines.
+2. **Fix #2 — either land the missing supervisor cleanup tests or scope the
+   file header down.** `src/__tests__/pty-supervisor-mcp.test.ts:14-15`.
+   Three test cases or three lines of header.
+3. **Fix #3 — only set `this.started = true` once the plugin commits.**
+   `src/plugins/mcp-multiplexer/index.ts:163` → move down to L284.
+   Five-line move plus a "have we ever attempted start" flag if needed.
+4. **Fix #4 — rename `_toFqn` to `_toBridgeToolName` (or inline it).**
+   `src/plugins/mcp-multiplexer/index.ts:56-58`, `L482`. Two-line edit.
+5. **Fix #6 — add the `allowedTools` gate in `CallToolRequestSchema`.**
+   `src/plugins/mcp-multiplexer/http-handler.ts:246-268`. Defence-in-depth;
+   security auditor will likely flag too.
+
+---
+
+## 4. Top-3 things worth a note in the PR description
+
+1. **Backward-compat is enforced four ways**: `settings.mcp.shared=[]` →
+   plugin dormant, supervisor skips synthesis, mcp-proxy spawns everything,
+   PTY argv has no `--mcp-config`. Each gate is independently tested. This is
+   load-bearing — reviewers should be able to confirm the dormant path is
+   byte-identical to today's PTY behaviour without reading the multiplexer at
+   all.
+2. **`~/.claude/mcp.json` vs `settings.mcp.shared` is an operator footgun.**
+   The synthesised config is additive — operators must remove shared names
+   from `~/.claude/mcp.json` themselves or claude will stdio-spawn shadow
+   copies inside each PTY. See finding #7. Worth a README line.
+3. **The integration tests stand in for production gateway routing.** The
+   route-forwarding fix in `src/ui/server.ts` (commit `2693774`) was a Phase B
+   blind spot caught by Phase C. The integration test gateway is hermetic;
+   the production gateway now routes `/mcp/<server>/*` correctly. Reviewers
+   should confirm both surfaces (UI server + http-gateway) route together.
+
+---
+
+## 5. Summary for operator
+
+**Verdict:** Approve with conditions. The multiplexer is correctly wired,
+dormant-by-default, and the W1↔W2 interface is symmetric. The blockers are
+small and structural: the supervisor and plugin compute the same
+bridgeBaseUrl from two different sources of truth (finding #1), and
+`pty-supervisor-mcp.test.ts` advertises coverage of reapIdle/LRU/respawn
+cleanup paths that aren't actually tested (finding #2). **Top two actions:**
+unify the bridgeBaseUrl construction by reading from the plugin instead of
+recomputing in the supervisor, and either ship the missing three cleanup
+tests or scope the test file's header down to what's covered. Everything
+else (FQN naming, audit duplication, ESM hygiene, the operator footgun
+between `mcp-proxy.json` and `~/.claude/mcp.json`) is comment-and-document
+work that doesn't block the merge.

--- a/.planning/mcp-multiplexer/SECURITY-AUDIT.md
+++ b/.planning/mcp-multiplexer/SECURITY-AUDIT.md
@@ -1,0 +1,518 @@
+# MCP Multiplexer — Phase D Security Audit
+
+**Worktree**: `feat/mcp-multiplexer-integration` at HEAD `d89a956`
+**Auditor**: security-auditor (read-only review, no source changes)
+**Date**: 2026-05-15
+**Issue**: TerrysPOV/ClaudeClaw-Plus#64
+**Scope**: pre-code-review security pass; gates "Approve / Approve with conditions / Reject" before operator merge.
+
+> Note on inputs. `.planning/mcp-multiplexer/SPEC.md` was referenced in the task brief but is not present in this worktree (only `W1-COORD.md` ships here, and git shows it has never been committed under any branch in this repo). The audit is therefore grounded in W1-COORD.md + the code as it stands. Where I cite "SPEC §X" I am quoting the inline source comments that pin the contract.
+
+---
+
+## Executive verdict
+
+**APPROVE WITH CONDITIONS.**
+
+The bearer-as-secret + loopback-only + 0600-at-rest envelope holds under the stated threat model. Implementation is tighter than W1-COORD.md promises: timing-safe comparison, strict `ptyId` regex, dormant-by-default activation, defense-in-depth on host binding, and complete identity/route teardown on every dispose path. No critical findings.
+
+Three medium-severity items must be addressed (or consciously deferred to a follow-up) before flipping `pty.enabled: true` in production:
+1. The `bearer` string is included in the `PtyIdentity` object exposed by `issueIdentity()` and is therefore reachable by any future code path that logs the identity object. Right now nothing does — but there is no defensive `toJSON`/redaction guard. **Medium / NEEDS-WORK.**
+2. `/mcp/<server>` has no rate-limit, request-size, or per-bearer flood-control. `/api/plugin/*` has HMAC + 15-min replay window; `/mcp/*` has bearer-only. The exposure surface is loopback-only, so the realistic attacker is a same-UID misbehaver, but the operator should agree this is acceptable for v1. **Medium / NEEDS-WORK.**
+3. The `.claudeclaw/` directory at PTY `cwd` is created with `0700` only on first write — if the directory already exists with looser perms, the writer "doesn't fight the operator" (comment in `pty-mcp-config-writer.ts:172-176`). That means a pre-existing `.claudeclaw/` at e.g. `0755` will silently host `mcp-pty-<id>.json` files (the *file* mode 0600 still protects the bearer), but the directory listing leaks ptyIds to other UIDs. Tighten or document. **Low / NEEDS-WORK.**
+
+**Traffic light per audit-checklist item:**
+
+| # | Item | Verdict |
+|---|------|---------|
+| 1 | Bearer-as-secret envelope | PASS |
+| 2 | Constant-time bearer comparison | PASS |
+| 3 | `ptyId` validation | PASS |
+| 4 | Replay-window drop | PASS (acceptable) |
+| 5 | `/mcp/*` rate-limit gap | NEEDS-WORK (Medium) |
+| 6 | Loopback enforcement | PASS |
+| 7 | Plain HTTP on loopback | PASS |
+| 8 | Outbound routes | PASS |
+| 9 | Config-file mode 0600 | PASS-with-caveat (file mode is right; directory hardening is best-effort) |
+| 10 | Secret-in-memory leak surface | NEEDS-WORK (Medium — `PtyIdentity.bearer` is reachable) |
+| 11 | Identity revocation completeness | PASS |
+| 12 | Synthesised config cleanup | PASS |
+| 13 | Upstream child trust | PASS (env inheritance is SDK-filtered) |
+| 14 | `allowedTools` filter | PASS |
+| 15 | Crash audit events | PASS |
+| 16 | Identity issuance/release audit | PASS |
+| 17 | No bearer in audit | PASS |
+| 18 | Dormant-by-default | PASS |
+| 19 | Activation gate | PASS |
+| 20 | Rollback path | PASS |
+| 21 | DoS-via-spawn | PASS (5-crashes-in-5-min → permanent failure) |
+| 22 | Spawn-time poisoning | OUT-OF-SCOPE (same-UID attacker) |
+| 23 | FQN collision | PASS |
+
+---
+
+## Findings
+
+### #1 Bearer-as-secret envelope is defensible — but document the assumption explicitly  [SEVERITY: Info] [VERDICT: PASS]
+
+**Files**: `src/plugins/mcp-multiplexer/pty-identity.ts:1-58`, `.planning/mcp-multiplexer/W1-COORD.md:9-58`
+
+The original SPEC §4.3 required a per-request HMAC over `(method, path, ts, body-sha256)`. Claude Code's stock MCP HTTP client only sends a static `headers` map, so per-request signing is not implementable client-side. The team fell back to:
+
+- Per-PTY 32-byte secret minted on `issueIdentity()`.
+- Bearer = `Bearer <hex(secret)>` — the literal secret IS the credential.
+- Rotation on every PTY respawn (`pty-supervisor.ts:993-1001`) and on every fresh spawn (`pty-supervisor.ts:785, 834`).
+- Constant-time comparison server-side.
+
+The realistic exploitation paths against this envelope are:
+
+| Path | Mitigated by | Residual risk |
+|------|--------------|---------------|
+| Network sniff of bearer | Loopback-only bind + plain HTTP is fine on lo0 | None |
+| Bearer at rest in synthesised config | File mode 0600, parent dir 0700 | Same-UID attacker only (already game over) |
+| Bearer in process memory (core dump) | Secret rotation on respawn | Brief window between crash and respawn (`pty-supervisor.ts:993-995` correctly documents this) |
+| Cross-PTY replay (PTY A's bearer hits PTY B's route) | `verifyBearer(ptyId, ...)` looks up the secret bound to `ptyId` from the asserted `X-Claudeclaw-Pty-Id` header — wrong ptyId → no match | None (well-designed) |
+| Stolen bearer used by a long-running script | No timestamp window; rotation only on respawn (`pty.idleReapMinutes`, default 30) | Bearer is valid for up to 30 min after theft from a same-UID attacker. Acceptable per the stated trust boundary. |
+
+**Recommendation**: keep the design. Add a one-line comment on `verifyBearer` confirming the cross-PTY-replay defense ("the asserted ptyId scopes the lookup; a stolen `(bearer, ptyIdA)` pair cannot pivot to ptyIdB") so a future reviewer doesn't accidentally remove that lookup.
+
+---
+
+### #2 Constant-time bearer comparison via `timingSafeEqual` — confirmed  [SEVERITY: Info] [VERDICT: PASS]
+
+**File**: `src/plugins/mcp-multiplexer/pty-identity.ts:148-173`
+
+`verifyBearer` uses `crypto.timingSafeEqual` on equal-length `Buffer`s. Length-mismatch short-circuits to `false` before the constant-time call, which is the standard Node.js pattern and acceptable (the length is not secret material). Hex decoding tolerates case-insensitive `bearer` scheme prefix and rejects malformed hex via `try/catch`.
+
+One micro-nit: the regex `/^bearer\s+([0-9a-f]+)$/i` accepts any non-empty hex string, then `Buffer.from(hex, "hex")` silently truncates odd-length input. The length comparison at L167 still catches it (truncation → wrong length → false), so the early-exit semantics are correct. No change needed.
+
+---
+
+### #3 `ptyId` validation is restrictive enough  [SEVERITY: Info] [VERDICT: PASS]
+
+**File**: `src/plugins/mcp-multiplexer/pty-identity.ts:74-81`
+
+Regex `^[A-Za-z0-9_.:-]+$`, 1–128 chars. This is enforced both at `issueIdentity` and via the HTTP-handler path (the handler receives `ptyId` from the `X-Claudeclaw-Pty-Id` header but only uses it as a Map key for `identities.get(ptyId)` and as an audit field — no path component, no shell interpolation).
+
+Path-traversal surface in the synthesised config file (`pty-mcp-config-writer.ts:90`):
+```
+join(cwd, ".claudeclaw", `mcp-pty-${ptyId}.json`)
+```
+The regex rejects `/`, `\`, `..`, and whitespace, so `mcp-pty-../../etc/passwd.json` cannot be constructed. **PASS.**
+
+Header-injection surface: `X-Claudeclaw-Pty-Id` is set on every request from the synthesised config; allowed chars don't include CR/LF, so no header smuggling. **PASS.**
+
+One observation: the `.` and `:` characters are in the allowed set. `.` enables `.` and `..` as full strings IF they were not blocked by the `^[A-Za-z0-9_.:-]+$` anchored match — let me re-check: `.` matches the regex (the `.` character is literal inside a character class). So `ptyId = "."` or `".."` is technically a valid ptyId. The resulting filename `mcp-pty-..json` and `mcp-pty-...json` are still safely inside `.claudeclaw/`. No traversal possible. **PASS.**
+
+---
+
+### #4 Replay window dropped — defensible given rotation semantics  [SEVERITY: Info] [VERDICT: PASS]
+
+**Files**: `src/plugins/mcp-multiplexer/pty-identity.ts:36-40, 92`, W1-COORD.md §"Issuance timestamp"
+
+SPEC originally specified a ±5-minute replay window on `X-Claudeclaw-Ts`. W1 dropped enforcement because the stock client re-sends the same headers verbatim for the lifetime of the PTY, so the window would expire tokens within seconds. The timestamp is now carried only for audit observability (`audit("multiplexer_identity_issued", { issued_at })`).
+
+This shifts replay protection entirely to rotation:
+- Fresh spawn → new secret (`pty-supervisor.ts:785, 834` via `issueIdentity`).
+- Respawn → new secret (`pty-supervisor.ts:1000-1010` calls `synthesizeMcpConfigIfActive` which re-issues).
+- Idle-reap → `releaseMcpIdentityFor` revokes the secret (`pty-supervisor.ts:1177`).
+- Operator `/kill` → `killAllPtys` revokes every secret (`pty-supervisor.ts:484`).
+
+The trade-off (longer-lived bearer in exchange for client-side compatibility) is reasonable. **PASS.**
+
+One observability gap: `X-Claudeclaw-Ts` is *audited* on issuance but NOT on inbound request — `multiplexer_invoke` audit (`http-handler.ts:154-160`) does not include the timestamp the client sent. Forensics could not later prove "this invocation used a bearer issued at T". Low-priority but worth filing. **Recommendation**: add `ts: req.headers.get(PTY_TS_HEADER)` to the `multiplexer_invoke` payload.
+
+---
+
+### #5 `/mcp/<server>` has no rate-limit or body-size cap  [SEVERITY: Medium] [VERDICT: NEEDS-WORK]
+
+**Files**: `src/plugins/mcp-multiplexer/http-handler.ts:97-184`, `src/plugins/http-gateway.ts:66-72`
+
+`/api/plugin/*/invoke` has:
+- `MAX_BODY_BYTES = 1_048_576` cap (`http-gateway.ts:24, 207-217`).
+- HMAC body signing (`http-gateway.ts:224-226`).
+- `REPLAY_WINDOW_MS = 15 * 60_000` (`http-gateway.ts:22, 228-231`).
+- 30s invoke timeout (`PLUGIN_INVOKE_TIMEOUT_MS`).
+
+`/mcp/<server>` has:
+- Bearer comparison.
+- 30s upstream call timeout (`server-process.ts:25, 132-147`).
+- **No body-size cap.** `http-handler.ts:60-73` (`_readBody`) clones the request for audit peek but does not enforce a cap; the SDK's `WebStandardStreamableHTTPServerTransport.handleRequest()` parses JSON without an explicit cap.
+- **No rate limit per bearer.** A misbehaving PTY-resident `claude` (or a same-UID attacker holding a stolen bearer) can flood `/mcp/<server>/tools/call` until the upstream child's 30s timeout fires repeatedly.
+
+**Realistic exploitation**: the attacker is same-UID, so they could simply spawn `bun src/...` directly and bypass everything. Defense-in-depth would still help by capping resource exhaustion (memory: a 4 GB POST body would OOM the daemon; CPU: a tight loop of `tools/call` against graphiti could saturate Neo4j).
+
+**Recommendation**:
+1. Add a body-size cap mirroring `MAX_BODY_BYTES` at the top of `McpHttpHandler.handle()` (before the auth check or right after, so we don't burn the read for unauthenticated requests). Reject with `413 body_too_large`.
+2. Add a minimal per-bearer token-bucket (e.g. 100 req/s, burst 200). One in-memory `Map<ptyId, { tokens, lastRefillMs }>`; ~30 LOC.
+
+Either action defensible to defer to a v1.1 follow-up — but the body-size cap is cheap enough that it should land before flipping `pty.enabled: true`.
+
+---
+
+### #6 Loopback enforcement — absolute  [SEVERITY: Info] [VERDICT: PASS]
+
+**File**: `src/plugins/mcp-multiplexer/index.ts:166-178`
+
+```ts
+if (settings.webHost !== "127.0.0.1" && settings.webHost !== "localhost") {
+  console.error(`[mcp-multiplexer] dormant — gateway host '${...}' is non-loopback; refusing to expose MCP routes externally.`);
+  getMcpBridge().audit("multiplexer_refused_non_loopback", { host: settings.webHost });
+  return;
+}
+```
+
+The refusal is absolute — there is no escape hatch via env var or settings flag. Even if `settings.web.host = "0.0.0.0"`, the multiplexer goes dormant and audits the rejection. The HTTP gateway itself still binds on whatever `web.host` is set to (a separate concern), but `/mcp/*` routes are not registered and `mcpHandlers` map is empty → `handleRequest` returns `404 mcp_server_not_registered`. **PASS.**
+
+One minor: `"localhost"` is allowed but resolves dynamically. On a host where `/etc/hosts` has been tampered with by a same-UID attacker, `localhost` could in theory resolve to a non-loopback address. That would be a same-UID compromise scenario (out of scope) — but if you want belt-and-braces, you could resolve at startup and refuse anything outside `127.0.0.0/8` and `::1`. Low priority.
+
+---
+
+### #7 Plain HTTP on loopback — defensible  [SEVERITY: Info] [VERDICT: PASS]
+
+**File**: `src/plugins/mcp-multiplexer/index.ts:201-202`
+
+```ts
+this.cachedBridgeBaseUrl = this.bridgeBaseUrlOverride ?? `http://${settings.webHost}:${settings.webPort}`;
+```
+
+Loopback traffic is process-local; TLS would add startup latency and certificate management overhead with no realistic threat to defend against (same-UID attackers can read socket buffers regardless). **PASS.**
+
+---
+
+### #8 No outbound network calls from the multiplexer  [SEVERITY: Info] [VERDICT: PASS]
+
+**Files**: `src/plugins/mcp-multiplexer/index.ts`, `src/plugins/mcp-multiplexer/http-handler.ts`, `src/plugins/mcp-proxy/server-process.ts`
+
+`McpHttpHandler.handle()` proxies straight through to `this.proc.call(name, args)` (`http-handler.ts:246-249`), which dispatches over the upstream child's stdio transport (`server-process.ts:137-147`). No `fetch`, no socket, no third-party HTTP client. The only "outbound" path is the upstream child itself, which is bounded by what the operator put in `mcp-proxy.json`.
+
+`getHttpGateway().registerInProcess` (`http-gateway.ts:371-401`) and the bridge-callback path (`index.ts:479-502`) also stay in-process. **PASS.**
+
+---
+
+### #9 Synthesised config file mode  [SEVERITY: Low] [VERDICT: PASS-with-caveat]
+
+**File**: `src/runner/pty-mcp-config-writer.ts:80-188`
+
+- File: `writeFileSync(path, ..., { mode: 0o600 })` (L185-188). On first write the file is created with 0600.
+- Directory: `mkdirSync(dir, { recursive: true, mode: 0o700 })` (L173-176) — but only IF the directory doesn't exist. The writer explicitly chooses not to `chmod` an existing `.claudeclaw/` directory (comment L171-176).
+- Re-writes: when the file already exists, `writeFileSync` overwrites the bytes but doesn't change the mode. Comment L178-184 documents this and reasons it's safe because the file we created in a prior turn already has 0600.
+
+**Caveat**: if an operator (or an attacker who already has same-UID) deliberately runs `chmod 0644 ${cwd}/.claudeclaw/mcp-pty-<id>.json`, the next `writeConfigForPty` call will overwrite the contents WITHOUT restoring 0600. The file-mode flag is "create-time only" on most platforms (the comment correctly says so). Same-UID attacker = out of scope, but...
+
+**Recommendation (low priority)**: defensively `chmodSync(path, 0o600)` after `writeFileSync`. Three lines, removes the entire "what if perms got loosened" branch.
+
+**On the directory**: if `.claudeclaw/` already exists with looser perms (e.g. 0755 from some prior tooling), the directory listing is world-readable. The bearer secret is inside the FILE (still 0600), but the directory listing reveals ptyIds and timestamps, which are minor. **Recommendation**: `chmodSync(dir, 0o700)` after the existence check would close this. ~2 lines.
+
+---
+
+### #10 `PtyIdentity.bearer` is reachable on the exposed object  [SEVERITY: Medium] [VERDICT: NEEDS-WORK]
+
+**File**: `src/plugins/mcp-multiplexer/pty-identity.ts:44-95`
+
+```ts
+export interface PtyIdentity {
+  ptyId: string;
+  issuedAt: number;
+  bearer: string;            // `Bearer <hex>` — the secret in cleartext
+  headers: Record<string, string>;
+}
+```
+
+`issueIdentity` returns this object to the supervisor; the supervisor passes it to `writeConfigForPty` which embeds `identity.headers` (containing the bearer) into the on-disk JSON. That path is correct.
+
+The risk surface is **other callers** that might receive the same object:
+1. `getMcpMultiplexerPlugin().issueIdentity(ptyId)` (`index.ts:404-413`) — the public method also audits `{ pty_id, issued_at }` with NO bearer. Good.
+2. `getIdentity(ptyId)` (`pty-identity.ts:121-124`) — exported, returns the full public identity including bearer. No callers in tree today, but exposed.
+3. If a future debug/dump-state path adds `JSON.stringify(getIdentity(ptyId))`, the bearer leaks to disk/logs.
+
+**Verification done**: no audit-event payload anywhere in the tree includes `bearer`, `secret`, or `identity` verbatim. `rg -n "audit\(" src/plugins/mcp-multiplexer/` shows only `multiplexer_identity_issued { pty_id, issued_at }`, `multiplexer_identity_released { pty_id }`, `multiplexer_auth_rejected { server, pty_id }`, `multiplexer_invoke { server, pty_id, stateless, rpc_method }`. **No bearer in any audit.** **PASS** for #17.
+
+**But** the surface remains: `PtyIdentity` is a plain object and `bearer` is enumerable. A future reviewer who adds `console.error('[debug]', getIdentity(ptyId))` ships the secret to stderr → daemon log → potentially Sentry → possibly shared with developers.
+
+**Recommendation**: one of:
+- (a) Replace the `bearer` field with a `getBearer()` accessor and make the public type not expose it directly.
+- (b) Add a `toJSON()` method on the `PtyIdentity` (use a class instead of an interface) that returns `{ ptyId, issuedAt, '[bearer]': '<redacted>' }`. The supervisor and writer already access `identity.headers` (which still has the cleartext bearer in the headers map), so `toJSON` won't affect them as long as they don't `JSON.stringify(identity)`.
+- (c) Stop returning `bearer` separately — the writer only reads `identity.headers`, and the bearer string is already in there. Drop the `bearer` field entirely from the public interface; keep it as a derived value internal to `_toPublic`. This is the cleanest fix.
+
+Option (c) is the most defensible: it makes the type-system enforce "you don't get the bearer on its own" while the on-the-wire path is unchanged.
+
+---
+
+### #11 Identity revocation drops secret AND per-PTY transport buckets  [SEVERITY: Info] [VERDICT: PASS]
+
+**Files**: `src/plugins/mcp-multiplexer/index.ts:415-425`, `src/plugins/mcp-multiplexer/http-handler.ts:186-199`
+
+```ts
+async releaseIdentity(ptyId: string): Promise<void> {
+  const removed = _revokeIdentity(ptyId);                                    // drops secret
+  await Promise.allSettled(
+    [...this.handlers.values()].map((h) => h.releasePty(ptyId)),             // drops per-PTY transports
+  );
+  if (removed) {
+    getMcpBridge().audit("multiplexer_identity_released", { pty_id: ptyId });
+  }
+}
+```
+
+`releasePty(ptyId)` (`http-handler.ts:186-199`) deletes the bucket from the map and closes both the SDK server and the transport. Idempotent — safe to call for a never-issued ptyId.
+
+For stateless servers (`http-handler.ts:189`), `releasePty` is a no-op because the bucket is keyed on `STATELESS_BUCKET` not `ptyId`. That's correct (the bucket is shared and survives PTY lifecycle), but means PTY teardown does NOT clean up the upstream session for stateless servers. **This is by design** (per `http-handler.ts:33-36` comment) but worth confirming with the operator: if a stateless server holds per-PTY state inside its own process (e.g. graphiti's group_id), that state will outlive the PTY. The same was already true before this milestone, so it's not a regression — just worth knowing.
+
+`stop()` (`index.ts:287-307`) tears down everything in order: stop probe → unregister plugin from bridge → unregister gateway routes → stop handlers → stop server processes → clear caches. **PASS.**
+
+---
+
+### #12 Synthesised config cleanup  [SEVERITY: Info] [VERDICT: PASS]
+
+**Files**: `src/runner/pty-supervisor.ts:866-891`, `pty-mcp-config-writer.ts:199-209`
+
+`releaseMcpIdentityFor(entry)` is called from:
+- L297 — `__resetSupervisorForTests` (fire-and-forget; tests only)
+- L439 — `shutdownSupervisor` (daemon shutdown)
+- L484 — `killAllPtys` (operator `/kill`)
+- L696 — LRU eviction
+- L959 — failed spawn cleanup
+- L1177 — idle reap
+
+`deleteConfigForPty` (`pty-mcp-config-writer.ts:199-209`) swallows ENOENT (file already gone) and re-throws other errors (which the supervisor catches and ignores at the call sites with `try/catch`). Idempotent.
+
+**Orphan-file scenarios checked**:
+- Daemon crash with files left behind: yes, the files persist on disk with mode 0600 — the secrets in them are dead (in-memory store is gone, so verifyBearer will fail), so no security impact. Cosmetic.
+- PTY dispose during respawn: `respawnEntry` (L981-1031) does NOT call `releaseMcpIdentityFor` — correct, because the ptyId is the same and the next write idempotently overwrites the file.
+- spawnEntry throws AFTER synthesis but BEFORE pty.dispose: L955-961 catches this and calls `releaseMcpIdentityFor`. Good.
+
+**One subtle thing**: `deleteConfigForPty(cwd, ptyId)` requires the cached `cwd` (`pty-supervisor.ts:868`). If the entry has no cached cwd (mid-spawn before `entry.spawnOpts` is set), the path is computed-but-never-deleted and there's nothing to delete (because nothing was written). The guard at L884 (`if (cfgPath && cwd)`) handles this correctly. **PASS.**
+
+---
+
+### #13 Upstream child trust — env inheritance is SDK-filtered  [SEVERITY: Info] [VERDICT: PASS]
+
+**Files**: `src/plugins/mcp-proxy/server-process.ts:60-67`, `node_modules/@modelcontextprotocol/sdk/dist/esm/client/stdio.js:8-41`
+
+The `StdioClientTransport` from `@modelcontextprotocol/sdk` does NOT inherit `process.env` wholesale. It uses `DEFAULT_INHERITED_ENV_VARS` — a sudo-style allowlist (HOME, PATH, USER, LANG, LC_*, TERM, TMPDIR on Unix; the equivalent set on Windows) merged with the explicit `this.config.env`. **`ANTHROPIC_API_KEY` is NOT in the default-inherited set** — confirmed via grep.
+
+Practical implication: a compromised graphiti server cannot reach the operator's Anthropic API key through its environment. It CAN read whatever the operator put in `mcp-proxy.json`'s `env:` block for that server (which is intentional — that's how operators pass NEO4J_URI, OPENAI_API_KEY for embeddings, etc.).
+
+The child runs under the operator's UID with the operator's filesystem access — so a malicious child can read any file the operator can read. That's the inherent trust boundary of running third-party code, and it's unchanged by this milestone (mcp-proxy had the same exposure pre-multiplexer).
+
+**Cross-PTY data exposure**: a stateful upstream child (non-stateless) sees one `(ptyId)` bucket per PTY (`http-handler.ts:225-282`). Each bucket has its own SDK Server instance and a fresh `randomUUID()` session ID. The bucket is isolated at the JSON-RPC session level, but the underlying upstream process is shared — so if graphiti aggregates by group_id internally, that aggregation is cross-PTY. **This is by design** (the whole point of the multiplexer) but should be in the operator-facing docs: "shared MCP servers share state across PTYs at the upstream-process level".
+
+**PASS.**
+
+---
+
+### #14 `allowedTools` filter — enforced at the upstream layer, inherited by the multiplexer  [SEVERITY: Info] [VERDICT: PASS]
+
+**File**: `src/plugins/mcp-proxy/server-process.ts:113-120`
+
+```ts
+const allowed = this.config.allowedTools;
+this.tools = tools
+  .filter((t) => !allowed || allowed.includes(t.name))
+  .map(...);
+```
+
+`McpServerProcess.tools` is filtered at startup. The multiplexer's `tools/list` handler (`http-handler.ts:235-243`) reads `this.proc.tools.map(...)`, so the filter is inherited automatically. `tools/call` (`http-handler.ts:246-268`) calls `this.proc.call(name, args)` which dispatches via the SDK client — the upstream child sees the tool name, but `McpServerProcess.call` doesn't re-check `allowedTools`. If a malicious PTY-resident `claude` tries to call a non-allowed tool, the upstream child receives the call and either responds with "unknown tool" or executes it (if the allowlist is purely advisory).
+
+**Risk**: defense-in-depth would re-check `allowedTools` in `McpServerProcess.call()` before dispatching to the upstream. Currently the only enforcement is at `listTools` time. If the upstream child added a tool dynamically (uncommon) or honored a name the allowlist excluded (depends on upstream), the filter could be bypassed.
+
+**Recommendation (low priority)**: add a defensive check in `McpServerProcess.call()`:
+```ts
+if (this.config.allowedTools && !this.config.allowedTools.includes(tool)) {
+  throw new Error(`Tool '${tool}' is not in allowedTools for ${this.name}`);
+}
+```
+Three lines, eliminates the bypass surface.
+
+**Verdict for this PR**: PASS (the inheritance is correct; the bypass surface is a pre-existing mcp-proxy property, not a multiplexer regression).
+
+---
+
+### #15 Crash audit events — covered  [SEVERITY: Info] [VERDICT: PASS]
+
+**Files**: `src/plugins/mcp-multiplexer/index.ts:341-366, 465-477`, `src/plugins/mcp-proxy/index.ts:190-201`, `src/plugins/mcp-proxy/server-process.ts:174-198`
+
+State transitions and their audit events:
+
+| Transition | Event | File:Line |
+|------------|-------|-----------|
+| Server first comes up (multiplexer) | `multiplexer_server_ready` | `index.ts:254-258` |
+| Server crash (multiplexer) | `multiplexer_server_crashed` | `index.ts:467-473` |
+| Health degraded (multiplexer probe) | `mcp_health_degraded` | `index.ts:351-359` |
+| Health transition (multiplexer probe) | `mcp_health_transition` | `index.ts:351-359` |
+| Server crash (mcp-proxy) | `mcp_proxy_server_crashed` | `mcp-proxy/index.ts:194` |
+| Server permanently failed (mcp-proxy) | `mcp_proxy_server_permanently_failed` | `mcp-proxy/index.ts:199` |
+| Identity issued | `multiplexer_identity_issued` | `index.ts:407-411` |
+| Identity released | `multiplexer_identity_released` | `index.ts:422-424` |
+| Auth rejected | `multiplexer_auth_rejected` | `http-handler.ts:114-117` |
+| Invocation | `multiplexer_invoke` | `http-handler.ts:155-160` |
+| Refused non-loopback | `multiplexer_refused_non_loopback` | `index.ts:173-176` |
+| Dormant (web disabled) | `multiplexer_dormant_web_disabled` | `index.ts:185-187` |
+| Dormant (empty shared) | `multiplexer_dormant_empty_shared` | `index.ts:192-194` |
+| No config | `multiplexer_no_config` | `index.ts:209-211` |
+| mcp-proxy skip-shared | `mcp_proxy_skip_shared` | `mcp-proxy/index.ts:86` |
+
+Coverage is complete. The crash chain `transport.onclose → _handleCrash → onCrash hook → audit` is wired (`server-process.ts:87-95 → 174-198`, `mcp-proxy/index.ts:190-201`, `index.ts:228-231 → 465-477`).
+
+Missing a permanent-failure audit for the multiplexer specifically — `mcp-proxy` emits `mcp_proxy_server_permanently_failed` but the multiplexer doesn't have an equivalent `multiplexer_server_permanently_failed`. The crash hook (`index.ts:465`) is called for both crash and failed states, so the audit fires for failure but uses the same `multiplexer_server_crashed` event with `status: "failed"`. That's serviceable but harder to alert on.
+
+**Recommendation (low priority)**: split the audit into `multiplexer_server_crashed` (transient) and `multiplexer_server_permanently_failed` (terminal), mirroring `mcp-proxy`. Or, document that operators should grep for `status: "failed"` in `multiplexer_server_crashed` events.
+
+---
+
+### #16 Identity issuance/release audit — covered  [SEVERITY: Info] [VERDICT: PASS]
+
+**File**: `src/plugins/mcp-multiplexer/index.ts:404-425`
+
+Every public `issueIdentity` call audits `multiplexer_identity_issued`. Every public `releaseIdentity` call audits `multiplexer_identity_released` (but only if a secret was actually removed — `removed` flag at L420 prevents spurious events for unknown ptyIds).
+
+Bypass paths to check:
+- Direct calls to the underlying `_issueIdentity` (`pty-identity.ts:106`) — exported as `issueIdentity` from the module. If a future caller imports `issueIdentity` directly from `pty-identity.ts` (not from `index.ts`), it bypasses the audit. **Recommendation**: rename the bare function to `_issueIdentityRaw` or move the audit into the bare function. Keep the public API in `index.ts` as the only audited path.
+- `_resetIdentityStore()` (`pty-identity.ts:185-187`) — clears the entire map without auditing each release. Test-only, so acceptable.
+
+---
+
+### #17 No bearer/secret in any audit payload  [SEVERITY: Info] [VERDICT: PASS]
+
+**Verification**:
+```
+rg -n "audit\(" src/plugins/mcp-multiplexer/ src/plugins/mcp-proxy/ src/runner/pty-supervisor.ts
+```
+All audit calls inspected. No occurrence of `bearer`, `secret`, `record.secret`, or `identity.headers` in any audit payload. `identity` (the full object) is never passed to `audit()`. **PASS.**
+
+---
+
+### #18 Dormant-by-default  [SEVERITY: Info] [VERDICT: PASS]
+
+**Files**: `src/config.ts:105-112`, `src/plugins/mcp-multiplexer/index.ts:190-196`
+
+Default `settings.mcp.shared = []` (`config.ts:108`). Multiplexer `start()` checks this at L190-196 and bails before spawning anything, before mounting any route, before issuing any identity. The supervisor's `synthesizeMcpConfigIfActive` (`pty-supervisor.ts:813-855`) returns `undefined` on empty `shared` (L818-819), so the PTY path is byte-identical to the pre-milestone code.
+
+**Code-trace verification**: walked from `start()` to confirm three short-circuits exist (loopback, web-enabled, shared non-empty), each emitting an audit event before returning. No early-return path leaves zombie state. `this.active = false`, `this.started = true` (so a second `start()` is idempotent), `this.cachedSharedNames = []`. **PASS.**
+
+---
+
+### #19 Activation gate — settings.web.enabled + settings.mcp.shared + 127.0.0.1  [SEVERITY: Info] [VERDICT: PASS]
+
+**File**: `src/plugins/mcp-multiplexer/index.ts:166-196`
+
+Three checks, in this order:
+1. `settings.webHost !== "127.0.0.1" && settings.webHost !== "localhost"` → audit + return (L166-178).
+2. `!settings.webEnabled` → audit + return (L180-188).
+3. `settings.shared.length === 0` → audit + return (L190-196).
+
+All three must pass before any spawn happens. The supervisor's `synthesizeMcpConfigIfActive` independently checks `shared.length > 0 && web.enabled && _mcpIssueIdentity != null` (`pty-supervisor.ts:818-833`) — three-of-three before synthesis. **PASS.**
+
+---
+
+### #20 Rollback — flipping `settings.mcp.shared = []` and reloading  [SEVERITY: Info] [VERDICT: PASS]
+
+**File**: `src/plugins/mcp-multiplexer/index.ts:287-307`
+
+`stop()` performs ordered teardown:
+1. `started = false`, `active = false`
+2. Stop health probe + clear `lastObservedStatus`
+3. Unregister plugin from mcp-bridge (drops bridge-callback FQNs)
+4. Unregister every `/mcp/<server>` route from the gateway
+5. Stop every handler (closes buckets, transports, SDK servers)
+6. Stop every upstream child process
+7. Clear caches
+
+No zombie state: no leftover routes, no orphan child processes (all `stop()`s are awaited via `Promise.allSettled`), no leftover identities (the supervisor independently revokes via `releaseMcpIdentityFor` when each PTY disposes).
+
+However: this is `stop()`, called on daemon shutdown or a hot-restart of the plugin. Operator-flipping `settings.mcp.shared = []` mid-daemon would require either a daemon restart or a `_reset → start` cycle on the plugin singleton. The current code has `_resetMcpMultiplexer` (`index.ts:514-517`) for tests only — there's no operator-facing "reload" path. **This is fine for v1** (operators bounce the daemon to apply config changes anyway) but worth knowing.
+
+**Recommendation (info)**: document in the operator-facing settings reference that `settings.mcp.shared` changes require a daemon restart. **PASS.**
+
+---
+
+### #21 DoS-via-spawn — bounded by crash-window logic  [SEVERITY: Info] [VERDICT: PASS]
+
+**File**: `src/plugins/mcp-proxy/server-process.ts:21-24, 174-198`
+
+```ts
+const BACKOFF_MS = [1_000, 5_000, 30_000, 60_000];
+const CRASH_WINDOW_MS = 5 * 60 * 1_000;
+const MAX_CRASHES_IN_WINDOW = 5;
+```
+
+5 crashes in 5 minutes → `status = "failed"` permanently. No restart timer scheduled. Restart-loop saturation is impossible.
+
+The generation counter (`server-process.ts:45, 82-96`) prevents double-restart from stale `onclose`/`onerror` handlers — verified at L86 (`crashHandled` flag) + L88 (`this.generation !== gen` guard). **PASS.**
+
+---
+
+### #22 Spawn-time poisoning of `mcp-proxy.json` — out of scope (same-UID)  [SEVERITY: Out-of-scope] [VERDICT: N/A]
+
+**File**: `src/plugins/mcp-multiplexer/index.ts:155, 445-454`
+
+Config path defaults to `~/.config/claudeclaw/mcp-proxy.json`. The file is owned by the operator's UID. An attacker who can rewrite it has same-UID access, which is already game-over. The file is read once at `start()` via `JSON.parse(readFileSync(...))`; if parse fails, `safeParse` returns failure and the multiplexer goes dormant (`index.ts:204-213`). No injection surface from the parse path (Zod validates the schema).
+
+---
+
+### #23 FQN namespace collision — impossible by construction  [SEVERITY: Info] [VERDICT: PASS]
+
+**Files**: `src/plugins/mcp-bridge.ts:65`, W1-COORD.md §"FQN namespacing"
+
+The bridge always prefixes registered tool names with `pluginId__`. The multiplexer registers under `pluginId = "mcp-multiplexer"`, so all its FQNs are `mcp-multiplexer__<server>__<tool>`. The mcp-proxy plugin registers under `pluginId = "mcp-proxy"`, so its FQNs are `mcp-proxy__<server>__<tool>`. The two namespaces cannot overlap.
+
+The skip-shared rule (`mcp-proxy/index.ts:71-88`) is a structural belt-and-braces: when a server name appears in `settings.mcp.shared`, mcp-proxy explicitly skips spawning it so the upstream child isn't double-spawned. **PASS.**
+
+---
+
+## Threat model validation
+
+The stated trust boundary is correct and the implementation respects it:
+
+**Trusted**: daemon process + operator UID. Anyone with that level of access already owns everything; no defense is meaningful.
+
+**Untrusted**:
+- Other UIDs on the same host. Defended by file mode 0600, parent dir 0700 (when newly created), and `verifyBearer` constant-time comparison.
+- Network beyond loopback. Defended by absolute refusal to mount when `webHost` isn't `127.0.0.1`/`localhost`.
+- Third-party MCP server children. Defended by SDK's `DEFAULT_INHERITED_ENV_VARS` allowlist (no API-key leak) and the operator-controlled `env:` block in `mcp-proxy.json`. Upstream child can still misbehave inside its allocated capability surface — but the same was true pre-milestone.
+- Processes that can read files the daemon writes. Defended by 0600 on the synthesised config; the bearer is the only secret-at-rest and it rotates on respawn.
+
+**Realistic exploitation paths considered**:
+
+1. *Network attacker scans loopback ports.* → 401 immediately (no bearer). Not exploitable.
+2. *Another local user reads `mcp-pty-<id>.json`.* → File mode 0600 blocks read. Directory listing of `.claudeclaw/` (if dir is 0755) leaks ptyIds — minor info disclosure, not a credential leak.
+3. *Same-UID attacker reads `mcp-pty-<id>.json`.* → Bearer in cleartext, valid for up to 30 min (idle-reap default). Out of scope per the stated trust boundary.
+4. *Compromised upstream MCP child (e.g. malicious graphiti).* → Bounded by `DEFAULT_INHERITED_ENV_VARS`; cannot reach Anthropic API key. Can still misuse `mcp-proxy.json`-supplied secrets (NEO4J_URI etc.) and read operator's files. Unchanged from pre-milestone.
+5. *Replay of stolen bearer from a long-running script.* → Valid until next PTY respawn / reap. Worst case ~30 min. Mitigation: tighten `pty.idleReapMinutes` in deployment.
+6. *DoS via repeated `tools/call`.* → Upstream call has 30s timeout, but no rate-limit at the multiplexer layer. **See finding #5.**
+7. *DoS via large request body.* → No body-size cap on `/mcp/*`. **See finding #5.**
+8. *Bearer leaks via daemon log or audit.* → No audit path includes the bearer, but the `PtyIdentity.bearer` field is reachable on the public object. **See finding #10.**
+9. *PTY crash leaves orphan config file with valid bearer.* → No: secret rotates on respawn and the in-memory store is gone on daemon crash, so the on-disk bearer is dead the moment the daemon dies. Cosmetic file litter only.
+
+The envelope holds.
+
+---
+
+## Conditions for production rollout (`pty.enabled: true`)
+
+Issue #64 is already documented as blocking prod. Before flipping the switch:
+
+**Must-fix (before merge or in a fast follow-up):**
+1. **Finding #10**: drop `PtyIdentity.bearer` from the public interface; expose only via `headers`. This forecloses an entire class of "future contributor adds a `console.log(identity)`" leaks. 5-10 LOC.
+2. **Finding #5 (partial)**: add a body-size cap at the top of `McpHttpHandler.handle()`. Mirroring `MAX_BODY_BYTES = 1_048_576` from the gateway is fine. ~15 LOC.
+
+**Should-fix (v1.1 or before scaling beyond a single operator):**
+3. **Finding #5 (partial)**: per-bearer rate-limit (token bucket). ~30 LOC.
+4. **Finding #14**: defensive `allowedTools` recheck in `McpServerProcess.call()`. 3 LOC.
+5. **Finding #9**: defensive `chmodSync(path, 0o600)` after writeFileSync; `chmodSync(dir, 0o700)` after the existence check. 4 LOC.
+6. **Finding #4**: include the client-asserted `X-Claudeclaw-Ts` in `multiplexer_invoke` audit payload. 1 LOC.
+7. **Finding #15**: split `multiplexer_server_crashed` into a terminal `multiplexer_server_permanently_failed` event. 5 LOC.
+
+**Should-document:**
+- Operator-facing note: `settings.mcp.shared` changes require a daemon restart.
+- Operator-facing note: stateless shared MCP servers share state across PTYs at the upstream-process level.
+- Threat model: bearer-as-secret + loopback + 0600 envelope; secret valid until PTY respawn (max ~`pty.idleReapMinutes`).
+
+---
+
+## Summary for operator
+
+**Verdict: APPROVE WITH CONDITIONS.** The bearer-as-secret + loopback + 0600 envelope is sound: constant-time auth, strict `ptyId` regex, dormant-by-default, three-of-three activation gates, complete teardown on every dispose path, full audit coverage with no bearer leakage. No critical findings.
+
+**Top two actions before flipping `pty.enabled: true`:** (1) drop the `bearer` field from the public `PtyIdentity` interface so a future `console.log(identity)` can't leak the secret (Finding #10, ~5 LOC); (2) add a body-size cap on `/mcp/*` matching the `1 MiB` cap already enforced on `/api/plugin/*` (Finding #5, ~15 LOC). Everything else is shoulds and documentation.

--- a/.planning/mcp-multiplexer/W1-COORD.md
+++ b/.planning/mcp-multiplexer/W1-COORD.md
@@ -69,9 +69,14 @@ export interface PtyIdentity {
   ptyId: string;
   /** Issuance timestamp in epoch milliseconds. */
   issuedAt: number;
-  /** Header literal for the synthesized --mcp-config JSON. */
-  bearer: string;            // `Bearer <hex>` — value, not just <hex>
-  /** Headers map for the synthesized --mcp-config JSON. */
+  /** Headers map for the synthesized --mcp-config JSON. The bearer
+   *  literal (`Bearer <hex>`) is at `headers["Authorization"]`. The
+   *  bearer is NEVER exposed as a standalone field on the public
+   *  interface — Phase D security finding #1 removed it as a
+   *  future-leak surface (a stray `console.log(identity)` would have
+   *  exposed the secret). Consumers needing verification go through
+   *  `verifyBearer(ptyId, header)` rather than reading the bearer
+   *  directly. */
   headers: Record<string, string>;
 }
 

--- a/.planning/mcp-multiplexer/W1-COORD.md
+++ b/.planning/mcp-multiplexer/W1-COORD.md
@@ -1,0 +1,177 @@
+# W1 Coordination Notes
+
+Living doc for cross-worktree decisions and any SPEC clarifications that
+W1 made while implementing. W2 reads this before writing
+`pty-mcp-config-writer.ts`.
+
+---
+
+## Resolved: HMAC scheme — bearer-as-secret, not per-request signature
+
+**SPEC §4.3 issue.** SPEC §4.3 describes a per-request HMAC scheme:
+
+> HMAC-SHA256(secret, "<method> <path>\n<ts>\n<body-sha256>"). The body-sha256
+> is the SHA-256 of the request body... <ts> is an ISO-8601 timestamp
+> included in the X-Claudeclaw-Ts header; the bridge rejects timestamps
+> outside a 5-minute window.
+
+This scheme assumes the MCP client can compute SHA-256 of the body and sign
+each request. **Claude Code's stock MCP HTTP client does not support that.**
+The `--mcp-config` JSON only supports a static `headers` map (per
+`claude mcp add --header "Authorization: Bearer ..."`); headers are fixed
+at config-load time and re-sent verbatim on every request.
+
+**Resolution.** Implement the pragmatic equivalent that the stock client can
+honour:
+
+- **Per-PTY secret.** 32-byte random buffer minted by
+  `issueIdentity(ptyId)` on each PTY spawn. Stored in memory only; never
+  on disk except inside the synthesized `--mcp-config` JSON (mode `0600`).
+- **Bearer literal.** `Authorization: Bearer <hex(secret)>` — the literal
+  32-byte hex secret IS the bearer. Verification is a constant-time
+  comparison against the stored secret for the asserted `ptyId`.
+- **Identifier header.** `X-Claudeclaw-Pty-Id: <ptyId>` carries the
+  PTY identity. The handler looks up the secret for that `ptyId` and
+  compares against the bearer.
+- **Issuance timestamp.** `X-Claudeclaw-Ts: <epoch_ms>` is the issuance
+  millisecond at which the identity was minted. Recorded in the audit log
+  for observability. NOT enforced as a replay window — Claude Code re-sends
+  the same headers on every request for the lifetime of the PTY, so a strict
+  replay window would expire tokens within seconds of issuance.
+
+**Why this is safe (operator-approved security envelope, SPEC §7 row 3).**
+The replay-protection role moves from per-request timestamp checks to
+**secret rotation on respawn**. The supervisor regenerates the secret on:
+- Every PTY spawn (fresh `ptyId` → new identity).
+- Every PTY respawn (crash recovery, idle reap, LRU eviction).
+The vulnerability window is bounded by PTY uptime since last respawn,
+which `settings.pty.idleReapMinutes` (default 30) keeps small.
+
+Combined with loopback-only binding (`127.0.0.1`), the threat model is:
+- An attacker on the same host who can read the synthesized config file
+  in `${cwd}/.claudeclaw/mcp-pty-<id>.json` (mode `0600`, owner-only).
+- That requires already having pwned the daemon's UID, at which point
+  HMAC is irrelevant — they could read the daemon's memory directly.
+
+If a future Claude Code version supports per-request signing, this layer
+can be tightened. For now, bearer-as-secret matches the actual
+capability of the stock MCP client.
+
+---
+
+## Published interface for W2
+
+W2 imports from `src/plugins/mcp-multiplexer/pty-identity.ts`:
+
+```typescript
+export interface PtyIdentity {
+  /** PTY session key (= sessionKey from pty-supervisor.PtyEntry). */
+  ptyId: string;
+  /** Issuance timestamp in epoch milliseconds. */
+  issuedAt: number;
+  /** Header literal for the synthesized --mcp-config JSON. */
+  bearer: string;            // `Bearer <hex>` — value, not just <hex>
+  /** Headers map for the synthesized --mcp-config JSON. */
+  headers: Record<string, string>;
+}
+
+export function issueIdentity(ptyId: string): PtyIdentity;
+export function revokeIdentity(ptyId: string): boolean;
+export function getIdentity(ptyId: string): PtyIdentity | undefined;
+export function verifyBearer(
+  ptyId: string,
+  bearerHeaderValue: string,
+): boolean;
+export function _resetIdentityStore(): void; // tests only
+```
+
+**Headers shape returned by `issueIdentity`:**
+
+```typescript
+{
+  "Authorization": "Bearer <hex-secret>",
+  "X-Claudeclaw-Pty-Id": "<ptyId>",
+  "X-Claudeclaw-Ts": "<epoch-ms-as-string>"
+}
+```
+
+W2 splatts this directly into the `headers` field of every HTTP MCP server
+entry in the synthesized `--mcp-config` JSON.
+
+W2 imports from `src/plugins/mcp-multiplexer/index.ts`:
+
+```typescript
+export interface McpMultiplexerPlugin {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  health(): Record<string, unknown>;
+  isActive(): boolean;
+  sharedServerNames(): string[];
+  /** Issue a fresh identity for a PTY. Replaces any existing identity
+   *  for the same ptyId (W2 calls this on every respawn). */
+  issueIdentity(ptyId: string): PtyIdentity;
+  /** Drop the identity, the (ptyId,server)→sessionId map entries,
+   *  and revoke the secret. Safe to call multiple times. */
+  releaseIdentity(ptyId: string): Promise<void>;
+  /** Base URL the synthesized --mcp-config writes for HTTP entries.
+   *  E.g. `http://127.0.0.1:4632`. */
+  bridgeBaseUrl(): string;
+}
+
+export function getMcpMultiplexerPlugin(): McpMultiplexerPlugin;
+export function _resetMcpMultiplexer(): void; // tests only
+```
+
+W2 calls in `pty-mcp-config-writer.ts`:
+
+```typescript
+const mux = getMcpMultiplexerPlugin();
+if (!mux.isActive()) return null; // backward-compat path
+const identity = mux.issueIdentity(ptyId);
+const base = mux.bridgeBaseUrl();
+const shared = mux.sharedServerNames();
+// for each name in shared:
+//   { type: "http",
+//     url: `${base}/mcp/${name}`,
+//     headers: identity.headers }
+```
+
+And in pty-supervisor dispose:
+
+```typescript
+await getMcpMultiplexerPlugin().releaseIdentity(ptyId);
+```
+
+---
+
+## FQN namespacing for bridge-callback registration
+
+The `PluginMcpBridge.registerPluginTool(pluginId, tool)` always prefixes
+the stored FQN with the pluginId — see `mcp-bridge.ts` L65:
+`const fqn = \`${pluginId}__${tool.name}\``.
+
+The multiplexer registers under `pluginId = "mcp-multiplexer"` (operator
+constraint) with the `name` argument set to `<server>__<tool>`. The
+resulting stored FQNs are therefore:
+
+- `mcp-multiplexer__<server>__<tool>` (multiplexer-claimed servers)
+- `mcp-proxy__<server>__<tool>` (mcp-proxy-claimed servers)
+
+These two FQN spaces never overlap; collision is impossible regardless of
+the skip-shared rule. The skip-shared rule remains as a structural
+guarantee against double-spawn of the upstream child.
+
+**Behavioural note for legacy callers.** When a server moves from
+`mcp-proxy` to `mcp-multiplexer` (operator adds it to
+`settings.mcp.shared`), tool callers that looked up
+`mcp-proxy__<server>__<tool>` must now look up
+`mcp-multiplexer__<server>__<tool>`. This is a small migration burden
+on any code that hardcodes FQNs (e.g. tests, scripted prompts); typical
+LLM `tools/list` callers walk the bridge's listing and don't care about
+the prefix.
+
+---
+
+## Open questions awaiting Phase C / operator decision
+
+(none currently — implementation matches SPEC + this clarification)

--- a/src/__tests__/mcp-multiplexer-integration.test.ts
+++ b/src/__tests__/mcp-multiplexer-integration.test.ts
@@ -1,0 +1,657 @@
+/**
+ * Phase C wire-level integration tests for the MCP multiplexer.
+ *
+ * Phase B's unit tests mock the MCP transport boundary; this file proves
+ * that the wire actually works:
+ *   - real `Bun.serve` HTTP listener (ephemeral port) mounted on the
+ *     `PluginHttpGateway`,
+ *   - real upstream MCP stdio child spawned by the multiplexer's
+ *     `McpServerProcess`,
+ *   - real MCP SDK `Client` + `StreamableHTTPClientTransport` talking
+ *     across the loopback boundary with per-PTY HMAC bearer headers.
+ *
+ * The fixture child is the existing `src/__tests__/fixtures/mock-mcp-server.ts`
+ * which exposes a deterministic `echo` tool over stdio.
+ *
+ * Scope is hermetic: every test uses a tmpdir-scoped `mcp-proxy.json`,
+ * binds the gateway to port 0, and tears down all spawned children +
+ * listeners in `afterEach`. None of these tests touch `~/.config`,
+ * require the `claude` CLI, or talk to the network beyond loopback.
+ *
+ * See `.planning/mcp-multiplexer/SPEC.md` §§4.1–4.6, 6.3, 7.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  McpMultiplexerPlugin,
+  _resetMcpMultiplexer,
+  type MuxSettingsView,
+} from "../plugins/mcp-multiplexer/index.js";
+import {
+  _resetHttpGateway,
+  getHttpGateway,
+} from "../plugins/http-gateway.js";
+import { _resetMcpBridge, getMcpBridge } from "../plugins/mcp-bridge.js";
+import { _resetIdentityStore } from "../plugins/mcp-multiplexer/pty-identity.js";
+
+const MOCK_SERVER = fileURLToPath(
+  new URL("./fixtures/mock-mcp-server.ts", import.meta.url),
+);
+const BUN_BIN = process.execPath;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function writeProxyConfig(dir: string, names: string[]): string {
+  const cfg = {
+    servers: Object.fromEntries(
+      names.map((name) => [
+        name,
+        {
+          command: BUN_BIN,
+          args: ["run", MOCK_SERVER],
+          enabled: true,
+          allowedTools: ["echo"],
+        },
+      ]),
+    ),
+  };
+  const path = join(dir, "mcp-proxy.json");
+  writeFileSync(path, JSON.stringify(cfg, null, 2));
+  return path;
+}
+
+function makeSettingsView(
+  partial: Partial<MuxSettingsView>,
+): () => MuxSettingsView {
+  const view: MuxSettingsView = {
+    webEnabled: true,
+    webHost: "127.0.0.1",
+    webPort: 4632,
+    shared: [],
+    stateless: [],
+    healthProbeIntervalMs: 0,
+    ...partial,
+  };
+  return () => view;
+}
+
+/** Start a hermetic Bun.serve listener on an ephemeral loopback port
+ *  that routes BOTH `/api/plugin/*` and `/mcp/*` to the gateway. The
+ *  `/mcp/*` route is the part missing from production `src/ui/server.ts`
+ *  today (it only routes `/api/plugin/`); we mount it here so the wire
+ *  test exercises the full gateway surface. The production gap is
+ *  surfaced in the Phase C report. */
+function startTestGateway(): {
+  origin: string;
+  port: number;
+  stop: () => Promise<void>;
+} {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    idleTimeout: 0,
+    fetch: async (req) => {
+      const url = new URL(req.url);
+      if (
+        url.pathname.startsWith("/api/plugin/") ||
+        url.pathname.startsWith("/mcp/")
+      ) {
+        const resp = await getHttpGateway().handleRequest(req, url);
+        if (resp !== null) return resp;
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const port = server.port;
+  return {
+    origin: `http://127.0.0.1:${port}`,
+    port,
+    stop: async () => {
+      server.stop(true);
+    },
+  };
+}
+
+/** Build a fully-headered MCP SDK Client pointed at the multiplexer. */
+async function connectClient(opts: {
+  origin: string;
+  server: string;
+  ptyId: string;
+  bearer: string;
+  clientName?: string;
+}): Promise<{ client: Client; close: () => Promise<void> }> {
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`${opts.origin}/mcp/${opts.server}`),
+    {
+      requestInit: {
+        headers: {
+          Authorization: opts.bearer,
+          "X-Claudeclaw-Pty-Id": opts.ptyId,
+        },
+      },
+    },
+  );
+  const client = new Client(
+    { name: opts.clientName ?? `test-client/${opts.ptyId}`, version: "1.0.0" },
+    { capabilities: {} },
+  );
+  await client.connect(transport);
+  return {
+    client,
+    close: async () => {
+      try {
+        await client.close();
+      } catch {}
+    },
+  };
+}
+
+// ── Suite plumbing ──────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let plugin: McpMultiplexerPlugin | null = null;
+let gateway: { origin: string; port: number; stop: () => Promise<void> } | null =
+  null;
+
+async function teardown(): Promise<void> {
+  if (plugin) {
+    try {
+      await plugin.stop();
+    } catch {}
+    plugin = null;
+  }
+  if (gateway) {
+    try {
+      await gateway.stop();
+    } catch {}
+    gateway = null;
+  }
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpMultiplexer();
+  _resetIdentityStore();
+}
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcp-mux-itest-"));
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpMultiplexer();
+  _resetIdentityStore();
+});
+
+afterEach(async () => {
+  await teardown();
+  try {
+    rmSync(tmpDir, { recursive: true });
+  } catch {}
+});
+
+// ── 1) End-to-end happy path ────────────────────────────────────────────────
+
+describe("mcp-multiplexer integration — happy path", () => {
+  it(
+    "real SDK client lists tools and round-trips a tools/call over loopback HTTP",
+    { timeout: 10000 },
+    async () => {
+      const cfg = writeProxyConfig(tmpDir, ["alpha"]);
+      plugin = new McpMultiplexerPlugin({
+        configPath: cfg,
+        settingsView: makeSettingsView({
+          webEnabled: true,
+          shared: ["alpha"],
+        }),
+      });
+      await plugin.start();
+      expect(plugin.isActive()).toBe(true);
+
+      gateway = startTestGateway();
+      const ident = plugin.issueIdentity("pty-happy");
+
+      const { client, close } = await connectClient({
+        origin: gateway.origin,
+        server: "alpha",
+        ptyId: "pty-happy",
+        bearer: ident.bearer,
+      });
+
+      try {
+        const tools = await client.listTools();
+        const names = tools.tools.map((t) => t.name).sort();
+        expect(names).toEqual(["echo"]);
+
+        const result = await client.callTool({
+          name: "echo",
+          arguments: { message: "wire works" },
+        });
+        // The handler wraps the upstream result as
+        // { content: [{ type: "text", text: JSON.stringify(upstreamJson) }] }
+        const content = (result.content as Array<{ type: string; text: string }>)[0];
+        expect(content?.type).toBe("text");
+        expect(content?.text).toContain("wire works");
+      } finally {
+        await close();
+      }
+    },
+  );
+});
+
+// ── 2) Per-PTY auth ─────────────────────────────────────────────────────────
+
+describe("mcp-multiplexer integration — per-PTY auth", () => {
+  it(
+    "two distinct PTY identities can both invoke without leaking session state",
+    { timeout: 10000 },
+    async () => {
+      const cfg = writeProxyConfig(tmpDir, ["alpha"]);
+      plugin = new McpMultiplexerPlugin({
+        configPath: cfg,
+        settingsView: makeSettingsView({
+          webEnabled: true,
+          shared: ["alpha"],
+        }),
+      });
+      await plugin.start();
+      gateway = startTestGateway();
+
+      const a = plugin.issueIdentity("pty-A");
+      const b = plugin.issueIdentity("pty-B");
+      expect(a.bearer).not.toBe(b.bearer);
+
+      const ca = await connectClient({
+        origin: gateway.origin,
+        server: "alpha",
+        ptyId: "pty-A",
+        bearer: a.bearer,
+      });
+      const cb = await connectClient({
+        origin: gateway.origin,
+        server: "alpha",
+        ptyId: "pty-B",
+        bearer: b.bearer,
+      });
+
+      try {
+        // Concurrent invocations — each must succeed independently.
+        const [ra, rb] = await Promise.all([
+          ca.client.callTool({
+            name: "echo",
+            arguments: { message: "from-A" },
+          }),
+          cb.client.callTool({
+            name: "echo",
+            arguments: { message: "from-B" },
+          }),
+        ]);
+
+        const ta = (ra.content as Array<{ text: string }>)[0]!.text;
+        const tb = (rb.content as Array<{ text: string }>)[0]!.text;
+        expect(ta).toContain("from-A");
+        expect(tb).toContain("from-B");
+
+        // For stateful (default) server, each PTY gets its own bucket.
+        const handler = plugin._getHandler("alpha");
+        const h = handler?.health() as {
+          stateless: boolean;
+          active_buckets: number;
+          bucket_keys: string[];
+        };
+        expect(h.stateless).toBe(false);
+        expect(h.bucket_keys.sort()).toEqual(["pty-A", "pty-B"]);
+      } finally {
+        await ca.close();
+        await cb.close();
+      }
+    },
+  );
+});
+
+// ── 3) Auth rejection ───────────────────────────────────────────────────────
+
+describe("mcp-multiplexer integration — auth rejection", () => {
+  it(
+    "forged bearer for a non-issued ptyId returns 401 with no upstream call",
+    { timeout: 10000 },
+    async () => {
+      const cfg = writeProxyConfig(tmpDir, ["alpha"]);
+      plugin = new McpMultiplexerPlugin({
+        configPath: cfg,
+        settingsView: makeSettingsView({
+          webEnabled: true,
+          shared: ["alpha"],
+        }),
+      });
+      await plugin.start();
+      gateway = startTestGateway();
+
+      // Audit hook to confirm no upstream invoke is recorded.
+      const events: Array<{ event: string; payload: Record<string, unknown> }> =
+        [];
+      const bridge = getMcpBridge();
+      const origAudit = bridge.audit.bind(bridge);
+      bridge.audit = (event, payload) => {
+        events.push({ event, payload });
+        origAudit(event, payload);
+      };
+
+      try {
+        // Forge bearer: 64 hex chars (the correct length) but a ptyId
+        // that was never issued.
+        const forged = `Bearer ${"a".repeat(64)}`;
+        const resp = await fetch(`${gateway.origin}/mcp/alpha`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json, text/event-stream",
+            Authorization: forged,
+            "X-Claudeclaw-Pty-Id": "pty-never-issued",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "tools/list",
+            params: {},
+          }),
+        });
+        expect(resp.status).toBe(401);
+        const body = (await resp.json()) as {
+          error: { code: string; message: string };
+        };
+        expect(body.error.code).toBe("invalid_bearer");
+
+        // Auth-rejected audit fired; no `multiplexer_invoke` event.
+        const rejected = events.find((e) => e.event === "multiplexer_auth_rejected");
+        expect(rejected).toBeDefined();
+        const invokes = events.filter((e) => e.event === "multiplexer_invoke");
+        expect(invokes).toHaveLength(0);
+      } finally {
+        bridge.audit = origAudit;
+      }
+    },
+  );
+
+  it(
+    "missing pty-id header returns 401 missing_pty_id",
+    { timeout: 10000 },
+    async () => {
+      const cfg = writeProxyConfig(tmpDir, ["alpha"]);
+      plugin = new McpMultiplexerPlugin({
+        configPath: cfg,
+        settingsView: makeSettingsView({
+          webEnabled: true,
+          shared: ["alpha"],
+        }),
+      });
+      await plugin.start();
+      gateway = startTestGateway();
+
+      const resp = await fetch(`${gateway.origin}/mcp/alpha`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: `Bearer ${"b".repeat(64)}`,
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 1,
+          method: "tools/list",
+          params: {},
+        }),
+      });
+      expect(resp.status).toBe(401);
+      const body = (await resp.json()) as {
+        error: { code: string; message: string };
+      };
+      expect(body.error.code).toBe("missing_pty_id");
+    },
+  );
+});
+
+// ── 4) Stateful vs stateless session demux ──────────────────────────────────
+
+describe("mcp-multiplexer integration — stateful vs stateless demux", () => {
+  it(
+    "stateful server creates per-PTY buckets; stateless server collapses to a single __stateless__ bucket",
+    { timeout: 10000 },
+    async () => {
+      const cfg = writeProxyConfig(tmpDir, ["alpha", "beta"]);
+      plugin = new McpMultiplexerPlugin({
+        configPath: cfg,
+        settingsView: makeSettingsView({
+          webEnabled: true,
+          shared: ["alpha", "beta"],
+          stateless: ["beta"],
+        }),
+      });
+      await plugin.start();
+      gateway = startTestGateway();
+
+      const a = plugin.issueIdentity("pty-1");
+      const b = plugin.issueIdentity("pty-2");
+
+      // STATEFUL server (`alpha`): use full SDK clients — each PTY's
+      // initialize() goes to its own SDK Server in its own bucket.
+      const a1 = await connectClient({
+        origin: gateway.origin,
+        server: "alpha",
+        ptyId: "pty-1",
+        bearer: a.bearer,
+      });
+      const a2 = await connectClient({
+        origin: gateway.origin,
+        server: "alpha",
+        ptyId: "pty-2",
+        bearer: b.bearer,
+      });
+      await a1.client.listTools();
+      await a2.client.listTools();
+
+      // STATELESS server (`beta`): both PTYs share a single SDK Server.
+      // The first PTY drives initialize() via the SDK Client; the second
+      // PTY hits the same bucket via a raw tools/list — re-initialising
+      // a shared SDK Server would (correctly) be rejected, which is the
+      // whole point of the stateless mode. We assert the bucket-collapse
+      // property on the handler health snapshot.
+      const b1 = await connectClient({
+        origin: gateway.origin,
+        server: "beta",
+        ptyId: "pty-1",
+        bearer: a.bearer,
+      });
+      await b1.client.listTools();
+
+      // PTY-2 reuses the existing __stateless__ bucket — send a raw
+      // tools/list bypassing client-side initialization. Auth still
+      // gates the request, so PTY-2 must use its own bearer. The SDK
+      // transport will reject this with 400 (no session ID) — that's
+      // fine; what matters is the request flowed past auth into the
+      // shared bucket without creating a new one, which is the
+      // collapse property we assert below on handler.health().
+      const resp = await fetch(`${gateway.origin}/mcp/beta`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json, text/event-stream",
+          Authorization: b.bearer,
+          "X-Claudeclaw-Pty-Id": "pty-2",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: 99,
+          method: "tools/list",
+          params: {},
+        }),
+      });
+      // Past auth (status !== 401, !== 404). The SDK transport may
+      // accept (200/202) or reject as malformed session (400) — either
+      // proves the request reached the bucket, not the auth wall.
+      expect(resp.status).not.toBe(401);
+      expect(resp.status).not.toBe(404);
+
+      try {
+        const alphaH = plugin._getHandler("alpha")?.health() as {
+          stateless: boolean;
+          bucket_keys: string[];
+        };
+        const betaH = plugin._getHandler("beta")?.health() as {
+          stateless: boolean;
+          bucket_keys: string[];
+        };
+
+        expect(alphaH.stateless).toBe(false);
+        expect(alphaH.bucket_keys.sort()).toEqual(["pty-1", "pty-2"]);
+
+        expect(betaH.stateless).toBe(true);
+        // STATELESS_BUCKET sentinel — one bucket regardless of PTY count.
+        expect(betaH.bucket_keys).toEqual(["__stateless__"]);
+      } finally {
+        await a1.close();
+        await a2.close();
+        await b1.close();
+      }
+    },
+  );
+});
+
+// ── 5) Bridge callback integration ──────────────────────────────────────────
+
+describe("mcp-multiplexer integration — bridge callback path", () => {
+  it(
+    "legacy in-process caller can invoke a shared tool via getMcpBridge() with no HTTP hop",
+    { timeout: 10000 },
+    async () => {
+      const cfg = writeProxyConfig(tmpDir, ["alpha"]);
+      plugin = new McpMultiplexerPlugin({
+        configPath: cfg,
+        settingsView: makeSettingsView({
+          webEnabled: true,
+          shared: ["alpha"],
+        }),
+      });
+      await plugin.start();
+      // Intentionally do NOT start the HTTP gateway listener — this
+      // exercises the in-process bridge path (SPEC §10 Q#2 (b)).
+
+      const bridge = getMcpBridge();
+      const fqns = bridge.listTools().map((t) => t.fqn);
+      expect(fqns).toContain("mcp-multiplexer__alpha__echo");
+
+      const result = await bridge.invokeTool("mcp-multiplexer__alpha__echo", {
+        arguments: { message: "via-bridge" },
+      });
+      // Upstream returns `{ echo: "via-bridge" }` which is JSON-parsed
+      // by `McpServerProcess.call`, so the bridge result is the object.
+      expect(result).toEqual({ echo: "via-bridge" });
+    },
+  );
+});
+
+// ── 6) Crash + health probe transition ──────────────────────────────────────
+
+describe("mcp-multiplexer integration — crash + health probe transition", () => {
+  it(
+    "killing the upstream child mid-test fires _onServerCrash and health probe emits mcp_health_degraded",
+    { timeout: 15000 },
+    async () => {
+      const cfg = writeProxyConfig(tmpDir, ["alpha"]);
+      plugin = new McpMultiplexerPlugin({
+        configPath: cfg,
+        settingsView: makeSettingsView({
+          webEnabled: true,
+          shared: ["alpha"],
+          // Keep the probe disabled so we drive sampling deterministically.
+          healthProbeIntervalMs: 0,
+        }),
+      });
+      await plugin.start();
+      expect(plugin.isActive()).toBe(true);
+
+      gateway = startTestGateway();
+
+      // Capture audit events emitted during the crash + probe sequence.
+      const events: Array<{ event: string; payload: Record<string, unknown> }> =
+        [];
+      const bridge = getMcpBridge();
+      const origAudit = bridge.audit.bind(bridge);
+      bridge.audit = (event, payload) => {
+        events.push({ event, payload });
+        origAudit(event, payload);
+      };
+
+      try {
+        // Confirm one healthy round-trip before the crash to prove the
+        // process really is up and serving tool calls.
+        const ident = plugin.issueIdentity("pty-pre-crash");
+        const c = await connectClient({
+          origin: gateway.origin,
+          server: "alpha",
+          ptyId: "pty-pre-crash",
+          bearer: ident.bearer,
+        });
+        await c.client.listTools();
+        await c.close();
+
+        // Reach into the real McpServerProcess and kill its transport.
+        // This is the same path a real upstream child crash takes —
+        // the SDK's StdioClientTransport fires `onclose` which the
+        // server-process's onCrash hook turns into the
+        // `multiplexer_server_crashed` audit + status mutation.
+        type ProcLike = {
+          servers: Map<
+            string,
+            { status: string; transport: { close?: () => Promise<void> } | null }
+          >;
+          lastObservedStatus: Map<string, string>;
+        };
+        const proc = (plugin as unknown as ProcLike).servers.get("alpha")!;
+        const initial = proc.status;
+
+        // Close the transport. McpServerProcess.transport.onclose then
+        // invokes _handleCrash → calls our onCrash → status mutates.
+        await proc.transport?.close?.();
+
+        // Allow the onclose handler to fire (microtask flush).
+        await new Promise((r) => setTimeout(r, 50));
+
+        // Status should have transitioned away from `up`. The crash
+        // handler schedules a restart timer with a 1s backoff for the
+        // first crash, so by now we expect `crashed` → `restarting`.
+        expect(["crashed", "restarting", "up"]).toContain(proc.status);
+
+        // Force-set status to `crashed` if a fast restart already
+        // happened — what we want to prove is that the probe transition
+        // emits the right audit event. Then drive the probe directly.
+        (proc as { status: string }).status = "crashed";
+        (
+          plugin as unknown as { lastObservedStatus: Map<string, string> }
+        ).lastObservedStatus.set("alpha", initial);
+
+        (plugin as unknown as { _sampleHealthForTests: () => void })._sampleHealthForTests();
+
+        const degraded = events.find((e) => e.event === "mcp_health_degraded");
+        expect(degraded).toBeDefined();
+        expect(degraded?.payload.server).toBe("alpha");
+        expect(degraded?.payload.current_status).toBe("crashed");
+
+        // The crash hook itself should also have audited a
+        // `multiplexer_server_crashed` event when the real onclose
+        // fired (proves the real onCrash → audit path works, not just
+        // the unit-level mutation).
+        const crashAudit = events.find(
+          (e) => e.event === "multiplexer_server_crashed",
+        );
+        expect(crashAudit).toBeDefined();
+        expect(crashAudit?.payload.server).toBe("alpha");
+      } finally {
+        bridge.audit = origAudit;
+      }
+    },
+  );
+});

--- a/src/__tests__/mcp-multiplexer-integration.test.ts
+++ b/src/__tests__/mcp-multiplexer-integration.test.ts
@@ -218,7 +218,7 @@ describe("mcp-multiplexer integration — happy path", () => {
         origin: gateway.origin,
         server: "alpha",
         ptyId: "pty-happy",
-        bearer: ident.bearer,
+        bearer: ident.headers.Authorization,
       });
 
       try {
@@ -262,19 +262,19 @@ describe("mcp-multiplexer integration — per-PTY auth", () => {
 
       const a = plugin.issueIdentity("pty-A");
       const b = plugin.issueIdentity("pty-B");
-      expect(a.bearer).not.toBe(b.bearer);
+      expect(a.headers.Authorization).not.toBe(b.headers.Authorization);
 
       const ca = await connectClient({
         origin: gateway.origin,
         server: "alpha",
         ptyId: "pty-A",
-        bearer: a.bearer,
+        bearer: a.headers.Authorization,
       });
       const cb = await connectClient({
         origin: gateway.origin,
         server: "alpha",
         ptyId: "pty-B",
-        bearer: b.bearer,
+        bearer: b.headers.Authorization,
       });
 
       try {
@@ -442,13 +442,13 @@ describe("mcp-multiplexer integration — stateful vs stateless demux", () => {
         origin: gateway.origin,
         server: "alpha",
         ptyId: "pty-1",
-        bearer: a.bearer,
+        bearer: a.headers.Authorization,
       });
       const a2 = await connectClient({
         origin: gateway.origin,
         server: "alpha",
         ptyId: "pty-2",
-        bearer: b.bearer,
+        bearer: b.headers.Authorization,
       });
       await a1.client.listTools();
       await a2.client.listTools();
@@ -463,7 +463,7 @@ describe("mcp-multiplexer integration — stateful vs stateless demux", () => {
         origin: gateway.origin,
         server: "beta",
         ptyId: "pty-1",
-        bearer: a.bearer,
+        bearer: a.headers.Authorization,
       });
       await b1.client.listTools();
 
@@ -479,7 +479,7 @@ describe("mcp-multiplexer integration — stateful vs stateless demux", () => {
         headers: {
           "Content-Type": "application/json",
           Accept: "application/json, text/event-stream",
-          Authorization: b.bearer,
+          Authorization: b.headers.Authorization,
           "X-Claudeclaw-Pty-Id": "pty-2",
         },
         body: JSON.stringify({
@@ -593,7 +593,7 @@ describe("mcp-multiplexer integration — crash + health probe transition", () =
           origin: gateway.origin,
           server: "alpha",
           ptyId: "pty-pre-crash",
-          bearer: ident.bearer,
+          bearer: ident.headers.Authorization,
         });
         await c.client.listTools();
         await c.close();

--- a/src/__tests__/mcp_proxy_skip_shared.test.ts
+++ b/src/__tests__/mcp_proxy_skip_shared.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Tests for the multiplexer-induced skip rule in `McpProxyPlugin.start()`:
+ * any server name present in `settings.mcp.shared` is dropped from the
+ * mcp-proxy startup list so the multiplexer can claim that upstream
+ * child exclusively. SPEC §4.1 step 4 + §6.2.
+ *
+ * These tests rely on the `cached` settings shim — they load real
+ * settings, override the `mcp.shared` field, then invoke the proxy. To
+ * keep them isolated from `~/.config/claudeclaw/...`, every test points
+ * the proxy at a tmpdir-scoped fake `mcp-proxy.json`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { McpProxyPlugin, _resetMcpProxy } from "../plugins/mcp-proxy/index.js";
+import { _resetMcpBridge, getMcpBridge } from "../plugins/mcp-bridge.js";
+import { _resetHttpGateway } from "../plugins/http-gateway.js";
+import { initConfig, loadSettings } from "../config.js";
+
+const MOCK_SERVER = fileURLToPath(
+  new URL("./fixtures/mock-mcp-server.ts", import.meta.url),
+);
+const BUN_BIN = process.execPath;
+
+function writeProxyConfig(dir: string, servers: string[]): string {
+  const cfg = {
+    servers: Object.fromEntries(
+      servers.map((name) => [
+        name,
+        {
+          command: BUN_BIN,
+          args: ["run", MOCK_SERVER],
+          enabled: true,
+          allowedTools: ["echo"],
+        },
+      ]),
+    ),
+  };
+  const path = join(dir, "mcp-proxy.json");
+  writeFileSync(path, JSON.stringify(cfg, null, 2));
+  return path;
+}
+
+let tmpDir: string;
+
+beforeEach(async () => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcp-proxy-skip-test-"));
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+  // Ensure settings.json exists, then load — the skip-shared helper
+  // mutates the cached settings object in-place. `initConfig` writes
+  // defaults if no file is present.
+  await initConfig();
+  await loadSettings();
+});
+
+afterEach(async () => {
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpProxy();
+  try {
+    rmSync(tmpDir, { recursive: true });
+  } catch {}
+});
+
+describe("McpProxyPlugin — skip rule for shared servers", () => {
+  it("starts every enabled server when mcp.shared is empty", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha", "beta"]);
+
+    // Patch live settings cache to ensure mcp.shared is empty.
+    const settings = (await loadSettings()) as unknown as {
+      mcp?: { shared?: string[] };
+    };
+    settings.mcp = { shared: [] };
+
+    const plugin = new McpProxyPlugin({
+      configPath: cfgPath,
+      tokenPath: join(tmpDir, "mcp-proxy.token"),
+    });
+    await plugin.start();
+
+    try {
+      const bridge = getMcpBridge();
+      const fqns = bridge.listTools().map((t) => t.fqn);
+      // mcp-proxy registers under pluginId "mcp-proxy" → fqn prefixed.
+      expect(fqns).toContain("mcp-proxy__alpha__echo");
+      expect(fqns).toContain("mcp-proxy__beta__echo");
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("skips servers listed in mcp.shared", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha", "beta", "gamma"]);
+
+    const settings = (await loadSettings()) as unknown as {
+      mcp?: { shared?: string[] };
+    };
+    settings.mcp = { shared: ["alpha", "beta"] };
+
+    const plugin = new McpProxyPlugin({
+      configPath: cfgPath,
+      tokenPath: join(tmpDir, "mcp-proxy.token"),
+    });
+    await plugin.start();
+
+    try {
+      const fqns = getMcpBridge().listTools().map((t) => t.fqn);
+      expect(fqns).not.toContain("mcp-proxy__alpha__echo");
+      expect(fqns).not.toContain("mcp-proxy__beta__echo");
+      // gamma was not in shared → mcp-proxy still owns it.
+      expect(fqns).toContain("mcp-proxy__gamma__echo");
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("missing mcp settings (W2 not yet wired) is treated as empty shared", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+
+    const settings = (await loadSettings()) as unknown as {
+      mcp?: { shared?: string[] };
+    };
+    delete settings.mcp;
+
+    const plugin = new McpProxyPlugin({
+      configPath: cfgPath,
+      tokenPath: join(tmpDir, "mcp-proxy.token"),
+    });
+    await plugin.start();
+
+    try {
+      const fqns = getMcpBridge().listTools().map((t) => t.fqn);
+      expect(fqns).toContain("mcp-proxy__alpha__echo");
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("non-array mcp.shared is treated as empty", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+
+    const settings = (await loadSettings()) as unknown as {
+      mcp?: unknown;
+    };
+    settings.mcp = { shared: "not-an-array" };
+
+    const plugin = new McpProxyPlugin({
+      configPath: cfgPath,
+      tokenPath: join(tmpDir, "mcp-proxy.token"),
+    });
+    await plugin.start();
+
+    try {
+      const fqns = getMcpBridge().listTools().map((t) => t.fqn);
+      expect(fqns).toContain("mcp-proxy__alpha__echo");
+    } finally {
+      await plugin.stop();
+    }
+  });
+});

--- a/src/__tests__/mcp_proxy_skip_shared.test.ts
+++ b/src/__tests__/mcp_proxy_skip_shared.test.ts
@@ -68,18 +68,13 @@ afterEach(async () => {
 });
 
 describe("McpProxyPlugin — skip rule for shared servers", () => {
-  it("starts every enabled server when mcp.shared is empty", async () => {
+  it("starts every enabled server when the multiplexer claims nothing", async () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha", "beta"]);
-
-    // Patch live settings cache to ensure mcp.shared is empty.
-    const settings = (await loadSettings()) as unknown as {
-      mcp?: { shared?: string[] };
-    };
-    settings.mcp = { shared: [] };
 
     const plugin = new McpProxyPlugin({
       configPath: cfgPath,
       tokenPath: join(tmpDir, "mcp-proxy.token"),
+      claimedByMultiplexer: () => new Set(),
     });
     await plugin.start();
 
@@ -94,17 +89,13 @@ describe("McpProxyPlugin — skip rule for shared servers", () => {
     }
   });
 
-  it("skips servers listed in mcp.shared", async () => {
+  it("skips servers actively claimed by the multiplexer", async () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha", "beta", "gamma"]);
-
-    const settings = (await loadSettings()) as unknown as {
-      mcp?: { shared?: string[] };
-    };
-    settings.mcp = { shared: ["alpha", "beta"] };
 
     const plugin = new McpProxyPlugin({
       configPath: cfgPath,
       tokenPath: join(tmpDir, "mcp-proxy.token"),
+      claimedByMultiplexer: () => new Set(["alpha", "beta"]),
     });
     await plugin.start();
 
@@ -112,46 +103,55 @@ describe("McpProxyPlugin — skip rule for shared servers", () => {
       const fqns = getMcpBridge().listTools().map((t) => t.fqn);
       expect(fqns).not.toContain("mcp-proxy__alpha__echo");
       expect(fqns).not.toContain("mcp-proxy__beta__echo");
-      // gamma was not in shared → mcp-proxy still owns it.
+      // gamma was not claimed → mcp-proxy still owns it.
       expect(fqns).toContain("mcp-proxy__gamma__echo");
     } finally {
       await plugin.stop();
     }
   });
 
-  it("missing mcp settings (W2 not yet wired) is treated as empty shared", async () => {
+  it("Codex PR #71 P1 regression — DOES NOT skip when multiplexer is dormant despite mcp.shared being populated", async () => {
+    // Scenario: operator put `mcp.shared = ["alpha"]` in settings, but the
+    // multiplexer plugin went dormant for any reason (web disabled,
+    // non-loopback host, zero claimed servers, missing mcp-proxy.json).
+    // Before the fix, mcp-proxy still skipped "alpha" → tools became
+    // unreachable from BOTH paths. After the fix, mcp-proxy spawns it
+    // because the multiplexer isn't actually serving it.
     const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
 
+    // Even with settings.mcp.shared populated, the multiplexer hasn't
+    // claimed anything → resolver returns empty set.
     const settings = (await loadSettings()) as unknown as {
       mcp?: { shared?: string[] };
     };
-    delete settings.mcp;
+    settings.mcp = { shared: ["alpha"] };
 
     const plugin = new McpProxyPlugin({
       configPath: cfgPath,
       tokenPath: join(tmpDir, "mcp-proxy.token"),
+      claimedByMultiplexer: () => new Set(), // dormant
     });
     await plugin.start();
 
     try {
       const fqns = getMcpBridge().listTools().map((t) => t.fqn);
+      // mcp-proxy still serves alpha — legacy callsites keep working.
       expect(fqns).toContain("mcp-proxy__alpha__echo");
     } finally {
       await plugin.stop();
     }
   });
 
-  it("non-array mcp.shared is treated as empty", async () => {
+  it("defaults to the production resolver when no test seam is provided", async () => {
+    // Smoke test: in the absence of an active multiplexer plugin singleton,
+    // the production resolver should return an empty set and proxy spawns
+    // everything.
     const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
-
-    const settings = (await loadSettings()) as unknown as {
-      mcp?: unknown;
-    };
-    settings.mcp = { shared: "not-an-array" };
 
     const plugin = new McpProxyPlugin({
       configPath: cfgPath,
       tokenPath: join(tmpDir, "mcp-proxy.token"),
+      // No claimedByMultiplexer override — uses default resolver.
     });
     await plugin.start();
 

--- a/src/__tests__/plugins/http-gateway-mcp-route.test.ts
+++ b/src/__tests__/plugins/http-gateway-mcp-route.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for the multiplexer-related additions to `PluginHttpGateway`:
+ * `/mcp/<server>` route delegation, `registerMcpHandler`, and
+ * `unregisterMcpHandler`. See `mcp-multiplexer/index.ts`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { PluginHttpGateway, _resetHttpGateway } from "../../plugins/http-gateway.js";
+import { _resetMcpBridge } from "../../plugins/mcp-bridge.js";
+
+function req(method: string, path: string, body?: unknown): Request {
+  return new Request(`http://localhost:4632${path}`, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+function url(path: string): URL {
+  return new URL(`http://localhost:4632${path}`);
+}
+
+describe("PluginHttpGateway — /mcp/<server> route delegation", () => {
+  let gw: PluginHttpGateway;
+
+  beforeEach(() => {
+    _resetHttpGateway();
+    _resetMcpBridge();
+    gw = new PluginHttpGateway();
+  });
+
+  afterEach(() => {
+    _resetHttpGateway();
+    _resetMcpBridge();
+  });
+
+  it("registers and dispatches to per-server handlers", async () => {
+    let calls = 0;
+    gw.registerMcpHandler("alpha", async () => {
+      calls++;
+      return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    });
+
+    expect(gw.hasMcpHandler("alpha")).toBe(true);
+
+    const r = await gw.handleRequest(req("POST", "/mcp/alpha"), url("/mcp/alpha"));
+    expect(r?.status).toBe(200);
+    const body = (await r!.json()) as { ok: boolean };
+    expect(body.ok).toBe(true);
+    expect(calls).toBe(1);
+  });
+
+  it("returns 404 for an unregistered server name", async () => {
+    const r = await gw.handleRequest(req("POST", "/mcp/missing"), url("/mcp/missing"));
+    expect(r?.status).toBe(404);
+    const body = (await r!.json()) as { error: { code: string; server: string } };
+    expect(body.error.code).toBe("mcp_server_not_registered");
+    expect(body.error.server).toBe("missing");
+  });
+
+  it("dispatches sub-paths to the same handler", async () => {
+    const seen: string[] = [];
+    gw.registerMcpHandler("alpha", async (r) => {
+      seen.push(new URL(r.url).pathname);
+      return new Response("ok", { status: 200 });
+    });
+
+    await gw.handleRequest(req("POST", "/mcp/alpha"), url("/mcp/alpha"));
+    await gw.handleRequest(req("POST", "/mcp/alpha/sub"), url("/mcp/alpha/sub"));
+    await gw.handleRequest(req("GET", "/mcp/alpha/foo/bar"), url("/mcp/alpha/foo/bar"));
+
+    expect(seen).toEqual(["/mcp/alpha", "/mcp/alpha/sub", "/mcp/alpha/foo/bar"]);
+  });
+
+  it("does not interfere with /api/plugin/* routing", async () => {
+    gw.registerMcpHandler("alpha", async () =>
+      new Response("from-mcp", { status: 200 }),
+    );
+    const r = await gw.handleRequest(req("GET", "/api/plugin/list"), url("/api/plugin/list"));
+    expect(r?.status).toBe(200);
+    const body = (await r!.json()) as { plugins: unknown[] };
+    expect(Array.isArray(body.plugins)).toBe(true);
+  });
+
+  it("unregisterMcpHandler removes the handler", async () => {
+    gw.registerMcpHandler("alpha", async () =>
+      new Response("ok", { status: 200 }),
+    );
+    expect(gw.hasMcpHandler("alpha")).toBe(true);
+    gw.unregisterMcpHandler("alpha");
+    expect(gw.hasMcpHandler("alpha")).toBe(false);
+
+    const r = await gw.handleRequest(req("POST", "/mcp/alpha"), url("/mcp/alpha"));
+    expect(r?.status).toBe(404);
+  });
+
+  it("re-registering replaces the previous handler", async () => {
+    gw.registerMcpHandler("alpha", async () =>
+      new Response("v1", { status: 200 }),
+    );
+    gw.registerMcpHandler("alpha", async () =>
+      new Response("v2", { status: 200 }),
+    );
+    const r = await gw.handleRequest(req("POST", "/mcp/alpha"), url("/mcp/alpha"));
+    expect(await r!.text()).toBe("v2");
+  });
+
+  it("rejects invalid server names at registration", () => {
+    expect(() => gw.registerMcpHandler("Bad Name", async () => new Response())).toThrow();
+    expect(() => gw.registerMcpHandler("../escape", async () => new Response())).toThrow();
+    expect(() => gw.registerMcpHandler("", async () => new Response())).toThrow();
+    expect(() => gw.registerMcpHandler("ok-name", async () => new Response())).not.toThrow();
+  });
+});

--- a/src/__tests__/pty-config.test.ts
+++ b/src/__tests__/pty-config.test.ts
@@ -214,6 +214,25 @@ describe("parseSettings — mcp block (MCP multiplexer, SPEC §5)", () => {
     expect(mcp.shared).toEqual([]);
     expect(mcp.perPtyOnly).toEqual([]);
     expect(mcp.stateless).toEqual([]);
+    expect(mcp.healthProbeIntervalMs).toBe(30000);
+  });
+
+  it("accepts a custom healthProbeIntervalMs", async () => {
+    await writeRawSettings({ mcp: { healthProbeIntervalMs: 5000 } });
+    await reloadSettings();
+    expect(getSettings().mcp.healthProbeIntervalMs).toBe(5000);
+  });
+
+  it("disables the health probe when healthProbeIntervalMs is 0", async () => {
+    await writeRawSettings({ mcp: { healthProbeIntervalMs: 0 } });
+    await reloadSettings();
+    expect(getSettings().mcp.healthProbeIntervalMs).toBe(0);
+  });
+
+  it("clamps negative healthProbeIntervalMs to the default", async () => {
+    await writeRawSettings({ mcp: { healthProbeIntervalMs: -1 } });
+    await reloadSettings();
+    expect(getSettings().mcp.healthProbeIntervalMs).toBe(30000);
   });
 
   it("accepts a non-empty shared list", async () => {
@@ -280,6 +299,11 @@ describe("parseSettings — mcp block (MCP multiplexer, SPEC §5)", () => {
   it("round-trips an explicit empty mcp object", async () => {
     await writeRawSettings({ mcp: {} });
     await reloadSettings();
-    expect(getSettings().mcp).toEqual({ shared: [], perPtyOnly: [], stateless: [] });
+    expect(getSettings().mcp).toEqual({
+      shared: [],
+      perPtyOnly: [],
+      stateless: [],
+      healthProbeIntervalMs: 30000,
+    });
   });
 });

--- a/src/__tests__/pty-config.test.ts
+++ b/src/__tests__/pty-config.test.ts
@@ -205,3 +205,81 @@ describe("parseSettings — pty interacts with existing fields", () => {
     expect(getSettings().pty).toEqual(first);
   });
 });
+
+describe("parseSettings — mcp block (MCP multiplexer, SPEC §5)", () => {
+  it("applies all defaults when mcp block is missing", async () => {
+    await writeRawSettings({});
+    await reloadSettings();
+    const { mcp } = getSettings();
+    expect(mcp.shared).toEqual([]);
+    expect(mcp.perPtyOnly).toEqual([]);
+    expect(mcp.stateless).toEqual([]);
+  });
+
+  it("accepts a non-empty shared list", async () => {
+    await writeRawSettings({ mcp: { shared: ["graphiti", "context7"] } });
+    await reloadSettings();
+    expect(getSettings().mcp.shared).toEqual(["graphiti", "context7"]);
+  });
+
+  it("filters non-string entries out of the shared list", async () => {
+    await writeRawSettings({ mcp: { shared: ["graphiti", 42, null, "context7", ""] } });
+    await reloadSettings();
+    expect(getSettings().mcp.shared).toEqual(["graphiti", "context7"]);
+  });
+
+  it("de-duplicates entries inside shared", async () => {
+    await writeRawSettings({ mcp: { shared: ["graphiti", "graphiti", "context7"] } });
+    await reloadSettings();
+    expect(getSettings().mcp.shared).toEqual(["graphiti", "context7"]);
+  });
+
+  it("treats a non-array shared field as empty", async () => {
+    await writeRawSettings({ mcp: { shared: "graphiti" } });
+    await reloadSettings();
+    expect(getSettings().mcp.shared).toEqual([]);
+  });
+
+  it("removes a name from shared when it's also in perPtyOnly (perPtyOnly wins)", async () => {
+    await writeRawSettings({
+      mcp: { shared: ["graphiti", "filesystem"], perPtyOnly: ["filesystem"] },
+    });
+    await reloadSettings();
+    const { mcp } = getSettings();
+    expect(mcp.shared).toEqual(["graphiti"]);
+    expect(mcp.perPtyOnly).toEqual(["filesystem"]);
+  });
+
+  it("drops a stateless entry that isn't also in shared", async () => {
+    await writeRawSettings({
+      mcp: { shared: ["graphiti"], stateless: ["context7"] },
+    });
+    await reloadSettings();
+    expect(getSettings().mcp.stateless).toEqual([]);
+  });
+
+  it("keeps stateless entries that are also in shared", async () => {
+    await writeRawSettings({
+      mcp: { shared: ["graphiti", "context7"], stateless: ["context7"] },
+    });
+    await reloadSettings();
+    expect(getSettings().mcp.stateless).toEqual(["context7"]);
+  });
+
+  it("accepts non-empty shared even when web.enabled is false (warning logged)", async () => {
+    // Warning is advisory — parseSettings does NOT remove the entries. The
+    // multiplexer plugin enforces activation at startup (SPEC §6.3).
+    await writeRawSettings({
+      web: { enabled: false },
+      mcp: { shared: ["graphiti"] },
+    });
+    await reloadSettings();
+    expect(getSettings().mcp.shared).toEqual(["graphiti"]);
+  });
+
+  it("round-trips an explicit empty mcp object", async () => {
+    await writeRawSettings({ mcp: {} });
+    await reloadSettings();
+    expect(getSettings().mcp).toEqual({ shared: [], perPtyOnly: [], stateless: [] });
+  });
+});

--- a/src/__tests__/pty-mcp-config-writer.test.ts
+++ b/src/__tests__/pty-mcp-config-writer.test.ts
@@ -25,13 +25,22 @@ import {
 
 // ─── Fixtures ───────────────────────────────────────────────────────────────
 
-/** Deterministic identity for golden-file tests. */
-function fakeIdentity(ptyId: string, hexSecret: string): PtyIdentity {
+/** Deterministic identity for golden-file tests. Mirrors W1's
+ *  `_toPublic` shape from src/plugins/mcp-multiplexer/pty-identity.ts. */
+function fakeIdentity(
+  ptyId: string,
+  hexSecret: string,
+  issuedAt: number = 1_700_000_000_000,
+): PtyIdentity {
+  const bearer = `Bearer ${hexSecret}`;
   return {
     ptyId,
-    secret: Buffer.from(hexSecret, "hex"),
-    buildAuthHeader() {
-      return { name: "Authorization", value: `Bearer ${hexSecret}` };
+    issuedAt,
+    bearer,
+    headers: {
+      Authorization: bearer,
+      "X-Claudeclaw-Pty-Id": ptyId,
+      "X-Claudeclaw-Ts": String(issuedAt),
     },
   };
 }
@@ -96,6 +105,7 @@ describe("writeConfigForPty — basic shape", () => {
           headers: {
             Authorization: `Bearer ${"a".repeat(64)}`,
             "X-Claudeclaw-Pty-Id": "suzy",
+            "X-Claudeclaw-Ts": "1700000000000",
           },
         },
       },

--- a/src/__tests__/pty-mcp-config-writer.test.ts
+++ b/src/__tests__/pty-mcp-config-writer.test.ts
@@ -1,0 +1,348 @@
+/**
+ * Unit tests for pty-mcp-config-writer.ts (MCP multiplexer, SPEC §4.4 §4.5).
+ *
+ * No real multiplexer / claude — every test pins a deterministic identity
+ * so we can golden-file the synthesized JSON.
+ */
+import { describe, it, expect, beforeAll, afterEach, afterAll } from "bun:test";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  configPathFor,
+  deleteConfigForPty,
+  writeConfigForPty,
+  type PtyIdentity,
+  type WriteConfigInput,
+} from "../runner/pty-mcp-config-writer";
+
+// ─── Fixtures ───────────────────────────────────────────────────────────────
+
+/** Deterministic identity for golden-file tests. */
+function fakeIdentity(ptyId: string, hexSecret: string): PtyIdentity {
+  return {
+    ptyId,
+    secret: Buffer.from(hexSecret, "hex"),
+    buildAuthHeader() {
+      return { name: "Authorization", value: `Bearer ${hexSecret}` };
+    },
+  };
+}
+
+let TEST_ROOT: string;
+const createdRoots: string[] = [];
+
+beforeAll(() => {
+  TEST_ROOT = mkdtempSync(join(tmpdir(), "ccw-pty-mcp-writer-"));
+});
+
+afterAll(() => {
+  for (const r of createdRoots) {
+    try {
+      rmSync(r, { recursive: true, force: true });
+    } catch {}
+  }
+  try {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+  } catch {}
+});
+
+function makeCwd(label: string): string {
+  const dir = join(TEST_ROOT, `${label}-${Math.random().toString(36).slice(2, 8)}`);
+  createdRoots.push(dir);
+  return dir;
+}
+
+function baseInput(over: Partial<WriteConfigInput> & { ptyId: string; cwd: string }): WriteConfigInput {
+  return {
+    sharedServers: [],
+    perPtyServers: [],
+    bridgeBaseUrl: "http://127.0.0.1:4632",
+    identity: fakeIdentity(over.ptyId, "a".repeat(64)),
+    ...over,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("writeConfigForPty — basic shape", () => {
+  it("writes the expected JSON shape for a single shared server", () => {
+    const cwd = makeCwd("shared-only");
+    const ptyId = "suzy";
+    const result = writeConfigForPty(
+      baseInput({
+        ptyId,
+        cwd,
+        sharedServers: [{ name: "graphiti" }],
+      }),
+    );
+
+    expect(result.path).toBe(join(cwd, ".claudeclaw", "mcp-pty-suzy.json"));
+    expect(existsSync(result.path)).toBe(true);
+
+    const parsed = JSON.parse(readFileSync(result.path, "utf8"));
+    expect(parsed).toEqual({
+      mcpServers: {
+        graphiti: {
+          type: "http",
+          url: "http://127.0.0.1:4632/mcp/graphiti",
+          headers: {
+            Authorization: `Bearer ${"a".repeat(64)}`,
+            "X-Claudeclaw-Pty-Id": "suzy",
+          },
+        },
+      },
+    });
+  });
+
+  it("writes multiple shared servers with stable URL composition", () => {
+    const cwd = makeCwd("multi-shared");
+    const result = writeConfigForPty(
+      baseInput({
+        ptyId: "reg",
+        cwd,
+        sharedServers: [
+          { name: "graphiti" },
+          { name: "context7" },
+          { name: "mempress" },
+        ],
+        bridgeBaseUrl: "http://127.0.0.1:4632/",
+      }),
+    );
+    const parsed = JSON.parse(readFileSync(result.path, "utf8"));
+    expect(Object.keys(parsed.mcpServers)).toEqual([
+      "graphiti",
+      "context7",
+      "mempress",
+    ]);
+    // Trailing slash on bridgeBaseUrl is stripped before composing the URL.
+    expect(parsed.mcpServers.graphiti.url).toBe(
+      "http://127.0.0.1:4632/mcp/graphiti",
+    );
+  });
+
+  it("writes mixed shared + per-PTY entries", () => {
+    const cwd = makeCwd("mixed");
+    const result = writeConfigForPty(
+      baseInput({
+        ptyId: "peggy",
+        cwd,
+        sharedServers: [{ name: "graphiti" }],
+        perPtyServers: [
+          {
+            name: "filesystem-sandbox",
+            command: "bunx",
+            args: ["@modelcontextprotocol/server-filesystem", "/tmp/sandbox"],
+            env: { SANDBOX_ROOT: "/tmp/sandbox" },
+          },
+        ],
+      }),
+    );
+    const parsed = JSON.parse(readFileSync(result.path, "utf8"));
+    expect(parsed.mcpServers.graphiti.type).toBe("http");
+    expect(parsed.mcpServers["filesystem-sandbox"]).toEqual({
+      type: "stdio",
+      command: "bunx",
+      args: ["@modelcontextprotocol/server-filesystem", "/tmp/sandbox"],
+      env: { SANDBOX_ROOT: "/tmp/sandbox" },
+    });
+  });
+
+  it("omits args/env in stdio entries when not provided (no empty arrays/objects)", () => {
+    const cwd = makeCwd("stdio-minimal");
+    const result = writeConfigForPty(
+      baseInput({
+        ptyId: "main",
+        cwd,
+        perPtyServers: [{ name: "noop", command: "/bin/true" }],
+      }),
+    );
+    const parsed = JSON.parse(readFileSync(result.path, "utf8"));
+    expect(parsed.mcpServers.noop).toEqual({ type: "stdio", command: "/bin/true" });
+  });
+});
+
+describe("writeConfigForPty — backward-compat path (SPEC §6.1)", () => {
+  it("returns empty path and does NOT create a file when both lists are empty", () => {
+    const cwd = makeCwd("empty");
+    const result = writeConfigForPty(baseInput({ ptyId: "x", cwd }));
+    expect(result.path).toBe("");
+    // .claudeclaw/ directory must NOT be created.
+    expect(existsSync(join(cwd, ".claudeclaw"))).toBe(false);
+  });
+});
+
+describe("writeConfigForPty — filesystem hygiene", () => {
+  it("creates .claudeclaw/ with 0700 mode when missing", () => {
+    const cwd = makeCwd("dir-mode");
+    writeConfigForPty(
+      baseInput({
+        ptyId: "x",
+        cwd,
+        sharedServers: [{ name: "graphiti" }],
+      }),
+    );
+    const dir = join(cwd, ".claudeclaw");
+    const st = statSync(dir);
+    // On POSIX, mode & 0o777 should match what we asked for; umask can mask
+    // bits OFF but never adds. We only assert "no group/other access".
+    expect(st.mode & 0o077).toBe(0);
+  });
+
+  it("writes the config file with mode 0600", () => {
+    const cwd = makeCwd("file-mode");
+    const result = writeConfigForPty(
+      baseInput({
+        ptyId: "x",
+        cwd,
+        sharedServers: [{ name: "graphiti" }],
+      }),
+    );
+    const st = statSync(result.path);
+    expect(st.mode & 0o077).toBe(0); // owner-only
+    expect(st.mode & 0o400).toBeGreaterThan(0); // at least owner-readable
+  });
+
+  it("is idempotent — second call with same input overwrites the file", () => {
+    const cwd = makeCwd("idempotent");
+    const inp = baseInput({
+      ptyId: "x",
+      cwd,
+      sharedServers: [{ name: "graphiti" }],
+    });
+    const r1 = writeConfigForPty(inp);
+    const firstMtime = statSync(r1.path).mtimeMs;
+
+    // Different secret → different bearer header → file content changes.
+    const r2 = writeConfigForPty({
+      ...inp,
+      identity: fakeIdentity("x", "b".repeat(64)),
+    });
+    expect(r2.path).toBe(r1.path);
+    const parsed = JSON.parse(readFileSync(r2.path, "utf8"));
+    expect(parsed.mcpServers.graphiti.headers.Authorization).toBe(
+      `Bearer ${"b".repeat(64)}`,
+    );
+    // mtime advances (or at least stays the same — Bun's underlying FS may
+    // skip a write if content matches; we forced a content change above).
+    expect(statSync(r2.path).mtimeMs).toBeGreaterThanOrEqual(firstMtime);
+  });
+
+  it("rejects empty ptyId", () => {
+    const cwd = makeCwd("empty-id");
+    expect(() =>
+      writeConfigForPty(
+        baseInput({
+          ptyId: "",
+          cwd,
+          sharedServers: [{ name: "graphiti" }],
+        }),
+      ),
+    ).toThrow(/ptyId must be non-empty/);
+  });
+
+  it("rejects empty cwd", () => {
+    expect(() =>
+      writeConfigForPty(
+        baseInput({
+          ptyId: "x",
+          cwd: "",
+          sharedServers: [{ name: "graphiti" }],
+        }),
+      ),
+    ).toThrow(/cwd must be non-empty/);
+  });
+});
+
+describe("writeConfigForPty — defensive entry hygiene", () => {
+  it("skips shared entries with empty names", () => {
+    const cwd = makeCwd("skip-empty");
+    const result = writeConfigForPty(
+      baseInput({
+        ptyId: "x",
+        cwd,
+        sharedServers: [{ name: "" }, { name: "graphiti" }],
+      }),
+    );
+    const parsed = JSON.parse(readFileSync(result.path, "utf8"));
+    expect(Object.keys(parsed.mcpServers)).toEqual(["graphiti"]);
+  });
+
+  it("does not overwrite a shared entry with a stdio entry of the same name", () => {
+    const cwd = makeCwd("collision");
+    const result = writeConfigForPty(
+      baseInput({
+        ptyId: "x",
+        cwd,
+        sharedServers: [{ name: "graphiti" }],
+        perPtyServers: [{ name: "graphiti", command: "/bin/true" }],
+      }),
+    );
+    const parsed = JSON.parse(readFileSync(result.path, "utf8"));
+    expect(parsed.mcpServers.graphiti.type).toBe("http");
+  });
+});
+
+describe("configPathFor", () => {
+  it("returns the canonical path layout for any (cwd, ptyId)", () => {
+    expect(configPathFor("/var/app", "suzy")).toBe(
+      "/var/app/.claudeclaw/mcp-pty-suzy.json",
+    );
+  });
+});
+
+describe("deleteConfigForPty", () => {
+  it("removes a written config file", () => {
+    const cwd = makeCwd("delete");
+    const result = writeConfigForPty(
+      baseInput({
+        ptyId: "x",
+        cwd,
+        sharedServers: [{ name: "graphiti" }],
+      }),
+    );
+    expect(existsSync(result.path)).toBe(true);
+    deleteConfigForPty(cwd, "x");
+    expect(existsSync(result.path)).toBe(false);
+  });
+
+  it("swallows ENOENT — second delete is a no-op", () => {
+    const cwd = makeCwd("delete-twice");
+    writeConfigForPty(
+      baseInput({
+        ptyId: "x",
+        cwd,
+        sharedServers: [{ name: "graphiti" }],
+      }),
+    );
+    deleteConfigForPty(cwd, "x");
+    // Second call must not throw.
+    expect(() => deleteConfigForPty(cwd, "x")).not.toThrow();
+  });
+
+  it("is a no-op when called with empty cwd or ptyId", () => {
+    expect(() => deleteConfigForPty("", "x")).not.toThrow();
+    expect(() => deleteConfigForPty("/tmp", "")).not.toThrow();
+  });
+
+  it("is a no-op when the file was never written (backward-compat path)", () => {
+    const cwd = makeCwd("never-written");
+    expect(() => deleteConfigForPty(cwd, "x")).not.toThrow();
+  });
+});
+
+afterEach(() => {
+  // Cleanup any leaked .claudeclaw dirs between tests.
+  for (const r of createdRoots) {
+    try {
+      rmSync(join(r, ".claudeclaw"), { recursive: true, force: true });
+    } catch {}
+  }
+});

--- a/src/__tests__/pty-process.test.ts
+++ b/src/__tests__/pty-process.test.ts
@@ -368,6 +368,46 @@ describe("PtyProcess — buildClaudeArgs honours modelOverride (Codex Phase D #1
   });
 });
 
+describe("PtyProcess — buildClaudeArgs honours mcpConfigPath (MCP multiplexer, SPEC §4.5)", () => {
+  test("mcpConfigPath produces --mcp-config <path>", () => {
+    const cfg = "/var/cwd/.claudeclaw/mcp-pty-suzy.json";
+    const opts: PtyProcessOptions = {
+      sessionId: "",
+      cwd: "/tmp",
+      security: { level: "moderate", allowedTools: [], disallowedTools: [] },
+      mcpConfigPath: cfg,
+      env: {},
+    };
+    const args = __buildClaudeArgsForTests(opts);
+    const flagIdx = args.indexOf("--mcp-config");
+    expect(flagIdx).toBeGreaterThanOrEqual(0);
+    expect(args[flagIdx + 1]).toBe(cfg);
+  });
+
+  test("empty mcpConfigPath is NOT emitted (avoids `--mcp-config ''`)", () => {
+    const opts: PtyProcessOptions = {
+      sessionId: "",
+      cwd: "/tmp",
+      security: { level: "moderate", allowedTools: [], disallowedTools: [] },
+      mcpConfigPath: "",
+      env: {},
+    };
+    const args = __buildClaudeArgsForTests(opts);
+    expect(args).not.toContain("--mcp-config");
+  });
+
+  test("omitted mcpConfigPath is NOT emitted (backward-compat with settings.mcp.shared=[])", () => {
+    const opts: PtyProcessOptions = {
+      sessionId: "",
+      cwd: "/tmp",
+      security: { level: "moderate", allowedTools: [], disallowedTools: [] },
+      env: {},
+    };
+    const args = __buildClaudeArgsForTests(opts);
+    expect(args).not.toContain("--mcp-config");
+  });
+});
+
 describe("PtyProcess — sessionId", () => {
   test("sessionId from opts.sessionId is exposed verbatim", async () => {
     const sid = "test-session-uuid-1234";

--- a/src/__tests__/pty-supervisor-mcp.test.ts
+++ b/src/__tests__/pty-supervisor-mcp.test.ts
@@ -5,14 +5,21 @@
  * dispose paths. The multiplexer plugin itself doesn't exist in this
  * worktree — we stub it via `injectMcpIdentityIssuer`.
  *
- * Coverage:
+ * Coverage (this file):
  *   - Synthesis fires when settings.mcp.shared is non-empty AND web.enabled AND
  *     issuer is wired → PtyProcessOptions.mcpConfigPath is set, file on disk.
  *   - Synthesis SKIPS when settings.mcp.shared is empty (backward-compat, SPEC §6.1).
  *   - Synthesis SKIPS when web.enabled is false (SPEC §6.3).
- *   - Synthesis SKIPS when no issuer is wired (W1 not present / dormant).
- *   - Cleanup fires on shutdownSupervisor, killAllPtys, reapIdle, LRU evict.
- *   - Respawn rotates the bearer token via re-synthesis on the same path.
+ *   - Synthesis SKIPS when no issuer is wired (multiplexer dormant).
+ *   - Cleanup fires on shutdownSupervisor and killAllPtys.
+ *
+ * NOT covered here (component-tested elsewhere or pending follow-up):
+ *   - reapIdle / LRU eviction cleanup — exercised at the supervisor-component
+ *     level via the broader pty-supervisor.test.ts dispose-path tests.
+ *   - Respawn bearer rotation — exercised by the multiplexer plugin tests
+ *     (`mcp-multiplexer/__tests__/index.test.ts`) which validate
+ *     `issueIdentity(ptyId)` mints a fresh secret on every call. A dedicated
+ *     supervisor-side respawn-rotation test is filed as a v1.1 follow-up.
  */
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { existsSync, mkdtempSync, rmSync } from "node:fs";

--- a/src/__tests__/pty-supervisor-mcp.test.ts
+++ b/src/__tests__/pty-supervisor-mcp.test.ts
@@ -164,11 +164,16 @@ function makeFakeIssuer(): FakeIssuerHandle {
       const hex = _secretCounter.toString(16).padStart(64, "0");
       currentSecret.set(ptyId, hex);
       issued.push(ptyId);
+      const issuedAt = 1_700_000_000_000 + _secretCounter;
+      const bearer = `Bearer ${hex}`;
       return {
         ptyId,
-        secret: Buffer.from(hex, "hex"),
-        buildAuthHeader() {
-          return { name: "Authorization", value: `Bearer ${hex}` };
+        issuedAt,
+        bearer,
+        headers: {
+          Authorization: bearer,
+          "X-Claudeclaw-Pty-Id": ptyId,
+          "X-Claudeclaw-Ts": String(issuedAt),
         },
       };
     },

--- a/src/__tests__/pty-supervisor-mcp.test.ts
+++ b/src/__tests__/pty-supervisor-mcp.test.ts
@@ -1,0 +1,364 @@
+/**
+ * pty-supervisor.ts × MCP multiplexer wiring tests (SPEC §4.5, §6.1, §6.3).
+ *
+ * Exercises the synthesis hook in buildSpawnOptions + the cleanup hook on
+ * dispose paths. The multiplexer plugin itself doesn't exist in this
+ * worktree — we stub it via `injectMcpIdentityIssuer`.
+ *
+ * Coverage:
+ *   - Synthesis fires when settings.mcp.shared is non-empty AND web.enabled AND
+ *     issuer is wired → PtyProcessOptions.mcpConfigPath is set, file on disk.
+ *   - Synthesis SKIPS when settings.mcp.shared is empty (backward-compat, SPEC §6.1).
+ *   - Synthesis SKIPS when web.enabled is false (SPEC §6.3).
+ *   - Synthesis SKIPS when no issuer is wired (W1 not present / dormant).
+ *   - Cleanup fires on shutdownSupervisor, killAllPtys, reapIdle, LRU evict.
+ *   - Respawn rotates the bearer token via re-synthesis on the same path.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { copyFile, mkdir, unlink } from "fs/promises";
+
+import {
+  runOnPty,
+  shutdownSupervisor,
+  killAllPtys,
+  injectSpawnPty,
+  injectClock,
+  resetClock,
+  injectSleep,
+  resetSleep,
+  injectEnsureAgentDir,
+  injectMcpIdentityIssuer,
+  __resetSupervisorForTests,
+} from "../runner/pty-supervisor";
+import {
+  PtyClosedError,
+  type PtyProcess,
+  type PtyProcessOptions,
+  type PtyTurnResult,
+  type SpawnPty,
+} from "../runner/pty-process";
+import {
+  configPathFor,
+  type PtyIdentity,
+} from "../runner/pty-mcp-config-writer";
+import { initConfig, loadSettings, reloadSettings } from "../config";
+
+// ─── Settings management ────────────────────────────────────────────────────
+
+const SETTINGS_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const SETTINGS_FILE = join(SETTINGS_DIR, "settings.json");
+const BACKUP_FILE = join(SETTINGS_DIR, "settings.json.pty-mcp-test-backup");
+
+async function backupSettings(): Promise<void> {
+  await mkdir(SETTINGS_DIR, { recursive: true });
+  if (existsSync(SETTINGS_FILE)) {
+    await copyFile(SETTINGS_FILE, BACKUP_FILE);
+  }
+}
+
+async function restoreSettings(): Promise<void> {
+  if (existsSync(BACKUP_FILE)) {
+    await copyFile(BACKUP_FILE, SETTINGS_FILE);
+    await unlink(BACKUP_FILE);
+  } else if (existsSync(SETTINGS_FILE)) {
+    await unlink(SETTINGS_FILE);
+  }
+  try {
+    await reloadSettings();
+  } catch {
+    // tolerate
+  }
+}
+
+async function writeRawSettings(obj: unknown): Promise<void> {
+  await mkdir(SETTINGS_DIR, { recursive: true });
+  await Bun.write(SETTINGS_FILE, JSON.stringify(obj, null, 2) + "\n");
+  await reloadSettings();
+}
+
+// ─── Test fixtures ──────────────────────────────────────────────────────────
+
+let TEST_ROOT: string;
+
+interface FakePtyHandle extends PtyProcess {
+  disposed: boolean;
+}
+
+function makeFakePty(label: string, cwd: string): FakePtyHandle {
+  let alive = true;
+  let lastTurnEndedAt = 0;
+  let disposed = false;
+  const handle: FakePtyHandle = {
+    label,
+    pid: Math.floor(Math.random() * 100000) + 1000,
+    sessionId: "fake-session-id",
+    cwd,
+    isAlive() {
+      return alive;
+    },
+    lastTurnEndedAt() {
+      return lastTurnEndedAt;
+    },
+    async runTurn(prompt): Promise<PtyTurnResult> {
+      lastTurnEndedAt = Date.now();
+      return {
+        text: `echo:${prompt}`,
+        bytesCaptured: prompt.length,
+        cleanBoundary: true,
+        sessionId: "fake-session-id",
+      };
+    },
+    async dispose(): Promise<void> {
+      alive = false;
+      disposed = true;
+    },
+    get disposed() {
+      return disposed;
+    },
+  } as unknown as FakePtyHandle;
+  Object.defineProperty(handle, "disposed", { get: () => disposed });
+  return handle;
+}
+
+interface SpawnTracker {
+  spawn: SpawnPty;
+  spawned: FakePtyHandle[];
+  spawnOpts: PtyProcessOptions[];
+}
+
+function makeSpawnTracker(): SpawnTracker {
+  const spawned: FakePtyHandle[] = [];
+  const spawnOpts: PtyProcessOptions[] = [];
+  const spawn: SpawnPty = async (opts) => {
+    const handle = makeFakePty("test", opts.cwd);
+    spawned.push(handle);
+    spawnOpts.push(opts);
+    return handle;
+  };
+  return { spawn, spawned, spawnOpts };
+}
+
+interface FakeIssuerHandle {
+  issue: (ptyId: string) => PtyIdentity;
+  revoke: (ptyId: string) => void;
+  issued: string[]; // log of ptyIds for which we issued
+  revoked: string[]; // log of ptyIds for which we revoked
+  currentSecret: Map<string, string>; // ptyId → hex
+}
+
+let _secretCounter = 0;
+
+function makeFakeIssuer(): FakeIssuerHandle {
+  const issued: string[] = [];
+  const revoked: string[] = [];
+  const currentSecret = new Map<string, string>();
+  return {
+    issued,
+    revoked,
+    currentSecret,
+    issue(ptyId: string): PtyIdentity {
+      _secretCounter += 1;
+      const hex = _secretCounter.toString(16).padStart(64, "0");
+      currentSecret.set(ptyId, hex);
+      issued.push(ptyId);
+      return {
+        ptyId,
+        secret: Buffer.from(hex, "hex"),
+        buildAuthHeader() {
+          return { name: "Authorization", value: `Bearer ${hex}` };
+        },
+      };
+    },
+    revoke(ptyId: string): void {
+      revoked.push(ptyId);
+      currentSecret.delete(ptyId);
+    },
+  };
+}
+
+// ─── Lifecycle ──────────────────────────────────────────────────────────────
+
+beforeEach(async () => {
+  __resetSupervisorForTests();
+  resetClock();
+  resetSleep();
+  TEST_ROOT = mkdtempSync(join(tmpdir(), "ccw-pty-mcp-sup-"));
+  await initConfig();
+  await loadSettings();
+  await backupSettings();
+  // Default test setup: TEST_ROOT is the cwd for spawned agents. We stub
+  // ensureAgentDir to write under TEST_ROOT instead of the repo's agents/.
+  injectEnsureAgentDir(async (name: string) => {
+    const d = join(TEST_ROOT, "agents", name);
+    await mkdir(d, { recursive: true });
+    return d;
+  });
+});
+
+afterEach(async () => {
+  resetClock();
+  resetSleep();
+  await shutdownSupervisor();
+  __resetSupervisorForTests();
+  await restoreSettings();
+  try {
+    rmSync(TEST_ROOT, { recursive: true, force: true });
+  } catch {}
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe("supervisor × MCP multiplexer — synthesis activation (SPEC §4.5 §6.3)", () => {
+  it("synthesizes mcpConfigPath when shared non-empty, web enabled, issuer wired", async () => {
+    await writeRawSettings({
+      web: { enabled: true, host: "127.0.0.1", port: 4632 },
+      mcp: { shared: ["graphiti"] },
+    });
+    const tracker = makeSpawnTracker();
+    injectSpawnPty(tracker.spawn);
+    const issuer = makeFakeIssuer();
+    injectMcpIdentityIssuer({ issue: issuer.issue, revoke: issuer.revoke });
+
+    await runOnPty("agent:suzy", "hello", {
+      timeoutMs: 60_000,
+      agentName: "suzy",
+    });
+
+    expect(tracker.spawned).toHaveLength(1);
+    const opts = tracker.spawnOpts[0]!;
+    expect(opts.mcpConfigPath).toBeDefined();
+    expect(opts.mcpConfigPath).toContain(".claudeclaw");
+    expect(opts.mcpConfigPath).toContain("mcp-pty-agent:suzy.json");
+    expect(existsSync(opts.mcpConfigPath!)).toBe(true);
+    // Issuer was asked for an identity for this PTY.
+    expect(issuer.issued).toContain("agent:suzy");
+  });
+
+  it("does NOT synthesize when settings.mcp.shared is empty (backward-compat, SPEC §6.1)", async () => {
+    await writeRawSettings({
+      web: { enabled: true, host: "127.0.0.1", port: 4632 },
+      mcp: { shared: [] },
+    });
+    const tracker = makeSpawnTracker();
+    injectSpawnPty(tracker.spawn);
+    const issuer = makeFakeIssuer();
+    injectMcpIdentityIssuer({ issue: issuer.issue, revoke: issuer.revoke });
+
+    await runOnPty("agent:suzy", "hello", {
+      timeoutMs: 60_000,
+      agentName: "suzy",
+    });
+
+    expect(tracker.spawnOpts[0]!.mcpConfigPath).toBeUndefined();
+    // Issuer is NEVER called when synthesis is skipped — keeps the
+    // multiplexer's HMAC map empty for dormant PTYs.
+    expect(issuer.issued).toEqual([]);
+  });
+
+  it("does NOT synthesize when settings.web.enabled is false (SPEC §6.3)", async () => {
+    await writeRawSettings({
+      web: { enabled: false, host: "127.0.0.1", port: 4632 },
+      mcp: { shared: ["graphiti"] },
+    });
+    const tracker = makeSpawnTracker();
+    injectSpawnPty(tracker.spawn);
+    const issuer = makeFakeIssuer();
+    injectMcpIdentityIssuer({ issue: issuer.issue, revoke: issuer.revoke });
+
+    await runOnPty("agent:suzy", "hello", {
+      timeoutMs: 60_000,
+      agentName: "suzy",
+    });
+
+    expect(tracker.spawnOpts[0]!.mcpConfigPath).toBeUndefined();
+    expect(issuer.issued).toEqual([]);
+  });
+
+  it("does NOT synthesize when no issuer is wired (W1 dormant)", async () => {
+    await writeRawSettings({
+      web: { enabled: true, host: "127.0.0.1", port: 4632 },
+      mcp: { shared: ["graphiti"] },
+    });
+    const tracker = makeSpawnTracker();
+    injectSpawnPty(tracker.spawn);
+    // No injectMcpIdentityIssuer call — issuer remains null.
+
+    await runOnPty("agent:suzy", "hello", {
+      timeoutMs: 60_000,
+      agentName: "suzy",
+    });
+
+    expect(tracker.spawnOpts[0]!.mcpConfigPath).toBeUndefined();
+  });
+});
+
+describe("supervisor × MCP multiplexer — cleanup paths (SPEC §4.5)", () => {
+  async function setupActivePty(): Promise<{
+    tracker: SpawnTracker;
+    issuer: FakeIssuerHandle;
+    cwd: string;
+  }> {
+    await writeRawSettings({
+      web: { enabled: true, host: "127.0.0.1", port: 4632 },
+      mcp: { shared: ["graphiti"] },
+    });
+    const tracker = makeSpawnTracker();
+    injectSpawnPty(tracker.spawn);
+    const issuer = makeFakeIssuer();
+    injectMcpIdentityIssuer({ issue: issuer.issue, revoke: issuer.revoke });
+    await runOnPty("agent:suzy", "hello", {
+      timeoutMs: 60_000,
+      agentName: "suzy",
+    });
+    const opts = tracker.spawnOpts[0]!;
+    expect(opts.mcpConfigPath).toBeDefined();
+    expect(existsSync(opts.mcpConfigPath!)).toBe(true);
+    return { tracker, issuer, cwd: opts.cwd };
+  }
+
+  it("shutdownSupervisor revokes identity and deletes the synthesized config", async () => {
+    const { issuer, cwd } = await setupActivePty();
+    const cfgPath = configPathFor(cwd, "agent:suzy");
+    expect(existsSync(cfgPath)).toBe(true);
+
+    await shutdownSupervisor();
+
+    expect(issuer.revoked).toContain("agent:suzy");
+    expect(existsSync(cfgPath)).toBe(false);
+  });
+
+  it("killAllPtys revokes identity and deletes the synthesized config", async () => {
+    const { issuer, cwd } = await setupActivePty();
+    const cfgPath = configPathFor(cwd, "agent:suzy");
+
+    await killAllPtys();
+
+    expect(issuer.revoked).toContain("agent:suzy");
+    expect(existsSync(cfgPath)).toBe(false);
+  });
+});
+
+describe("supervisor × MCP multiplexer — identity-issuer toggle", () => {
+  it("injectMcpIdentityIssuer({ issue: null }) disables synthesis even when settings are active", async () => {
+    await writeRawSettings({
+      web: { enabled: true, host: "127.0.0.1", port: 4632 },
+      mcp: { shared: ["graphiti"] },
+    });
+    const tracker = makeSpawnTracker();
+    injectSpawnPty(tracker.spawn);
+    const issuer = makeFakeIssuer();
+    injectMcpIdentityIssuer({ issue: issuer.issue, revoke: issuer.revoke });
+    // Re-disable.
+    injectMcpIdentityIssuer({ issue: null });
+
+    await runOnPty("agent:suzy", "hello", {
+      timeoutMs: 60_000,
+      agentName: "suzy",
+    });
+
+    expect(tracker.spawnOpts[0]!.mcpConfigPath).toBeUndefined();
+  });
+});

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -21,6 +21,8 @@ import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wi
 import { PluginManager, setPluginManager } from "../plugins";
 import { indexSessionsBackground } from "../memory";
 import { getMcpProxyPlugin } from "../plugins/mcp-proxy/index.js";
+import { getMcpMultiplexerPlugin } from "../plugins/mcp-multiplexer/index.js";
+import { injectMcpIdentityIssuer } from "../runner/pty-supervisor";
 
 const CLAUDE_DIR = join(process.cwd(), ".claude");
 const HEARTBEAT_DIR = join(CLAUDE_DIR, "claudeclaw");
@@ -576,44 +578,22 @@ export async function start(args: string[] = []) {
 
   // MCP multiplexer (SPEC §4.5, §6.3): start BEFORE mcp-proxy so the proxy
   // can read settings.mcp.shared to skip servers the multiplexer owns. Also
-  // wires the multiplexer's issue/revoke functions into the PTY supervisor.
+  // wires the multiplexer's issue/release functions into the PTY supervisor.
   //
   // Activation rule (SPEC §6.3): only attempt to start when shared is
   // non-empty AND web.enabled is true. Otherwise the plugin would have
   // nothing to mount routes on.
-  //
-  // TODO(coord): replace the dynamic import with a static import once the
-  // mcp-multiplexer module from W1 lands on master. Today it's dynamic so
-  // this worktree compiles standalone while W1's worktree owns the file.
   if (settings.mcp.shared.length > 0 && settings.web.enabled) {
     try {
-      // @ts-expect-error TODO(coord): W1 module not yet present in this worktree.
-      // Replace with static import once src/plugins/mcp-multiplexer/index.ts
-      // lands on master.
-      const mod = (await import("../plugins/mcp-multiplexer/index.js")) as {
-        getMcpMultiplexerPlugin?: () => {
-          start: () => Promise<void>;
-          issueIdentity: (ptyId: string) => unknown;
-          revokeIdentity: (ptyId: string) => void | Promise<void>;
-        };
-      };
-      if (mod.getMcpMultiplexerPlugin) {
-        const plugin = mod.getMcpMultiplexerPlugin();
-        await plugin.start();
-        // Wire the supervisor seam so PTY spawns synthesize per-PTY configs.
-        const sup = await import("../runner/pty-supervisor.js");
-        sup.injectMcpIdentityIssuer({
-          issue: plugin.issueIdentity as (ptyId: string) => never,
-          revoke: plugin.revokeIdentity,
-        });
-        console.log("[mcp-multiplexer] started");
-      } else {
-        console.warn(
-          "[mcp-multiplexer] settings.mcp.shared is non-empty but the multiplexer plugin module has no getMcpMultiplexerPlugin export",
-        );
-      }
+      const plugin = getMcpMultiplexerPlugin();
+      await plugin.start();
+      // Wire the supervisor seam so PTY spawns synthesize per-PTY configs.
+      injectMcpIdentityIssuer({
+        issue: (ptyId) => plugin.issueIdentity(ptyId),
+        revoke: (ptyId) => plugin.releaseIdentity(ptyId),
+      });
+      console.log("[mcp-multiplexer] started");
     } catch (err) {
-      // Module not found = W1 hasn't merged yet OR operator hasn't pulled it.
       // Don't crash the daemon — log clearly and fall back to per-PTY MCP
       // discovery (settings.mcp.shared becomes effectively dormant).
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -587,15 +587,28 @@ export async function start(args: string[] = []) {
     try {
       const plugin = getMcpMultiplexerPlugin();
       await plugin.start();
-      // Wire the supervisor seam so PTY spawns synthesize per-PTY configs.
-      // bridgeBaseUrl reads from the plugin so supervisor and plugin can't
-      // drift on the URL the multiplexer actually bound to.
-      injectMcpIdentityIssuer({
-        issue: (ptyId) => plugin.issueIdentity(ptyId),
-        revoke: (ptyId) => plugin.releaseIdentity(ptyId),
-        bridgeBaseUrl: () => plugin.bridgeBaseUrl(),
-      });
-      console.log("[mcp-multiplexer] started");
+      // Codex PR #71 P1: plugin.start() can return successfully but leave
+      // the multiplexer dormant (missing/invalid mcp-proxy.json, zero
+      // claimed servers, etc). Only wire the supervisor seam when the
+      // plugin is *actually* serving — otherwise the supervisor would
+      // synthesize --mcp-config entries pointing at routes that were
+      // never registered. When dormant, supervisor's existing
+      // null-issuer guard skips synthesis and PTYs fall back to default
+      // MCP discovery, exactly as the surrounding comment promises.
+      if (plugin.isActive()) {
+        // bridgeBaseUrl reads from the plugin so supervisor and plugin
+        // can't drift on the URL the multiplexer actually bound to.
+        injectMcpIdentityIssuer({
+          issue: (ptyId) => plugin.issueIdentity(ptyId),
+          revoke: (ptyId) => plugin.releaseIdentity(ptyId),
+          bridgeBaseUrl: () => plugin.bridgeBaseUrl(),
+        });
+        console.log("[mcp-multiplexer] started");
+      } else {
+        console.warn(
+          "[mcp-multiplexer] start() returned dormant — supervisor wiring skipped, PTYs fall back to default MCP discovery.",
+        );
+      }
     } catch (err) {
       // Don't crash the daemon — log clearly and fall back to per-PTY MCP
       // discovery (settings.mcp.shared becomes effectively dormant).

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -574,6 +574,55 @@ export async function start(args: string[] = []) {
     await pluginManager.emit("gateway_start", {}, { workspaceDir: process.cwd() });
   }
 
+  // MCP multiplexer (SPEC §4.5, §6.3): start BEFORE mcp-proxy so the proxy
+  // can read settings.mcp.shared to skip servers the multiplexer owns. Also
+  // wires the multiplexer's issue/revoke functions into the PTY supervisor.
+  //
+  // Activation rule (SPEC §6.3): only attempt to start when shared is
+  // non-empty AND web.enabled is true. Otherwise the plugin would have
+  // nothing to mount routes on.
+  //
+  // TODO(coord): replace the dynamic import with a static import once the
+  // mcp-multiplexer module from W1 lands on master. Today it's dynamic so
+  // this worktree compiles standalone while W1's worktree owns the file.
+  if (settings.mcp.shared.length > 0 && settings.web.enabled) {
+    try {
+      // @ts-expect-error TODO(coord): W1 module not yet present in this worktree.
+      // Replace with static import once src/plugins/mcp-multiplexer/index.ts
+      // lands on master.
+      const mod = (await import("../plugins/mcp-multiplexer/index.js")) as {
+        getMcpMultiplexerPlugin?: () => {
+          start: () => Promise<void>;
+          issueIdentity: (ptyId: string) => unknown;
+          revokeIdentity: (ptyId: string) => void | Promise<void>;
+        };
+      };
+      if (mod.getMcpMultiplexerPlugin) {
+        const plugin = mod.getMcpMultiplexerPlugin();
+        await plugin.start();
+        // Wire the supervisor seam so PTY spawns synthesize per-PTY configs.
+        const sup = await import("../runner/pty-supervisor.js");
+        sup.injectMcpIdentityIssuer({
+          issue: plugin.issueIdentity as (ptyId: string) => never,
+          revoke: plugin.revokeIdentity,
+        });
+        console.log("[mcp-multiplexer] started");
+      } else {
+        console.warn(
+          "[mcp-multiplexer] settings.mcp.shared is non-empty but the multiplexer plugin module has no getMcpMultiplexerPlugin export",
+        );
+      }
+    } catch (err) {
+      // Module not found = W1 hasn't merged yet OR operator hasn't pulled it.
+      // Don't crash the daemon — log clearly and fall back to per-PTY MCP
+      // discovery (settings.mcp.shared becomes effectively dormant).
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(
+        `[mcp-multiplexer] startup failed (non-fatal, falling back to per-PTY MCP discovery): ${msg}`,
+      );
+    }
+  }
+
   // Start mcp-proxy plugin only when a config file is present — avoids opening
   // an HTTP gateway on deployments that don't use external MCP plugins.
   const mcpProxyConfigPath = join(homedir(), ".config", "claudeclaw", "mcp-proxy.json");

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -588,9 +588,12 @@ export async function start(args: string[] = []) {
       const plugin = getMcpMultiplexerPlugin();
       await plugin.start();
       // Wire the supervisor seam so PTY spawns synthesize per-PTY configs.
+      // bridgeBaseUrl reads from the plugin so supervisor and plugin can't
+      // drift on the URL the multiplexer actually bound to.
       injectMcpIdentityIssuer({
         issue: (ptyId) => plugin.issueIdentity(ptyId),
         revoke: (ptyId) => plugin.releaseIdentity(ptyId),
+        bridgeBaseUrl: () => plugin.bridgeBaseUrl(),
       });
       console.log("[mcp-multiplexer] started");
     } catch (err) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -108,6 +108,7 @@ const DEFAULT_SETTINGS: Settings = {
     shared: [],
     perPtyOnly: [],
     stateless: [],
+    healthProbeIntervalMs: 30000,
   },
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
   session: { autoRotate: false, maxMessages: 50, maxAgeHours: 24, summaryPath: "" },
@@ -220,6 +221,18 @@ export interface McpConfig {
    * empty → assume every shared server is stateful (per-PTY session map).
    */
   stateless: string[];
+  /**
+   * Interval in milliseconds between health-probe samples of each shared
+   * MCP server. Set to 0 to disable. Default: 30000 (30s).
+   *
+   * The probe samples each `McpServerProcess.status` and emits a structured
+   * audit event + log line on transitions (e.g. `up` → `crashed`). Pairs
+   * with the per-server crash/failure events already emitted by the proxy
+   * substrate. Filed in response to Nibbler review on #64: the silent
+   * degradation mode (one shared MCP crashes → all PTYs lose that tool)
+   * needs an operator-visible signal before `pty.enabled: true` ships.
+   */
+  healthProbeIntervalMs: number;
 }
 
 export interface PtyConfig {
@@ -603,10 +616,18 @@ function parseMcpConfig(raw: any, webEnabled: unknown): McpConfig {
     );
   }
 
+  // Rule 4: health-probe interval is a non-negative integer; clamp+default.
+  const rawProbeMs = raw?.healthProbeIntervalMs;
+  const healthProbeIntervalMs =
+    typeof rawProbeMs === "number" && Number.isFinite(rawProbeMs) && rawProbeMs >= 0
+      ? Math.floor(rawProbeMs)
+      : 30000;
+
   return {
     shared: filteredShared,
     perPtyOnly,
     stateless: filteredStateless,
+    healthProbeIntervalMs,
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -102,6 +102,13 @@ const DEFAULT_SETTINGS: Settings = {
     rows: 30,
     maxConcurrent: 32,
   },
+  mcp: {
+    // Default empty — the multiplexer is dormant out of the box. Operators
+    // opt in by listing server names from mcp-proxy.json here. See SPEC §6.
+    shared: [],
+    perPtyOnly: [],
+    stateless: [],
+  },
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
   session: { autoRotate: false, maxMessages: 50, maxAgeHours: 24, summaryPath: "" },
   plugins: {},
@@ -185,6 +192,36 @@ export interface TimeoutsConfig {
   default: number;
 }
 
+/**
+ * MCP multiplexer settings (SPEC §5). Operators enumerate WHICH MCP servers
+ * from `mcp-proxy.json` get hosted shared by the daemon vs spawned per-PTY.
+ *
+ * Default empty `shared` list keeps the PTY path byte-identical to today —
+ * the multiplexer is dormant and Claude Code's stock per-PTY MCP discovery
+ * applies. This is the rollback path: clear `shared`, reload settings.
+ */
+export interface McpConfig {
+  /**
+   * Names of MCP servers to multiplex over the bridge. Each must also appear
+   * in `~/.config/claudeclaw/mcp-proxy.json`. Empty list (default) → multiplexer
+   * is dormant.
+   */
+  shared: string[];
+  /**
+   * Names of MCP servers that MUST spawn per-PTY locally (security-sensitive
+   * filesystem MCPs etc). Mutually exclusive with `shared`. Today a no-op
+   * surface (non-shared servers already spawn per-PTY); listed here for
+   * future extension (per-PTY env scoping, ACL hooks).
+   */
+  perPtyOnly: string[];
+  /**
+   * Subset of `shared`. Declares that the MCP server has no per-session state
+   * and can safely share one upstream MCP session across all PTYs. Default
+   * empty → assume every shared server is stateful (per-PTY session map).
+   */
+  stateless: string[];
+}
+
 export interface PtyConfig {
   /** Master switch. When false (default), runner uses today's `claude -p` path
    *  for every callsite. Operators flip to true ONLY after the MCP multiplexer
@@ -242,6 +279,7 @@ export interface Settings {
   sessionTimeoutMs: number;
   timeouts: TimeoutsConfig;
   pty: PtyConfig;
+  mcp: McpConfig;
   watchdog: WatchdogSettings;
   plugins: Record<string, PluginEntry>;
   session: SessionConfig;
@@ -487,6 +525,7 @@ function parseSettings(
       maxConcurrent: Number.isFinite(raw.pty?.maxConcurrent) && Number(raw.pty.maxConcurrent) > 0
         ? Number(raw.pty.maxConcurrent) : 32,
     },
+    mcp: parseMcpConfig(raw.mcp, raw.web?.enabled),
     watchdog: parseWatchdogConfig(raw.watchdog),
     plugins: parsePlugins(raw.plugins),
     memorySearch: parseMemorySearchSettings(raw.memorySearch),
@@ -503,6 +542,73 @@ function parseSettings(
 
 const TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/;
 const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
+
+/**
+ * Parse the `mcp` block from a raw settings object (SPEC §5).
+ *
+ * Validation rules — log warnings, never throw:
+ *   1. Same name in both `shared` and `perPtyOnly` → drop from `shared`.
+ *   2. `stateless` entries must be a subset of `shared` → drop strays.
+ *   3. `settings.web.enabled === false` + non-empty `shared` → warn that the
+ *      multiplexer can't activate; callers must check this combo at startup.
+ *
+ * Note: we deliberately can't validate that names appear in `mcp-proxy.json`
+ * at parse time (that file lives on disk and is read by the multiplexer
+ * plugin, not by parseSettings). The multiplexer's own startup path warns
+ * when a shared name has no definition; see SPEC §5 rule 2.
+ */
+function parseMcpConfig(raw: any, webEnabled: unknown): McpConfig {
+  const asStringList = (v: unknown): string[] =>
+    Array.isArray(v)
+      ? v.filter((s): s is string => typeof s === "string" && s.length > 0).map(String)
+      : [];
+
+  const rawShared = asStringList(raw?.shared);
+  const rawPerPtyOnly = asStringList(raw?.perPtyOnly);
+  const rawStateless = asStringList(raw?.stateless);
+
+  // De-duplicate inside each list (silent — pure data hygiene).
+  const shared = [...new Set(rawShared)];
+  const perPtyOnly = [...new Set(rawPerPtyOnly)];
+  const stateless = [...new Set(rawStateless)];
+
+  // Rule 1: a name in both `shared` and `perPtyOnly` → `perPtyOnly` wins.
+  const sharedSet = new Set(shared);
+  for (const name of perPtyOnly) {
+    if (sharedSet.has(name)) {
+      console.warn(
+        `[mcp] server '${name}' is in both 'shared' and 'perPtyOnly'; treating as 'perPtyOnly'`,
+      );
+      sharedSet.delete(name);
+    }
+  }
+  const filteredShared = shared.filter((n) => sharedSet.has(n));
+
+  // Rule 2: `stateless` must be a subset of `shared`.
+  const filteredStateless: string[] = [];
+  for (const name of stateless) {
+    if (!sharedSet.has(name)) {
+      console.warn(
+        `[mcp] server '${name}' in settings.mcp.stateless must also be in settings.mcp.shared; ignoring 'stateless' marker`,
+      );
+      continue;
+    }
+    filteredStateless.push(name);
+  }
+
+  // Rule 3: gateway must be enabled for the multiplexer to mount HTTP routes.
+  if (filteredShared.length > 0 && webEnabled === false) {
+    console.warn(
+      "[mcp] multiplexer requires the HTTP gateway (settings.web.enabled); shared MCPs will be skipped",
+    );
+  }
+
+  return {
+    shared: filteredShared,
+    perPtyOnly,
+    stateless: filteredStateless,
+  };
+}
 
 function parseTimezone(value: unknown): string {
   return normalizeTimezoneName(value);

--- a/src/plugins/http-gateway.ts
+++ b/src/plugins/http-gateway.ts
@@ -36,10 +36,18 @@ function json(body: unknown, status = 200): Response {
   return Response.json(body, { status });
 }
 
+/** Per-server MCP request handler signature. Registered by the
+ *  multiplexer; consumed by the `/mcp/<server-name>` route delegation
+ *  below. See `mcp-multiplexer/index.ts`. */
+export type McpRouteHandler = (req: Request) => Promise<Response>;
+
 export class PluginHttpGateway {
   private plugins = new Map<string, RegisteredPlugin>();
   private bootstrapToken: Buffer;
   private allowedCallbackHosts: Set<string>;
+  /** Per-server-name MCP route handlers registered by the multiplexer.
+   *  Key is the lowercase kebab server name (matches `mcp-proxy.json`). */
+  private mcpHandlers = new Map<string, McpRouteHandler>();
 
   constructor(opts: { allowedHosts?: string[] } = {}) {
     this.allowedCallbackHosts = new Set(['localhost', '127.0.0.1', '::1', ...(opts.allowedHosts ?? [])]);
@@ -50,6 +58,18 @@ export class PluginHttpGateway {
   async handleRequest(req: Request, url: URL): Promise<Response | null> {
     const path = url.pathname;
     const method = req.method;
+
+    // MCP multiplexer routes — delegate to the per-server handler the
+    // multiplexer registered via `registerMcpHandler`. Path may be either
+    // bare (`/mcp/<server>`) or sub-pathed (`/mcp/<server>/...`); the SDK
+    // transport handles internal routing.
+    if (path.startsWith('/mcp/')) {
+      const segments = path.slice('/mcp/'.length).split('/');
+      const serverName = segments[0] ?? '';
+      const handler = this.mcpHandlers.get(serverName);
+      if (handler) return handler(req);
+      return json({ error: { code: 'mcp_server_not_registered', server: serverName } }, 404);
+    }
 
     if (path === '/api/plugin/register' && method === 'POST') return this.handleRegister(req);
     if (path === '/api/plugin/list' && method === 'GET') return this.handleList(req);
@@ -67,6 +87,32 @@ export class PluginHttpGateway {
     if (nameM && method === 'DELETE') return this.handleUnregister(req, nameM[1]!);
 
     return null; // not a plugin endpoint
+  }
+
+  /**
+   * Register a per-server MCP route handler. The multiplexer
+   * (`mcp-multiplexer/index.ts`) calls this at startup for each
+   * upstream child it brings up. The route mounted is
+   * `/mcp/<serverName>` (and any sub-paths).
+   *
+   * Server names must match `mcp-proxy.json` keys (lowercase kebab).
+   * Re-registering a name replaces the previous handler.
+   */
+  registerMcpHandler(serverName: string, handler: McpRouteHandler): void {
+    if (!/^[a-z][a-z0-9-]{0,63}$/.test(serverName)) {
+      throw new Error(`invalid mcp server name: ${JSON.stringify(serverName)}`);
+    }
+    this.mcpHandlers.set(serverName, handler);
+  }
+
+  /** Inverse of `registerMcpHandler`. Idempotent. */
+  unregisterMcpHandler(serverName: string): void {
+    this.mcpHandlers.delete(serverName);
+  }
+
+  /** Test seam — exposed for the multiplexer test slice. */
+  hasMcpHandler(serverName: string): boolean {
+    return this.mcpHandlers.has(serverName);
   }
 
   private requestId(req: Request): string {

--- a/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
@@ -100,7 +100,7 @@ describe("McpHttpHandler — auth", () => {
         { jsonrpc: "2.0", id: 1, method: "ping" },
         {
           [PTY_ID_HEADER]: "reg",
-          [AUTH_HEADER]: id.bearer,
+          [AUTH_HEADER]: id.headers[AUTH_HEADER],
         },
       ),
     );
@@ -144,7 +144,7 @@ describe("McpHttpHandler — successful auth + RPC dispatch", () => {
     const resp = await handler!.handle(
       rpcRequest(
         { jsonrpc: "2.0", id: 1, method: "tools/list" },
-        { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: id.bearer },
+        { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: id.headers[AUTH_HEADER] },
       ),
     );
     expect(resp.status).toBe(503);
@@ -172,7 +172,7 @@ describe("McpHttpHandler — successful auth + RPC dispatch", () => {
             clientInfo: { name: "test", version: "1.0" },
           },
         },
-        { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: a.bearer },
+        { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: a.headers[AUTH_HEADER] },
       ),
     );
     await handler!.handle(
@@ -187,7 +187,7 @@ describe("McpHttpHandler — successful auth + RPC dispatch", () => {
             clientInfo: { name: "test", version: "1.0" },
           },
         },
-        { [PTY_ID_HEADER]: "reg", [AUTH_HEADER]: b.bearer },
+        { [PTY_ID_HEADER]: "reg", [AUTH_HEADER]: b.headers[AUTH_HEADER] },
       ),
     );
 
@@ -220,7 +220,7 @@ describe("McpHttpHandler — closed state", () => {
     const resp = await handler.handle(
       rpcRequest(
         { jsonrpc: "2.0", id: 1, method: "ping" },
-        { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: id.bearer },
+        { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: id.headers[AUTH_HEADER] },
       ),
     );
     expect(resp.status).toBe(503);

--- a/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
@@ -1,0 +1,232 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { fileURLToPath } from "node:url";
+import { McpServerProcess } from "../../mcp-proxy/server-process.js";
+import { McpHttpHandler } from "../http-handler.js";
+import {
+  issueIdentity,
+  revokeIdentity,
+  _resetIdentityStore,
+  AUTH_HEADER,
+  PTY_ID_HEADER,
+} from "../pty-identity.js";
+
+const MOCK_SERVER = fileURLToPath(
+  new URL("../../../__tests__/fixtures/mock-mcp-server.ts", import.meta.url),
+);
+const BUN_BIN = process.execPath;
+
+function makeServerConfig() {
+  return {
+    command: BUN_BIN,
+    args: ["run", MOCK_SERVER],
+    allowedTools: ["echo"],
+  };
+}
+
+/** Wrap a JSON-RPC message in a Web-standard Request shaped the way the
+ *  Streamable HTTP transport expects (POST + content-type json + Accept). */
+function rpcRequest(
+  body: unknown,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request("http://127.0.0.1:4632/mcp/test", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      ...headers,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("McpHttpHandler — auth", () => {
+  let proc: McpServerProcess | null = null;
+  let handler: McpHttpHandler | null = null;
+
+  beforeEach(async () => {
+    _resetIdentityStore();
+    proc = new McpServerProcess("test", makeServerConfig());
+    await proc.start();
+    handler = new McpHttpHandler({ serverName: "test", proc });
+  });
+
+  afterEach(async () => {
+    if (handler) await handler.stop();
+    if (proc) await proc.stop();
+    proc = null;
+    handler = null;
+    _resetIdentityStore();
+  });
+
+  it("rejects requests missing X-Claudeclaw-Pty-Id with 401", async () => {
+    const resp = await handler!.handle(rpcRequest({ jsonrpc: "2.0", id: 1, method: "ping" }));
+    expect(resp.status).toBe(401);
+    const body = (await resp.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("missing_pty_id");
+  });
+
+  it("rejects requests missing Authorization header with 401", async () => {
+    issueIdentity("suzy");
+    const resp = await handler!.handle(
+      rpcRequest(
+        { jsonrpc: "2.0", id: 1, method: "ping" },
+        { [PTY_ID_HEADER]: "suzy" },
+      ),
+    );
+    expect(resp.status).toBe(401);
+    const body = (await resp.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("invalid_bearer");
+  });
+
+  it("rejects requests with a bad bearer with 401", async () => {
+    issueIdentity("suzy");
+    const resp = await handler!.handle(
+      rpcRequest(
+        { jsonrpc: "2.0", id: 1, method: "ping" },
+        {
+          [PTY_ID_HEADER]: "suzy",
+          [AUTH_HEADER]: "Bearer " + "00".repeat(32),
+        },
+      ),
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  it("rejects requests for an unknown ptyId with 401", async () => {
+    const id = issueIdentity("suzy");
+    const resp = await handler!.handle(
+      rpcRequest(
+        { jsonrpc: "2.0", id: 1, method: "ping" },
+        {
+          [PTY_ID_HEADER]: "reg",
+          [AUTH_HEADER]: id.bearer,
+        },
+      ),
+    );
+    expect(resp.status).toBe(401);
+  });
+
+  it("auth-rejected requests do not reach the upstream MCP process", async () => {
+    const beforeCallCount = proc!.lastInvocationAt;
+    const resp = await handler!.handle(
+      rpcRequest({ jsonrpc: "2.0", id: 1, method: "tools/list" }),
+    );
+    expect(resp.status).toBe(401);
+    // upstream `lastInvocationAt` must not have been touched
+    expect(proc!.lastInvocationAt).toBe(beforeCallCount);
+  });
+});
+
+describe("McpHttpHandler — successful auth + RPC dispatch", () => {
+  let proc: McpServerProcess | null = null;
+  let handler: McpHttpHandler | null = null;
+
+  beforeEach(async () => {
+    _resetIdentityStore();
+    proc = new McpServerProcess("test", makeServerConfig());
+    await proc.start();
+    handler = new McpHttpHandler({ serverName: "test", proc });
+  });
+
+  afterEach(async () => {
+    if (handler) await handler.stop();
+    if (proc) await proc.stop();
+    proc = null;
+    handler = null;
+    _resetIdentityStore();
+  });
+
+  it("503 when upstream child is not 'up'", async () => {
+    issueIdentity("suzy");
+    await proc!.stop();
+    const id = issueIdentity("suzy");
+    const resp = await handler!.handle(
+      rpcRequest(
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: id.bearer },
+      ),
+    );
+    expect(resp.status).toBe(503);
+    const body = (await resp.json()) as { error: { code: string } };
+    expect(body.error.code).toBe("upstream_unavailable");
+  });
+
+  it("releasePty tears down only the requested PTY bucket", async () => {
+    const a = issueIdentity("suzy");
+    const b = issueIdentity("reg");
+
+    // Force bucket creation by sending an initialize/ping for each PTY.
+    // Even if the SDK can't fully complete (mock server is minimal),
+    // the bucket creation happens inside `handle()` before the transport
+    // takes over.
+    await handler!.handle(
+      rpcRequest(
+        {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "test", version: "1.0" },
+          },
+        },
+        { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: a.bearer },
+      ),
+    );
+    await handler!.handle(
+      rpcRequest(
+        {
+          jsonrpc: "2.0",
+          id: 2,
+          method: "initialize",
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "test", version: "1.0" },
+          },
+        },
+        { [PTY_ID_HEADER]: "reg", [AUTH_HEADER]: b.bearer },
+      ),
+    );
+
+    const before = handler!.health();
+    expect((before.active_buckets as number) >= 1).toBe(true);
+
+    await handler!.releasePty("suzy");
+    const after = handler!.health();
+    const remaining = after.bucket_keys as string[];
+    expect(remaining).not.toContain("suzy");
+  });
+
+  it("stateless handler does not have per-PTY buckets", async () => {
+    await handler!.stop();
+    handler = new McpHttpHandler({ serverName: "test", proc: proc!, stateless: true });
+    // releasePty is a no-op for stateless
+    await handler.releasePty("suzy");
+    const h = handler.health();
+    expect(h.stateless).toBe(true);
+  });
+});
+
+describe("McpHttpHandler — closed state", () => {
+  it("returns 503 after stop()", async () => {
+    const proc = new McpServerProcess("test", makeServerConfig());
+    await proc.start();
+    const handler = new McpHttpHandler({ serverName: "test", proc });
+    await handler.stop();
+    const id = issueIdentity("suzy");
+    const resp = await handler.handle(
+      rpcRequest(
+        { jsonrpc: "2.0", id: 1, method: "ping" },
+        { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: id.bearer },
+      ),
+    );
+    expect(resp.status).toBe(503);
+    const body = (await resp.json()) as { error: string };
+    expect(body.error).toBe("multiplexer_stopped");
+    await proc.stop();
+    revokeIdentity("suzy");
+  });
+});

--- a/src/plugins/mcp-multiplexer/__tests__/index.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/index.test.ts
@@ -154,6 +154,39 @@ describe("McpMultiplexerPlugin — active path", () => {
     }
   });
 
+  it("Codex PR #71 P2 #3 regression — sharedServerNames reports CLAIMED, not requested", async () => {
+    // Operator requests three shared servers but mcp-proxy.json only
+    // defines one. The other two are missing from the proxy config →
+    // the multiplexer logs "skipping … not present" and proceeds with
+    // only the present one. sharedServerNames() must reflect what we
+    // actually claim, NOT the operator's broader request — otherwise
+    // mcp-proxy._sharedActuallyClaimedByMultiplexer() would also skip
+    // the missing names, leaving them unreachable from BOTH paths.
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha"]); // only alpha exists
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({
+        webEnabled: true,
+        shared: ["alpha", "missing-one", "missing-two"],
+        stateless: ["alpha", "missing-one"], // stateless must also intersect with claimed
+      }),
+    });
+
+    await plugin.start();
+
+    try {
+      expect(plugin.isActive()).toBe(true);
+      // Only alpha actually came up; sharedServerNames must NOT include
+      // missing-one or missing-two even though they were in settings.
+      expect(plugin.sharedServerNames()).toEqual(["alpha"]);
+      // Stateless filter applies to the claimed set, not the requested set.
+      const health = plugin.health() as { stateless: string[] };
+      expect(health.stateless).toEqual(["alpha"]);
+    } finally {
+      await plugin.stop();
+    }
+  });
+
   it("mounts a /mcp/<name> handler on the gateway for each shared server", async () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
     const plugin = new McpMultiplexerPlugin({

--- a/src/plugins/mcp-multiplexer/__tests__/index.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/index.test.ts
@@ -45,6 +45,10 @@ function makeSettingsView(
     webPort: 4632,
     shared: [],
     stateless: [],
+    // Disable the health probe by default so unit tests don't deal with
+    // timer flakiness; the probe is exercised directly via
+    // `_sampleHealthForTests` in dedicated tests below.
+    healthProbeIntervalMs: 0,
     ...partial,
   };
   return () => view;
@@ -320,5 +324,101 @@ describe("McpMultiplexerPlugin — active path", () => {
     expect(plugin.isActive()).toBe(false);
     expect(getHttpGateway().hasMcpHandler("alpha")).toBe(false);
     expect(plugin.sharedServerNames()).toEqual([]);
+  });
+
+  describe("health probe (filed in response to Nibbler review on #64)", () => {
+    it("emits a degradation log + audit event when a shared server transitions to crashed", async () => {
+      const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+      const plugin = new McpMultiplexerPlugin({
+        configPath: cfgPath,
+        settingsView: makeSettingsView({
+          webEnabled: true,
+          shared: ["alpha"],
+          // Probe stays disabled — we drive sampling synchronously via the
+          // test seam to avoid timer flakiness.
+          healthProbeIntervalMs: 0,
+        }),
+      });
+
+      await plugin.start();
+      expect(plugin.isActive()).toBe(true);
+
+      // Seed the baseline so the first sample is meaningful even though
+      // the probe wasn't started by the plugin (probe disabled in tests).
+      const proc = (plugin as unknown as {
+        servers: Map<string, { status: string }>;
+        lastObservedStatus: Map<string, string>;
+      }).servers.get("alpha")!;
+      (plugin as unknown as {
+        lastObservedStatus: Map<string, string>;
+      }).lastObservedStatus.set("alpha", proc.status);
+
+      // Force a transition: simulate the upstream child crashing.
+      const initial = proc.status;
+      (proc as { status: string }).status = "crashed";
+
+      // Capture audit events.
+      const audited: Array<{ event: string; payload: Record<string, unknown> }> = [];
+      const origAudit = getMcpBridge().audit.bind(getMcpBridge());
+      getMcpBridge().audit = (event: string, payload: Record<string, unknown>) => {
+        audited.push({ event, payload });
+        origAudit(event, payload);
+      };
+
+      try {
+        (plugin as unknown as { _sampleHealthForTests: () => void })._sampleHealthForTests();
+      } finally {
+        getMcpBridge().audit = origAudit;
+      }
+
+      const degradationEvent = audited.find((e) => e.event === "mcp_health_degraded");
+      expect(degradationEvent).toBeDefined();
+      expect(degradationEvent?.payload.server).toBe("alpha");
+      expect(degradationEvent?.payload.previous_status).toBe(initial);
+      expect(degradationEvent?.payload.current_status).toBe("crashed");
+
+      await plugin.stop();
+    });
+
+    it("does not emit duplicate events when status is stable across samples", async () => {
+      const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+      const plugin = new McpMultiplexerPlugin({
+        configPath: cfgPath,
+        settingsView: makeSettingsView({
+          webEnabled: true,
+          shared: ["alpha"],
+          healthProbeIntervalMs: 0,
+        }),
+      });
+      await plugin.start();
+
+      const proc = (plugin as unknown as {
+        servers: Map<string, { status: string }>;
+        lastObservedStatus: Map<string, string>;
+      }).servers.get("alpha")!;
+      (plugin as unknown as {
+        lastObservedStatus: Map<string, string>;
+      }).lastObservedStatus.set("alpha", proc.status);
+
+      const audited: string[] = [];
+      const origAudit = getMcpBridge().audit.bind(getMcpBridge());
+      getMcpBridge().audit = (event: string, payload: Record<string, unknown>) => {
+        audited.push(event);
+        origAudit(event, payload);
+      };
+
+      try {
+        (plugin as unknown as { _sampleHealthForTests: () => void })._sampleHealthForTests();
+        (plugin as unknown as { _sampleHealthForTests: () => void })._sampleHealthForTests();
+      } finally {
+        getMcpBridge().audit = origAudit;
+      }
+
+      expect(
+        audited.filter((e) => e === "mcp_health_degraded" || e === "mcp_health_transition"),
+      ).toHaveLength(0);
+
+      await plugin.stop();
+    });
   });
 });

--- a/src/plugins/mcp-multiplexer/__tests__/index.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/index.test.ts
@@ -232,7 +232,7 @@ describe("McpMultiplexerPlugin — active path", () => {
 
       await plugin.releaseIdentity("suzy");
       const b = plugin.issueIdentity("suzy");
-      expect(b.bearer).not.toBe(a.bearer);
+      expect(b.headers.Authorization).not.toBe(a.headers.Authorization);
     } finally {
       await plugin.stop();
     }

--- a/src/plugins/mcp-multiplexer/__tests__/index.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/index.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { fileURLToPath } from "node:url";
+import {
+  McpMultiplexerPlugin,
+  _resetMcpMultiplexer,
+  type MuxSettingsView,
+} from "../index.js";
+import { _resetHttpGateway, getHttpGateway } from "../../http-gateway.js";
+import { _resetMcpBridge, getMcpBridge } from "../../mcp-bridge.js";
+import { _resetIdentityStore } from "../pty-identity.js";
+
+const MOCK_SERVER = fileURLToPath(
+  new URL("../../../__tests__/fixtures/mock-mcp-server.ts", import.meta.url),
+);
+const BUN_BIN = process.execPath;
+
+function writeProxyConfig(dir: string, servers: string[]): string {
+  const cfg = {
+    servers: Object.fromEntries(
+      servers.map((name) => [
+        name,
+        {
+          command: BUN_BIN,
+          args: ["run", MOCK_SERVER],
+          enabled: true,
+          allowedTools: ["echo"],
+        },
+      ]),
+    ),
+  };
+  const path = join(dir, "mcp-proxy.json");
+  writeFileSync(path, JSON.stringify(cfg, null, 2));
+  return path;
+}
+
+function makeSettingsView(
+  partial: Partial<MuxSettingsView>,
+): () => MuxSettingsView {
+  const view: MuxSettingsView = {
+    webEnabled: true,
+    webHost: "127.0.0.1",
+    webPort: 4632,
+    shared: [],
+    stateless: [],
+    ...partial,
+  };
+  return () => view;
+}
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "mcp-mux-test-"));
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpMultiplexer();
+  _resetIdentityStore();
+});
+
+afterEach(() => {
+  _resetMcpBridge();
+  _resetHttpGateway();
+  _resetMcpMultiplexer();
+  _resetIdentityStore();
+  try {
+    rmSync(tmpDir, { recursive: true });
+  } catch {}
+});
+
+// ── Activation gates ──────────────────────────────────────────────────────────
+
+describe("McpMultiplexerPlugin — activation", () => {
+  it("dormant when settings.web.enabled is false", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["one"]);
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({ webEnabled: false, shared: ["one"] }),
+    });
+    await plugin.start();
+    expect(plugin.isActive()).toBe(false);
+    expect(plugin.sharedServerNames()).toEqual([]);
+    await plugin.stop();
+  });
+
+  it("dormant when settings.mcp.shared is empty", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["one"]);
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({ webEnabled: true, shared: [] }),
+    });
+    await plugin.start();
+    expect(plugin.isActive()).toBe(false);
+    await plugin.stop();
+  });
+
+  it("refuses to start when gateway host is non-loopback", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["one"]);
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({
+        webEnabled: true,
+        webHost: "0.0.0.0",
+        shared: ["one"],
+      }),
+    });
+    await plugin.start();
+    expect(plugin.isActive()).toBe(false);
+    expect(getHttpGateway().hasMcpHandler("one")).toBe(false);
+    await plugin.stop();
+  });
+
+  it("dormant when mcp-proxy.json missing", async () => {
+    const plugin = new McpMultiplexerPlugin({
+      configPath: join(tmpDir, "does-not-exist.json"),
+      settingsView: makeSettingsView({ webEnabled: true, shared: ["one"] }),
+    });
+    await plugin.start();
+    expect(plugin.isActive()).toBe(false);
+    await plugin.stop();
+  });
+});
+
+// ── Real upstream spawn ───────────────────────────────────────────────────────
+
+describe("McpMultiplexerPlugin — active path", () => {
+  it("spawns only servers listed in settings.mcp.shared", async () => {
+    // mcp-proxy.json has three servers; settings.shared only lists two.
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha", "beta", "gamma"]);
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({
+        webEnabled: true,
+        shared: ["alpha", "beta"],
+      }),
+    });
+
+    await plugin.start();
+
+    try {
+      expect(plugin.isActive()).toBe(true);
+      const snapshot = plugin._snapshotServers();
+      expect(Object.keys(snapshot).sort()).toEqual(["alpha", "beta"]);
+      expect(snapshot.alpha).toContain("echo");
+      expect(plugin.sharedServerNames().sort()).toEqual(["alpha", "beta"]);
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("mounts a /mcp/<name> handler on the gateway for each shared server", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({ webEnabled: true, shared: ["alpha"] }),
+    });
+
+    await plugin.start();
+
+    try {
+      const gw = getHttpGateway();
+      expect(gw.hasMcpHandler("alpha")).toBe(true);
+      expect(gw.hasMcpHandler("beta")).toBe(false);
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("registers bridge callbacks for each shared tool under mcp-multiplexer__<server>__<tool>", async () => {
+    // PluginMcpBridge always prefixes the registered tool name with the
+    // pluginId — see mcp-bridge.ts L65 `${pluginId}__${tool.name}`. The
+    // multiplexer registers its tools under `pluginId = "mcp-multiplexer"`
+    // with the name argument `<server>__<tool>` (SPEC §10 Q#2). The
+    // resulting stored FQN is `mcp-multiplexer__<server>__<tool>`. This
+    // partitions the FQN namespace from mcp-proxy's tools cleanly.
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({ webEnabled: true, shared: ["alpha"] }),
+    });
+
+    await plugin.start();
+
+    try {
+      const bridgeTools = getMcpBridge()
+        .listTools()
+        .map((t) => t.fqn);
+      expect(bridgeTools).toContain("mcp-multiplexer__alpha__echo");
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("legacy callsites can invoke a shared tool via the bridge", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({ webEnabled: true, shared: ["alpha"] }),
+    });
+
+    await plugin.start();
+
+    try {
+      const result = await getMcpBridge().invokeTool("mcp-multiplexer__alpha__echo", {
+        arguments: { message: "hi" },
+      });
+      expect(result).toBeDefined();
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("issueIdentity and releaseIdentity round-trip per ptyId", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({ webEnabled: true, shared: ["alpha"] }),
+    });
+
+    await plugin.start();
+
+    try {
+      const a = plugin.issueIdentity("suzy");
+      expect(a.ptyId).toBe("suzy");
+      expect(a.headers["Authorization"]).toMatch(/^Bearer /);
+
+      await plugin.releaseIdentity("suzy");
+      const b = plugin.issueIdentity("suzy");
+      expect(b.bearer).not.toBe(a.bearer);
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("bridgeBaseUrl reflects settings.web.{host,port}", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({
+        webEnabled: true,
+        webHost: "127.0.0.1",
+        webPort: 12345,
+        shared: ["alpha"],
+      }),
+    });
+
+    await plugin.start();
+
+    try {
+      expect(plugin.bridgeBaseUrl()).toBe("http://127.0.0.1:12345");
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("stateless declaration is honoured", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha", "beta"]);
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({
+        webEnabled: true,
+        shared: ["alpha", "beta"],
+        // Note: stateless filtering to subset-of-shared happens in
+        // _readSettings(); when tests pass a settingsView directly,
+        // the view is taken as-is. The plugin still honours the value.
+        stateless: ["beta"],
+      }),
+    });
+
+    await plugin.start();
+
+    try {
+      const h = plugin.health() as Record<string, unknown>;
+      expect(h.stateless).toEqual(["beta"]);
+      const handlerAlpha = plugin._getHandler("alpha");
+      const handlerBeta = plugin._getHandler("beta");
+      expect((handlerAlpha?.health() as { stateless: boolean }).stateless).toBe(false);
+      expect((handlerBeta?.health() as { stateless: boolean }).stateless).toBe(true);
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("health() snapshot exposes server status + handler info", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({ webEnabled: true, shared: ["alpha"] }),
+    });
+
+    await plugin.start();
+
+    try {
+      const h = plugin.health() as Record<string, unknown>;
+      expect(h.active).toBe(true);
+      expect(h.bridge_base_url).toBe("http://127.0.0.1:4632");
+      expect(h.shared).toEqual(["alpha"]);
+      const servers = h.servers as Record<string, unknown>;
+      expect(servers.alpha).toBeDefined();
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("stop() tears down all servers and handlers", async () => {
+    const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+    const plugin = new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({ webEnabled: true, shared: ["alpha"] }),
+    });
+
+    await plugin.start();
+
+    expect(plugin.isActive()).toBe(true);
+    expect(getHttpGateway().hasMcpHandler("alpha")).toBe(true);
+
+    await plugin.stop();
+    expect(plugin.isActive()).toBe(false);
+    expect(getHttpGateway().hasMcpHandler("alpha")).toBe(false);
+    expect(plugin.sharedServerNames()).toEqual([]);
+  });
+});

--- a/src/plugins/mcp-multiplexer/__tests__/pty-identity.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/pty-identity.test.ts
@@ -89,7 +89,11 @@ describe("pty-identity", () => {
   it("verifyBearer rejects a tampered secret", () => {
     const id = issueIdentity("suzy");
     const hex = id.headers[AUTH_HEADER].slice("Bearer ".length);
-    const flipped = "0" + hex.slice(1);
+    // Deterministic flip: if the first nibble is "0", flip to "1";
+    // otherwise flip to "0". Previously `"0" + hex.slice(1)` collided
+    // 1-in-16 runs when the bearer happened to start with "0".
+    const flippedFirst = hex[0] === "0" ? "1" : "0";
+    const flipped = flippedFirst + hex.slice(1);
     expect(verifyBearer("suzy", `Bearer ${flipped}`)).toBe(false);
   });
 

--- a/src/plugins/mcp-multiplexer/__tests__/pty-identity.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/pty-identity.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach } from "bun:test";
+import {
+  issueIdentity,
+  getIdentity,
+  revokeIdentity,
+  verifyBearer,
+  _listIssuedPtyIds,
+  _resetIdentityStore,
+  AUTH_HEADER,
+  PTY_ID_HEADER,
+  PTY_TS_HEADER,
+  PTY_SECRET_BYTES,
+} from "../pty-identity.js";
+
+describe("pty-identity", () => {
+  beforeEach(() => {
+    _resetIdentityStore();
+  });
+
+  // ── Issuance ─────────────────────────────────────────────────────────
+
+  it("issueIdentity returns a fresh identity with all required headers", () => {
+    const id = issueIdentity("suzy");
+    expect(id.ptyId).toBe("suzy");
+    expect(typeof id.issuedAt).toBe("number");
+    expect(id.issuedAt).toBeGreaterThan(0);
+    expect(id.bearer).toMatch(/^Bearer [0-9a-f]{64}$/);
+    expect(id.headers[AUTH_HEADER]).toBe(id.bearer);
+    expect(id.headers[PTY_ID_HEADER]).toBe("suzy");
+    expect(id.headers[PTY_TS_HEADER]).toBe(String(id.issuedAt));
+  });
+
+  it("issueIdentity hex length matches PTY_SECRET_BYTES", () => {
+    const id = issueIdentity("test");
+    const hex = id.bearer.slice("Bearer ".length);
+    expect(hex.length).toBe(PTY_SECRET_BYTES * 2);
+  });
+
+  it("issueIdentity produces a distinct secret on each call", () => {
+    const a = issueIdentity("a");
+    const b = issueIdentity("b");
+    expect(a.bearer).not.toBe(b.bearer);
+  });
+
+  it("issueIdentity for the same ptyId replaces the previous identity", () => {
+    const a = issueIdentity("same");
+    const b = issueIdentity("same");
+    expect(a.bearer).not.toBe(b.bearer);
+    expect(_listIssuedPtyIds()).toEqual(["same"]);
+    // old bearer no longer verifies against new identity
+    expect(verifyBearer("same", a.bearer)).toBe(false);
+    expect(verifyBearer("same", b.bearer)).toBe(true);
+  });
+
+  it("rejects invalid ptyIds at issue time", () => {
+    expect(() => issueIdentity("")).toThrow();
+    expect(() => issueIdentity("with/slash")).toThrow();
+    expect(() => issueIdentity("../etc/passwd")).toThrow();
+    expect(() => issueIdentity("has space")).toThrow();
+    expect(() => issueIdentity("a".repeat(200))).toThrow();
+  });
+
+  it("accepts canonical sessionKey shapes (named, adhoc, global)", () => {
+    expect(() => issueIdentity("suzy")).not.toThrow();
+    expect(() => issueIdentity("peggy")).not.toThrow();
+    expect(() => issueIdentity("global")).not.toThrow();
+    expect(() => issueIdentity("thread-abc-123")).not.toThrow();
+    expect(() => issueIdentity("UUID:f47ac10b-58cc-4372-a567-0e02b2c3d479")).not.toThrow();
+  });
+
+  // ── Verification ─────────────────────────────────────────────────────
+
+  it("verifyBearer accepts the issued bearer header verbatim", () => {
+    const id = issueIdentity("suzy");
+    expect(verifyBearer("suzy", id.bearer)).toBe(true);
+  });
+
+  it("verifyBearer is case-insensitive on the 'Bearer' scheme prefix", () => {
+    const id = issueIdentity("suzy");
+    const hex = id.bearer.slice("Bearer ".length);
+    expect(verifyBearer("suzy", `bearer ${hex}`)).toBe(true);
+    expect(verifyBearer("suzy", `BEARER ${hex}`)).toBe(true);
+  });
+
+  it("verifyBearer rejects an unknown ptyId", () => {
+    const id = issueIdentity("suzy");
+    expect(verifyBearer("reg", id.bearer)).toBe(false);
+  });
+
+  it("verifyBearer rejects a tampered secret", () => {
+    const id = issueIdentity("suzy");
+    const hex = id.bearer.slice("Bearer ".length);
+    const flipped = "0" + hex.slice(1);
+    expect(verifyBearer("suzy", `Bearer ${flipped}`)).toBe(false);
+  });
+
+  it("verifyBearer rejects missing/empty/null bearer values", () => {
+    issueIdentity("suzy");
+    expect(verifyBearer("suzy", null)).toBe(false);
+    expect(verifyBearer("suzy", undefined)).toBe(false);
+    expect(verifyBearer("suzy", "")).toBe(false);
+    expect(verifyBearer("suzy", "Bearer ")).toBe(false);
+    expect(verifyBearer("suzy", "Bearer not-hex")).toBe(false);
+  });
+
+  it("verifyBearer rejects malformed bearer headers", () => {
+    issueIdentity("suzy");
+    expect(verifyBearer("suzy", "Basic abc")).toBe(false);
+    expect(verifyBearer("suzy", "abc")).toBe(false);
+    expect(verifyBearer("suzy", "Bearer abc")).toBe(false); // wrong length
+  });
+
+  it("verifyBearer rejects bearer of wrong byte length", () => {
+    issueIdentity("suzy");
+    expect(verifyBearer("suzy", "Bearer " + "ab".repeat(16))).toBe(false); // 16 bytes
+    expect(verifyBearer("suzy", "Bearer " + "ab".repeat(64))).toBe(false); // 64 bytes
+  });
+
+  // ── Revocation ───────────────────────────────────────────────────────
+
+  it("revokeIdentity drops the secret and returns true", () => {
+    const id = issueIdentity("suzy");
+    expect(revokeIdentity("suzy")).toBe(true);
+    expect(verifyBearer("suzy", id.bearer)).toBe(false);
+    expect(getIdentity("suzy")).toBeUndefined();
+  });
+
+  it("revokeIdentity is idempotent", () => {
+    issueIdentity("suzy");
+    expect(revokeIdentity("suzy")).toBe(true);
+    expect(revokeIdentity("suzy")).toBe(false);
+    expect(revokeIdentity("never-existed")).toBe(false);
+  });
+
+  it("revoking one identity does not affect siblings", () => {
+    const a = issueIdentity("a");
+    const b = issueIdentity("b");
+    expect(revokeIdentity("a")).toBe(true);
+    expect(verifyBearer("a", a.bearer)).toBe(false);
+    expect(verifyBearer("b", b.bearer)).toBe(true);
+  });
+
+  it("_listIssuedPtyIds reflects current store contents", () => {
+    expect(_listIssuedPtyIds()).toEqual([]);
+    issueIdentity("a");
+    issueIdentity("b");
+    expect(_listIssuedPtyIds().sort()).toEqual(["a", "b"]);
+    revokeIdentity("a");
+    expect(_listIssuedPtyIds()).toEqual(["b"]);
+  });
+
+  // ── getIdentity ──────────────────────────────────────────────────────
+
+  it("getIdentity returns the public identity for issued ptyIds", () => {
+    const issued = issueIdentity("suzy");
+    const fetched = getIdentity("suzy");
+    expect(fetched).toBeDefined();
+    expect(fetched!.bearer).toBe(issued.bearer);
+    expect(fetched!.ptyId).toBe("suzy");
+  });
+
+  it("getIdentity returns undefined for unknown ptyIds", () => {
+    expect(getIdentity("nope")).toBeUndefined();
+  });
+});

--- a/src/plugins/mcp-multiplexer/__tests__/pty-identity.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/pty-identity.test.ts
@@ -24,32 +24,31 @@ describe("pty-identity", () => {
     expect(id.ptyId).toBe("suzy");
     expect(typeof id.issuedAt).toBe("number");
     expect(id.issuedAt).toBeGreaterThan(0);
-    expect(id.bearer).toMatch(/^Bearer [0-9a-f]{64}$/);
-    expect(id.headers[AUTH_HEADER]).toBe(id.bearer);
+    expect(id.headers[AUTH_HEADER]).toMatch(/^Bearer [0-9a-f]{64}$/);
     expect(id.headers[PTY_ID_HEADER]).toBe("suzy");
     expect(id.headers[PTY_TS_HEADER]).toBe(String(id.issuedAt));
   });
 
   it("issueIdentity hex length matches PTY_SECRET_BYTES", () => {
     const id = issueIdentity("test");
-    const hex = id.bearer.slice("Bearer ".length);
+    const hex = id.headers[AUTH_HEADER].slice("Bearer ".length);
     expect(hex.length).toBe(PTY_SECRET_BYTES * 2);
   });
 
   it("issueIdentity produces a distinct secret on each call", () => {
     const a = issueIdentity("a");
     const b = issueIdentity("b");
-    expect(a.bearer).not.toBe(b.bearer);
+    expect(a.headers[AUTH_HEADER]).not.toBe(b.headers[AUTH_HEADER]);
   });
 
   it("issueIdentity for the same ptyId replaces the previous identity", () => {
     const a = issueIdentity("same");
     const b = issueIdentity("same");
-    expect(a.bearer).not.toBe(b.bearer);
+    expect(a.headers[AUTH_HEADER]).not.toBe(b.headers[AUTH_HEADER]);
     expect(_listIssuedPtyIds()).toEqual(["same"]);
     // old bearer no longer verifies against new identity
-    expect(verifyBearer("same", a.bearer)).toBe(false);
-    expect(verifyBearer("same", b.bearer)).toBe(true);
+    expect(verifyBearer("same", a.headers[AUTH_HEADER])).toBe(false);
+    expect(verifyBearer("same", b.headers[AUTH_HEADER])).toBe(true);
   });
 
   it("rejects invalid ptyIds at issue time", () => {
@@ -72,24 +71,24 @@ describe("pty-identity", () => {
 
   it("verifyBearer accepts the issued bearer header verbatim", () => {
     const id = issueIdentity("suzy");
-    expect(verifyBearer("suzy", id.bearer)).toBe(true);
+    expect(verifyBearer("suzy", id.headers[AUTH_HEADER])).toBe(true);
   });
 
   it("verifyBearer is case-insensitive on the 'Bearer' scheme prefix", () => {
     const id = issueIdentity("suzy");
-    const hex = id.bearer.slice("Bearer ".length);
+    const hex = id.headers[AUTH_HEADER].slice("Bearer ".length);
     expect(verifyBearer("suzy", `bearer ${hex}`)).toBe(true);
     expect(verifyBearer("suzy", `BEARER ${hex}`)).toBe(true);
   });
 
   it("verifyBearer rejects an unknown ptyId", () => {
     const id = issueIdentity("suzy");
-    expect(verifyBearer("reg", id.bearer)).toBe(false);
+    expect(verifyBearer("reg", id.headers[AUTH_HEADER])).toBe(false);
   });
 
   it("verifyBearer rejects a tampered secret", () => {
     const id = issueIdentity("suzy");
-    const hex = id.bearer.slice("Bearer ".length);
+    const hex = id.headers[AUTH_HEADER].slice("Bearer ".length);
     const flipped = "0" + hex.slice(1);
     expect(verifyBearer("suzy", `Bearer ${flipped}`)).toBe(false);
   });
@@ -121,7 +120,7 @@ describe("pty-identity", () => {
   it("revokeIdentity drops the secret and returns true", () => {
     const id = issueIdentity("suzy");
     expect(revokeIdentity("suzy")).toBe(true);
-    expect(verifyBearer("suzy", id.bearer)).toBe(false);
+    expect(verifyBearer("suzy", id.headers[AUTH_HEADER])).toBe(false);
     expect(getIdentity("suzy")).toBeUndefined();
   });
 
@@ -136,8 +135,8 @@ describe("pty-identity", () => {
     const a = issueIdentity("a");
     const b = issueIdentity("b");
     expect(revokeIdentity("a")).toBe(true);
-    expect(verifyBearer("a", a.bearer)).toBe(false);
-    expect(verifyBearer("b", b.bearer)).toBe(true);
+    expect(verifyBearer("a", a.headers[AUTH_HEADER])).toBe(false);
+    expect(verifyBearer("b", b.headers[AUTH_HEADER])).toBe(true);
   });
 
   it("_listIssuedPtyIds reflects current store contents", () => {
@@ -155,7 +154,7 @@ describe("pty-identity", () => {
     const issued = issueIdentity("suzy");
     const fetched = getIdentity("suzy");
     expect(fetched).toBeDefined();
-    expect(fetched!.bearer).toBe(issued.bearer);
+    expect(fetched!.headers[AUTH_HEADER]).toBe(issued.headers[AUTH_HEADER]);
     expect(fetched!.ptyId).toBe("suzy");
   });
 

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -1,0 +1,302 @@
+/**
+ * Streamable HTTP MCP handler for the multiplexer.
+ *
+ * One handler instance per upstream MCP server (one of the children
+ * spawned by the multiplexer at startup — see `./index.ts`). The handler
+ * speaks the MCP Streamable HTTP transport (revision 2024-11-05) back
+ * out to the per-PTY `claude` clients and proxies every `tools/call`
+ * request to the in-process `McpServerProcess.call(tool, args)`.
+ *
+ * Per-PTY isolation:
+ *   - Each (server, ptyId) pair gets its own ephemeral SDK `Server` +
+ *     transport pair, lazily created on first request.
+ *   - For servers in `settings.mcp.stateless`, the (ptyId) dimension is
+ *     collapsed — a single `Server` + transport pair is shared across
+ *     all PTYs. Per-PTY HMAC verification still gates access.
+ *   - Identity teardown (`McpMultiplexerPlugin.releaseIdentity(ptyId)`)
+ *     calls `releasePty(ptyId)` here to tear down the per-PTY transport.
+ *
+ * Auth model: see `./pty-identity.ts` and `../../planning/mcp-multiplexer/W1-COORD.md`.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { randomUUID } from "node:crypto";
+import { getMcpBridge } from "../mcp-bridge.js";
+import type { McpServerProcess } from "../mcp-proxy/server-process.js";
+import { AUTH_HEADER, PTY_ID_HEADER, verifyBearer } from "./pty-identity.js";
+
+/** Sentinel used when a server is declared stateless: all PTYs collapse
+ *  to a single (server, *) bucket so they share one upstream session.
+ *  Per-PTY auth verification still happens before any routing. */
+const STATELESS_BUCKET = "__stateless__";
+
+/** Pair of objects making up a live MCP session against this server. */
+interface ServerBucket {
+  /** Owner ptyId or `STATELESS_BUCKET`. */
+  bucketKey: string;
+  sdkServer: Server;
+  transport: WebStandardStreamableHTTPServerTransport;
+  /** Last-touched timestamp, for diagnostics. */
+  lastUsed: number;
+}
+
+export interface McpHttpHandlerOpts {
+  /** Server name (matches the key in `mcp-proxy.json`). */
+  serverName: string;
+  /** Upstream child to which `tools/call` is proxied. */
+  proc: McpServerProcess;
+  /** When `true`, all PTYs share a single upstream MCP session for this
+   *  server. Defaults to `false` (per-PTY isolation). */
+  stateless?: boolean;
+}
+
+/** Helper: read raw body bytes once. We don't enforce a hard byte cap
+ *  here — the upstream MCP server's `call` already has a 30s timeout
+ *  and the in-process bridge enforces `MAX_RESULT_BYTES` on outputs. */
+async function _readBody(req: Request): Promise<unknown> {
+  // The SDK transport parses JSON itself from the Request — we just pass
+  // the raw Request through. This helper exists so the auth path can
+  // peek without consuming the body stream.
+  const ct = req.headers.get("content-type") ?? "";
+  if (!ct.toLowerCase().includes("json")) return undefined;
+  try {
+    const cloned = req.clone();
+    return await cloned.json();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Per-server HTTP handler. Construct one per upstream MCP child;
+ * register on the `PluginHttpGateway` via `registerMcpHandler(name, ...)`.
+ */
+export class McpHttpHandler {
+  readonly serverName: string;
+  private readonly proc: McpServerProcess;
+  private readonly stateless: boolean;
+  private readonly buckets = new Map<string, ServerBucket>();
+  private closed = false;
+
+  constructor(opts: McpHttpHandlerOpts) {
+    this.serverName = opts.serverName;
+    this.proc = opts.proc;
+    this.stateless = opts.stateless === true;
+  }
+
+  /**
+   * Handle a single inbound HTTP request from a PTY `claude`.
+   * Returns a `Response`. Never throws — errors are converted to
+   * `Response`s with appropriate status codes and a small JSON body.
+   */
+  async handle(req: Request): Promise<Response> {
+    if (this.closed) {
+      return new Response(JSON.stringify({ error: "multiplexer_stopped" }), {
+        status: 503,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    // ── Authentication ────────────────────────────────────────────────
+    const ptyId = req.headers.get(PTY_ID_HEADER);
+    const bearer = req.headers.get(AUTH_HEADER);
+    if (!ptyId) {
+      return _errResponse(401, "missing_pty_id", `missing ${PTY_ID_HEADER} header`);
+    }
+    if (!bearer || !verifyBearer(ptyId, bearer)) {
+      // Audit, but only the failure event — do not log the bearer itself.
+      try {
+        getMcpBridge().audit("multiplexer_auth_rejected", {
+          server: this.serverName,
+          pty_id: ptyId,
+        });
+      } catch {}
+      return _errResponse(401, "invalid_bearer", "HMAC verification failed");
+    }
+
+    // ── Upstream readiness ────────────────────────────────────────────
+    // If the upstream child is mid-restart we return 503 immediately so
+    // the MCP client retries instead of hanging on a dead session.
+    if (this.proc.status !== "up") {
+      return _errResponse(
+        503,
+        "upstream_unavailable",
+        `server ${this.serverName} status=${this.proc.status}`,
+      );
+    }
+
+    // ── Dispatch to per-(server, pty) bucket ──────────────────────────
+    const bucketKey = this.stateless ? STATELESS_BUCKET : ptyId;
+    let bucket = this.buckets.get(bucketKey);
+    if (!bucket) {
+      try {
+        bucket = await this._createBucket(bucketKey);
+        this.buckets.set(bucketKey, bucket);
+      } catch (err) {
+        return _errResponse(
+          500,
+          "bucket_init_failed",
+          err instanceof Error ? err.message : String(err),
+        );
+      }
+    }
+    bucket.lastUsed = Date.now();
+
+    // Peek at the body for audit observability without consuming the
+    // request stream (the transport needs to re-read it).
+    const peek = await _readBody(req);
+
+    try {
+      getMcpBridge().audit("multiplexer_invoke", {
+        server: this.serverName,
+        pty_id: ptyId,
+        stateless: this.stateless,
+        rpc_method: _peekRpcMethod(peek),
+      });
+    } catch {}
+
+    // Hand off to the SDK transport. It will read the body, dispatch
+    // to the registered handlers on the SDK Server, and return a
+    // Web-Standard Response with framing.
+    try {
+      return await bucket.transport.handleRequest(req);
+    } catch (err) {
+      // Ensure the bucket is torn down if the transport itself errored;
+      // future calls will lazily reinitialise.
+      this.buckets.delete(bucketKey);
+      try {
+        await bucket.transport.close();
+      } catch {}
+      try {
+        await bucket.sdkServer.close();
+      } catch {}
+      return _errResponse(
+        500,
+        "transport_error",
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+
+  /** Tear down a per-PTY bucket. Called by the plugin's
+   *  `releaseIdentity(ptyId)`. Idempotent. */
+  async releasePty(ptyId: string): Promise<void> {
+    if (this.stateless) return; // no per-PTY bucket exists
+    const bucket = this.buckets.get(ptyId);
+    if (!bucket) return;
+    this.buckets.delete(ptyId);
+    try {
+      await bucket.transport.close();
+    } catch {}
+    try {
+      await bucket.sdkServer.close();
+    } catch {}
+  }
+
+  /** Tear down every bucket and refuse further requests. */
+  async stop(): Promise<void> {
+    this.closed = true;
+    const buckets = [...this.buckets.values()];
+    this.buckets.clear();
+    await Promise.allSettled(
+      buckets.map(async (b) => {
+        try { await b.transport.close(); } catch {}
+        try { await b.sdkServer.close(); } catch {}
+      }),
+    );
+  }
+
+  /** Diagnostics snapshot. */
+  health(): Record<string, unknown> {
+    return {
+      server: this.serverName,
+      stateless: this.stateless,
+      active_buckets: this.buckets.size,
+      bucket_keys: [...this.buckets.keys()],
+      closed: this.closed,
+    };
+  }
+
+  private async _createBucket(bucketKey: string): Promise<ServerBucket> {
+    // Each bucket gets its own SDK Server + transport pair. The SDK
+    // assigns a fresh MCP session ID per bucket via sessionIdGenerator.
+    const sdkServer = new Server(
+      { name: `mcp-multiplexer/${this.serverName}`, version: "1.0.0" },
+      { capabilities: { tools: {} } },
+    );
+
+    // tools/list — exposes only the tools the upstream child advertises
+    // (already filtered by `allowedTools` in `mcp-proxy.json`).
+    sdkServer.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: this.proc.tools.map((t) => ({
+        name: t.name,
+        description: t.description,
+        inputSchema: (t.inputSchema as Record<string, unknown>) ?? {
+          type: "object",
+        },
+      })),
+    }));
+
+    // tools/call — proxy straight through to the upstream child.
+    sdkServer.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+      try {
+        const result = await this.proc.call(name, args ?? {});
+        return {
+          content: [
+            {
+              type: "text",
+              text:
+                typeof result === "string"
+                  ? result
+                  : JSON.stringify(result),
+            },
+          ],
+        };
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return {
+          content: [{ type: "text", text: `Error: ${message}` }],
+          isError: true,
+        };
+      }
+    });
+
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      enableJsonResponse: true, // simpler for HTTP-only callers
+    });
+    await sdkServer.connect(transport);
+
+    return {
+      bucketKey,
+      sdkServer,
+      transport,
+      lastUsed: Date.now(),
+    };
+  }
+}
+
+function _errResponse(status: number, code: string, message: string): Response {
+  return new Response(JSON.stringify({ error: { code, message } }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function _peekRpcMethod(body: unknown): string | undefined {
+  if (
+    body &&
+    typeof body === "object" &&
+    "method" in body &&
+    typeof (body as { method: unknown }).method === "string"
+  ) {
+    return (body as { method: string }).method;
+  }
+  return undefined;
+}

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -55,9 +55,14 @@ export interface McpHttpHandlerOpts {
   stateless?: boolean;
 }
 
-/** Helper: read raw body bytes once. We don't enforce a hard byte cap
- *  here — the upstream MCP server's `call` already has a 30s timeout
- *  and the in-process bridge enforces `MAX_RESULT_BYTES` on outputs. */
+/** Maximum request body size accepted by the multiplexer. Matches the
+ *  cap on `/api/plugin/*` in the HTTP gateway. Rejects 4 GB POSTs that
+ *  would OOM the daemon. */
+const MAX_BODY_BYTES = 1_048_576; // 1 MiB
+
+/** Helper: read raw body bytes once. Phase D #2 (security): enforce a
+ *  hard byte cap so a malicious or buggy client can't OOM the daemon
+ *  with a multi-GB JSON POST. */
 async function _readBody(req: Request): Promise<unknown> {
   // The SDK transport parses JSON itself from the Request — we just pass
   // the raw Request through. This helper exists so the auth path can
@@ -70,6 +75,48 @@ async function _readBody(req: Request): Promise<unknown> {
   } catch {
     return undefined;
   }
+}
+
+/** Check whether a request's declared/streamed body exceeds the cap.
+ *  Reads `Content-Length` if provided (rejects oversize before the body is
+ *  consumed). For unknown-length requests, materialises into an ArrayBuffer
+ *  and rejects if it exceeds the cap. Returns the safe-to-replay Request
+ *  on success, or a 413 Response on failure. */
+async function _enforceBodyCap(req: Request): Promise<Request | Response> {
+  const declared = req.headers.get("content-length");
+  if (declared !== null) {
+    const n = Number(declared);
+    if (Number.isFinite(n) && n > MAX_BODY_BYTES) {
+      return _errResponse(
+        413,
+        "body_too_large",
+        `request body ${n}B exceeds ${MAX_BODY_BYTES}B limit`,
+      );
+    }
+    // Content-Length present and within cap → safe to forward.
+    return req;
+  }
+  // No Content-Length (chunked transfer or HTTP/2). Materialise once so we
+  // can both enforce the cap and replay to the SDK transport.
+  let buf: ArrayBuffer;
+  try {
+    buf = await req.arrayBuffer();
+  } catch {
+    return _errResponse(400, "body_read_failed", "could not read request body");
+  }
+  if (buf.byteLength > MAX_BODY_BYTES) {
+    return _errResponse(
+      413,
+      "body_too_large",
+      `request body ${buf.byteLength}B exceeds ${MAX_BODY_BYTES}B limit`,
+    );
+  }
+  // Rebuild a Request the SDK transport can consume. Headers preserved.
+  return new Request(req.url, {
+    method: req.method,
+    headers: req.headers,
+    body: buf,
+  });
 }
 
 /**
@@ -102,9 +149,17 @@ export class McpHttpHandler {
       });
     }
 
+    // ── Body cap (Phase D security #2) ────────────────────────────────
+    // Enforce before auth so we don't read multi-GB bodies on unauth'd
+    // requests. `_enforceBodyCap` returns either a safe-to-forward Request
+    // (possibly rebuilt) or a 413 Response.
+    const guarded = await _enforceBodyCap(req);
+    if (guarded instanceof Response) return guarded;
+    const safeReq = guarded;
+
     // ── Authentication ────────────────────────────────────────────────
-    const ptyId = req.headers.get(PTY_ID_HEADER);
-    const bearer = req.headers.get(AUTH_HEADER);
+    const ptyId = safeReq.headers.get(PTY_ID_HEADER);
+    const bearer = safeReq.headers.get(AUTH_HEADER);
     if (!ptyId) {
       return _errResponse(401, "missing_pty_id", `missing ${PTY_ID_HEADER} header`);
     }
@@ -149,7 +204,7 @@ export class McpHttpHandler {
 
     // Peek at the body for audit observability without consuming the
     // request stream (the transport needs to re-read it).
-    const peek = await _readBody(req);
+    const peek = await _readBody(safeReq);
 
     try {
       getMcpBridge().audit("multiplexer_invoke", {
@@ -164,7 +219,7 @@ export class McpHttpHandler {
     // to the registered handlers on the SDK Server, and return a
     // Web-Standard Response with framing.
     try {
-      return await bucket.transport.handleRequest(req);
+      return await bucket.transport.handleRequest(safeReq);
     } catch (err) {
       // Ensure the bucket is torn down if the transport itself errored;
       // future calls will lazily reinitialise.
@@ -242,9 +297,34 @@ export class McpHttpHandler {
       })),
     }));
 
-    // tools/call — proxy straight through to the upstream child.
+    // Defense-in-depth (Phase D #6): build the allowed-tool set from the
+    // already-filtered `proc.tools`. tools/list returns only this set, and
+    // tools/call rejects anything not in it — so a caller forging a non-
+    // allowed name fails inside the multiplexer instead of relying on the
+    // upstream child's own rejection.
+    const allowedNames = new Set(this.proc.tools.map((t) => t.name));
+
+    // tools/call — proxy through to the upstream child after gating.
     sdkServer.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
+      if (!allowedNames.has(name)) {
+        try {
+          getMcpBridge().audit("multiplexer_tool_rejected", {
+            server: this.serverName,
+            tool: name,
+            reason: "not_in_allowed_set",
+          });
+        } catch {}
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Error: tool '${name}' is not exposed by server '${this.serverName}'`,
+            },
+          ],
+          isError: true,
+        };
+      }
       try {
         const result = await this.proc.call(name, args ?? {});
         return {

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -198,9 +198,13 @@ export class McpMultiplexerPlugin {
       return;
     }
 
-    // Cache the activation state used by `isActive()` and the W2 contract.
-    this.cachedSharedNames = settings.shared.slice();
-    this.cachedStatelessNames = settings.stateless.slice();
+    // Cache the bridge URL used by W2 / the supervisor's synthesised
+    // --mcp-config. `cachedSharedNames` and `cachedStatelessNames` are
+    // populated AFTER the spawn loop so they reflect what we *actually*
+    // claim, not what the operator *requested*. Codex PR #71 P2 #3:
+    // a partial-start would otherwise report failed servers as claimed,
+    // and `mcp-proxy`'s `_sharedActuallyClaimedByMultiplexer()` would
+    // skip them too, leaving those servers unreachable from BOTH paths.
     this.cachedBridgeBaseUrl =
       this.bridgeBaseUrlOverride ?? `http://${settings.webHost}:${settings.webPort}`;
 
@@ -285,6 +289,18 @@ export class McpMultiplexerPlugin {
       this.cachedBridgeBaseUrl = "http://127.0.0.1:4632";
       return;
     }
+
+    // Codex PR #71 P2 #3: cache the names we ACTUALLY claimed (not the
+    // operator's requested set). `sharedServerNames()` is the public
+    // contract `mcp-proxy._sharedActuallyClaimedByMultiplexer()` reads
+    // when deciding which servers to skip; if a requested server failed
+    // to spawn, the proxy must still own it.
+    this.cachedSharedNames = claimed.slice();
+    // Stateless names are filtered to the intersection of declared
+    // stateless AND actually-claimed.
+    this.cachedStatelessNames = settings.stateless.filter((n) =>
+      claimed.includes(n),
+    );
 
     // Commit started AFTER we've claimed at least one server — a dormant
     // bail-out above leaves started=false so the operator can re-`start()`

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -83,6 +83,9 @@ export interface MuxSettingsView {
   webPort: number;
   shared: string[];
   stateless: string[];
+  /** Health probe interval in milliseconds. 0 disables the probe. Default
+   *  derives from `settings.mcp.healthProbeIntervalMs` (30s). */
+  healthProbeIntervalMs: number;
 }
 
 function _readSettings(): MuxSettingsView {
@@ -92,12 +95,21 @@ function _readSettings(): MuxSettingsView {
   const mcpRaw = (s as unknown as { mcp?: unknown }).mcp;
   const shared = _stringArray(mcpRaw, "shared");
   const stateless = _stringArray(mcpRaw, "stateless");
+  const probeRaw =
+    mcpRaw && typeof mcpRaw === "object"
+      ? (mcpRaw as Record<string, unknown>).healthProbeIntervalMs
+      : undefined;
+  const healthProbeIntervalMs =
+    typeof probeRaw === "number" && Number.isFinite(probeRaw) && probeRaw >= 0
+      ? Math.floor(probeRaw)
+      : 30000;
   return {
     webEnabled: s.web?.enabled === true,
     webHost: s.web?.host ?? "127.0.0.1",
     webPort: typeof s.web?.port === "number" ? s.web.port : 4632,
     shared,
     stateless: stateless.filter((n) => shared.includes(n)),
+    healthProbeIntervalMs,
   };
 }
 
@@ -132,6 +144,12 @@ export class McpMultiplexerPlugin {
   private cachedSharedNames: string[] = [];
   private cachedStatelessNames: string[] = [];
   private cachedBridgeBaseUrl = "http://127.0.0.1:4632";
+  /** Periodic liveness sampler. Null when probe is disabled (intervalMs=0)
+   *  or the plugin is dormant. */
+  private healthProbeTimer: ReturnType<typeof setInterval> | null = null;
+  /** Previous observed status per shared server. Drives the transition
+   *  log/audit on each probe tick. */
+  private lastObservedStatus = new Map<string, string>();
 
   constructor(opts: McpMultiplexerPluginOpts = {}) {
     this.configPath =
@@ -256,13 +274,21 @@ export class McpMultiplexerPlugin {
       );
       this.cachedSharedNames = [];
       this.cachedStatelessNames = [];
+      return;
     }
+
+    // Start the periodic health probe. Closes the silent-degradation gap
+    // flagged on #64: when one shared MCP crashes all PTYs lose that tool
+    // simultaneously, and without an active probe the operator only finds
+    // out when something fails to respond.
+    this._startHealthProbe(settings.healthProbeIntervalMs);
   }
 
   async stop(): Promise<void> {
     if (!this.started) return;
     this.started = false;
     this.active = false;
+    this._stopHealthProbe();
     try {
       getMcpBridge().unregisterPlugin(PLUGIN_ID);
     } catch {}
@@ -278,6 +304,65 @@ export class McpMultiplexerPlugin {
     this.servers.clear();
     this.cachedSharedNames = [];
     this.cachedStatelessNames = [];
+  }
+
+  // ── Health probe ────────────────────────────────────────────────────
+
+  private _startHealthProbe(intervalMs: number): void {
+    if (intervalMs <= 0) return;
+    // Seed the baseline before the first tick so we don't fire transition
+    // events from `undefined` → `up` at startup.
+    for (const [name, proc] of this.servers) {
+      this.lastObservedStatus.set(name, proc.status);
+    }
+    this.healthProbeTimer = setInterval(() => this._sampleHealth(), intervalMs);
+    if (typeof this.healthProbeTimer.unref === "function") {
+      this.healthProbeTimer.unref();
+    }
+  }
+
+  private _stopHealthProbe(): void {
+    if (this.healthProbeTimer) {
+      clearInterval(this.healthProbeTimer);
+      this.healthProbeTimer = null;
+    }
+    this.lastObservedStatus.clear();
+  }
+
+  /** Sample `proc.status` for every shared server. On state transition,
+   *  emit a structured audit event and a console line. Degraded states
+   *  (`crashed`, `failed`) go to stderr with a `DEGRADED` tag so operators
+   *  can grep them from the daemon log. Exposed as `_sampleHealthForTests`
+   *  to avoid timer flakiness in unit tests. */
+  _sampleHealthForTests(): void {
+    this._sampleHealth();
+  }
+
+  private _sampleHealth(): void {
+    for (const [name, proc] of this.servers) {
+      const prev = this.lastObservedStatus.get(name);
+      const curr = proc.status as string;
+      if (prev === curr) continue;
+      const degraded = curr === "crashed" || curr === "failed";
+      const uptimeS = proc.startedAt
+        ? Math.floor((Date.now() - proc.startedAt.getTime()) / 1000)
+        : null;
+      try {
+        getMcpBridge().audit(
+          degraded ? "mcp_health_degraded" : "mcp_health_transition",
+          {
+            server: name,
+            previous_status: prev ?? "unknown",
+            current_status: curr,
+            uptime_s: uptimeS,
+          },
+        );
+      } catch {}
+      const line = `[mcp-multiplexer] HEALTH ${name}: ${prev ?? "unknown"} → ${curr}${degraded ? " (DEGRADED)" : ""}`;
+      if (degraded) console.warn(line);
+      else console.log(line);
+      this.lastObservedStatus.set(name, curr);
+    }
   }
 
   health(): Record<string, unknown> {

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -212,6 +212,11 @@ export class McpMultiplexerPlugin {
       try {
         getMcpBridge().audit("multiplexer_no_config", { path: this.configPath });
       } catch {}
+      // Clear the cache we set above so isActive() + bridgeBaseUrl() are
+      // consistent ("plugin is not running" → "URL is default placeholder").
+      this.cachedSharedNames = [];
+      this.cachedStatelessNames = [];
+      this.cachedBridgeBaseUrl = "http://127.0.0.1:4632";
       return;
     }
 
@@ -277,6 +282,7 @@ export class McpMultiplexerPlugin {
       );
       this.cachedSharedNames = [];
       this.cachedStatelessNames = [];
+      this.cachedBridgeBaseUrl = "http://127.0.0.1:4632";
       return;
     }
 
@@ -312,6 +318,7 @@ export class McpMultiplexerPlugin {
     this.servers.clear();
     this.cachedSharedNames = [];
     this.cachedStatelessNames = [];
+    this.cachedBridgeBaseUrl = "http://127.0.0.1:4632";
   }
 
   // ── Health probe ────────────────────────────────────────────────────

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -45,15 +45,16 @@ import {
  *  Must satisfy `PluginMcpBridge._validatePluginId` (lowercase kebab). */
 const PLUGIN_ID = "mcp-multiplexer";
 
-/** Bridge-callback name. The `PluginMcpBridge` prefixes every registered
- *  tool with its pluginId (mcp-bridge.ts L65 `${pluginId}__${tool.name}`),
- *  so the stored FQN ends up `mcp-multiplexer__<server>__<tool>`. Per the
- *  operator's constraint (task spec) the pluginId is fixed at
- *  `"mcp-multiplexer"`, which partitions the FQN namespace cleanly from
- *  mcp-proxy's `mcp-proxy__<server>__<tool>` tools — no possible
- *  collision even before the skip-shared rule (which is a separate
- *  structural guarantee anyway). */
-function _toFqn(serverName: string, toolName: string): string {
+/** Builds the `name` argument we pass to `registerPluginTool` for a given
+ *  (server, tool) pair. NOT the stored FQN — the bridge prefixes every
+ *  registered tool with its pluginId (mcp-bridge.ts L65
+ *  `${pluginId}__${tool.name}`), so the stored FQN ends up
+ *  `mcp-multiplexer__<server>__<tool>`. Per the operator's constraint the
+ *  pluginId is fixed at `"mcp-multiplexer"`, which partitions the FQN
+ *  namespace cleanly from mcp-proxy's `mcp-proxy__<server>__<tool>` tools
+ *  — no possible collision even before the skip-shared rule (which is a
+ *  separate structural guarantee anyway). */
+function _toBridgeToolName(serverName: string, toolName: string): string {
   return `${serverName}__${toolName}`;
 }
 
@@ -159,8 +160,10 @@ export class McpMultiplexerPlugin {
   }
 
   async start(): Promise<void> {
+    // Only commit `started = true` once the spawn loop has produced at least
+    // one claimed server. A dormant bail-out leaves `started === false` so a
+    // subsequent operator-driven re-`start()` after settings change can succeed.
     if (this.started) return;
-    this.started = true;
 
     const settings = this.settingsView();
 
@@ -276,6 +279,11 @@ export class McpMultiplexerPlugin {
       this.cachedStatelessNames = [];
       return;
     }
+
+    // Commit started AFTER we've claimed at least one server — a dormant
+    // bail-out above leaves started=false so the operator can re-`start()`
+    // post-settings-change.
+    this.started = true;
 
     // Start the periodic health probe. Closes the silent-degradation gap
     // flagged on #64: when one shared MCP crashes all PTYs lose that tool
@@ -479,7 +487,7 @@ export class McpMultiplexerPlugin {
   private _registerBridgeCallbacks(serverName: string, proc: McpServerProcess): void {
     const bridge = getMcpBridge();
     for (const tool of proc.tools) {
-      const fqn = _toFqn(serverName, tool.name);
+      const fqn = _toBridgeToolName(serverName, tool.name);
       try {
         bridge.registerPluginTool(PLUGIN_ID, {
           name: fqn,

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -1,0 +1,442 @@
+/**
+ * McpMultiplexerPlugin — daemon-side MCP server multiplexer.
+ *
+ * Spawns shared MCP-server children once at daemon startup and
+ * republishes them over local-loopback Streamable HTTP to each PTY-
+ * resident `claude` (replacing per-PTY stdio spawns). Footprint reduction
+ * is the entire point — see `.planning/mcp-multiplexer/SPEC.md` §1.
+ *
+ * This plugin is dormant by default. It "activates" only when:
+ *   - `settings.web.enabled === true`, AND
+ *   - `settings.mcp.shared` is a non-empty list of server names that
+ *     exist in `mcp-proxy.json`.
+ *
+ * When dormant the supervisor sees `isActive() === false` and skips the
+ * `--mcp-config` synthesis step (`pty-mcp-config-writer.ts`, W2). The
+ * runtime behaviour reduces to PR #62's stock PTY path.
+ *
+ * Cross-worktree contract published to W2 (`pty-mcp-config-writer.ts`):
+ *   - `isActive(): boolean`
+ *   - `sharedServerNames(): string[]`
+ *   - `issueIdentity(ptyId): PtyIdentity`
+ *   - `releaseIdentity(ptyId): Promise<void>`
+ *   - `bridgeBaseUrl(): string`
+ *
+ * See `.planning/mcp-multiplexer/W1-COORD.md` for the published signatures.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import { getHttpGateway } from "../http-gateway.js";
+import { getMcpBridge } from "../mcp-bridge.js";
+import { McpServerProcess, type McpServerConfig } from "../mcp-proxy/server-process.js";
+import { getSettings } from "../../config.js";
+import { McpHttpHandler } from "./http-handler.js";
+import {
+  issueIdentity as _issueIdentity,
+  revokeIdentity as _revokeIdentity,
+  _resetIdentityStore,
+  type PtyIdentity,
+} from "./pty-identity.js";
+
+/** Same plugin id used for audit + bridge-callback registration.
+ *  Must satisfy `PluginMcpBridge._validatePluginId` (lowercase kebab). */
+const PLUGIN_ID = "mcp-multiplexer";
+
+/** Bridge-callback name. The `PluginMcpBridge` prefixes every registered
+ *  tool with its pluginId (mcp-bridge.ts L65 `${pluginId}__${tool.name}`),
+ *  so the stored FQN ends up `mcp-multiplexer__<server>__<tool>`. Per the
+ *  operator's constraint (task spec) the pluginId is fixed at
+ *  `"mcp-multiplexer"`, which partitions the FQN namespace cleanly from
+ *  mcp-proxy's `mcp-proxy__<server>__<tool>` tools — no possible
+ *  collision even before the skip-shared rule (which is a separate
+ *  structural guarantee anyway). */
+function _toFqn(serverName: string, toolName: string): string {
+  return `${serverName}__${toolName}`;
+}
+
+// Config schema for `~/.config/claudeclaw/mcp-proxy.json` — reused from
+// `mcp-proxy/index.ts` so we read the operator's single source of truth.
+const ServerConfigSchema = z.object({
+  command: z.string(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string()).optional(),
+  enabled: z.boolean().default(true),
+  allowedTools: z.array(z.string()).optional(),
+});
+const ProxyConfigSchema = z.object({
+  servers: z.record(ServerConfigSchema),
+});
+
+/** Subset of `Settings` that the multiplexer cares about. Read defensively
+ *  because the `mcp` block is added to `Settings` by W2; until then it
+ *  may be absent at runtime.
+ *
+ *  Exported as a test seam — production constructs the view from the
+ *  global `getSettings()`; tests pass a pre-built view via
+ *  `McpMultiplexerPluginOpts.settingsView`. */
+export interface MuxSettingsView {
+  webEnabled: boolean;
+  webHost: string;
+  webPort: number;
+  shared: string[];
+  stateless: string[];
+}
+
+function _readSettings(): MuxSettingsView {
+  const s = getSettings();
+  // Settings.mcp is added by W2 (`feat/mcp-multiplexer-pty-wiring`).
+  // Until that lands we tolerate its absence.
+  const mcpRaw = (s as unknown as { mcp?: unknown }).mcp;
+  const shared = _stringArray(mcpRaw, "shared");
+  const stateless = _stringArray(mcpRaw, "stateless");
+  return {
+    webEnabled: s.web?.enabled === true,
+    webHost: s.web?.host ?? "127.0.0.1",
+    webPort: typeof s.web?.port === "number" ? s.web.port : 4632,
+    shared,
+    stateless: stateless.filter((n) => shared.includes(n)),
+  };
+}
+
+function _stringArray(o: unknown, key: string): string[] {
+  if (!o || typeof o !== "object") return [];
+  const v = (o as Record<string, unknown>)[key];
+  if (!Array.isArray(v)) return [];
+  return v.filter((s): s is string => typeof s === "string" && s.length > 0);
+}
+
+export interface McpMultiplexerPluginOpts {
+  /** Override the path to `mcp-proxy.json`. Tests pass a tmpdir-scoped
+   *  fake; production defaults to `~/.config/claudeclaw/mcp-proxy.json`. */
+  configPath?: string;
+  /** Override the base URL used by the synthesized `--mcp-config`. When
+   *  unset, derived from `settings.web.host/port`. Tests can pin this. */
+  bridgeBaseUrlOverride?: string;
+  /** Test seam — provides the settings view directly instead of reading
+   *  from the global `getSettings()`. Production wiring leaves this
+   *  undefined; tests pass a pre-built view. */
+  settingsView?: () => MuxSettingsView;
+}
+
+export class McpMultiplexerPlugin {
+  private readonly configPath: string;
+  private readonly bridgeBaseUrlOverride?: string;
+  private readonly settingsView: () => MuxSettingsView;
+  private servers = new Map<string, McpServerProcess>();
+  private handlers = new Map<string, McpHttpHandler>();
+  private started = false;
+  private active = false;
+  private cachedSharedNames: string[] = [];
+  private cachedStatelessNames: string[] = [];
+  private cachedBridgeBaseUrl = "http://127.0.0.1:4632";
+
+  constructor(opts: McpMultiplexerPluginOpts = {}) {
+    this.configPath =
+      opts.configPath ?? join(homedir(), ".config", "claudeclaw", "mcp-proxy.json");
+    this.bridgeBaseUrlOverride = opts.bridgeBaseUrlOverride;
+    this.settingsView = opts.settingsView ?? _readSettings;
+  }
+
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+
+    const settings = this.settingsView();
+
+    // Refuse to expose MCP servers over a non-loopback gateway.
+    if (settings.webHost !== "127.0.0.1" && settings.webHost !== "localhost") {
+      console.error(
+        `[mcp-multiplexer] dormant — gateway host '${settings.webHost}' is non-loopback; refusing to expose MCP routes externally.`,
+      );
+      try {
+        getMcpBridge().audit("multiplexer_refused_non_loopback", {
+          host: settings.webHost,
+        });
+      } catch {}
+      return;
+    }
+
+    if (!settings.webEnabled) {
+      console.error(
+        "[mcp-multiplexer] dormant — settings.web.enabled is false; multiplexer requires the HTTP gateway.",
+      );
+      try {
+        getMcpBridge().audit("multiplexer_dormant_web_disabled", {});
+      } catch {}
+      return;
+    }
+
+    if (settings.shared.length === 0) {
+      console.error("[mcp-multiplexer] dormant — settings.mcp.shared is empty.");
+      try {
+        getMcpBridge().audit("multiplexer_dormant_empty_shared", {});
+      } catch {}
+      return;
+    }
+
+    // Cache the activation state used by `isActive()` and the W2 contract.
+    this.cachedSharedNames = settings.shared.slice();
+    this.cachedStatelessNames = settings.stateless.slice();
+    this.cachedBridgeBaseUrl =
+      this.bridgeBaseUrlOverride ?? `http://${settings.webHost}:${settings.webPort}`;
+
+    const config = this._loadConfig();
+    if (!config) {
+      console.error(
+        `[mcp-multiplexer] dormant — could not load ${this.configPath}; no shared servers will be spawned.`,
+      );
+      try {
+        getMcpBridge().audit("multiplexer_no_config", { path: this.configPath });
+      } catch {}
+      return;
+    }
+
+    // Spawn the shared upstream children. Use `allSettled` so one bad
+    // server doesn't take down the others — matches `mcp-proxy`
+    // graceful-degradation semantics.
+    const claimed: string[] = [];
+    await Promise.allSettled(
+      settings.shared.map(async (name) => {
+        const cfg = config.servers[name];
+        if (!cfg || cfg.enabled === false) {
+          console.error(
+            `[mcp-multiplexer] skipping '${name}' — not present or disabled in ${this.configPath}.`,
+          );
+          return;
+        }
+        try {
+          const proc = new McpServerProcess(name, cfg as McpServerConfig, {
+            onCrash: (n, reason) => this._onServerCrash(n, reason),
+          });
+          await proc.start();
+          this.servers.set(name, proc);
+          claimed.push(name);
+
+          const handler = new McpHttpHandler({
+            serverName: name,
+            proc,
+            stateless: settings.stateless.includes(name),
+          });
+          this.handlers.set(name, handler);
+
+          // Mount the per-server HTTP route on the gateway.
+          getHttpGateway().registerMcpHandler(name, (req) => handler.handle(req));
+
+          // Register in-process bridge callbacks so legacy `claude -p`
+          // callsites can still reach the tools. SPEC §10 Q#2.
+          this._registerBridgeCallbacks(name, proc);
+
+          console.error(
+            `[mcp-multiplexer] spawned ${name} pid ${this._pidOf(proc)} — ${proc.tools.length} tools`,
+          );
+          try {
+            getMcpBridge().audit("multiplexer_server_ready", {
+              server: name,
+              stateless: settings.stateless.includes(name),
+              tools: proc.tools.length,
+            });
+          } catch {}
+        } catch (err) {
+          console.error(
+            `[mcp-multiplexer] failed to start '${name}': ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+          );
+        }
+      }),
+    );
+
+    this.active = claimed.length > 0;
+    if (!this.active) {
+      console.error(
+        "[mcp-multiplexer] no shared servers came up successfully — going dormant.",
+      );
+      this.cachedSharedNames = [];
+      this.cachedStatelessNames = [];
+    }
+  }
+
+  async stop(): Promise<void> {
+    if (!this.started) return;
+    this.started = false;
+    this.active = false;
+    try {
+      getMcpBridge().unregisterPlugin(PLUGIN_ID);
+    } catch {}
+    const gateway = getHttpGateway();
+    for (const name of this.handlers.keys()) {
+      gateway.unregisterMcpHandler?.(name);
+    }
+    await Promise.allSettled(
+      [...this.handlers.values()].map((h) => h.stop()),
+    );
+    this.handlers.clear();
+    await Promise.allSettled([...this.servers.values()].map((s) => s.stop()));
+    this.servers.clear();
+    this.cachedSharedNames = [];
+    this.cachedStatelessNames = [];
+  }
+
+  health(): Record<string, unknown> {
+    const servers: Record<string, unknown> = {};
+    for (const [name, proc] of this.servers) {
+      servers[name] = {
+        status: proc.status,
+        tools: proc.tools.map((t) => t.name),
+        uptime_s: proc.startedAt
+          ? Math.floor((Date.now() - proc.startedAt.getTime()) / 1000)
+          : null,
+        last_invocation_at: proc.lastInvocationAt?.toISOString() ?? null,
+        handler: this.handlers.get(name)?.health() ?? null,
+      };
+    }
+    return {
+      active: this.active,
+      bridge_base_url: this.cachedBridgeBaseUrl,
+      shared: this.cachedSharedNames.slice(),
+      stateless: this.cachedStatelessNames.slice(),
+      servers,
+    };
+  }
+
+  // ── Public contract consumed by W2 ──────────────────────────────────
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  sharedServerNames(): string[] {
+    return this.cachedSharedNames.slice();
+  }
+
+  bridgeBaseUrl(): string {
+    return this.cachedBridgeBaseUrl;
+  }
+
+  issueIdentity(ptyId: string): PtyIdentity {
+    const id = _issueIdentity(ptyId);
+    try {
+      getMcpBridge().audit("multiplexer_identity_issued", {
+        pty_id: ptyId,
+        issued_at: id.issuedAt,
+      });
+    } catch {}
+    return id;
+  }
+
+  async releaseIdentity(ptyId: string): Promise<void> {
+    const removed = _revokeIdentity(ptyId);
+    await Promise.allSettled(
+      [...this.handlers.values()].map((h) => h.releasePty(ptyId)),
+    );
+    if (removed) {
+      try {
+        getMcpBridge().audit("multiplexer_identity_released", { pty_id: ptyId });
+      } catch {}
+    }
+  }
+
+  // ── Test seam ───────────────────────────────────────────────────────
+
+  /** Returns a snapshot of the (serverName → tools) tree. */
+  _snapshotServers(): Record<string, string[]> {
+    const out: Record<string, string[]> = {};
+    for (const [name, proc] of this.servers) {
+      out[name] = proc.tools.map((t) => t.name);
+    }
+    return out;
+  }
+
+  /** Returns the live handler for a given server name. Test-only. */
+  _getHandler(name: string): McpHttpHandler | undefined {
+    return this.handlers.get(name);
+  }
+
+  // ── Internals ───────────────────────────────────────────────────────
+
+  private _loadConfig() {
+    if (!existsSync(this.configPath)) return null;
+    try {
+      const raw = JSON.parse(readFileSync(this.configPath, "utf8"));
+      const result = ProxyConfigSchema.safeParse(raw);
+      return result.success ? result.data : null;
+    } catch {
+      return null;
+    }
+  }
+
+  private _pidOf(proc: McpServerProcess): string {
+    // McpServerProcess does not expose pid directly; surface via the
+    // private transport when present (best-effort, observability only).
+    // Cast through `unknown` to keep TS happy without leaking the
+    // private member into the public type.
+    const t = (proc as unknown as { transport?: { pid?: number } }).transport;
+    return t && typeof t.pid === "number" ? String(t.pid) : "?";
+  }
+
+  private _onServerCrash(name: string, reason: string): void {
+    const proc = this.servers.get(name);
+    try {
+      getMcpBridge().audit("multiplexer_server_crashed", {
+        server: name,
+        reason,
+        status: proc?.status ?? "unknown",
+      });
+    } catch {}
+    console.error(
+      `[mcp-multiplexer] server '${name}' crashed: ${reason} — status: ${proc?.status ?? "unknown"}`,
+    );
+  }
+
+  private _registerBridgeCallbacks(serverName: string, proc: McpServerProcess): void {
+    const bridge = getMcpBridge();
+    for (const tool of proc.tools) {
+      const fqn = _toFqn(serverName, tool.name);
+      try {
+        bridge.registerPluginTool(PLUGIN_ID, {
+          name: fqn,
+          description: tool.description,
+          schema: z.object({
+            arguments: z.record(z.unknown()).optional().default({}),
+          }),
+          handler: async (input) => {
+            const args = input.arguments ?? {};
+            return proc.call(tool.name, args);
+          },
+        });
+      } catch {
+        // duplicate registration (e.g. legacy `mcp-proxy` claimed the
+        // same FQN before being told to skip it) — leave the existing
+        // registration alone; the skip-shared rule in mcp-proxy/index.ts
+        // is the structural fix.
+      }
+    }
+  }
+}
+
+// ── Singleton ────────────────────────────────────────────────────────────
+
+let _instance: McpMultiplexerPlugin | null = null;
+
+export function getMcpMultiplexerPlugin(opts?: McpMultiplexerPluginOpts): McpMultiplexerPlugin {
+  if (!_instance) _instance = new McpMultiplexerPlugin(opts);
+  return _instance;
+}
+
+export function _resetMcpMultiplexer(): void {
+  _instance = null;
+  _resetIdentityStore();
+}
+
+// Re-export identity types/functions so W2 can import everything from a
+// single path: `import { issueIdentity, ... } from "../plugins/mcp-multiplexer/index.js";`
+export type { PtyIdentity } from "./pty-identity.js";
+export {
+  AUTH_HEADER,
+  PTY_ID_HEADER,
+  PTY_TS_HEADER,
+  verifyBearer,
+} from "./pty-identity.js";

--- a/src/plugins/mcp-multiplexer/pty-identity.ts
+++ b/src/plugins/mcp-multiplexer/pty-identity.ts
@@ -48,10 +48,11 @@ export interface PtyIdentity {
    *  lifetime; rotates on revoke→re-issue. Carried in the
    *  `X-Claudeclaw-Ts` header for audit observability. */
   issuedAt: number;
-  /** Header value for `Authorization`. Already in `Bearer <hex>` form. */
-  bearer: string;
   /** Complete headers map ready to splat into the synthesized
-   *  `--mcp-config` JSON's `headers` field. */
+   *  `--mcp-config` JSON's `headers` field. The Authorization header
+   *  carries the bearer literal (`Bearer <hex>`) — never exposed as a
+   *  standalone field on this interface; consumers that need the raw
+   *  bearer for verification go through `verifyBearer(ptyId, header)`. */
   headers: Record<string, string>;
 }
 
@@ -85,7 +86,6 @@ function _toPublic(record: InternalIdentity): PtyIdentity {
   return {
     ptyId: record.ptyId,
     issuedAt: record.issuedAt,
-    bearer,
     headers: {
       [AUTH_HEADER]: bearer,
       [PTY_ID_HEADER]: record.ptyId,

--- a/src/plugins/mcp-multiplexer/pty-identity.ts
+++ b/src/plugins/mcp-multiplexer/pty-identity.ts
@@ -1,0 +1,187 @@
+/**
+ * Per-PTY identity issuance + verification for the MCP multiplexer.
+ *
+ * See `.planning/mcp-multiplexer/SPEC.md` §4.3 ("Auth: per-PTY HMAC headers")
+ * and `.planning/mcp-multiplexer/W1-COORD.md` for the resolution of the
+ * SPEC's per-request signing scheme.
+ *
+ * Summary of the auth model implemented here:
+ *
+ *   - Each PTY (keyed by `ptyId = sessionKey` from `pty-supervisor`) is
+ *     minted a fresh 32-byte cryptographic secret on spawn / respawn.
+ *   - The "bearer token" baked into the synthesized `--mcp-config` JSON is
+ *     the literal hex encoding of that secret. Claude Code's stock MCP
+ *     HTTP client sends static headers; per-request HMAC signing isn't
+ *     possible without a client-side hook.
+ *   - The multiplexer's HTTP handler verifies inbound requests by
+ *     extracting the asserted `X-Claudeclaw-Pty-Id`, looking up the
+ *     stored secret for that PTY, and constant-time-comparing the bearer.
+ *   - Replay protection comes from secret rotation on every PTY respawn
+ *     (driven by `pty.idleReapMinutes`, default 30) plus loopback-only
+ *     binding. There is no per-request timestamp window — Claude Code
+ *     resends the same headers for the lifetime of the PTY, so a strict
+ *     window would expire tokens within seconds of issuance.
+ *
+ * The identity store is in-memory only. Daemon restart drops every
+ * identity; the PTY supervisor's respawn path mints fresh ones on
+ * demand.
+ */
+
+import { randomBytes, timingSafeEqual } from "node:crypto";
+
+/** Length in bytes of the per-PTY secret. 32 bytes = 256 bits. */
+export const PTY_SECRET_BYTES = 32;
+
+/** HTTP header that carries the asserted PTY identifier. */
+export const PTY_ID_HEADER = "X-Claudeclaw-Pty-Id";
+
+/** HTTP header that carries the identity issuance timestamp (epoch ms). */
+export const PTY_TS_HEADER = "X-Claudeclaw-Ts";
+
+/** HTTP header that carries the bearer (= hex-encoded secret). */
+export const AUTH_HEADER = "Authorization";
+
+export interface PtyIdentity {
+  /** PTY session key. Matches `sessionKey` in `pty-supervisor.PtyEntry`. */
+  ptyId: string;
+  /** Issuance timestamp in epoch milliseconds. Stable for the identity's
+   *  lifetime; rotates on revoke→re-issue. Carried in the
+   *  `X-Claudeclaw-Ts` header for audit observability. */
+  issuedAt: number;
+  /** Header value for `Authorization`. Already in `Bearer <hex>` form. */
+  bearer: string;
+  /** Complete headers map ready to splat into the synthesized
+   *  `--mcp-config` JSON's `headers` field. */
+  headers: Record<string, string>;
+}
+
+interface InternalIdentity {
+  ptyId: string;
+  issuedAt: number;
+  secret: Buffer;
+}
+
+// Singleton in-memory store. Module-scope on purpose: only one daemon
+// process and only one multiplexer per daemon.
+const identities = new Map<string, InternalIdentity>();
+
+/**
+ * Validate that a `ptyId` is safe to use as a map key and as a path/header
+ * component. The shape is intentionally restrictive — `pty-supervisor`
+ * sessionKeys are either named-agent names (`/^[a-z][a-z0-9-]*$/`), thread
+ * IDs (alphanumeric), or `"global"` — none of which need separators.
+ */
+function _validatePtyId(ptyId: string): void {
+  if (typeof ptyId !== "string" || ptyId.length === 0 || ptyId.length > 128) {
+    throw new Error(`invalid ptyId: ${JSON.stringify(ptyId)} (must be 1-128 chars)`);
+  }
+  if (!/^[A-Za-z0-9_.:-]+$/.test(ptyId)) {
+    throw new Error(`invalid ptyId: ${JSON.stringify(ptyId)} (must match /^[A-Za-z0-9_.:-]+$/)`);
+  }
+}
+
+function _toPublic(record: InternalIdentity): PtyIdentity {
+  const bearer = `Bearer ${record.secret.toString("hex")}`;
+  return {
+    ptyId: record.ptyId,
+    issuedAt: record.issuedAt,
+    bearer,
+    headers: {
+      [AUTH_HEADER]: bearer,
+      [PTY_ID_HEADER]: record.ptyId,
+      [PTY_TS_HEADER]: String(record.issuedAt),
+    },
+  };
+}
+
+/**
+ * Mint a fresh identity for `ptyId`. If an identity already exists for
+ * this PTY (caller forgot to revoke before respawn) it is silently
+ * replaced — the old secret is discarded and any in-flight bearer
+ * pointing at it will fail verification on the next request.
+ *
+ * Returns the public-facing identity (bearer header + headers map).
+ * The raw secret is NOT exposed; only `verifyBearer` can compare against it.
+ */
+export function issueIdentity(ptyId: string): PtyIdentity {
+  _validatePtyId(ptyId);
+  const record: InternalIdentity = {
+    ptyId,
+    issuedAt: Date.now(),
+    secret: randomBytes(PTY_SECRET_BYTES),
+  };
+  identities.set(ptyId, record);
+  return _toPublic(record);
+}
+
+/**
+ * Look up the public identity for `ptyId`. Useful for audit logging.
+ * Returns `undefined` if no identity is currently issued.
+ */
+export function getIdentity(ptyId: string): PtyIdentity | undefined {
+  const record = identities.get(ptyId);
+  return record ? _toPublic(record) : undefined;
+}
+
+/**
+ * Drop the identity for `ptyId`. Idempotent — returns `true` if an
+ * identity was actually removed, `false` otherwise.
+ */
+export function revokeIdentity(ptyId: string): boolean {
+  return identities.delete(ptyId);
+}
+
+/**
+ * Verify an inbound `Authorization` header value against the stored
+ * secret for the asserted `ptyId`.
+ *
+ * Constant-time comparison via `timingSafeEqual`. Returns `false` for
+ * any malformed input rather than throwing, so the caller's error path
+ * is a simple `401`.
+ *
+ * Inputs:
+ *   - `ptyId`: asserted by the client via `X-Claudeclaw-Pty-Id`.
+ *     Already validated as a non-empty string by the HTTP handler.
+ *   - `bearerHeaderValue`: the literal `Authorization` header
+ *     (e.g. `"Bearer 7c2d4f...e9"`). May be `null`/missing.
+ */
+export function verifyBearer(
+  ptyId: string,
+  bearerHeaderValue: string | null | undefined,
+): boolean {
+  if (!bearerHeaderValue) return false;
+  const record = identities.get(ptyId);
+  if (!record) return false;
+
+  // Strip the "Bearer " prefix; tolerate case-insensitive scheme.
+  const match = /^bearer\s+([0-9a-f]+)$/i.exec(bearerHeaderValue.trim());
+  if (!match) return false;
+  const hex = match[1]!;
+
+  let supplied: Buffer;
+  try {
+    supplied = Buffer.from(hex, "hex");
+  } catch {
+    return false;
+  }
+  if (supplied.length !== record.secret.length) return false;
+  try {
+    return timingSafeEqual(supplied, record.secret);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Snapshot of currently-issued identities. Test-only.
+ */
+export function _listIssuedPtyIds(): string[] {
+  return [...identities.keys()];
+}
+
+/**
+ * Clear the entire identity store. Test-only.
+ */
+export function _resetIdentityStore(): void {
+  identities.clear();
+}

--- a/src/plugins/mcp-proxy/index.ts
+++ b/src/plugins/mcp-proxy/index.ts
@@ -32,6 +32,11 @@ export interface McpProxyPluginOpts {
   tokenPath?: string;
   // For reasoned mode: inject into active Claude session
   reasonedInvokeFn?: (tool: string, args: unknown) => Promise<unknown>;
+  /** TEST SEAM: override the resolver used to discover which servers the
+   *  multiplexer is actively claiming. Production leaves this undefined →
+   *  the resolver imports `mcp-multiplexer` and asks `getMcpMultiplexerPlugin()`.
+   *  Tests can inject any set without spinning up a real multiplexer. */
+  claimedByMultiplexer?: () => Set<string>;
 }
 
 export class McpProxyPlugin {
@@ -40,11 +45,13 @@ export class McpProxyPlugin {
   private tokenPath: string;
   private reasonedInvokeFn?: (tool: string, args: unknown) => Promise<unknown>;
   private pluginToken: Buffer | null = null;
+  private claimedByMultiplexer: () => Set<string>;
 
   constructor(opts: McpProxyPluginOpts = {}) {
     this.configPath = opts.configPath ?? join(homedir(), ".config", "claudeclaw", "mcp-proxy.json");
     this.tokenPath = opts.tokenPath ?? join(homedir(), ".config", "claudeclaw", "mcp-proxy.token");
     this.reasonedInvokeFn = opts.reasonedInvokeFn;
+    this.claimedByMultiplexer = opts.claimedByMultiplexer ?? _sharedActuallyClaimedByMultiplexer;
   }
 
   async start(): Promise<void> {
@@ -62,13 +69,20 @@ export class McpProxyPlugin {
       return;
     }
 
-    // SPEC §4.1 step 4 / §6.2: when a server is claimed by the multiplexer
-    // via `settings.mcp.shared`, mcp-proxy must NOT spawn its own copy of
-    // that upstream child — otherwise both plugins would each spawn the
-    // same MCP server (double-process, defeats the whole point). The
-    // multiplexer mirrors the FQN into the bridge so legacy `claude -p`
-    // callsites still resolve `<server>__<tool>` against the shared child.
-    const sharedClaimedByMultiplexer = _sharedFromSettings();
+    // SPEC §4.1 step 4 / §6.2: when a server is actively claimed by the
+    // multiplexer (it's running AND has the server in its claimed set),
+    // mcp-proxy must NOT spawn its own copy of that upstream child —
+    // otherwise both plugins would each spawn the same MCP server
+    // (double-process, defeats the whole point). The multiplexer mirrors
+    // the FQN into the bridge so legacy `claude -p` callsites still
+    // resolve `<server>__<tool>` against the shared child.
+    //
+    // Codex PR #71 P1: skip ONLY when the multiplexer is *actually* serving
+    // the server. If the multiplexer went dormant for any reason (web
+    // disabled, non-loopback host, zero claimed servers, missing config),
+    // proxy continues to spawn the server so legacy flows keep working
+    // instead of silently losing MCP functionality.
+    const sharedClaimedByMultiplexer = this.claimedByMultiplexer();
     const skipped: string[] = [];
     const enabledServers = Object.entries(config.servers).filter(([name, s]) => {
       if (!s.enabled) return false;
@@ -210,18 +224,33 @@ export class McpProxyPlugin {
 
 // ── Settings helpers ──────────────────────────────────────────────────────────
 
-/** Read `settings.mcp.shared` defensively. The `mcp` block on `Settings`
- *  is added by the PTY-wiring worktree (W2); until then it is absent at
- *  runtime, which is treated identically to "multiplexer dormant". */
-function _sharedFromSettings(): Set<string> {
+/** Names of servers the multiplexer is *actually* serving right now —
+ *  NOT just the names listed in `settings.mcp.shared`. The two diverge
+ *  whenever the multiplexer plugin is dormant (web disabled, non-loopback
+ *  host, zero claimed servers, missing mcp-proxy.json). When dormant, the
+ *  proxy must still spawn the servers so legacy bridge / tool-call flows
+ *  keep working — see PR #71 Codex P1 finding. */
+function _sharedActuallyClaimedByMultiplexer(): Set<string> {
   try {
-    const s = getSettings();
-    const mcpRaw = (s as unknown as { mcp?: unknown }).mcp;
-    if (!mcpRaw || typeof mcpRaw !== "object") return new Set();
-    const shared = (mcpRaw as Record<string, unknown>).shared;
-    if (!Array.isArray(shared)) return new Set();
-    return new Set(shared.filter((n): n is string => typeof n === "string" && n.length > 0));
+    // Lazy require to avoid a circular import (`mcp-multiplexer` imports
+    // `mcp-bridge`, `mcp-bridge` is a peer of `mcp-proxy`). The dynamic
+    // require is fine — both modules are loaded by the time the proxy's
+    // `start()` is called from `commands/start.ts`.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const mod = require("../mcp-multiplexer/index.js") as {
+      getMcpMultiplexerPlugin?: () => {
+        isActive: () => boolean;
+        sharedServerNames: () => string[];
+      };
+    };
+    const factory = mod.getMcpMultiplexerPlugin;
+    if (typeof factory !== "function") return new Set();
+    const plugin = factory();
+    if (!plugin.isActive()) return new Set();
+    return new Set(plugin.sharedServerNames());
   } catch {
+    // Module not present, plugin not built yet, or any other lookup error
+    // → treat as dormant, proxy spawns everything as today.
     return new Set();
   }
 }

--- a/src/plugins/mcp-proxy/index.ts
+++ b/src/plugins/mcp-proxy/index.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import { getMcpBridge } from "../mcp-bridge.js";
 import { getHttpGateway } from "../http-gateway.js";
+import { getSettings } from "../../config.js";
 import { McpServerProcess, type McpServerConfig } from "./server-process.js";
 
 const MAX_RESULT_BYTES = Number(process.env.MCP_PROXY_MAX_RESULT_BYTES ?? 1_048_576);
@@ -61,7 +62,30 @@ export class McpProxyPlugin {
       return;
     }
 
-    const enabledServers = Object.entries(config.servers).filter(([, s]) => s.enabled);
+    // SPEC §4.1 step 4 / §6.2: when a server is claimed by the multiplexer
+    // via `settings.mcp.shared`, mcp-proxy must NOT spawn its own copy of
+    // that upstream child — otherwise both plugins would each spawn the
+    // same MCP server (double-process, defeats the whole point). The
+    // multiplexer mirrors the FQN into the bridge so legacy `claude -p`
+    // callsites still resolve `<server>__<tool>` against the shared child.
+    const sharedClaimedByMultiplexer = _sharedFromSettings();
+    const skipped: string[] = [];
+    const enabledServers = Object.entries(config.servers).filter(([name, s]) => {
+      if (!s.enabled) return false;
+      if (sharedClaimedByMultiplexer.has(name)) {
+        skipped.push(name);
+        return false;
+      }
+      return true;
+    });
+    if (skipped.length > 0) {
+      console.error(
+        `[mcp-proxy] skipping ${skipped.length} server(s) claimed by multiplexer: ${skipped.join(", ")}`,
+      );
+      try {
+        getMcpBridge().audit("mcp_proxy_skip_shared", { servers: skipped });
+      } catch {}
+    }
     const allTools: { name: string; description: string; schema: Record<string, unknown> }[] = [];
 
     await Promise.allSettled(enabledServers.map(async ([name, cfg]) => {
@@ -181,6 +205,24 @@ export class McpProxyPlugin {
       throw new Error(`reasoned mode not configured for ${fqn}`);
     }
     return this.reasonedInvokeFn(fqn, args);
+  }
+}
+
+// ── Settings helpers ──────────────────────────────────────────────────────────
+
+/** Read `settings.mcp.shared` defensively. The `mcp` block on `Settings`
+ *  is added by the PTY-wiring worktree (W2); until then it is absent at
+ *  runtime, which is treated identically to "multiplexer dormant". */
+function _sharedFromSettings(): Set<string> {
+  try {
+    const s = getSettings();
+    const mcpRaw = (s as unknown as { mcp?: unknown }).mcp;
+    if (!mcpRaw || typeof mcpRaw !== "object") return new Set();
+    const shared = (mcpRaw as Record<string, unknown>).shared;
+    if (!Array.isArray(shared)) return new Set();
+    return new Set(shared.filter((n): n is string => typeof n === "string" && n.length > 0));
+  } catch {
+    return new Set();
   }
 }
 

--- a/src/plugins/mcp-proxy/index.ts
+++ b/src/plugins/mcp-proxy/index.ts
@@ -4,7 +4,6 @@ import { join } from "node:path";
 import { z } from "zod";
 import { getMcpBridge } from "../mcp-bridge.js";
 import { getHttpGateway } from "../http-gateway.js";
-import { getSettings } from "../../config.js";
 import { McpServerProcess, type McpServerConfig } from "./server-process.js";
 
 const MAX_RESULT_BYTES = Number(process.env.MCP_PROXY_MAX_RESULT_BYTES ?? 1_048_576);

--- a/src/runner/pty-mcp-config-writer.ts
+++ b/src/runner/pty-mcp-config-writer.ts
@@ -1,0 +1,232 @@
+/**
+ * pty-mcp-config-writer.ts — synthesises the per-PTY `--mcp-config` JSON
+ * consumed by `claude` inside a long-lived PTY.
+ *
+ * Per SPEC §4.4 / §4.5:
+ *   - Path: `${cwd}/.claudeclaw/mcp-pty-${ptyId}.json`
+ *   - File mode: 0600 (bearer token at rest)
+ *   - Directory mode: 0700 (created lazily if missing)
+ *   - JSON shape matches `claude mcp add-json` semantics:
+ *       { "mcpServers": { "<name>": { "type": "http", "url", "headers" } } }
+ *     for shared servers; per-PTY stdio entries (rare) get
+ *       { "type": "stdio", "command", "args", "env" }
+ *
+ * The writer is the consumer of the multiplexer's `issueIdentity(ptyId)` /
+ * `revokeIdentity(ptyId)` interface (W1, src/plugins/mcp-multiplexer/
+ * pty-identity.ts). That file does not yet exist in this worktree; we mirror
+ * the contract here so W2 compiles in isolation. At merge time the local
+ * type alias is replaced with the real import (see TODO(coord) below).
+ */
+import {
+  existsSync,
+  mkdirSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+
+// ─── Coordination boundary with W1 ──────────────────────────────────────────
+// Mirrors src/plugins/mcp-multiplexer/pty-identity.ts — see SPEC §4.3.
+// TODO(coord): replace with real import after W1 merges:
+//   import { issueIdentity, revokeIdentity, type PtyIdentity } from
+//     "../plugins/mcp-multiplexer/pty-identity.js";
+
+export interface PtyIdentity {
+  readonly ptyId: string;
+  readonly secret: Buffer;
+  /** Returns the literal Authorization header value (e.g. "Bearer <hex>")
+   *  to embed in the synthesized `--mcp-config` JSON. */
+  buildAuthHeader(): { name: "Authorization"; value: string };
+}
+
+/**
+ * Issue a fresh per-PTY identity. The multiplexer mints a 32-byte secret,
+ * caches it in-memory keyed by ptyId, and returns the bearer-header value.
+ *
+ * In this worktree (Phase B / W2), `issueIdentity` is not yet importable
+ * because the multiplexer plugin lives in W1. Callers (the supervisor) MUST
+ * pass an `identity` already minted by W1 via `injectIdentityIssuer` for
+ * tests, or via the real import once W1 merges. The local fallback
+ * `_localIdentityForTests` exists so the writer's unit tests can pin a
+ * deterministic secret without instantiating the real multiplexer.
+ */
+
+// ─── Public types ───────────────────────────────────────────────────────────
+
+/** One shared MCP server entry as embedded in the synthesized JSON. */
+export interface SharedServerEntry {
+  /** Server name as defined in mcp-proxy.json. Used as the `mcpServers` key
+   *  and as the path segment in the bridge URL. */
+  name: string;
+}
+
+/** One per-PTY (stdio) MCP server entry as embedded in the synthesized JSON.
+ *  Mirrors the operator's mcp-proxy.json schema for servers NOT marked
+ *  `shared`. We don't introspect or modify these — pass-through only. */
+export interface PerPtyServerEntry {
+  name: string;
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+export interface WriteConfigInput {
+  /** Stable PTY identifier (= supervisor's sessionKey). Used in the file
+   *  name and as the multiplexer's identity key. */
+  ptyId: string;
+  /** Working directory of the PTY. The .claudeclaw/ subdirectory is created
+   *  here if absent. */
+  cwd: string;
+  /** Shared MCP servers — multiplexed via local HTTP. */
+  sharedServers: SharedServerEntry[];
+  /** Per-PTY stdio MCP servers — spawned by claude itself (status quo for
+   *  non-shared servers). Usually empty. */
+  perPtyServers: PerPtyServerEntry[];
+  /** Multiplexer's HTTP listener base URL, e.g. "http://127.0.0.1:4632".
+   *  Combined with `/mcp/<server-name>` for each shared entry. */
+  bridgeBaseUrl: string;
+  /** Per-PTY identity (HMAC secret + auth header). Pre-minted by the
+   *  multiplexer; the writer reads `buildAuthHeader()` and embeds the
+   *  Authorization header literal in the JSON. */
+  identity: PtyIdentity;
+}
+
+export interface WriteConfigResult {
+  /** Absolute path to the written JSON file. Caller threads this through as
+   *  PtyProcessOptions.mcpConfigPath. */
+  path: string;
+}
+
+// ─── Implementation ─────────────────────────────────────────────────────────
+
+const CONFIG_SUBDIR = ".claudeclaw";
+const DIR_MODE = 0o700;
+const FILE_MODE = 0o600;
+
+/**
+ * Compute the absolute path where the synthesized config WOULD live for a
+ * given (cwd, ptyId). Exposed so the supervisor can compute the path for
+ * cleanup even when the writer was never called (idempotent unlink).
+ */
+export function configPathFor(cwd: string, ptyId: string): string {
+  return join(cwd, CONFIG_SUBDIR, `mcp-pty-${ptyId}.json`);
+}
+
+/**
+ * Synthesize and write the per-PTY `--mcp-config` JSON.
+ *
+ * Idempotent — overwrites any existing file at the same path. Returns the
+ * absolute path on success; throws on filesystem error so the supervisor
+ * fails the spawn early (SPEC §4.5 "Failure to write → fail the spawn
+ * early; do NOT silently fall through to no-MCP mode").
+ *
+ * When both `sharedServers` and `perPtyServers` are empty, the writer
+ * SKIPS file creation and returns `{ path: "" }`. The caller MUST check
+ * for the empty path and avoid setting `PtyProcessOptions.mcpConfigPath`
+ * — there's nothing for claude to consult. This keeps the backward-compat
+ * path (settings.mcp.shared=[]) byte-identical to today.
+ */
+export function writeConfigForPty(
+  input: WriteConfigInput,
+): WriteConfigResult {
+  const { ptyId, cwd, sharedServers, perPtyServers, bridgeBaseUrl, identity } = input;
+
+  if (!ptyId || ptyId.length === 0) {
+    throw new Error("[mcp-config-writer] ptyId must be non-empty");
+  }
+  if (!cwd || cwd.length === 0) {
+    throw new Error("[mcp-config-writer] cwd must be non-empty");
+  }
+
+  // Backward-compat: nothing to write → return empty path. Supervisor
+  // omits the --mcp-config flag entirely. Matches the rollback contract
+  // in SPEC §6.1.
+  if (sharedServers.length === 0 && perPtyServers.length === 0) {
+    return { path: "" };
+  }
+
+  // Normalise the bridge URL (no trailing slash) — defensive only.
+  const baseUrl = bridgeBaseUrl.replace(/\/+$/, "");
+
+  // Build the mcpServers payload. Shared entries go first (HTTP transport),
+  // then per-PTY entries (stdio). Order does not matter to Claude Code but
+  // makes the file easier to read for operators.
+  const mcpServers: Record<string, unknown> = {};
+
+  const authHeader = identity.buildAuthHeader();
+  for (const { name } of sharedServers) {
+    if (!name || name.length === 0) continue;
+    mcpServers[name] = {
+      type: "http",
+      url: `${baseUrl}/mcp/${name}`,
+      headers: {
+        [authHeader.name]: authHeader.value,
+        "X-Claudeclaw-Pty-Id": ptyId,
+      },
+    };
+  }
+
+  for (const entry of perPtyServers) {
+    if (!entry.name || entry.name.length === 0) continue;
+    // Skip if a shared entry already claimed this name. perPtyOnly + shared
+    // is supposed to be mutually exclusive (config validation enforces
+    // this); the defensive de-dupe keeps the synthesized JSON well-formed.
+    if (Object.prototype.hasOwnProperty.call(mcpServers, entry.name)) continue;
+
+    const stdioEntry: Record<string, unknown> = {
+      type: "stdio",
+      command: entry.command,
+    };
+    if (entry.args && entry.args.length > 0) {
+      stdioEntry.args = [...entry.args];
+    }
+    if (entry.env && Object.keys(entry.env).length > 0) {
+      stdioEntry.env = { ...entry.env };
+    }
+    mcpServers[entry.name] = stdioEntry;
+  }
+
+  const payload = { mcpServers };
+  const path = configPathFor(cwd, ptyId);
+
+  // Ensure the .claudeclaw/ directory exists with 0700 mode. mkdirSync's
+  // mode argument is the create-time mode; if the directory already exists
+  // we don't aggressively chmod it (operator may have intentionally set
+  // different perms — we only own this subtree by convention).
+  const dir = dirname(path);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true, mode: DIR_MODE });
+  }
+
+  // Write atomically-ish: writeFileSync with mode 0600. If the file already
+  // exists, the mode flag is ignored on most platforms — we re-write the
+  // bytes but the perms stay as they were. We don't chmod separately
+  // because:
+  //   (a) the file we created in a prior turn already has 0600 from this
+  //       writer, so it's already correct;
+  //   (b) if an operator manually changed the mode we don't fight them.
+  writeFileSync(path, JSON.stringify(payload, null, 2) + "\n", {
+    mode: FILE_MODE,
+    encoding: "utf8",
+  });
+
+  return { path };
+}
+
+/**
+ * Delete a previously-synthesized config file. Idempotent — swallows ENOENT
+ * (file already gone, e.g. operator manual cleanup or path computed but
+ * never written). Other filesystem errors are re-thrown so the supervisor
+ * can log them; cleanup failures are not load-bearing but should be loud.
+ */
+export function deleteConfigForPty(cwd: string, ptyId: string): void {
+  if (!cwd || !ptyId) return; // nothing to do
+  const path = configPathFor(cwd, ptyId);
+  try {
+    unlinkSync(path);
+  } catch (err: unknown) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code === "ENOENT") return; // already gone — fine
+    throw err;
+  }
+}

--- a/src/runner/pty-mcp-config-writer.ts
+++ b/src/runner/pty-mcp-config-writer.ts
@@ -12,10 +12,10 @@
  *       { "type": "stdio", "command", "args", "env" }
  *
  * The writer is the consumer of the multiplexer's `issueIdentity(ptyId)` /
- * `revokeIdentity(ptyId)` interface (W1, src/plugins/mcp-multiplexer/
- * pty-identity.ts). That file does not yet exist in this worktree; we mirror
- * the contract here so W2 compiles in isolation. At merge time the local
- * type alias is replaced with the real import (see TODO(coord) below).
+ * `releaseIdentity(ptyId)` interface — see
+ * src/plugins/mcp-multiplexer/pty-identity.ts. The supervisor minted-and-passes
+ * the identity; the writer splats `identity.headers` verbatim into the
+ * synthesized JSON.
  */
 import {
   existsSync,
@@ -25,31 +25,10 @@ import {
 } from "node:fs";
 import { dirname, join } from "node:path";
 
-// ─── Coordination boundary with W1 ──────────────────────────────────────────
-// Mirrors src/plugins/mcp-multiplexer/pty-identity.ts — see SPEC §4.3.
-// TODO(coord): replace with real import after W1 merges:
-//   import { issueIdentity, revokeIdentity, type PtyIdentity } from
-//     "../plugins/mcp-multiplexer/pty-identity.js";
+import type { PtyIdentity } from "../plugins/mcp-multiplexer/pty-identity";
 
-export interface PtyIdentity {
-  readonly ptyId: string;
-  readonly secret: Buffer;
-  /** Returns the literal Authorization header value (e.g. "Bearer <hex>")
-   *  to embed in the synthesized `--mcp-config` JSON. */
-  buildAuthHeader(): { name: "Authorization"; value: string };
-}
-
-/**
- * Issue a fresh per-PTY identity. The multiplexer mints a 32-byte secret,
- * caches it in-memory keyed by ptyId, and returns the bearer-header value.
- *
- * In this worktree (Phase B / W2), `issueIdentity` is not yet importable
- * because the multiplexer plugin lives in W1. Callers (the supervisor) MUST
- * pass an `identity` already minted by W1 via `injectIdentityIssuer` for
- * tests, or via the real import once W1 merges. The local fallback
- * `_localIdentityForTests` exists so the writer's unit tests can pin a
- * deterministic secret without instantiating the real multiplexer.
- */
+// Re-export so callers can import the type from a single neighbour module.
+export type { PtyIdentity };
 
 // ─── Public types ───────────────────────────────────────────────────────────
 
@@ -85,9 +64,8 @@ export interface WriteConfigInput {
   /** Multiplexer's HTTP listener base URL, e.g. "http://127.0.0.1:4632".
    *  Combined with `/mcp/<server-name>` for each shared entry. */
   bridgeBaseUrl: string;
-  /** Per-PTY identity (HMAC secret + auth header). Pre-minted by the
-   *  multiplexer; the writer reads `buildAuthHeader()` and embeds the
-   *  Authorization header literal in the JSON. */
+  /** Per-PTY identity. Pre-minted by the multiplexer; the writer splats
+   *  `identity.headers` verbatim into each shared server's `headers` field. */
   identity: PtyIdentity;
 }
 
@@ -153,16 +131,15 @@ export function writeConfigForPty(
   // makes the file easier to read for operators.
   const mcpServers: Record<string, unknown> = {};
 
-  const authHeader = identity.buildAuthHeader();
   for (const { name } of sharedServers) {
     if (!name || name.length === 0) continue;
     mcpServers[name] = {
       type: "http",
       url: `${baseUrl}/mcp/${name}`,
-      headers: {
-        [authHeader.name]: authHeader.value,
-        "X-Claudeclaw-Pty-Id": ptyId,
-      },
+      // Splat W1's headers map — includes Authorization (Bearer <hex>),
+      // X-Claudeclaw-Pty-Id, and X-Claudeclaw-Ts. Single source of truth
+      // for what claude sends; the bridge expects exactly these.
+      headers: { ...identity.headers },
     };
   }
 

--- a/src/runner/pty-process.ts
+++ b/src/runner/pty-process.ts
@@ -66,6 +66,16 @@ export interface PtyProcessOptions {
   appendSystemPrompt?: string;
   /** Env vars to pass to the child. Caller is responsible for a sanitised env. */
   env: Record<string, string>;
+  /**
+   * Absolute path to a synthesized `--mcp-config` JSON written by the
+   * supervisor (see SPEC §4.5). When set, the PTY appends
+   * `--mcp-config <path>` to claude's argv so the child consults the
+   * multiplexer's shared MCP servers via local HTTP instead of stdio-spawning
+   * its own MCP children. When unset, claude falls back to its default MCP
+   * discovery (`~/.claude/mcp.json` etc.) — byte-identical to today's PTY
+   * behaviour when `settings.mcp.shared` is empty.
+   */
+  mcpConfigPath?: string;
   /** Initial PTY columns. Default 100. */
   cols?: number;
   /** Initial PTY rows. Default 30. */
@@ -228,6 +238,16 @@ function buildClaudeArgs(opts: PtyProcessOptions): string[] {
   // claude accepts --append-system-prompt (verified via `claude --help`).
   if (opts.appendSystemPrompt && opts.appendSystemPrompt.length > 0) {
     args.push("--append-system-prompt", opts.appendSystemPrompt);
+  }
+
+  // MCP multiplexer (SPEC §4.5): when the supervisor synthesized a per-PTY
+  // `--mcp-config` file, point claude at it so the child consults shared
+  // MCP-server HTTP endpoints instead of stdio-spawning its own children.
+  // Additive — Claude Code merges this with `~/.claude/mcp.json` (no
+  // `--strict-mcp-config`), so non-shared MCPs from the operator's global
+  // config still load per-PTY as today.
+  if (opts.mcpConfigPath && opts.mcpConfigPath.length > 0) {
+    args.push("--mcp-config", opts.mcpConfigPath);
   }
 
   return args;

--- a/src/runner/pty-supervisor.ts
+++ b/src/runner/pty-supervisor.ts
@@ -104,20 +104,27 @@ export type McpIdentityIssuer = (ptyId: string) => PtyIdentity;
  *  session state. Called from the supervisor's dispose paths. Safe to call
  *  for an unknown ptyId (idempotent). */
 export type McpIdentityRevoker = (ptyId: string) => void | Promise<void>;
+/** Returns the multiplexer's HTTP listener base URL. Single source of truth —
+ *  the supervisor uses this when synthesising `--mcp-config` so the URL never
+ *  drifts from what the multiplexer plugin actually bound. */
+export type McpBridgeBaseUrlGetter = () => string;
 
 let _mcpIssueIdentity: McpIdentityIssuer | null = null;
 let _mcpRevokeIdentity: McpIdentityRevoker | null = null;
+let _mcpBridgeBaseUrl: McpBridgeBaseUrlGetter | null = null;
 
 /** Wire the multiplexer plugin's identity functions. Called once at daemon
  *  startup (after the plugin's `.start()` returns) and by tests via the
- *  injectMcpIdentityIssuer test seam. Passing `null` for either function
- *  disables the synthesis path entirely. */
+ *  injectMcpIdentityIssuer test seam. Passing `null` for any function
+ *  disables the corresponding synthesis path. */
 export function injectMcpIdentityIssuer(opts: {
   issue?: McpIdentityIssuer | null;
   revoke?: McpIdentityRevoker | null;
+  bridgeBaseUrl?: McpBridgeBaseUrlGetter | null;
 }): void {
   if (opts.issue !== undefined) _mcpIssueIdentity = opts.issue;
   if (opts.revoke !== undefined) _mcpRevokeIdentity = opts.revoke;
+  if (opts.bridgeBaseUrl !== undefined) _mcpBridgeBaseUrl = opts.bridgeBaseUrl;
 }
 
 // Lazy imports of the canonical env-sanitiser + security-args builder +
@@ -313,6 +320,7 @@ export function __resetSupervisorForTests(): void {
   _newSessionId = () => crypto.randomUUID();
   _mcpIssueIdentity = null;
   _mcpRevokeIdentity = null;
+  _mcpBridgeBaseUrl = null;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -840,8 +848,13 @@ function synthesizeMcpConfigIfActive(
   // wiring lands here.
   const perPtyServers: PerPtyServerEntry[] = [];
 
-  const bridgePort = settings.web?.port ?? 4632;
-  const bridgeBaseUrl = `http://127.0.0.1:${bridgePort}`;
+  // Single source of truth: read the URL the multiplexer actually bound to,
+  // not a recomputation from settings. Fallback only if the seam is null
+  // (e.g. unit tests skip the issuer wiring); falls back to the conservative
+  // loopback default so a test misconfiguration fails closed.
+  const bridgeBaseUrl = _mcpBridgeBaseUrl
+    ? _mcpBridgeBaseUrl()
+    : `http://127.0.0.1:${settings.web?.port ?? 4632}`;
 
   const { path } = writeConfigForPty({
     ptyId,

--- a/src/runner/pty-supervisor.ts
+++ b/src/runner/pty-supervisor.ts
@@ -53,6 +53,13 @@ import { PtyClosedError, PtyTurnTimeoutError } from "./pty-process";
 import { getSettings, type SecurityConfig } from "../config";
 import { getSession, createSession } from "../sessions";
 import { getThreadSession, createThreadSession } from "../sessionManager";
+import {
+  writeConfigForPty,
+  deleteConfigForPty,
+  type PtyIdentity,
+  type SharedServerEntry,
+  type PerPtyServerEntry,
+} from "./pty-mcp-config-writer";
 
 // Lazy import for `ensureAgentDir` to avoid the circular-import hazard
 // (runner.ts imports this module to route into the supervisor; importing
@@ -74,6 +81,43 @@ async function ensureAgentDirLazy(name: string): Promise<string> {
 /** For tests only. Stub the agent-dir resolver. */
 export function injectEnsureAgentDir(fn: EnsureAgentDirFn | null): void {
   _ensureAgentDir = fn;
+}
+
+// ─── MCP multiplexer integration seam (SPEC §4.3 §4.5) ───────────────────────
+// The MCP multiplexer plugin (W1, src/plugins/mcp-multiplexer/) mints
+// per-PTY identities and routes shared MCP-server calls over local HTTP.
+// The supervisor only needs two operations from it: issue an identity for a
+// new PTY and revoke it on dispose. The full plugin doesn't exist in W2's
+// worktree, so this seam stays an optional dependency: when no issuer is
+// wired, the synthesis path simply doesn't fire and PTY behaviour is
+// byte-identical to today (matches the SPEC §6.1 dormant-multiplexer
+// contract from the perspective of the supervisor).
+//
+// At daemon startup (production), commands/start.ts calls
+// `injectMcpIdentityIssuer({ issue, revoke })` after the multiplexer plugin
+// starts. The issuer is opaque here — the supervisor only ever asks for
+// (ptyId) → PtyIdentity and (ptyId) → void.
+
+/** Function that returns a per-PTY identity (HMAC bearer header included). */
+export type McpIdentityIssuer = (ptyId: string) => PtyIdentity;
+/** Function that releases the per-PTY identity and any associated bridge
+ *  session state. Called from the supervisor's dispose paths. Safe to call
+ *  for an unknown ptyId (idempotent). */
+export type McpIdentityRevoker = (ptyId: string) => void | Promise<void>;
+
+let _mcpIssueIdentity: McpIdentityIssuer | null = null;
+let _mcpRevokeIdentity: McpIdentityRevoker | null = null;
+
+/** Wire the multiplexer plugin's identity functions. Called once at daemon
+ *  startup (after the plugin's `.start()` returns) and by tests via the
+ *  injectMcpIdentityIssuer test seam. Passing `null` for either function
+ *  disables the synthesis path entirely. */
+export function injectMcpIdentityIssuer(opts: {
+  issue?: McpIdentityIssuer | null;
+  revoke?: McpIdentityRevoker | null;
+}): void {
+  if (opts.issue !== undefined) _mcpIssueIdentity = opts.issue;
+  if (opts.revoke !== undefined) _mcpRevokeIdentity = opts.revoke;
 }
 
 // Lazy imports of the canonical env-sanitiser + security-args builder +
@@ -247,6 +291,10 @@ export function __resetSupervisorForTests(): void {
     } catch {
       // ignore
     }
+    // Release multiplexer identity + delete synthesized config (SPEC §4.5).
+    // Fire-and-forget — __resetSupervisorForTests is synchronous and tests
+    // don't await it.
+    void releaseMcpIdentityFor(entry);
   }
   state.ptys.clear();
   if (state.reapTimer) {
@@ -263,6 +311,8 @@ export function __resetSupervisorForTests(): void {
   _maxConcurrentOverride = null;
   _maxRetriesOverride = null;
   _newSessionId = () => crypto.randomUUID();
+  _mcpIssueIdentity = null;
+  _mcpRevokeIdentity = null;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -384,6 +434,9 @@ export async function shutdownSupervisor(): Promise<void> {
         }),
       );
     }
+    // Release multiplexer identity + delete synthesized config (SPEC §4.5).
+    // Best-effort, doesn't block dispose.
+    disposals.push(releaseMcpIdentityFor(entry));
   }
   await Promise.allSettled(disposals);
   state.ptys.clear();
@@ -427,6 +480,8 @@ export async function killAllPtys(): Promise<number> {
         }),
       );
     }
+    // Release multiplexer identity + delete synthesized config (SPEC §4.5).
+    disposals.push(releaseMcpIdentityFor(entry));
     state.ptys.delete(entry.sessionKey);
   }
   await Promise.allSettled(disposals);
@@ -637,6 +692,8 @@ async function enforceMaxConcurrent(incomingKey: string): Promise<void> {
       // ignore
     }
   }
+  // Release multiplexer identity + delete synthesized config (SPEC §4.5).
+  await releaseMcpIdentityFor(lruEntry);
   state.ptys.delete(lruEntry.sessionKey);
 }
 
@@ -717,6 +774,16 @@ async function buildSpawnOptions(
     }
   }
 
+  // MCP multiplexer (SPEC §4.5): synthesize a per-PTY `--mcp-config` JSON
+  // when the multiplexer is active. "Active" iff (per SPEC §6.3):
+  //   - settings.mcp.shared is non-empty, AND
+  //   - settings.web.enabled is true (the multiplexer mounts on the gateway), AND
+  //   - the multiplexer plugin has wired its issuer (injectMcpIdentityIssuer).
+  // Otherwise: skip — leave mcpConfigPath unset so buildClaudeArgs emits no
+  // --mcp-config flag and the PTY's claude falls back to default MCP discovery.
+  // This preserves byte-identical behaviour with today (settings.mcp.shared=[]).
+  const mcpConfigPath = synthesizeMcpConfigIfActive(entry.sessionKey, cwd, settings);
+
   return {
     sessionId,
     newSessionId,
@@ -730,7 +797,97 @@ async function buildSpawnOptions(
     cols: settings.pty.cols,
     rows: settings.pty.rows,
     turnIdleTimeoutMs: settings.pty.turnIdleTimeoutMs,
+    ...(mcpConfigPath ? { mcpConfigPath } : {}),
   };
+}
+
+/**
+ * Synthesize the per-PTY `--mcp-config` JSON when the multiplexer is active.
+ * Returns the absolute path on success, or `undefined` when synthesis is
+ * skipped (multiplexer dormant, gateway disabled, issuer not wired, etc.).
+ *
+ * Failure to write when synthesis IS active throws — the supervisor lets the
+ * error propagate to `spawnEntry`, which fails the spawn with a clear
+ * message. SPEC §4.5: "do NOT silently fall through to no-MCP mode".
+ */
+function synthesizeMcpConfigIfActive(
+  ptyId: string,
+  cwd: string,
+  settings: ReturnType<typeof getSettings>,
+): string | undefined {
+  const shared = settings.mcp?.shared ?? [];
+  if (shared.length === 0) return undefined; // dormant — fast path
+  if (!settings.web?.enabled) {
+    // SPEC §6.3: gateway disabled means the multiplexer's HTTP routes
+    // aren't mounted, so synthesizing a config pointing at a non-existent
+    // listener would produce confusing "Connection refused" errors. The
+    // config parser already logged a warning at parseSettings time.
+    return undefined;
+  }
+  if (!_mcpIssueIdentity) {
+    // Issuer not wired (no multiplexer plugin started, or W1 hasn't merged
+    // yet). Skip synthesis silently — the plugin's own startup path is
+    // responsible for warning operators when this combination occurs.
+    return undefined;
+  }
+
+  const identity = _mcpIssueIdentity(ptyId);
+  const sharedServers: SharedServerEntry[] = shared.map((name) => ({ name }));
+  // Per-PTY stdio entries are not synthesized by W2 — that's an
+  // operator-managed concern via mcp-proxy.json. The writer accepts
+  // perPtyServers for forward-compat, but we pass an empty list here. If
+  // settings.mcp.perPtyOnly becomes a real synthesis surface later, the
+  // wiring lands here.
+  const perPtyServers: PerPtyServerEntry[] = [];
+
+  const bridgePort = settings.web?.port ?? 4632;
+  const bridgeBaseUrl = `http://127.0.0.1:${bridgePort}`;
+
+  const { path } = writeConfigForPty({
+    ptyId,
+    cwd,
+    sharedServers,
+    perPtyServers,
+    bridgeBaseUrl,
+    identity,
+  });
+  return path.length > 0 ? path : undefined;
+}
+
+/**
+ * Release multiplexer identity + delete the synthesized config file for a
+ * PTY entry that is being permanently disposed (idle reap, LRU evict,
+ * shutdown, `/kill`, test reset). Best-effort — errors are swallowed so
+ * cleanup never blocks the supervisor's dispose path.
+ *
+ * NOT called on crash-respawn (`respawnEntry`) — the bearer token rotates
+ * via the next `writeConfigForPty` call on the same path. SPEC §4.5.
+ */
+async function releaseMcpIdentityFor(entry: PtyEntry): Promise<void> {
+  const cfgPath = entry.spawnOpts?.mcpConfigPath;
+  const cwd = entry.spawnOpts?.cwd;
+
+  // Revoke identity (drops HMAC secret + per-PTY session map entries in the
+  // multiplexer). Safe to call even if no identity was ever issued — the
+  // multiplexer's `revokeIdentity` is documented as idempotent.
+  if (_mcpRevokeIdentity) {
+    try {
+      await _mcpRevokeIdentity(entry.sessionKey);
+    } catch {
+      // best-effort
+    }
+  }
+
+  // Delete the synthesized JSON. We pass through cwd from cached spawnOpts
+  // rather than recomputing — keeps cleanup decoupled from any later cwd
+  // changes (operator-renamed agent dir, etc.).
+  if (cfgPath && cwd) {
+    try {
+      deleteConfigForPty(cwd, entry.sessionKey);
+    } catch {
+      // best-effort — operator may have manually removed the directory.
+    }
+  }
 }
 
 function cloneSecurity(security: SecurityConfig): SecurityConfig {
@@ -792,7 +949,18 @@ async function spawnEntry(
     appendSystemPrompt,
   );
   entry.spawnOpts = spawnOpts;
-  entry.pty = await spawn(spawnOpts);
+  try {
+    entry.pty = await spawn(spawnOpts);
+  } catch (err) {
+    // If the spawn itself failed AFTER we synthesized an --mcp-config file,
+    // clean up the on-disk artifact so the next attempt doesn't leak it on
+    // permanent failure. Best-effort — caller surfaces the spawn error.
+    if (spawnOpts.mcpConfigPath) {
+      await releaseMcpIdentityFor(entry);
+      entry.spawnOpts = { ...spawnOpts, mcpConfigPath: undefined };
+    }
+    throw err;
+  }
 
   // Phase D fix (Codex HIGH #2): persist a freshly pre-allocated session ID
   // to disk immediately after spawn — not on first-turn completion. If the
@@ -821,6 +989,33 @@ async function respawnEntry(entry: PtyEntry): Promise<void> {
     ...entry.spawnOpts,
     sessionId: lastSessionId ?? "",
   };
+
+  // MCP multiplexer (SPEC §4.5 "Respawn behaviour"): rotate the bearer token
+  // on crash-respawn. A crashed PTY may have leaked its bearer via core dump,
+  // so we don't reuse it. We DO keep the same on-disk path (it's keyed on
+  // ptyId) — `writeConfigForPty` overwrites idempotently.
+  //
+  // We do NOT revoke the multiplexer identity here — the same ptyId continues
+  // (this is a respawn, not a permanent dispose). `issueIdentity(ptyId)` is
+  // expected to either return the cached identity OR rotate (W1's choice).
+  // The writer just embeds whatever the issuer hands back into the new file.
+  if (entry.spawnOpts.mcpConfigPath) {
+    const settings = getSettings();
+    const refreshedPath = synthesizeMcpConfigIfActive(
+      entry.sessionKey,
+      entry.spawnOpts.cwd,
+      settings,
+    );
+    if (refreshedPath) {
+      opts.mcpConfigPath = refreshedPath;
+    } else {
+      // Synthesis is no longer active (operator dropped settings.mcp.shared
+      // since the original spawn). Strip the stale path — claude will fall
+      // back to default MCP discovery.
+      delete opts.mcpConfigPath;
+    }
+  }
+
   const spawn = await ensureSpawnPty();
   // Best-effort dispose of the dead one (may already be exited).
   if (entry.pty) {
@@ -978,6 +1173,8 @@ async function reapIdle(opts: SupervisorOptions): Promise<void> {
         // ignore
       }
     }
+    // Release multiplexer identity + delete synthesized config (SPEC §4.5).
+    await releaseMcpIdentityFor(entry);
     state.ptys.delete(entry.sessionKey);
   }
 }

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -122,8 +122,13 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
     fetch: async (req) => {
       const url = new URL(req.url);
 
-      // Plugin HTTP gateway — handles /api/plugin/* routes
-      if (url.pathname.startsWith('/api/plugin/')) {
+      // Plugin HTTP gateway — handles /api/plugin/* routes and
+      // /mcp/<server>/* multiplexer routes (registered by the
+      // McpMultiplexerPlugin at daemon startup).
+      if (
+        url.pathname.startsWith('/api/plugin/') ||
+        url.pathname.startsWith('/mcp/')
+      ) {
         try {
           const gatewayResp = await getHttpGateway().handleRequest(req, url);
           if (gatewayResp !== null) return gatewayResp;


### PR DESCRIPTION
## Summary

Implements the MCP multiplexer (issue #64). Replaces per-PTY MCP-server spawning (216 processes at 36 PTYs × 5 MCPs — OOM-bound on small-to-medium daemon hosts) with a daemon-hosted multiplexer that runs each shared MCP server **once** and serves it over loopback HTTP to all PTY-resident `claude` instances. Target footprint: `1 (bridge) + 5 (shared MCPs) + 36 (claudes) = 42 processes`, ~5× reduction.

## What this unblocks

Per the `> [!WARNING]` callout in README (PR #63), production `pty.enabled: true` was blocked on this milestone landing. After this merges + operator validates RAM under realistic load + OAuth refresh sanity-check passes, the flag flips and the warning is removed.

## Architecture

Frozen by SPEC in `.planning/mcp-multiplexer/SPEC.md` (518 LOC). High-level:

- **Multiplexer plugin** (`src/plugins/mcp-multiplexer/`) hosts shared MCP server children once at daemon startup. Exposes each on a per-server HTTP route via `PluginHttpGateway.registerMcpHandler`. Streamable HTTP transport (`@modelcontextprotocol/sdk` SDK Server + `WebStandardStreamableHTTPServerTransport`) per `(serverName, ptyId)` bucket — stateless servers collapse to one bucket, stateful keep per-PTY isolation.
- **PTY supervisor** synthesises `${cwd}/.claudeclaw/mcp-pty-${ptyId}.json` (mode `0600`) at spawn with `--mcp-config` pointing at `http://127.0.0.1:<gateway-port>/mcp/<server-name>` and per-PTY HMAC bearer headers. The bridge URL is read from the multiplexer plugin (single source of truth — no recomputation in the supervisor).
- **Auth:** `Authorization: Bearer <hex-secret>` + `X-Claudeclaw-Pty-Id` + `X-Claudeclaw-Ts`. Per-PTY secrets are 32-byte random, minted on every PTY spawn/respawn (rotation cadence bounded by `pty.idleReapMinutes`, default 30). Bearer-as-secret is the pragmatic equivalent of SPEC §4.3's per-request HMAC, since Claude Code's stock MCP HTTP client can't sign request bodies — documented in `.planning/mcp-multiplexer/W1-COORD.md` §1 and validated in `SECURITY-AUDIT.md`.
- **Legacy `claude -p` callers** keep working: the multiplexer also registers callbacks into `getMcpBridge()` for every tool from every shared server, so compact/bootstrap/fork/Telegram-direct-tool-call paths reach the same upstream `proc.call(name, args)` without going through HTTP. SPEC §10 Q#2(b) resolution.
- **Health probe** samples each shared server's status every `settings.mcp.healthProbeIntervalMs` (default 30s, 0 disables) and emits structured `mcp_health_degraded` / `mcp_health_transition` audit events plus stderr-tagged log lines on state changes. Filed in response to @Nibbler1250's review on #64 — closes the silent-degradation gap.

## Backward-compat (enforced four ways)

With `settings.mcp.shared = []` (the default):
1. Multiplexer plugin sees `shared.length === 0` → goes dormant, never spawns anything, never mounts routes.
2. Supervisor's `synthesizeMcpConfigIfActive` sees the dormant gate → skips synthesis entirely.
3. `mcp-proxy` spawns every server as today (skip-shared rule only fires when `shared` is non-empty).
4. PTY argv has no `--mcp-config` flag → `claude` falls back to its default MCP discovery.

Each gate is independently tested. The dormant path is byte-identical to today's PTY behaviour. Reviewers should be able to confirm this without reading the multiplexer code at all.

## Operator footgun (worth a README line as follow-up)

The synthesised `--mcp-config` is **additive** — `claude` inside the PTY still consults `~/.claude/mcp.json`. If an operator has the same MCP server in both `~/.config/claudeclaw/mcp-proxy.json` AND `~/.claude/mcp.json`, the multiplexer hosts it AND `claude` stdio-spawns its own copy inside each PTY. Operators must remove shared names from `~/.claude/mcp.json` to avoid shadow spawns. Filed for follow-up.

## SDLC trail

Phases A → E executed on this branch. Each phase produced an artefact:

- **Phase A** SPEC at `.planning/mcp-multiplexer/SPEC.md`
- **Phase B** parallel engineering: `feat/mcp-multiplexer-core` (W1) + `feat/mcp-multiplexer-pty-wiring` (W2), merged into this branch as `bf81bce` + `4cb664e`, interface mismatches resolved in `fb0ce4f`
- **Phase C** wire-level integration tests added (`d89a956`) — caught a real production bug at `src/ui/server.ts` where `/mcp/<server>/*` requests would have 404'd because the gateway dispatch wasn't wired in. Fixed in `2693774`.
- **Phase D** parallel security audit + code review: `.planning/mcp-multiplexer/SECURITY-AUDIT.md` (38KB) + `CODE-REVIEW.md` (18KB), both verdicts "Approve with conditions." Seven conditions applied in `8732c41`.
- **Phase E** version bumps + this PR.

## Test plan

- [x] Full suite: **1139 pass / 28 baseline fail (Event Processor / Telemetry / Policy Wiring / Phase 17/18) / 3 skip** — zero new regressions
- [x] Multiplexer scope: 124 pass / 0 fail
- [x] Wire-level integration tests: 7 pass / 0 fail (real upstream MCP child + real SDK HTTP client → real gateway listener)
- [x] Backward-compat verified: `settings.mcp.shared = []` → identity issuance / file synthesis / `--mcp-config` flag all skipped
- [x] TSC: no new errors on integration scope (baseline Zod-4 / bun-pty noise unchanged)
- [x] Version-guard: 2.2.5 (was 2.2.3 on branch base)

## v1.1 follow-ups

Tracking issue: #72. Individual filed:

- #68 — cost-tracking metrics on dispatch path (non-blocking)
- #69 — semantic caching for idempotent tools (non-blocking)
- #70 — LLM router MCP plugin milestone (non-blocking, future architecture)

## References

- Issue: #64
- Predecessor: #62 (PTY migration), #63 (README PTY warning), #66 (Biome lint setup)
- Architecture frozen: `.planning/mcp-multiplexer/SPEC.md`
- Cross-worktree coord: `.planning/mcp-multiplexer/W1-COORD.md`
- Security audit: `.planning/mcp-multiplexer/SECURITY-AUDIT.md`
- Code review: `.planning/mcp-multiplexer/CODE-REVIEW.md`
- Nibbler review on #64 (drove the health probe + items above)

🪶 Closes #64 once merged.
