### PR TITLE
fix(runner): seal ANTHROPIC_API_KEY leak through bun-pty parent-env merge

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.16",
+      "version": "2.2.17",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.16",
+  "version": "2.2.17",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/runner.test.ts
+++ b/src/__tests__/runner.test.ts
@@ -124,3 +124,170 @@ describe("Phase 18: runner modelOverride wiring", () => {
   // options.modelOverride. Documented here rather than asserted because the
   // runClaudeOnce spy only captures the primary model arg, not fallback.
 });
+
+// ─── withCleanProcessEnv (issue: bun-pty env leak) ───────────────────────────
+//
+// Regression cover for the production failure where `claude` 2.1.89's
+// "Detected a custom API key" interactive gate leaked into Discord. Root
+// cause: bun-pty's Rust wrapper does NOT call CommandBuilder::env_clear()
+// before adding env pairs, so portable_pty MERGES the caller-supplied env
+// with the parent process env at fork(). Sanitising the opts.env Record via
+// cleanSpawnEnv() was not sufficient because the daemon's process.env still
+// had ANTHROPIC_API_KEY (loaded from /etc/claudeclaw/.claudeclaw-env), which
+// claude inherited at fork() time. withCleanProcessEnv strips the keys from
+// process.env around the synchronous FFI call.
+describe("withCleanProcessEnv", () => {
+  const STRIP_KEYS = [
+    "ANTHROPIC_API_KEY",
+    "CLAUDECODE",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+  ] as const;
+
+  function snapshot(): Record<string, string | undefined> {
+    const out: Record<string, string | undefined> = {};
+    for (const k of STRIP_KEYS) out[k] = process.env[k];
+    return out;
+  }
+
+  function restore(snap: Record<string, string | undefined>): void {
+    for (const [k, v] of Object.entries(snap)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+
+  it("removes strip-list keys from process.env while fn is running", () => {
+    const original = snapshot();
+    try {
+      process.env.ANTHROPIC_API_KEY = "sk-ant-must-not-leak-to-child";
+      process.env.CLAUDECODE = "1";
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = "oauth-test";
+      process.env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST = "true";
+
+      const seen = runnerMod.withCleanProcessEnv(() => ({
+        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+        CLAUDECODE: process.env.CLAUDECODE,
+        CLAUDE_CODE_OAUTH_TOKEN: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+        CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST: process.env.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST,
+      }));
+
+      expect(seen.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(seen.CLAUDECODE).toBeUndefined();
+      expect(seen.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+      expect(seen.CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST).toBeUndefined();
+    } finally {
+      restore(original);
+    }
+  });
+
+  it("restores originals after fn returns", () => {
+    const original = snapshot();
+    try {
+      process.env.ANTHROPIC_API_KEY = "sk-ant-restore-me";
+      process.env.CLAUDECODE = "1";
+
+      runnerMod.withCleanProcessEnv(() => {
+        expect(process.env.ANTHROPIC_API_KEY).toBeUndefined();
+      });
+
+      expect(process.env.ANTHROPIC_API_KEY).toBe("sk-ant-restore-me");
+      expect(process.env.CLAUDECODE).toBe("1");
+    } finally {
+      restore(original);
+    }
+  });
+
+  it("restores originals even when fn throws", () => {
+    const original = snapshot();
+    try {
+      process.env.ANTHROPIC_API_KEY = "sk-ant-restore-on-throw";
+
+      expect(() => {
+        runnerMod.withCleanProcessEnv(() => {
+          throw new Error("boom");
+        });
+      }).toThrow("boom");
+
+      expect(process.env.ANTHROPIC_API_KEY).toBe("sk-ant-restore-on-throw");
+    } finally {
+      restore(original);
+    }
+  });
+
+  it("leaves keys absent that were absent originally", () => {
+    const original = snapshot();
+    try {
+      for (const k of STRIP_KEYS) delete process.env[k];
+
+      runnerMod.withCleanProcessEnv(() => {
+        for (const k of STRIP_KEYS) {
+          expect(process.env[k]).toBeUndefined();
+        }
+      });
+
+      for (const k of STRIP_KEYS) {
+        expect(process.env[k]).toBeUndefined();
+      }
+    } finally {
+      restore(original);
+    }
+  });
+
+  it("returns fn's return value", () => {
+    expect(runnerMod.withCleanProcessEnv(() => 42)).toBe(42);
+    expect(runnerMod.withCleanProcessEnv(() => "hello")).toBe("hello");
+  });
+
+  // Hetzner-discovered regression: Bun's `delete process.env.X` only updates
+  // the JS hash — libc `environ` retains the value. bun-pty's Rust wrapper
+  // reads `environ` via `std::env::vars_os()` so its spawned child still
+  // inherits the un-stripped value. withCleanProcessEnv MUST also call libc
+  // unsetenv so the child fork sees a clean env.
+  //
+  // This test spawns a real bun-pty child running `/bin/sh -c env` and
+  // verifies the strip-list keys do not appear in the child's environment
+  // dump — proving the libc-level strip works end-to-end against the same
+  // codepath that production uses.
+  it("strips keys at the libc level so bun-pty children do not inherit them via fork+exec", async () => {
+    const SECRET = "sk-ant-libc-regression-do-not-leak";
+    const original = snapshot();
+    try {
+      // Set ANTHROPIC_API_KEY via libc so it actually lives in environ
+      // (mirrors how the daemon's launcher sources /home/claw/.claudeclaw-env
+      // and exec's bun — by the time bun starts, the var is in libc environ).
+      process.env.ANTHROPIC_API_KEY = SECRET;
+
+      const { spawn } = await import("bun-pty");
+
+      const out = runnerMod.withCleanProcessEnv(() => {
+        const p = spawn("/bin/sh", ["-c", "env"], {
+          name: "xterm-256color",
+          cols: 80,
+          rows: 24,
+          cwd: "/tmp",
+          // Explicit env intentionally minimal — the leak would come via
+          // bun-pty's parent-env merge, NOT this explicit map.
+          env: { PATH: "/usr/bin:/bin" },
+        });
+        let buf = "";
+        p.onData((d: string) => {
+          buf += d;
+        });
+        return new Promise<string>((resolve) => {
+          // The child exits after `env` prints; give it time to flush.
+          setTimeout(() => {
+            resolve(buf);
+          }, 400);
+        });
+      });
+
+      const dump = await out;
+      // The child must not have seen ANTHROPIC_API_KEY at all.
+      expect(dump).not.toContain(SECRET);
+      expect(dump).not.toMatch(/(^|\n)ANTHROPIC_API_KEY=/);
+    } finally {
+      restore(original);
+    }
+  }, 5000);
+});

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -195,19 +195,141 @@ const COMPACT_TIMEOUT_ENABLED = true;
  * or `ANTHROPIC_API_KEY` will silently leak into PTY-mode spawns and bill
  * against raw API credits instead of the operator's subscription.
  */
+/**
+ * Canonical strip list shared by `cleanSpawnEnv` and `withCleanProcessEnv`.
+ * Keep these in sync — both helpers MUST agree, or one will reintroduce a
+ * leak the other prevents.
+ */
+const SPAWN_ENV_STRIP_KEYS = [
+  "CLAUDECODE",
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+  "ANTHROPIC_API_KEY", // see comment above — prevents accidental API-key billing
+] as const;
+
 export function cleanSpawnEnv(): Record<string, string> {
-  const stripped = new Set([
-    "CLAUDECODE",
-    "CLAUDE_CODE_OAUTH_TOKEN",
-    "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
-    "ANTHROPIC_API_KEY", // see comment above — prevents accidental API-key billing
-  ]);
+  const stripped = new Set<string>(SPAWN_ENV_STRIP_KEYS);
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
     if (stripped.has(key)) continue;
     if (typeof value === "string") out[key] = value;
   }
   return out;
+}
+
+/**
+ * Run `fn` with `SPAWN_ENV_STRIP_KEYS` temporarily deleted from `process.env`,
+ * then restore the originals. Required because `bun-pty`'s Rust wrapper does
+ * NOT call `CommandBuilder::env_clear()` — `portable_pty` MERGES the
+ * caller-supplied env with the parent process env at fork() time, so just
+ * passing a sanitised env Record (`cleanSpawnEnv()`) is not enough. The
+ * spawned `claude` still sees `ANTHROPIC_API_KEY` from the daemon's
+ * `process.env` (typically loaded from `/etc/claudeclaw/.claudeclaw-env`),
+ * triggers the "Detected a custom API key" interactive gate in claude 2.1.89,
+ * and dumps the prompt — with a truncated key — into the PTY. That output
+ * then leaks to the user-visible surface (Discord, Telegram, etc.).
+ *
+ * Safety: This mutates global state. It is ONLY race-free because:
+ *   1. Bun is single-threaded JS — no preemption between sync statements.
+ *   2. `bun-pty.spawn` is a synchronous FFI call: it does fork+exec inside
+ *      the Rust shared library and returns the handle BEFORE the JS event
+ *      loop resumes. The child inherits the parent's env at fork() time,
+ *      which is during the FFI call, AFTER our delete and BEFORE our restore.
+ *   3. `fn` MUST be synchronous (or at least, the work that depends on
+ *      `process.env` being stripped must finish before any `await`). Do NOT
+ *      pass an async function that awaits between delete and the actual
+ *      spawn — the event loop could schedule other JS that observes the
+ *      stripped env.
+ *
+ * If you find yourself wanting to wrap async work, refactor that work to
+ * have the spawn as the only call inside `withCleanProcessEnv` and do the
+ * rest outside.
+ */
+/**
+ * Lazy-loaded `libc.unsetenv` / `libc.setenv` bindings.
+ *
+ * Bun (and Node) implement `delete process.env.X` and `process.env.X = "..."`
+ * by mutating an in-process hash — they do NOT call libc `unsetenv()` /
+ * `setenv()`. That means the underlying `environ` array still has the
+ * original value, and any native code (or child process spawned via fork+exec
+ * without explicit `env_clear()`) sees the un-stripped env.
+ *
+ * `bun-pty`'s Rust wrapper relies on `portable_pty::CommandBuilder`, which
+ * inherits parent env via `std::env::vars_os()` → reads `environ` → sees the
+ * un-stripped value. So `withCleanProcessEnv` MUST also call libc `unsetenv`
+ * to actually remove the var before spawn.
+ */
+let _libcUnsetEnv: ((name: Buffer) => number) | null = null;
+let _libcSetEnv: ((name: Buffer, value: Buffer, overwrite: number) => number) | null = null;
+let _libcLoadAttempted = false;
+
+function loadLibc(): void {
+  if (_libcLoadAttempted) return;
+  _libcLoadAttempted = true;
+  try {
+    // bun:ffi is only available under Bun — import lazily to avoid blowing
+    // up under tsc / non-Bun tooling.
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic Bun runtime import
+    const { dlopen, FFIType } = require("bun:ffi") as any;
+    const candidates =
+      process.platform === "darwin"
+        ? ["libSystem.B.dylib", "/usr/lib/libSystem.B.dylib"]
+        : ["libc.so.6", "libc.so"];
+    for (const candidate of candidates) {
+      try {
+        const lib = dlopen(candidate, {
+          unsetenv: { args: [FFIType.cstring], returns: FFIType.i32 },
+          setenv: {
+            args: [FFIType.cstring, FFIType.cstring, FFIType.i32],
+            returns: FFIType.i32,
+          },
+        });
+        _libcUnsetEnv = lib.symbols.unsetenv;
+        _libcSetEnv = lib.symbols.setenv;
+        return;
+      } catch {
+        // try next candidate
+      }
+    }
+  } catch {
+    // bun:ffi unavailable (e.g. test env). withCleanProcessEnv will fall back
+    // to JS-only delete; that's correct for tests against /bin/cat etc. but
+    // would re-leak under real bun-pty + native fork. Surface this loudly
+    // in production via logging.
+  }
+}
+
+export function withCleanProcessEnv<T>(fn: () => T): T {
+  loadLibc();
+  const restore: Record<string, string | undefined> = {};
+  for (const k of SPAWN_ENV_STRIP_KEYS) {
+    restore[k] = process.env[k];
+    // 1. JS-side delete so anything checking process.env directly sees it gone.
+    delete process.env[k];
+    // 2. libc unsetenv so anything reading via `environ` (bun-pty's Rust
+    //    `std::env::vars_os()`) ALSO sees it gone. Without this, the child
+    //    inherits the original value via fork+exec.
+    if (_libcUnsetEnv) {
+      _libcUnsetEnv(Buffer.from(`${k}\0`, "utf8"));
+    }
+  }
+  try {
+    return fn();
+  } finally {
+    for (const k of SPAWN_ENV_STRIP_KEYS) {
+      const v = restore[k];
+      if (v !== undefined) {
+        // Restore on BOTH sides: JS hash (so process.env.X reads work) and
+        // libc environ (so subsequent fork+exec children see it). Bun does
+        // not keep these in sync for assignment any more than it does for
+        // delete, so we touch both explicitly.
+        process.env[k] = v;
+        if (_libcSetEnv) {
+          _libcSetEnv(Buffer.from(`${k}\0`, "utf8"), Buffer.from(`${v}\0`, "utf8"), 1);
+        }
+      }
+    }
+  }
 }
 
 export type CompactEvent =

--- a/src/runner/pty-process.ts
+++ b/src/runner/pty-process.ts
@@ -32,6 +32,7 @@
  */
 import { spawn as ptySpawn, type IPty } from "bun-pty";
 import type { SecurityConfig } from "../config";
+import { withCleanProcessEnv } from "../runner";
 import {
   createParser,
   decodeTurn,
@@ -776,13 +777,24 @@ export function spawnPty(opts: PtyProcessOptions): Promise<PtyProcess> {
 
     let pty: IPty;
     try {
-      pty = ptySpawn(cmd, args, {
-        name: "xterm-256color",
-        cols,
-        rows,
-        cwd: opts.cwd,
-        env: opts.env,
-      });
+      // bun-pty's Rust wrapper does NOT call CommandBuilder::env_clear()
+      // before adding env vars — portable_pty MERGES the caller-supplied
+      // env with the parent process env at fork() time. So passing a
+      // sanitised `opts.env` is not enough: the child claude still inherits
+      // ANTHROPIC_API_KEY (and the other Claude-Code internals) from this
+      // daemon's process.env, hits claude 2.1.89's "Detected a custom API
+      // key" interactive gate, and leaks the prompt + a truncated key into
+      // the PTY (visible on Discord/Telegram). withCleanProcessEnv strips
+      // those keys from process.env around the synchronous FFI call.
+      pty = withCleanProcessEnv(() =>
+        ptySpawn(cmd, args, {
+          name: "xterm-256color",
+          cols,
+          rows,
+          cwd: opts.cwd,
+          env: opts.env,
+        }),
+      );
     } catch (err) {
       reject(
         new Error(


### PR DESCRIPTION
## Summary

- `cleanSpawnEnv()` returns a sanitised env Record without ANTHROPIC_API_KEY, but the spawned claude still inherited it because bun-pty's Rust wrapper does NOT call `CommandBuilder::env_clear()` — `portable_pty` MERGES the caller-supplied env with the parent process env at fork() time.
- JS-level `delete process.env[k]` is not enough: Bun (and Node) do NOT propagate `delete` to libc `unsetenv`. The underlying `environ` array retains the original value, and bun-pty's Rust side reads `environ` via `std::env::vars_os()` → child still inherits.
- New `withCleanProcessEnv()` helper calls `libc.unsetenv()` via Bun FFI to strip the canonical keys from `environ` around the synchronous FFI spawn, then restores via `libc.setenv()`. Race-free because Bun is single-threaded and bun-pty's spawn is a sync FFI call (fork+exec returns before the JS event loop resumes).

## Production impact

Without this, flipping `pty.enabled: true` on a daemon that has `ANTHROPIC_API_KEY` in its launcher env (e.g. sourced from Doppler) makes claude 2.1.89 hit the "Detected a custom API key" interactive gate and leaks the prompt — including a truncated key — into the PTY output (Discord, Telegram).

Verified end-to-end on Hetzner: bun-pty child previously inherited the var via libc `environ` despite the JS `delete`; with `libc.unsetenv()` it no longer does. Manual claude smoke under a stripped env starts cleanly (no API-key gate, OAuth auth via `~/.claude/.credentials.json`).

## Test plan

- [x] 5 unit tests for `withCleanProcessEnv`: strip during fn, restore after, restore on throw, no-op when keys absent, return-value pass-through.
- [x] 1 end-to-end regression: spawns a real `bun-pty` child running `/bin/sh -c env` and asserts the strip-list keys are absent in the child's environment dump. Pre-fix, this test reproduces the leak; post-fix, it passes.
- [x] Full `pty-process.test.ts` + `pty-supervisor.test.ts` + `pty-trust-prompt.test.ts` + `pty-integration.test.ts` suites green (79 pass, 5 skip).
- [x] Manual smoke on Hetzner with `pty.enabled: true`: claude starts cleanly under stripped env, no API-key gate.

## Known follow-up (NOT in this PR)

End-to-end PTY mode still has a separate timing bug: `_waitForReadySettle()` in `pty-process.ts:710` resolves on first byte from claude, but claude's TUI takes a couple of seconds to fully paint after that. The supervisor writes the prompt into a half-painted TUI and the bytes get eaten. Fix is a two-phase wait (first byte → quiet window). Will be filed as a separate issue.

## Out of scope

- bun-pty upstream PR to add `envClear` option on `IPtyForkOptions`. Worth filing but not required for this fix.