### PR TITLE
fix(runner): make PTY response capture actually return clean model output (parser quiet timing + marker recognition)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.18",
+      "version": "2.2.19",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.19",
+      "version": "2.2.20",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.18",
+  "version": "2.2.19",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.19",
+  "version": "2.2.20",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/scripts/capture-sentinel-fixture.ts
+++ b/scripts/capture-sentinel-fixture.ts
@@ -27,8 +27,8 @@ import { resolve as resolvePath } from "node:path";
 function parseArgs(argv: string[]): Record<string, string> {
   const out: Record<string, string> = {};
   for (let i = 0; i < argv.length; i++) {
-    const a = argv[i]!;
-    if (a.startsWith("--")) {
+    const a = argv[i];
+    if (a?.startsWith("--")) {
       const key = a.slice(2);
       const val = argv[i + 1];
       if (val && !val.startsWith("--")) {

--- a/src/__tests__/pty-output-parser.test.ts
+++ b/src/__tests__/pty-output-parser.test.ts
@@ -415,7 +415,7 @@ describe("extractResponseText", () => {
       "● Pong 🏓",
       "",
       "─".repeat(50),
-      "❯ Try \"how do I log an error?\"",
+      '❯ Try "how do I log an error?"',
       "─".repeat(50),
       "⏵⏵ bypass permissions on (shift+tab to cycle)",
       "╭────── 🦞 ClaudeClaw+ 🦞 ──────╮",
@@ -458,7 +458,7 @@ describe("extractResponseText", () => {
   // TUI splash, prompt-echo, and footer into the response shown to the
   // user (Discord/Telegram).
   test("recognises `●` (U+25CF) as the assistant marker (claude 2.1.89)", () => {
-    const text = "garbage\n● Pong 🏓\n────────────\n❯ Try \"...\"";
+    const text = 'garbage\n● Pong 🏓\n────────────\n❯ Try "..."';
     expect(extractResponseText(text)).toBe("Pong 🏓");
   });
 
@@ -478,7 +478,7 @@ describe("extractResponseText", () => {
       "● Pong 🏓",
       "",
       "─".repeat(100),
-      "❯ Try \"how do I log an error?\"",
+      '❯ Try "how do I log an error?"',
       "─".repeat(100),
       "⏵⏵ bypass permissions on (shift+tab to cycle)",
     ].join("\n");
@@ -537,7 +537,7 @@ describe("extractResponseText", () => {
     const footer = [
       "",
       "─".repeat(100),
-      "❯ Try \"write a test for reprocess-clippings.py\"",
+      '❯ Try "write a test for reprocess-clippings.py"',
       "─".repeat(100),
       "⏵⏵ bypass permissions on (shift+tab to cycle) /buddy",
       "╭────── 🦞 ClaudeClaw+ 🦞 ──────╮",

--- a/src/__tests__/pty-output-parser.test.ts
+++ b/src/__tests__/pty-output-parser.test.ts
@@ -396,18 +396,37 @@ describe("normaliseNewlines", () => {
 });
 
 describe("extractResponseText", () => {
-  test("extracts text after ⏺ and before terminator sigil", () => {
-    const text = "garbage\n⏺hello world✻ Worked for 2s\n more";
+  test("extracts text after a line-anchored `⏺ ` and before terminator sigil", () => {
+    const text = "garbage\n⏺ hello world✻ Worked for 2s\n more";
     expect(extractResponseText(text)).toBe("hello world");
   });
 
-  test("handles ⏺ with leading space", () => {
-    const text = "garbage\n⏺ hello world✻ Worked for 2s";
-    expect(extractResponseText(text)).toBe("hello world");
+  // The marker must be at line-start and followed by a space — this is
+  // exactly how claude's TUI prints the assistant message. A bare `⏺` or
+  // `●` embedded inside a TUI element (e.g. the ClaudeClaw+ status box
+  // row `│ ● live │ 🎮 │`) MUST NOT be picked up; pre-fix that bug
+  // caused the captured "response" to be the TUI footer (everything from
+  // the status-box marker onwards) instead of the model output.
+  test("ignores `●` not at line-start (e.g. inside the ClaudeClaw+ status-box row)", () => {
+    // Realistic shape: response marker, then the `─` separator the TUI
+    // prints before re-rendering the input area, then the status box
+    // which contains another `●` we MUST NOT pick up.
+    const text = [
+      "● Pong 🏓",
+      "",
+      "─".repeat(50),
+      "❯ Try \"how do I log an error?\"",
+      "─".repeat(50),
+      "⏵⏵ bypass permissions on (shift+tab to cycle)",
+      "╭────── 🦞 ClaudeClaw+ 🦞 ──────╮",
+      "│ 📋 7 jobs │ ● live │ 🎮 │",
+      "╰───────────────────────────────╯",
+    ].join("\n");
+    expect(extractResponseText(text)).toBe("Pong 🏓");
   });
 
-  test("uses the LAST ⏺ (response area, not echoed prompt)", () => {
-    const text = "⏺nope ✻done\n⏺yes✻";
+  test("uses the LAST line-anchored marker (response area, not echoed prompt)", () => {
+    const text = "⏺ nope ✻done\n⏺ yes✻";
     expect(extractResponseText(text)).toBe("yes");
   });
 
@@ -431,6 +450,104 @@ describe("extractResponseText", () => {
     expect(extractResponseText(text)).toBe(
       "The prompt looked like `user@host ❯` when I tested it.",
     );
+  });
+
+  // Issue #87 follow-up: claude 2.1.89 emits `●` (U+25CF BLACK CIRCLE)
+  // rather than `⏺` (U+23FA RECORD). Pre-fix, lastIndexOf("⏺") returned
+  // -1 and we fell back to the WHOLE stripped buffer — captures leaked
+  // TUI splash, prompt-echo, and footer into the response shown to the
+  // user (Discord/Telegram).
+  test("recognises `●` (U+25CF) as the assistant marker (claude 2.1.89)", () => {
+    const text = "garbage\n● Pong 🏓\n────────────\n❯ Try \"...\"";
+    expect(extractResponseText(text)).toBe("Pong 🏓");
+  });
+
+  test("real-world claude 2.1.89 turn: banner + prompt-echo + response + footer", () => {
+    // Verbatim shape captured from Hetzner (ANSI stripped). The marker
+    // before the model response is `●`, and the divider that follows is
+    // 100 horizontal-line chars before the next TUI input prompt.
+    const text = [
+      "▐▛███▜▌ Claude Code v2.1.89",
+      "▝▜█████▛▘ Sonnet 4.6 · Claude Max",
+      "▘▘ ▝▝   ~/project",
+      "",
+      "❯ [2026-05-16 18:33:59 UTC+1]",
+      "[Discord Channel: 1488536365477138602]",
+      "Message: Ping",
+      "",
+      "● Pong 🏓",
+      "",
+      "─".repeat(100),
+      "❯ Try \"how do I log an error?\"",
+      "─".repeat(100),
+      "⏵⏵ bypass permissions on (shift+tab to cycle)",
+    ].join("\n");
+    expect(extractResponseText(text)).toBe("Pong 🏓");
+  });
+
+  test("uses the LAST marker even when both `●` and `⏺` appear", () => {
+    // Defensive: if a future claude version mixes both, the most recent
+    // marker is the one that introduces the assistant response.
+    const text = "⏺ earlier\n● later✻";
+    expect(extractResponseText(text)).toBe("later");
+  });
+
+  test("multi-line response is preserved until divider", () => {
+    const text = `● Line one\nLine two\nLine three\n${"─".repeat(50)}\n❯ Try "next"`;
+    expect(extractResponseText(text)).toBe("Line one\nLine two\nLine three");
+  });
+
+  test("a short horizontal-line run (<4) is NOT a terminator", () => {
+    // 3 chars of ─ inside response (e.g. a markdown table) must not split.
+    const text = "● A row: ─ ─ ─ that crosses cells.";
+    expect(extractResponseText(text)).toBe("A row: ─ ─ ─ that crosses cells.");
+  });
+
+  // Hetzner-discovered shape: claude's TUI re-renders the entire screen
+  // for every turn, so a turn-2 capture contains the FULL conversation
+  // history (banner, turn-1 prompt + response, turn-2 prompt + response)
+  // followed by the input area re-render and the ClaudeClaw+ status box.
+  // The extractor must find the LATEST line-anchored marker (turn 2's
+  // response) and stop at the next divider — ignoring both turn 1's
+  // marker AND the status-box `●`.
+  //
+  // Note: claude 2.1.89 emits `●Pong` (no space) for short single-token
+  // responses after ANSI strip. The marker regex accepts an optional
+  // space after the marker glyph.
+  test("multi-turn TUI re-render: picks the LATEST `●` response, not turn-1's or the status-box `●`", () => {
+    const banner = [
+      "▐▛███▜▌ Claude Code v2.1.89",
+      "▝▜█████▛▘ Sonnet 4.6 · Claude Max",
+      "▘▘ ▝▝   ~/project",
+    ].join("\n");
+    const turn1 = [
+      "❯ [2026-05-16 18:33:59 UTC+1]",
+      "[Discord Channel: 1488536365477138602]",
+      "Message: Ping",
+      "",
+      "●Pong 🏓",
+    ].join("\n");
+    const turn2 = [
+      "❯ [2026-05-16 19:51:02 UTC+1]",
+      "[Discord Channel: 1488536365477138602]",
+      "Message: Ping",
+      "",
+      "●Pong",
+    ].join("\n");
+    const footer = [
+      "",
+      "─".repeat(100),
+      "❯ Try \"write a test for reprocess-clippings.py\"",
+      "─".repeat(100),
+      "⏵⏵ bypass permissions on (shift+tab to cycle) /buddy",
+      "╭────── 🦞 ClaudeClaw+ 🦞 ──────╮",
+      "│ 📋 7 jobs │ ● live │ 🎮 │",
+      "╰───────────────────────────────╯",
+      "⏵⏵ bypass permissions on (shift+tab to cycle)",
+    ].join("\n");
+    const fullScreen = [banner, "", turn1, "", turn2, footer].join("\n");
+
+    expect(extractResponseText(fullScreen)).toBe("Pong");
   });
 });
 

--- a/src/__tests__/pty-output-parser.test.ts
+++ b/src/__tests__/pty-output-parser.test.ts
@@ -32,6 +32,52 @@ const FIXTURE_MARKERS = join(FIXTURE_DIR, "sentinel-turn-sample.markers.json");
 // ─── Synthetic flow tests (single + multi turn) ──────────────────────────────
 
 describe("pty-output-parser — sentinel flow (synthetic)", () => {
+  // Issue #87 regression: pre-fix, `quiet` could fire after `startTurn` even
+  // though zero response bytes had arrived. The 500ms quiet window expired
+  // between the prompt write and claude's first ack-echo (~500–800ms on
+  // claude 2.1.89). The supervisor wrote the sentinel prematurely; claude's
+  // TUI echoed the sentinel keystrokes back fast; sentinel-found fired;
+  // runTurn returned with only the TUI splash + prompt-echo bytes as the
+  // "response" — model output never had a chance to arrive.
+  test("issue #87: quiet does NOT fire until at least one byte has arrived since startTurn", () => {
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-87";
+    const sentinelBytes = encodeSentinel(buildSentinel(uuid));
+
+    let now = 1000;
+    // Pre-turn data exists in the stream (e.g. TUI banner from spawn).
+    feed(parser, new TextEncoder().encode("pre-turn banner bytes"), now);
+    expect(parser.state).toBe("idle");
+
+    startTurn(parser, uuid, sentinelBytes, now);
+    expect(parser.state).toBe("accumulating");
+    expect(parser.sawByteSinceTurnStart).toBe(false);
+
+    // The quiet window elapses with ZERO bytes since startTurn (claude has
+    // received the prompt but hasn't started emitting its response yet).
+    // Pre-fix this would emit `quiet`; post-fix it must not.
+    now += 200;
+    expect(tick(parser, now)).toEqual([]);
+
+    // Even after several elapsed quiet windows, still no `quiet` — we need
+    // an actual response byte before the parser will conclude "claude is
+    // silent because it's done responding".
+    now += 5000;
+    expect(tick(parser, now)).toEqual([]);
+
+    // First response byte arrives. Now the quiet window can be counted.
+    feed(parser, new TextEncoder().encode("a"), now);
+    expect(parser.sawByteSinceTurnStart).toBe(true);
+
+    // Within the quiet window after that byte → still no quiet.
+    expect(tick(parser, now + 50)).toEqual([]);
+
+    // After the quiet window → quiet fires.
+    const qEvs = tick(parser, now + 200);
+    expect(qEvs.length).toBe(1);
+    expect(qEvs[0]!.type).toBe("quiet");
+  });
+
   test("happy path: prompt → response → quiet → sentinel echo → complete", () => {
     const enc = new TextEncoder();
     const parser = createParser({ quietWindowMs: 100 });

--- a/src/runner/pty-output-parser.ts
+++ b/src/runner/pty-output-parser.ts
@@ -97,6 +97,14 @@ export interface Parser {
    *  every new byte so the supervisor only writes the sentinel once per
    *  quiet period. */
   quietEmitted: boolean;
+  /** Whether at least one byte has been seen SINCE the current turn started.
+   *  Issue #87: pre-fix, `quiet` could fire 500ms after `startTurn` even
+   *  though claude hadn't emitted a single byte of response yet — the
+   *  initial "silence" was just claude's latency between receiving the
+   *  prompt and starting to echo. We now only emit `quiet` once we've
+   *  observed at least one byte after turn start, so quiet truly means
+   *  "claude was responding and has stopped." */
+  sawByteSinceTurnStart: boolean;
   /** Carry-over from previous chunks needed to detect a sentinel that
    *  straddles a chunk boundary. At most `sentinelBytes.length - 1` bytes. */
   pending: Uint8Array;
@@ -116,6 +124,7 @@ export function createParser(opts?: { quietWindowMs?: number }): Parser {
     lastByteAt: 0,
     quietWindowMs: opts?.quietWindowMs ?? DEFAULT_QUIET_WINDOW_MS,
     quietEmitted: false,
+    sawByteSinceTurnStart: false,
     pending: new Uint8Array(0),
     pendingBaseOffset: 0,
   };
@@ -143,6 +152,7 @@ export function startTurn(
   parser.sentinelOffset = 0;
   parser.lastByteAt = now;
   parser.quietEmitted = false;
+  parser.sawByteSinceTurnStart = false;
   parser.pending = new Uint8Array(0);
   parser.pendingBaseOffset = parser.totalBytes;
   return { type: "turn-start", offset: parser.turnStartOffset };
@@ -164,6 +174,9 @@ export function feed(parser: Parser, chunk: Uint8Array, now: number): ParserEven
   parser.totalBytes += chunk.length;
   parser.lastByteAt = now;
   parser.quietEmitted = false; // any new byte resets the quiet emitter
+  if (parser.state === "accumulating" || parser.state === "awaiting-sentinel") {
+    parser.sawByteSinceTurnStart = true;
+  }
 
   // We only scan for the sentinel after the supervisor has actually written
   // it (state === "awaiting-sentinel"). Until then there's nothing to find,
@@ -216,6 +229,14 @@ export function feed(parser: Parser, chunk: Uint8Array, now: number): ParserEven
 export function tick(parser: Parser, now: number): ParserEvent[] {
   if (parser.state !== "accumulating") return [];
   if (parser.quietEmitted) return [];
+  // Issue #87: don't fire `quiet` until claude has emitted at least one byte
+  // of response. Otherwise the initial silence between prompt write and
+  // claude's first ack-echo (often ~500–800ms on claude 2.1.89) gets
+  // interpreted as "claude is done", the sentinel is written prematurely
+  // into claude's input buffer, claude echoes it back, the parser sees
+  // sentinel-found, and the turn returns with only the TUI splash + prompt
+  // echo as the "response" — model output never had a chance to arrive.
+  if (!parser.sawByteSinceTurnStart) return [];
   if (now - parser.lastByteAt < parser.quietWindowMs) return [];
   parser.quietEmitted = true;
   return [{ type: "quiet", offset: parser.totalBytes }];

--- a/src/runner/pty-output-parser.ts
+++ b/src/runner/pty-output-parser.ts
@@ -342,18 +342,46 @@ export function normaliseNewlines(text: string): string {
  *   3. Trim whitespace; if empty, fall back to the whole stripped buffer.
  */
 export function extractResponseText(strippedNormalised: string): string {
-  const marker = "⏺";
+  // Claude 2.1.89 emits `●` (U+25CF BLACK CIRCLE) before the assistant
+  // message. Older versions used `⏺` (U+23FA RECORD button). Accept both.
+  //
+  // The marker MUST be anchored at the start of a line. claude's TUI
+  // uses `●` in plenty of other places too — the ClaudeClaw+ status box
+  // (`│ ● live │ 🎮 │`) renders the same glyph inside a box-drawn row,
+  // and the status box paints AFTER the model response in the stream. A
+  // naive `lastIndexOf("●")` would pick the box marker and return only
+  // the TUI footer as the "response". The space after the marker is
+  // optional: claude 2.1.89 ANSI-strips down to `●Pong` (no space) for
+  // short responses; longer responses (or ones with leading punctuation)
+  // come through as `● Body...`.
+  const markerRe = /(?:^|\n)([●⏺]) ?/gu;
   // Spinner glyphs and `⎿` tool-result indent are the natural terminators
-  // that follow the assistant message in the TUI. We intentionally do NOT
-  // include `❯` alone — it can legitimately appear inside response text
-  // (e.g. a shell-prompt example).
-  const terminatorRe = /[✻✶✳✢✽✺✷·◉]| {2,}⎿/u;
-  const idx = strippedNormalised.lastIndexOf(marker);
-  if (idx < 0) return strippedNormalised.trim();
+  // that follow the assistant message in the TUI. We also terminate on a
+  // line of 4+ horizontal box-drawing chars (`─` U+2500 or `━` U+2501) —
+  // claude's TUI prints that as the divider above the next input prompt
+  // after a response completes. We intentionally do NOT include `❯` alone
+  // — it can legitimately appear inside response text (e.g. a shell-prompt
+  // example).
+  const terminatorRe = /[✻✶✳✢✽✺✷·◉]| {2,}⎿|\n[─━]{4,}/u;
 
-  let after = strippedNormalised.slice(idx + marker.length);
-  if (after.startsWith(" ")) after = after.slice(1);
+  // Find the LAST line-anchored marker. Take whichever appears latest in
+  // the stream (handles streams that contain multiple turns or a turn
+  // whose response includes nested assistant markers).
+  let lastMarkerStart = -1;
+  let lastMarkerEnd = -1;
+  for (const m of strippedNormalised.matchAll(markerRe)) {
+    // m.index points at the `\n` (or position 0). The marker character
+    // itself begins at index + (newline ? 1 : 0). Easiest: m[0] is either
+    // "\n● " or "● " (at string start); the marker char is the
+    // penultimate char of the match. After-text begins right after.
+    const matchStart = m.index ?? 0;
+    const afterStart = matchStart + m[0].length;
+    lastMarkerStart = matchStart;
+    lastMarkerEnd = afterStart;
+  }
+  if (lastMarkerStart < 0) return strippedNormalised.trim();
 
+  const after = strippedNormalised.slice(lastMarkerEnd);
   const termMatch = after.match(terminatorRe);
   const body = termMatch ? after.slice(0, termMatch.index) : after;
   const trimmed = body.trim();


### PR DESCRIPTION
Closes #87.

Two-part fix that together make PTY-mode response capture work end-to-end on claude 2.1.89. Either fix alone is insufficient — both are required for a Discord "Ping" to return a clean "Pong".

## Part 1 — Parser doesn't fire `quiet` until claude has emitted a response byte

**Root cause:** `lastByteAt` is set to `now` at `startTurn()`, so the quiet timer started counting from the moment of the prompt write. On claude 2.1.89, there's a 500–800ms latency between the prompt being written to the PTY and claude emitting its first ack/echo byte. Within the default 500ms `quietWindow`, that latency expired silently — the parser concluded "claude is silent → must be at the input prompt" and emitted a `quiet` event. The supervisor then wrote the sentinel into claude's input buffer, claude's TUI echoed those keystrokes back fast (keystroke echo, not model output), the parser found the sentinel, and `runTurn` returned cleanly. **The model never had a chance to respond.**

Pre-fix Hetzner trace:
```
t=0      runTurn enters, prompt written, parser.totalBytes=30
t=507    quiet.event fires  ← ZERO bytes seen since startTurn
t=508    writeSentinel (premature)
t=587    claude finally starts echoing
t=1201   sentinel-found  ← TUI echo of injected sentinel
t=1206   runTurn resolves textLen=464 (TUI splash + prompt echo only)
```

**Fix:** track `sawByteSinceTurnStart` on the parser. Set to `false` at `startTurn()`, flipped to `true` on any `feed()` during the active turn. `tick()` refuses to emit `quiet` until that's true. Result: `quiet` now genuinely means "claude was responding and has stopped."

## Part 2 — `extractResponseText` recognises `●` and anchors at line-start

**Root cause:** claude 2.1.89 prints the assistant marker as `●` (U+25CF BLACK CIRCLE) at the start of a line, where older versions used `⏺` (U+23FA RECORD button). Pre-fix, `extractResponseText` only looked for `⏺`, so the marker was never found — it fell back to returning the WHOLE stripped buffer. Every PTY response shown to Discord/Telegram was the full TUI screen: banner, echoed prompt, model response, divider, footer.

Two sub-problems:

1. **`●` not recognised.** Added to the marker set alongside `⏺`.

2. **`●` appears in non-response places.** The ClaudeClaw+ status box (`│ 📋 7 jobs │ ● live │ 🎮 │`) renders `●` inside a box-drawing row, and the status box paints AFTER the model response in the stream — so a naive `lastIndexOf("●")` would anchor at the box marker and return only the TUI footer as "the response". Solved by requiring the marker to be at the start of a line: `/(?:^|\n)([●⏺]) ?/gu`. The trailing space is optional because claude 2.1.89 strips down to `●Pong` (no space) for short single-token responses; longer responses come through as `● Body...`.

Use `matchAll` and take the LAST match so multi-turn captures (claude's TUI re-renders the whole screen on every turn — turn-N's capture contains turns 1..N-1's content too) pick the most recent `●`, not the first.

Also added `\n[─━]{4,}` to the terminator set. claude prints a long horizontal-line divider above the next input prompt after a response completes; that divider is a reliable end-of-response marker. Required 4+ consecutive chars so a single `─` inside response text (e.g. a markdown table cell border) doesn't truncate.

## End-to-end verification

Hetzner with `pty.enabled: true`, both fixes deployed:
- Discord "Ping" → "Pong" rendered cleanly in Discord, no banner/footer/box noise.
- Multiple consecutive turns work (each turn picks the LATEST `●` response).
- Daemon now serves from the subscription billing pool via long-lived PTYs.

## Tests

New parser regressions (all green pre-AND-post fix, except where noted):
- `issue #87: quiet does NOT fire until at least one byte has arrived since startTurn` — covers Part 1, pre-fix FAILS
- `recognises '●' (U+25CF) as the assistant marker (claude 2.1.89)` — covers Part 2
- `real-world claude 2.1.89 turn: banner + prompt-echo + response + footer`
- `ignores '●' not at line-start (e.g. inside the ClaudeClaw+ status-box row)`
- `multi-turn TUI re-render: picks the LATEST '●' response, not turn-1's or the status-box '●'` — verbatim fixture of the broken Hetzner capture
- `uses the LAST marker even when both '●' and '⏺' appear`
- `multi-line response is preserved until divider`
- `a short horizontal-line run (<4) is NOT a terminator`

Two legacy tests updated to use `⏺ ` with a space (matching real TUI shape) now that the marker is line-anchored + space-required.

Full pty-* suite: **111 pass, 5 skip, 0 fail**.

## Test plan
- [x] Unit + integration tests green
- [x] Hetzner smoke: Discord "Ping" → "Pong" rendered cleanly, no TUI noise
- [x] Hetzner now running on `pty.enabled: true` end-to-end (subscription billing pool active)