### PR TITLE
fix(runner): _waitForReadySettle two-phase wait + Codex P2 test seed via libc

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.17",
+      "version": "2.2.18",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.17",
+  "version": "2.2.18",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/pty-process.test.ts
+++ b/src/__tests__/pty-process.test.ts
@@ -95,6 +95,93 @@ describe("PtyProcess — lifecycle", () => {
   });
 });
 
+// ─── _waitForReadySettle: two-phase (paint + quiet) (issue #84) ─────────────
+//
+// Regression for the production failure where claude 2.1.89's TUI startup
+// banner leaked to Discord as the "model response". Pre-fix, readySettle
+// resolved on the first byte from claude — but the TUI takes ~1–2s to fully
+// paint. spawnPty would return early, the supervisor's first runTurn wrote
+// the prompt into a half-painted TUI, and the sentinel-echo path captured
+// only the splash bytes.
+//
+// Post-fix: resolve only after a quietWindowMs gap of NO data following the
+// first byte. The tests below simulate a slow paint with /bin/sh and assert
+// spawnPty doesn't resolve until the paint goes quiet.
+
+describe("PtyProcess — _waitForReadySettle two-phase (issue #84)", () => {
+  test("does NOT resolve on first byte — waits for quiet window after paint", async () => {
+    // Script: emit bytes immediately, again at 200ms, again at 400ms, then
+    // stay silent. With quietWindowMs=300, the quiet timer should reset on
+    // each chunk and only fire ~300ms after the last (400ms) chunk — so
+    // spawnPty should resolve at ~700ms, NOT at first-byte (~0ms).
+    const t0 = Date.now();
+    const proc = await spawnPty(
+      baseOpts({
+        _commandOverride: "/bin/sh",
+        _argsOverride: [
+          "-c",
+          // Trailing `sleep 5` keeps the process alive past the quiet
+          // window — spawnPty rejects if the child exits before settle.
+          "printf paint1; sleep 0.2; printf paint2; sleep 0.2; printf paint3; sleep 5",
+        ],
+        _skipReadySettle: false,
+        quietWindowMs: 300,
+      }),
+    );
+    const elapsed = Date.now() - t0;
+
+    // Quiet timer fires 300ms after the last chunk (paint3 at ~400ms) →
+    // expect ≥ ~600ms total. Pre-fix this resolved at ~0ms.
+    // Loose bound to avoid flakiness across CI environments.
+    expect(elapsed).toBeGreaterThanOrEqual(500);
+    // And not absurdly long either — the hard timeout is 3s.
+    expect(elapsed).toBeLessThan(3000);
+
+    await proc.dispose();
+  });
+
+  test("hard timeout fires when the TUI never paints", async () => {
+    // Script: silent for 2s then exit. With _waitForReadySettle's 3s hard
+    // timeout, spawn should still resolve at ~2s (when the process exits
+    // and onExit fires nothing through _handleData) — actually the hard
+    // timer's the only path that fires. To prove the hard timeout works
+    // in isolation, use a longer-silent process and trust the 3s cap.
+    const t0 = Date.now();
+    const proc = await spawnPty(
+      baseOpts({
+        _commandOverride: "/bin/sh",
+        _argsOverride: ["-c", "sleep 5"],
+        _skipReadySettle: false,
+        quietWindowMs: 100,
+      }),
+    );
+    const elapsed = Date.now() - t0;
+    // Hard timeout in spawnPty is 3000ms; allow some slack.
+    expect(elapsed).toBeGreaterThanOrEqual(2800);
+    expect(elapsed).toBeLessThan(3500);
+    await proc.dispose();
+  }, 7000);
+
+  test("resolves quickly when first byte is followed by long silence", async () => {
+    // Script: emit one chunk immediately, then 5s silence. With
+    // quietWindowMs=200, expect resolve at ~200ms — much faster than the
+    // 3s hard timeout.
+    const t0 = Date.now();
+    const proc = await spawnPty(
+      baseOpts({
+        _commandOverride: "/bin/sh",
+        _argsOverride: ["-c", "printf banner; sleep 5"],
+        _skipReadySettle: false,
+        quietWindowMs: 200,
+      }),
+    );
+    const elapsed = Date.now() - t0;
+    expect(elapsed).toBeGreaterThanOrEqual(150);
+    expect(elapsed).toBeLessThan(1500);
+    await proc.dispose();
+  });
+});
+
 // ─── runTurn: sentinel-echo round-trip against /bin/cat ─────────────────────
 //
 // /bin/cat is the simplest live test for the sentinel flow: it echoes

