### PR TITLE
fix(sessions): treat null/missing sessionId records as no-session (production hotfix)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.9",
+      "version": "2.2.10",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.9",
+  "version": "2.2.10",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/sessions.test.ts
+++ b/src/__tests__/sessions.test.ts
@@ -112,4 +112,53 @@ describe("sessions agent-scoped", () => {
     expect(existsSync(sessionPath)).toBe(false);
     expect(existsSync(join(AGENTS_DIR, name, backupName!))).toBe(true);
   });
+
+  // Production hotfix 2026-05-16 — heartbeat-path writer left
+  // `{ sessionId: null, ... }` in the global session.json, and the next
+  // Discord message crashed with `null is not an object (evaluating
+  // 'existing.sessionId.slice')`. The loader now normalises null/missing
+  // sessionId to "no session" so the runner falls through to the fresh-
+  // session path instead of crashing.
+  it("getSession returns null for a record with sessionId: null", async () => {
+    const name = uniq("null-sid");
+    const dir = join(AGENTS_DIR, name);
+    await mkdir(dir, { recursive: true });
+    const sessionPath = join(dir, "session.json");
+    await Bun.write(
+      sessionPath,
+      JSON.stringify(
+        {
+          sessionId: null,
+          createdAt: null,
+          lastUsedAt: "2026-05-16T07:57:38.250Z",
+          turnCount: 0,
+          compactWarned: false,
+        },
+        null,
+        2,
+      ),
+    );
+    expect(await getSession(name)).toBeNull();
+  });
+
+  it("getSession returns null for a record missing sessionId entirely", async () => {
+    const name = uniq("no-sid");
+    const dir = join(AGENTS_DIR, name);
+    await mkdir(dir, { recursive: true });
+    const sessionPath = join(dir, "session.json");
+    await Bun.write(
+      sessionPath,
+      JSON.stringify({ createdAt: "2026-05-16T07:00:00.000Z", turnCount: 0 }, null, 2),
+    );
+    expect(await getSession(name)).toBeNull();
+  });
+
+  it("getSession returns null for a record with empty-string sessionId", async () => {
+    const name = uniq("empty-sid");
+    const dir = join(AGENTS_DIR, name);
+    await mkdir(dir, { recursive: true });
+    const sessionPath = join(dir, "session.json");
+    await Bun.write(sessionPath, JSON.stringify({ sessionId: "", turnCount: 0 }, null, 2));
+    expect(await getSession(name)).toBeNull();
+  });
 });

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -29,18 +29,40 @@ function sessionPathFor(agentName?: string): string {
   return SESSION_FILE;
 }
 
+/** Validate that a loaded session record has a usable `sessionId`. A
+ *  truthy record with `sessionId: null` (or missing / non-string) is
+ *  treated as no session — callers like `runner.ts` derive
+ *  `isNew = !existing` and then unconditionally dereference
+ *  `existing.sessionId.slice(...)`, so a partially-written record on
+ *  disk would crash the daemon at first use. Seen in production
+ *  2026-05-16: a heartbeat-path writer left
+ *  `{ sessionId: null, createdAt: null, lastUsedAt: "...", turnCount: 0, ... }`
+ *  in the global session.json, and the next Discord message crashed
+ *  with "null is not an object (evaluating 'existing.sessionId.slice')".
+ *  Until the writer is hardened (separate issue), the loader normalises
+ *  any null/missing sessionId to "no session" so callers fall through
+ *  to the fresh-session path instead of crashing. */
+function _isUsableSession(record: unknown): record is GlobalSession {
+  if (!record || typeof record !== "object") return false;
+  const sid = (record as { sessionId?: unknown }).sessionId;
+  return typeof sid === "string" && sid.length > 0;
+}
+
 async function loadSession(agentName?: string): Promise<GlobalSession | null> {
   // Agent sessions bypass the module-level cache (cache is global-only).
   if (agentName) {
     try {
-      return await Bun.file(sessionPathFor(agentName)).json();
+      const raw = await Bun.file(sessionPathFor(agentName)).json();
+      return _isUsableSession(raw) ? raw : null;
     } catch {
       return null;
     }
   }
   if (current) return current;
   try {
-    current = await Bun.file(SESSION_FILE).json();
+    const raw = await Bun.file(SESSION_FILE).json();
+    if (!_isUsableSession(raw)) return null;
+    current = raw;
     return current;
   } catch {
     return null;
@@ -144,7 +166,8 @@ async function loadFallbackSession(
   threadId?: string,
 ): Promise<GlobalSession | null> {
   try {
-    return await Bun.file(fallbackSessionPathFor(agentName, threadId)).json();
+    const raw = await Bun.file(fallbackSessionPathFor(agentName, threadId)).json();
+    return _isUsableSession(raw) ? raw : null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Production incident

Daemon crashed on every Discord message after the auto-restart at **2026-05-16T07:34 UTC** (post-#74 redeploy). Error visible on Discord:

```
Error: null is not an object (evaluating 'existing.sessionId.slice')
```

Root cause: the global `session.json` on Hetzner held this shape:

```json
{
  "sessionId": null,
  "createdAt": null,
  "lastUsedAt": "2026-05-16T07:57:38.250Z",
  "turnCount": 0,
  "compactWarned": false
}
```

Runner's load-and-dispatch path in `runner.ts`:

```ts
const existing = await getSession(...)
const isNew = !existing                       // false — record exists
if (existing) startSession(existing.sessionId)
// ...
`resume ${existing.sessionId.slice(0, 8)}`    // CRASH: .slice on null
```

Six callsites in `runner.ts` dereference `existing.sessionId` without null-guarding, relying on the contract that "if `existing` is truthy, `sessionId` is a string". A partially-written record broke that contract.

## Hot patch already applied to production

- Backed up the broken file as `session.json.broken-20260516`
- Removed `/home/claw/project/.claude/claudeclaw/session.json`
- `sudo systemctl restart claudeclaw` — daemon back up at PID 689295
- Discord recovered

## This PR — durable fix

- `loadSession` and `loadFallbackSession` now validate via a new `_isUsableSession(record)` guard: a truthy record with `sessionId === null` / `undefined` / non-string / empty-string is treated as no session.
- Callers (runner.ts and friends) see `getSession(...) === null` → `isNew = true` → fresh-session path → no crash.
- Same validation applied to agent-scoped, global, and fallback load paths so the bug class can't recur in any session category.

Three regression tests added covering all three null-shape variants:

- `sessionId: null` (literal — exactly what production hit)
- `sessionId` missing entirely
- `sessionId: ""` (empty string)

## Out of scope

**Root cause not fixed in this PR.** Something on the heartbeat / write path is producing the `{ sessionId: null, createdAt: null, ... }` shape. The loader now defensively normalises it away, but the writer should be hardened too. Filing a separate issue to find and fix the writer; not blocking-for-production (this PR unblocks Discord).

## Test plan

- [x] `bun test src/__tests__/sessions.test.ts` — 9 pass / 0 fail
- [x] Three regression tests cover null / missing / empty-string sessionId variants
- [x] Version bumped to 2.2.9 (collides with PR #75's bump — first-to-merge wins, second rebases)

## References

- Production incident: 2026-05-16 07:57:38 UTC (Discord error: `null is not an object (evaluating 'existing.sessionId.slice')`)
- Adjacent PR #75 (Zod v4 migration, also surfaced from Nibbler's production testing pass)
- Backup of broken file on Hetzner: `/home/claw/project/.claude/claudeclaw/session.json.broken-20260516`
