### PR TITLE
fix(supervisor): validate stored sessionId is resumable before --resume; overwrite stale records (#89)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.20",
+      "version": "2.2.21",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.20",
+  "version": "2.2.21",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/pty-integration.test.ts
+++ b/src/__tests__/pty-integration.test.ts
@@ -43,6 +43,7 @@ import {
   resetClock,
   injectSleep,
   resetSleep,
+  injectIsSessionResumable,
   __resetSupervisorForTests,
   __reapNowForTests,
   runOnPty,
@@ -189,6 +190,12 @@ beforeEach(async () => {
   resetSleep();
   // Stub ensureAgentDir so we don't pollute the repo's agents/ directory.
   injectEnsureAgentDir(async (name: string) => join(TEST_PROJECT_DIR, "agents", name));
+  // Issue #89: stub the resumability probe so tests that pre-seed
+  // session.json don't get them treated as phantoms (the probe checks
+  // for a `.jsonl` on disk under claude's projects dir, which fake-PTY
+  // tests never create). Tests that exercise the phantom path override
+  // this with their own stub.
+  injectIsSessionResumable(async () => true);
   // Default settings: PTY enabled, fast backoff so retry tests don't wait
   // wall-clock. turnIdleTimeoutMs is the per-turn hard-cap safety-net.
   // quietWindowMs / sentinelMaxWaitMs control the sentinel-echo round-trip

--- a/src/__tests__/pty-supervisor.test.ts
+++ b/src/__tests__/pty-supervisor.test.ts
@@ -25,6 +25,7 @@ import {
   injectMaxConcurrentForTests,
   injectMaxRetriesForTests,
   injectNewSessionId,
+  injectIsSessionResumable,
   killAllPtys,
   __resetSupervisorForTests,
   __isSupervisorInitialisedForTests,
@@ -169,6 +170,11 @@ beforeEach(async () => {
   await reloadSettings();
   // Stub the agent-dir resolver so we don't touch the real filesystem.
   injectEnsureAgentDir(async (name: string) => `/tmp/agents/${name}`);
+  // Issue #89: stub the resumability probe to return true by default so
+  // tests that seed sessions.json don't get them treated as phantoms.
+  // Individual tests that want to exercise the phantom path inject their
+  // own stub returning false.
+  injectIsSessionResumable(async () => true);
 });
 
 afterEach(async () => {
@@ -1059,7 +1065,9 @@ describe("pty-supervisor fresh-session persistence (Codex Phase D #2)", () => {
     let captured: PtyProcessOptions | null = null;
     const { spawn } = makeSpawnTracker((opts) => {
       captured = opts;
-      return makeFakePty("agent:alice", {});
+      // Honour the supervisor's pre-allocated --session-id (claude would
+      // create the session under that UUID).
+      return makeFakePty("agent:alice", { initialSessionId: opts.newSessionId });
     });
     injectSpawnPty(spawn);
     injectNewSessionId(() => "uuid-alice-fresh");
@@ -1085,7 +1093,9 @@ describe("pty-supervisor fresh-session persistence (Codex Phase D #2)", () => {
     let captured: PtyProcessOptions | null = null;
     const { spawn } = makeSpawnTracker((opts) => {
       captured = opts;
-      return makeFakePty("thread:t-fresh", {});
+      // Honour the supervisor's pre-allocated --session-id (claude would
+      // create the session under that UUID).
+      return makeFakePty("thread:t-fresh", { initialSessionId: opts.newSessionId });
     });
     injectSpawnPty(spawn);
     injectNewSessionId(() => "uuid-thread-fresh");
@@ -1109,7 +1119,11 @@ describe("pty-supervisor fresh-session persistence (Codex Phase D #2)", () => {
     let captured: PtyProcessOptions | null = null;
     const { spawn } = makeSpawnTracker((opts) => {
       captured = opts;
-      return makeFakePty("global", {});
+      // Honour the supervisor's pre-allocated --session-id (claude would
+      // create the session under that UUID). Without this, the fake PTY
+      // returns a different sessionId from runTurn and (post-#89)
+      // persistSessionId would overwrite the pre-allocated one.
+      return makeFakePty("global", { initialSessionId: opts.newSessionId });
     });
     injectSpawnPty(spawn);
     injectNewSessionId(() => "uuid-global-fresh");
@@ -1188,6 +1202,82 @@ describe("pty-supervisor fresh-session persistence (Codex Phase D #2)", () => {
 
     await runOnPty("global", "again", { timeoutMs: 60_000 });
     expect(captured!.sessionId).toBe("uuid-global-seed");
+    expect(captured!.newSessionId).toBeUndefined();
+  });
+
+  // Issue #89 regression: eager-persistence wrote a sessionId to disk
+  // for a PTY whose first turn failed (no `.jsonl` ever got created by
+  // claude). On the next boot the supervisor used to pass that phantom
+  // UUID to `--resume`, claude exited 1 with "No conversation found",
+  // supervisor retried 5x, daemon surfaced "max retries exhausted" to
+  // the user. Required three manual sessions.json cleanups during the
+  // 2026-05-16 PTY rollout.
+  //
+  // Post-fix: the supervisor validates resumability via
+  // `_isSessionResumable(cwd, sessionId)` before passing the stored ID
+  // to --resume. If the probe returns false (the `.jsonl` is missing),
+  // the stored ID is dropped and a fresh UUID is pre-allocated via
+  // `--session-id <new>` — exactly the same path as a brand-new
+  // sessionKey would take.
+  it("issue #89: stale persisted sessionId without a .jsonl is treated as no-session", async () => {
+    await resetSession();
+    // Seed the global session store as if a prior PTY had persisted a
+    // sessionId at spawn-time (Codex HIGH #2 path) but never logged a turn.
+    const { spawn: seedSpawn } = makeSpawnTracker(() =>
+      makeFakePty("global", { initialSessionId: "uuid-phantom" }),
+    );
+    injectSpawnPty(seedSpawn);
+    injectNewSessionId(() => "uuid-phantom");
+    await runOnPty("global", "seed-phantom", { timeoutMs: 60_000 });
+    expect((await getSession())?.sessionId).toBe("uuid-phantom");
+
+    // Daemon restart: in-memory supervisor state wiped, on-disk
+    // session.json still has uuid-phantom.
+    __resetSupervisorForTests();
+
+    // Simulate the phantom condition: the `.jsonl` for uuid-phantom does
+    // NOT exist (claude exited before writing it).
+    injectIsSessionResumable(async (_cwd, sessionId) => sessionId !== "uuid-phantom");
+
+    let captured: PtyProcessOptions | null = null;
+    const { spawn: spawn2 } = makeSpawnTracker((opts) => {
+      captured = opts;
+      return makeFakePty("global", { initialSessionId: opts.sessionId || opts.newSessionId });
+    });
+    injectSpawnPty(spawn2);
+    injectNewSessionId(() => "uuid-fresh-replacement");
+
+    await runOnPty("global", "next message", { timeoutMs: 60_000 });
+
+    // Supervisor must NOT have passed the phantom as sessionId to
+    // --resume. Instead it allocated a fresh session via --session-id.
+    expect(captured!.sessionId).toBe("");
+    expect(captured!.newSessionId).toBe("uuid-fresh-replacement");
+  });
+
+  it("issue #89: a resumable stored sessionId is honoured (no regression)", async () => {
+    await resetSession();
+    const { spawn: seedSpawn } = makeSpawnTracker(() =>
+      makeFakePty("global", { initialSessionId: "uuid-real" }),
+    );
+    injectSpawnPty(seedSpawn);
+    injectNewSessionId(() => "uuid-real");
+    await runOnPty("global", "seed", { timeoutMs: 60_000 });
+
+    __resetSupervisorForTests();
+    // Resumability probe returns true → existing happy path.
+    injectIsSessionResumable(async () => true);
+
+    let captured: PtyProcessOptions | null = null;
+    const { spawn: spawn2 } = makeSpawnTracker((opts) => {
+      captured = opts;
+      return makeFakePty("global", { initialSessionId: opts.sessionId });
+    });
+    injectSpawnPty(spawn2);
+    injectNewSessionId(() => "uuid-must-not-be-used");
+
+    await runOnPty("global", "again", { timeoutMs: 60_000 });
+    expect(captured!.sessionId).toBe("uuid-real");
     expect(captured!.newSessionId).toBeUndefined();
   });
 });

--- a/src/runner/pty-supervisor.ts
+++ b/src/runner/pty-supervisor.ts
@@ -239,6 +239,66 @@ let _sleep: (ms: number) => Promise<void> = (ms) => new Promise<void>((r) => set
  *  (Codex HIGH #2). */
 let _newSessionId: () => string = () => crypto.randomUUID();
 
+/**
+ * Issue #89: tells the supervisor whether `claude --resume <sessionId>`
+ * has a chance of succeeding for a given `(cwd, sessionId)` pair. claude
+ * persists each conversation as `~/.claude/projects/<mangled-cwd>/<id>.jsonl`
+ * — the directory may be created at spawn but the JSONL is only written
+ * once claude has actually logged a turn. If the JSONL is absent, the
+ * sessionId is a phantom (eager pre-allocation from a PTY whose first
+ * turn failed) and `--resume` will exit 1 with "No conversation found".
+ *
+ * The mangling rule: replace each `/` in the absolute path with `-`. So
+ * `/home/claw/project` → `-home-claw-project`. claude does this in its
+ * own filesystem layout and we match it.
+ *
+ * Injectable so tests can stub the filesystem layer.
+ */
+let _isSessionResumable: (cwd: string, sessionId: string) => Promise<boolean> = async (
+  cwd,
+  sessionId,
+) => {
+  try {
+    const { homedir } = await import("node:os");
+    const { resolve: resolvePath } = await import("node:path");
+    const { existsSync } = await import("node:fs");
+    const mangled = resolvePath(cwd).replace(/\//g, "-");
+    const jsonlPath = resolvePath(homedir(), ".claude", "projects", mangled, `${sessionId}.jsonl`);
+    return existsSync(jsonlPath);
+  } catch {
+    // Fail-closed: if anything goes wrong probing the filesystem, treat
+    // the session as non-resumable. We'd rather lose one turn's continuity
+    // than surface "max retries exhausted" to the user.
+    return false;
+  }
+};
+
+/** For tests only. Inject a deterministic resumability check. */
+export function injectIsSessionResumable(
+  fn: ((cwd: string, sessionId: string) => Promise<boolean>) | null,
+): void {
+  _isSessionResumable =
+    fn ??
+    (async (cwd, sessionId) => {
+      try {
+        const { homedir } = await import("node:os");
+        const { resolve: resolvePath } = await import("node:path");
+        const { existsSync } = await import("node:fs");
+        const mangled = resolvePath(cwd).replace(/\//g, "-");
+        const jsonlPath = resolvePath(
+          homedir(),
+          ".claude",
+          "projects",
+          mangled,
+          `${sessionId}.jsonl`,
+        );
+        return existsSync(jsonlPath);
+      } catch {
+        return false;
+      }
+    });
+}
+
 /** For tests only. Inject a fake spawnPty before any runOnPty call. */
 export function injectSpawnPty(fn: SpawnPty | null): void {
   _spawnPty = fn;
@@ -724,6 +784,27 @@ async function buildSpawnOptions(
     sessionId = g?.sessionId ?? "";
   }
 
+  // Issue #89: validate the stored sessionId is actually resumable BEFORE
+  // passing it to `claude --resume`. The Phase D eager-persistence (Codex
+  // HIGH #2) writes the UUID to sessions.json at spawn-time so a daemon
+  // crash between spawn and first turn doesn't lose the conversation —
+  // but if claude exits BEFORE writing its `.jsonl` (auth gate, parser
+  // bug, OOM, anything), the persisted UUID is now a phantom. Every
+  // subsequent `--resume <phantom>` errors with "No conversation found"
+  // and claude exits 1; the supervisor retries 5x and surfaces "max
+  // retries exhausted" to the user. Required three manual sessions.json
+  // cleanups during the 2026-05-16 PTY rollout.
+  //
+  // The resumability test: `<sessionId>.jsonl` exists in claude's project
+  // dir for `cwd`. Directory presence is not enough (claude creates the
+  // dir on startup but doesn't write the jsonl until it's logged at
+  // least one turn). Fail-closed: if we can't confirm, treat as phantom
+  // and allocate a fresh session. Worst case we lose continuity for one
+  // bad record; far better than user-visible "max retries exhausted".
+  if (sessionId && !(await _isSessionResumable(cwd, sessionId))) {
+    sessionId = "";
+  }
+
   // Phase D fix (Codex HIGH #2): no stored session ID for this key. Pre-allocate
   // a deterministic UUID and pass it via `--session-id` so the conversation
   // survives daemon restart / idle reap / `/kill` / crash. Without this, fresh
@@ -1154,15 +1235,22 @@ async function persistSessionId(entry: PtyEntry, sessionId: string): Promise<voi
   if (entry.spawnOpts?.sessionId && entry.spawnOpts.sessionId === sessionId) {
     return;
   }
-  // First-time capture — write to the right store and update our cached opts.
+  // Issue #89: if a record exists on disk but holds a DIFFERENT sessionId
+  // (e.g. a phantom left over from a prior PTY whose first turn failed),
+  // overwrite it with the fresh ID. createThreadSession / createSession
+  // both overwrite unconditionally, so we drop the prior `!existing`
+  // guard — that guard was the reason a stale-then-fresh sequence kept
+  // the on-disk sessionId pinned to the stale value across all subsequent
+  // messages, breaking conversation continuity even though the runtime
+  // recovered cleanly.
   if (entry.threadId) {
     const existing = await getThreadSession(entry.threadId);
-    if (!existing) {
+    if (!existing || existing.sessionId !== sessionId) {
       await createThreadSession(entry.threadId, sessionId);
     }
   } else {
     const existing = await getSession(entry.agentName);
-    if (!existing) {
+    if (!existing || existing.sessionId !== sessionId) {
       await createSession(sessionId, entry.agentName);
     }
   }


### PR DESCRIPTION
Closes #89.

## Root cause

The Phase D eager-persistence (Codex HIGH #2 from #62) writes the pre-allocated sessionId to `sessions.json` at PTY spawn time so the conversation survives daemon restart between spawn and first response. But if claude exits BEFORE writing its `.jsonl` (auth gate, parser bug, OOM, fast-fail of any kind), the persisted UUID is a phantom — every subsequent message tries `--resume <phantom>`, claude exits 1 with `No conversation found`, supervisor retries 5x, daemon surfaces `max retries exhausted` to the user.

Required three manual `sessions.json` cleanups during the 2026-05-16 PTY rollout (post-#83, post-#86, post-#88 each surfaced this).

A second compounding bug: `persistSessionId` was guarded with `if (!existing) createThreadSession(...)`. So even after our runtime recovery, the on-disk record kept pointing at the phantom UUID across every subsequent message, breaking conversation continuity even though no error surfaced.

## Fix (two parts)

1. **Resumability probe at `buildSpawnOptions`.** New injectable `_isSessionResumable(cwd, sessionId)` checks for `~/.claude/projects/<mangled-cwd>/<sessionId>.jsonl`. Directory presence is NOT enough — claude creates the dir at startup but only writes the `.jsonl` once a turn has logged. If absent, the stored sessionId is treated as no-session: the supervisor clears it and falls through to the existing `--session-id <new>` pre-allocation path. Fail-closed: filesystem-probe errors return false (lose one turn's continuity, never surface "max retries exhausted").

2. **Drop the `!existing` guard in `persistSessionId`.** When a record exists but holds a DIFFERENT sessionId, overwrite. `createThreadSession` and `createSession` both overwrite unconditionally; the prior guard was pinning the on-disk store to whatever was written first.

## Verification

End-to-end on Hetzner:
- Staged phantom UUID `phantom2-uuid-89-overwrite-test-...` for thread `1488536365477138602` in `sessions.json`.
- Operator sent "Ping" via Discord in `#claudeclaw-general`.
- Pre-fix: would have surfaced `max retries exhausted` and left the phantom on disk.
- Post-fix: daemon detected the missing `.jsonl`, allocated fresh `9a627338-314e-4573-b753-d51b0db49c74`, claude responded "Pong", `sessions.json` was overwritten with the fresh UUID. Subsequent turns on the same channel resume cleanly (`turnCount: 3` after multiple Ping rounds).

## Tests

New regressions in `pty-supervisor.test.ts`:
- `issue #89: stale persisted sessionId without a .jsonl is treated as no-session` — pre-fix FAILS (supervisor passes phantom as `sessionId`); post-fix PASSES (allocates fresh `newSessionId`).
- `issue #89: a resumable stored sessionId is honoured (no regression)` — confirms the happy path still works.

Updated three legacy fake-PTY tests to honour the supervisor's pre-allocated `--session-id` (`initialSessionId: opts.newSessionId`) so `persistSessionId`'s overwrite path doesn't trip on the fake PTY returning a counter-based session-N id.

Updated test setup in both `pty-supervisor.test.ts` and `pty-integration.test.ts` to inject the new `_isSessionResumable` stub returning `true` by default — tests that exercise the phantom path override it explicitly.

Full pty-* suite: **122 pass, 5 skip, 0 fail**.
Full-repo `bun run lint`: zero errors.

## Test plan
- [x] Unit + integration tests green
- [x] Hetzner smoke: staged phantom + Discord Ping → fresh session allocated + persisted, model responded cleanly
- [x] Hetzner sessions.json verified post-fix: phantom replaced with fresh UUID, multi-turn resumability working