--- a/src/__tests__/runner.test.ts
+++ b/src/__tests__/runner.test.ts
@@ -286,11 +286,7 @@ describe("withCleanProcessEnv", () => {
         "libc dlopen failed in test setup — cannot seed environ via setenv to exercise the libc-unset codepath",
       );
     }
-    libc.setenv(
-      Buffer.from("ANTHROPIC_API_KEY\0", "utf8"),
-      Buffer.from(`${SECRET}\0`, "utf8"),
-      1,
-    );
+    libc.setenv(Buffer.from("ANTHROPIC_API_KEY\0", "utf8"), Buffer.from(`${SECRET}\0`, "utf8"), 1);
     // Also reflect into JS hash so snapshot/restore see consistent state.
     process.env.ANTHROPIC_API_KEY = SECRET;
 

--- a/src/__tests__/runner.test.ts
+++ b/src/__tests__/runner.test.ts
@@ -252,12 +252,49 @@ describe("withCleanProcessEnv", () => {
   it("strips keys at the libc level so bun-pty children do not inherit them via fork+exec", async () => {
     const SECRET = "sk-ant-libc-regression-do-not-leak";
     const original = snapshot();
-    try {
-      // Set ANTHROPIC_API_KEY via libc so it actually lives in environ
-      // (mirrors how the daemon's launcher sources /home/claw/.claudeclaw-env
-      // and exec's bun — by the time bun starts, the var is in libc environ).
-      process.env.ANTHROPIC_API_KEY = SECRET;
+    // Codex P2 from PR #83 (issue #85): Bun's `process.env.X = "..."` does
+    // NOT update libc `environ` (mirroring the documented `delete` behaviour
+    // on `withCleanProcessEnv`). If we seeded via process.env, the var
+    // would never be in environ to begin with — and the bun-pty child would
+    // pass the assertion whether or not `libc.unsetenv` actually runs.
+    //
+    // Seed via libc `setenv` directly so the var genuinely lives in
+    // environ, matching the production daemon's startup state (launcher
+    // sources /home/claw/.claudeclaw-env via `set -a; source …; set +a`
+    // before exec'ing bun — by the time bun starts, the var is in environ).
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic Bun runtime import
+    const { dlopen, FFIType } = (await import("bun:ffi")) as any;
+    const libcCandidates =
+      process.platform === "darwin"
+        ? ["libSystem.B.dylib", "/usr/lib/libSystem.B.dylib"]
+        : ["libc.so.6", "libc.so"];
+    let libc: { setenv: (n: Buffer, v: Buffer, o: number) => number } | null = null;
+    for (const candidate of libcCandidates) {
+      try {
+        const lib = dlopen(candidate, {
+          setenv: {
+            args: [FFIType.cstring, FFIType.cstring, FFIType.i32],
+            returns: FFIType.i32,
+          },
+        });
+        libc = { setenv: lib.symbols.setenv };
+        break;
+      } catch {}
+    }
+    if (!libc) {
+      throw new Error(
+        "libc dlopen failed in test setup — cannot seed environ via setenv to exercise the libc-unset codepath",
+      );
+    }
+    libc.setenv(
+      Buffer.from("ANTHROPIC_API_KEY\0", "utf8"),
+      Buffer.from(`${SECRET}\0`, "utf8"),
+      1,
+    );
+    // Also reflect into JS hash so snapshot/restore see consistent state.
+    process.env.ANTHROPIC_API_KEY = SECRET;
 
+    try {
       const { spawn } = await import("bun-pty");
 
       const out = runnerMod.withCleanProcessEnv(() => {

--- a/src/__tests__/runner.test.ts
+++ b/src/__tests__/runner.test.ts
@@ -268,7 +268,10 @@ describe("withCleanProcessEnv", () => {
       process.platform === "darwin"
         ? ["libSystem.B.dylib", "/usr/lib/libSystem.B.dylib"]
         : ["libc.so.6", "libc.so"];
-    let libc: { setenv: (n: Buffer, v: Buffer, o: number) => number } | null = null;
+    let libc: {
+      setenv: (n: Buffer, v: Buffer, o: number) => number;
+      unsetenv: (n: Buffer) => number;
+    } | null = null;
     for (const candidate of libcCandidates) {
       try {
         const lib = dlopen(candidate, {
@@ -276,8 +279,9 @@ describe("withCleanProcessEnv", () => {
             args: [FFIType.cstring, FFIType.cstring, FFIType.i32],
             returns: FFIType.i32,
           },
+          unsetenv: { args: [FFIType.cstring], returns: FFIType.i32 },
         });
-        libc = { setenv: lib.symbols.setenv };
+        libc = { setenv: lib.symbols.setenv, unsetenv: lib.symbols.unsetenv };
         break;
       } catch {}
     }
@@ -286,6 +290,10 @@ describe("withCleanProcessEnv", () => {
         "libc dlopen failed in test setup — cannot seed environ via setenv to exercise the libc-unset codepath",
       );
     }
+    // Snapshot the libc-level value BEFORE we mutate it, so the teardown
+    // can restore it (or unset if absent). Bun's process.env reflects the
+    // libc environ at startup, so this snapshot is accurate at test entry.
+    const libcOriginalApiKey = original.ANTHROPIC_API_KEY;
     libc.setenv(Buffer.from("ANTHROPIC_API_KEY\0", "utf8"), Buffer.from(`${SECRET}\0`, "utf8"), 1);
     // Also reflect into JS hash so snapshot/restore see consistent state.
     process.env.ANTHROPIC_API_KEY = SECRET;
@@ -320,6 +328,20 @@ describe("withCleanProcessEnv", () => {
       expect(dump).not.toContain(SECRET);
       expect(dump).not.toMatch(/(^|\n)ANTHROPIC_API_KEY=/);
     } finally {
+      // Codex P2 follow-up: we mutated libc environ via setenv, so the JS-
+      // side `restore(original)` is not enough — without libc cleanup the
+      // seeded key would persist in environ and contaminate later fork+exec
+      // tests with order-dependent failures. Restore (or unset) libc first,
+      // then sync the JS hash.
+      if (libcOriginalApiKey !== undefined) {
+        libc.setenv(
+          Buffer.from("ANTHROPIC_API_KEY\0", "utf8"),
+          Buffer.from(`${libcOriginalApiKey}\0`, "utf8"),
+          1,
+        );
+      } else {
+        libc.unsetenv(Buffer.from("ANTHROPIC_API_KEY\0", "utf8"));
+      }
       restore(original);
     }
   }, 5000);

--- a/src/runner/pty-process.ts
+++ b/src/runner/pty-process.ts
@@ -702,36 +702,68 @@ class PtyProcessImpl implements PtyProcess {
   // ─── internal: used only by spawnPty to await TUI settle ─────────────
 
   /**
-   * Resolve once the TUI shows signs of life — either the first chunk of
-   * data has arrived OR `timeoutMs` has elapsed. Without OSC 9;4 markers
-   * we can't distinguish "TUI fully painted" from "TUI starting paint", so
-   * we use first-byte arrival as a lightweight readiness proxy.
+   * Resolve once the TUI has both painted (first data chunk arrived) AND
+   * gone quiet for `quietWindowMs` (no new data for that long, meaning the
+   * paint is done and the TUI is awaiting input). Falls back to resolve on
+   * `timeoutMs` regardless, so a stalled/silent claude doesn't deadlock
+   * spawn.
+   *
+   * Issue #84: pre-fix, this resolved on the FIRST BYTE — but claude
+   * 2.1.89's TUI takes ~1–2 seconds to fully paint after the first byte.
+   * `spawnPty` would return early, the supervisor's first `runTurn` wrote
+   * the user prompt into a half-painted TUI, and claude either ate those
+   * bytes or interpreted them as navigation keys. The sentinel-echo path
+   * then captured only the splash banner and returned it as the "model
+   * response" (visible to Discord/Telegram users).
+   *
+   * Two-phase model:
+   *   1. Wait for first data byte (TUI started painting).
+   *   2. Wait for `quietWindowMs` of NO new data (TUI finished painting
+   *      and is silent at the input prompt).
+   * On every incoming chunk after phase 1, reset the quiet timer.
    */
   _waitForReadySettle(timeoutMs: number): Promise<void> {
     return new Promise<void>((resolve) => {
       let resolved = false;
+      let quietTimer: ReturnType<typeof setTimeout> | null = null;
+      const originalHandler = this._handleData.bind(this);
+
       const done = () => {
         if (resolved) return;
         resolved = true;
+        if (quietTimer) this._clearTimeout(quietTimer);
+        this._clearTimeout(hardTimer);
+        // Restore the original handler so subsequent runTurn calls don't
+        // pay the patched-handler overhead and don't leak the closure.
+        this._handleData = originalHandler;
         resolve();
       };
 
-      if (this._firstDataAt > 0) {
-        // Data already arrived before this was called.
-        done();
-        return;
-      }
+      const scheduleQuiet = () => {
+        if (quietTimer) this._clearTimeout(quietTimer);
+        quietTimer = this._setTimeout(done, this._quietWindowMs);
+      };
 
-      const timer = this._setTimeout(done, timeoutMs);
-      // Patch _handleData to resolve on first byte.
-      const originalHandler = this._handleData.bind(this);
+      // Hard timeout: if the TUI never paints AT ALL within timeoutMs,
+      // resolve anyway and let the caller proceed. This also guards
+      // against a TUI that paints forever without ever going quiet.
+      const hardTimer = this._setTimeout(done, timeoutMs);
+
+      // Patch _handleData to reset the quiet timer on every incoming
+      // chunk. The quiet timer only starts firing after the first chunk
+      // (paint started) and only resolves once a full quietWindowMs has
+      // elapsed with no further chunks (paint finished).
       this._handleData = (data: string) => {
         originalHandler(data);
-        if (this._firstDataAt > 0) {
-          this._clearTimeout(timer);
-          done();
-        }
+        scheduleQuiet();
       };
+
+      // If data already arrived before this was called, kick off the
+      // quiet timer immediately — we may never see another byte and don't
+      // want to wait the full hard timeout.
+      if (this._firstDataAt > 0) {
+        scheduleQuiet();
+      }
     });
   }
 }

--- a/src/runner/pty-process.ts
+++ b/src/runner/pty-process.ts
@@ -201,7 +201,6 @@ export class PtyClosedError extends Error {
 
 // ─── Internal helpers ───────────────────────────────────────────────────────
 
-const DEFAULT_TURN_IDLE_TIMEOUT_MS = 30_000;
 const DEFAULT_QUIET_WINDOW_MS = 500;
 const DEFAULT_SENTINEL_MAX_WAIT_MS = 30_000;
 const DEFAULT_QUIET_TICK_MS = 50;
@@ -276,7 +275,6 @@ class PtyProcessImpl implements PtyProcess {
   private _alive: boolean = true;
   private _lastTurnEndedAt: number = 0;
   private _pty: IPty;
-  private readonly _idleTimeoutMs: number;
   private readonly _quietWindowMs: number;
   private readonly _sentinelMaxWaitMs: number;
   private readonly _now: () => number;
@@ -324,7 +322,6 @@ class PtyProcessImpl implements PtyProcess {
       opts.sessionId && opts.sessionId.length > 0 ? opts.sessionId : (opts.newSessionId ?? "");
     this.cwd = opts.cwd;
     this.label = `${opts.agentName ?? "pty"}:${pty.pid}`;
-    this._idleTimeoutMs = opts.turnIdleTimeoutMs ?? DEFAULT_TURN_IDLE_TIMEOUT_MS;
     this._quietWindowMs = opts.quietWindowMs ?? DEFAULT_QUIET_WINDOW_MS;
     this._sentinelMaxWaitMs = opts.sentinelMaxWaitMs ?? DEFAULT_SENTINEL_MAX_WAIT_MS;
     this._now = opts._now ?? (() => Date.now());


### PR DESCRIPTION
Closes #84, closes #85.

## #84 — `_waitForReadySettle` resolves too early

Pre-fix, `_waitForReadySettle()` at [`src/runner/pty-process.ts:710`](https://github.com/TerrysPOV/ClaudeClaw-Plus/blob/main/src/runner/pty-process.ts#L710) resolved on the FIRST BYTE arriving from claude. But claude 2.1.89's TUI takes ~1–2s to fully paint after that first byte. `spawnPty()` returned early, the supervisor's first `runTurn()` wrote the prompt into a half-painted TUI, claude either ate those bytes or interpreted them as navigation keys, and the sentinel-echo path then captured only the splash banner — which got returned as the "model response" (visible to Discord/Telegram users).

**Fix:** two-phase wait — resolve only after (1) first data byte arrived AND (2) `quietWindowMs` of silence followed. On every chunk after the first, reset the quiet timer. Hard timeout (3s) still guards against a TUI that never paints. On `done`, restore the original `_handleData` so subsequent `runTurn` calls don't pay the patched-handler overhead and don't leak the closure.

## #85 — Codex P2: libc-level regression test seeded the wrong way

The libc-level regression in `runner.test.ts` (added in PR #83) seeded `ANTHROPIC_API_KEY` via `process.env.X = SECRET`. But the very docstring on `withCleanProcessEnv` documents that Bun's `process.env` writes do NOT update libc `environ`. So the seed never landed in environ, and the bun-pty child wouldn't have inherited it via the parent-env merge regardless of whether `libc.unsetenv` ran — the assertion passed vacuously.

**Fix:** seed via `libc.setenv()` (Bun FFI) directly, matching production where the daemon's launcher sources `/home/claw/.claudeclaw-env` via `set -a; source …; set +a` before `exec`'ing bun. Verified: temporarily disabling `libc.unsetenv` inside `withCleanProcessEnv` now causes the test to **fail** (child genuinely inherits the secret via fork+exec env merge). Restoring it: passes.

## Tests

Three new tests in `pty-process.test.ts` against `/bin/sh` with controlled timing — no fakes, no fragile fixtures:

- **does NOT resolve on first byte:** script emits 3 chunks 200ms apart then idles; spawnPty resolves ~500–700ms after the last chunk, not at 0ms.
- **hard timeout fires when TUI is silent:** script sleeps for 5s with no output; spawnPty resolves at the 3s cap.
- **resolves quickly when first byte is followed by long silence:** one chunk then 5s sleep; resolves at ~200ms (quiet window), not the 3s cap.

One updated test in `runner.test.ts`:

- **strips keys at the libc level so bun-pty children do not inherit them via fork+exec:** now seeds via `libc.setenv` so the regression actually exercises the libc-unset path.

Full suite: `bun test src/__tests__/pty-process.test.ts src/__tests__/pty-supervisor.test.ts src/__tests__/pty-trust-prompt.test.ts src/__tests__/pty-integration.test.ts` → 82 pass, 5 skip, 0 fail.

## Hetzner smoke (with `pty.enabled: true`)

Confirms #84 fixed: claude TUI paints fully, the prompt IS rendered in claude's input area, claude shows the "Grooving" thinking indicator. Prompt is reaching the model.

## Known follow-up (will file as a new issue)

A separate bug surfaced during smoke test: claude receives the prompt and starts thinking, but `runTurn()` returns at ~5s with no model response and no sentinel string in the capture. None of the four documented completion paths (sentinel-found, sentinelMaxWaitMs default 30s, opts.timeoutMs 60s, PtyClosedError) explain a 5s return. Needs instrumentation to identify the actual completion path before fixing. NOT in scope for this PR.

## Test plan
- [x] Unit + integration tests green
- [x] Hetzner smoke: PTY mode with patched code reaches the "Grooving" state (proves prompt delivery works post-fix)
- [x] Rolled back to `pty.enabled: false` pending follow-up