### PR TITLE
feat(mcp-multiplexer): per-bearer rate limit on /mcp/<server> (#72 item 1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.21",
+      "version": "2.2.22",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.21",
+  "version": "2.2.22",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -333,6 +333,23 @@ export interface McpConfig {
    * default is used.
    */
   sessionPersistencePath: string;
+  /**
+   * Per-bearer (i.e. per-PTY) rate limit on `/mcp/<server>` requests
+   * (#72 item 1). The `/mcp/<server>` route is bearer-only: a leaked
+   * bearer would otherwise allow full replay of MCP calls against the
+   * shared upstream until the issuing PTY respawns. Defense-in-depth
+   * cap on requests per PTY per sliding window.
+   *
+   * Default: 600 requests per 60s (10/sec sustained — generous for
+   * tool-call traffic, tight enough to limit damage from a leaked
+   * bearer). Set `maxRequestsPerWindow: 0` to disable.
+   */
+  rateLimit: {
+    /** Cap on requests per `windowMs` per `ptyId`. 0 = disabled. */
+    maxRequestsPerWindow: number;
+    /** Sliding-window length in milliseconds. */
+    windowMs: number;
+  };
 }
 
 export interface PtyConfig {
@@ -831,6 +848,23 @@ function parseMcpConfig(raw: any, webEnabled: unknown): McpConfig {
     }
   }
 
+  // Rule 8: per-bearer rate limit (#72 item 1). Sensible defaults; allow
+  // operators to tune via settings.mcp.rateLimit. `maxRequestsPerWindow: 0`
+  // (or any non-positive integer) disables the cap entirely.
+  const DEFAULT_RATE_MAX = 600;
+  const DEFAULT_RATE_WINDOW_MS = 60_000;
+  const rawRateMax = raw?.rateLimit?.maxRequestsPerWindow;
+  const rawRateWin = raw?.rateLimit?.windowMs;
+  let rateMaxRequestsPerWindow = DEFAULT_RATE_MAX;
+  if (typeof rawRateMax === "number" && Number.isFinite(rawRateMax)) {
+    rateMaxRequestsPerWindow = Math.max(0, Math.floor(rawRateMax));
+  }
+  let rateWindowMs = DEFAULT_RATE_WINDOW_MS;
+  if (typeof rawRateWin === "number" && Number.isFinite(rawRateWin) && rawRateWin > 0) {
+    // Floor at 100ms so accidentally tiny windows can't pin the CPU.
+    rateWindowMs = Math.max(100, Math.floor(rawRateWin));
+  }
+
   return {
     shared: filteredShared,
     perPtyOnly,
@@ -839,6 +873,10 @@ function parseMcpConfig(raw: any, webEnabled: unknown): McpConfig {
     sessionPersistenceEnabled,
     sessionMaxAgeSeconds,
     sessionPersistencePath,
+    rateLimit: {
+      maxRequestsPerWindow: rateMaxRequestsPerWindow,
+      windowMs: rateWindowMs,
+    },
   };
 }
 

--- a/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
@@ -383,6 +383,47 @@ describe("McpHttpHandler — per-bearer rate limit (#72 item 1)", () => {
     expect(regAllowed.status).not.toBe(429);
   });
 
+  // Codex PR #91 P2: when an identity is released and re-issued for the
+  // same ptyId (the normal releaseIdentity → issueIdentity rotation on
+  // PTY respawn / operator-initiated revoke), the rate-limit window must
+  // NOT leak across the rotation — the fresh bearer is a fresh session
+  // and should start with an empty bucket.
+  it("releasePty clears the rate-limit window so a re-issued identity isn't pre-throttled", async () => {
+    let t = 1_000_000;
+    handler = new McpHttpHandler({
+      serverName: "test",
+      proc: proc!,
+      rateLimit: { maxRequestsPerWindow: 2, windowMs: 10_000 },
+      _now: () => t,
+    });
+    const send = (bearer: string) =>
+      handler!.handle(
+        rpcRequest(
+          { jsonrpc: "2.0", id: 1, method: "tools/list" },
+          { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: bearer },
+        ),
+      );
+
+    // Exhaust the window under the first identity.
+    const id1 = issueIdentity("suzy");
+    await send(id1.headers[AUTH_HEADER]);
+    await send(id1.headers[AUTH_HEADER]);
+    const blocked1 = await send(id1.headers[AUTH_HEADER]);
+    expect(blocked1.status).toBe(429);
+
+    // Release the identity (mirrors plugin.releaseIdentity → handler.releasePty).
+    await handler.releasePty("suzy");
+    revokeIdentity("suzy");
+
+    // Issue a fresh identity for the same ptyId — same window has not
+    // elapsed yet (clock unchanged). Pre-fix the new bearer would still
+    // see the old 3 timestamps and get 429 immediately. Post-fix the
+    // bucket is empty and the first request is allowed.
+    const id2 = issueIdentity("suzy");
+    const fresh = await send(id2.headers[AUTH_HEADER]);
+    expect(fresh.status).not.toBe(429);
+  });
+
   it("rate-limit check runs AFTER bearer verification (bad bearer → 401, not 429)", async () => {
     let t = 1_000_000;
     handler = new McpHttpHandler({

--- a/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
@@ -222,3 +222,183 @@ describe("McpHttpHandler — closed state", () => {
     revokeIdentity("suzy");
   });
 });
+
+// ─── Per-bearer rate limit (#72 item 1) ──────────────────────────────────────
+//
+// The /mcp/<server> route is bearer-only — no HMAC + replay window like the
+// /api/plugin/* routes. A leaked bearer could permit unlimited replay against
+// the shared upstream until the issuing PTY respawns. Defense-in-depth: cap
+// requests per (server, ptyId) per sliding window.
+
+describe("McpHttpHandler — per-bearer rate limit (#72 item 1)", () => {
+  let proc: McpServerProcess | null = null;
+  let handler: McpHttpHandler | null = null;
+
+  beforeEach(async () => {
+    _resetIdentityStore();
+    proc = new McpServerProcess("test", makeServerConfig());
+    await proc.start();
+  });
+
+  afterEach(async () => {
+    if (handler) await handler.stop();
+    if (proc) await proc.stop();
+    proc = null;
+    handler = null;
+    _resetIdentityStore();
+  });
+
+  it("disabled by default (no rateLimit opt → no cap)", async () => {
+    handler = new McpHttpHandler({ serverName: "test", proc: proc! });
+    // 50 calls in a tight loop — none should be rate-limited.
+    issueIdentity("suzy");
+    const id = issueIdentity("suzy");
+    for (let i = 0; i < 50; i++) {
+      const resp = await handler.handle(
+        rpcRequest(
+          { jsonrpc: "2.0", id: i, method: "tools/list" },
+          { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: id.headers[AUTH_HEADER] },
+        ),
+      );
+      // Pass through to upstream (not 429); status could be 200 or 4xx from
+      // the transport, but MUST NOT be 429.
+      expect(resp.status).not.toBe(429);
+    }
+  });
+
+  it("returns 429 + Retry-After once the per-window cap is exceeded", async () => {
+    // Inject a fixed clock so the window timing is deterministic.
+    let t = 1_000_000;
+    handler = new McpHttpHandler({
+      serverName: "test",
+      proc: proc!,
+      rateLimit: { maxRequestsPerWindow: 3, windowMs: 10_000 },
+      _now: () => t,
+    });
+    const id = issueIdentity("suzy");
+    const send = () =>
+      handler!.handle(
+        rpcRequest(
+          { jsonrpc: "2.0", id: 1, method: "tools/list" },
+          { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: id.headers[AUTH_HEADER] },
+        ),
+      );
+
+    // First 3 requests within the window: allowed (not 429).
+    for (let i = 0; i < 3; i++) {
+      const resp = await send();
+      expect(resp.status).not.toBe(429);
+    }
+    // 4th request: rejected with 429 + Retry-After header.
+    const blocked = await send();
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("retry-after")).toBeTruthy();
+    const body = (await blocked.json()) as {
+      error: string;
+      retry_after_seconds: number;
+    };
+    expect(body.error).toBe("rate_limited");
+    expect(body.retry_after_seconds).toBeGreaterThanOrEqual(1);
+    expect(body.retry_after_seconds).toBeLessThanOrEqual(10);
+  });
+
+  it("does not consume upstream when rate-limited", async () => {
+    let t = 1_000_000;
+    handler = new McpHttpHandler({
+      serverName: "test",
+      proc: proc!,
+      rateLimit: { maxRequestsPerWindow: 1, windowMs: 10_000 },
+      _now: () => t,
+    });
+    const id = issueIdentity("suzy");
+    const send = () =>
+      handler!.handle(
+        rpcRequest(
+          { jsonrpc: "2.0", id: 1, method: "tools/list" },
+          { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: id.headers[AUTH_HEADER] },
+        ),
+      );
+    await send();
+    const before = proc!.lastInvocationAt;
+    const blocked = await send();
+    expect(blocked.status).toBe(429);
+    // Upstream MUST NOT have been hit by the rejected request.
+    expect(proc!.lastInvocationAt).toBe(before);
+  });
+
+  it("window slides — old requests age out and new ones are allowed", async () => {
+    let t = 1_000_000;
+    handler = new McpHttpHandler({
+      serverName: "test",
+      proc: proc!,
+      rateLimit: { maxRequestsPerWindow: 2, windowMs: 1_000 },
+      _now: () => t,
+    });
+    const id = issueIdentity("suzy");
+    const send = () =>
+      handler!.handle(
+        rpcRequest(
+          { jsonrpc: "2.0", id: 1, method: "tools/list" },
+          { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: id.headers[AUTH_HEADER] },
+        ),
+      );
+
+    await send(); // t=1_000_000
+    await send(); // t=1_000_000
+    const blocked = await send(); // exceeds cap
+    expect(blocked.status).toBe(429);
+
+    // Advance past the window.
+    t += 1_500;
+    const allowed = await send();
+    expect(allowed.status).not.toBe(429);
+  });
+
+  it("rate limit is per-ptyId (a leaked bearer for `suzy` doesn't starve `reg`)", async () => {
+    let t = 1_000_000;
+    handler = new McpHttpHandler({
+      serverName: "test",
+      proc: proc!,
+      rateLimit: { maxRequestsPerWindow: 2, windowMs: 10_000 },
+      _now: () => t,
+    });
+    const idSuzy = issueIdentity("suzy");
+    const idReg = issueIdentity("reg");
+    const sendAs = (pty: string, bearer: string) =>
+      handler!.handle(
+        rpcRequest(
+          { jsonrpc: "2.0", id: 1, method: "tools/list" },
+          { [PTY_ID_HEADER]: pty, [AUTH_HEADER]: bearer },
+        ),
+      );
+
+    // Exhaust suzy's window.
+    await sendAs("suzy", idSuzy.headers[AUTH_HEADER]);
+    await sendAs("suzy", idSuzy.headers[AUTH_HEADER]);
+    const suzyBlocked = await sendAs("suzy", idSuzy.headers[AUTH_HEADER]);
+    expect(suzyBlocked.status).toBe(429);
+
+    // reg's window is independent — should still pass.
+    const regAllowed = await sendAs("reg", idReg.headers[AUTH_HEADER]);
+    expect(regAllowed.status).not.toBe(429);
+  });
+
+  it("rate-limit check runs AFTER bearer verification (bad bearer → 401, not 429)", async () => {
+    let t = 1_000_000;
+    handler = new McpHttpHandler({
+      serverName: "test",
+      proc: proc!,
+      rateLimit: { maxRequestsPerWindow: 1, windowMs: 10_000 },
+      _now: () => t,
+    });
+    issueIdentity("suzy");
+    // Bad bearer — should be 401 even though we're below the rate limit.
+    const resp = await handler.handle(
+      rpcRequest(
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: `Bearer ${"00".repeat(32)}` },
+      ),
+    );
+    expect(resp.status).toBe(401);
+  });
+});

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -354,6 +354,15 @@ export class McpHttpHandler {
    *  not be replayed on next daemon start — the next time this ptyId
    *  appears the supervisor will mint fresh identity + sessionId. */
   async releasePty(ptyId: string): Promise<void> {
+    // Codex PR #91 P2: clear the per-PTY rate-limit window FIRST. When a
+    // PTY is reaped and a new identity is issued for the same ptyId
+    // (the normal `releaseIdentity` → `issueIdentity` rotation in
+    // index.ts), the fresh bearer would otherwise inherit the prior
+    // session's timestamps and immediately hit 429s based on traffic
+    // it didn't originate. Cleared unconditionally — stateless handlers
+    // still keyed the window by ptyId (we use `STATELESS_BUCKET` for
+    // the SDK session, but `_checkRateLimit` keys on the actual ptyId).
+    this._rlWindows.delete(ptyId);
     if (this.stateless) return; // no per-PTY bucket exists
     // Drop the persisted record FIRST so that even if the bucket's
     // already gone (race with transport_error path) the disk state is

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -58,6 +58,14 @@ export interface McpHttpHandlerOpts {
    *  (no per-PTY identity to bind to). When undefined, the handler is
    *  byte-identical to PR #71. */
   persistence?: SessionPersistenceStore;
+  /** Optional per-bearer rate limit config (#72 item 1). When omitted or
+   *  `maxRequestsPerWindow <= 0`, no limit is enforced. */
+  rateLimit?: {
+    maxRequestsPerWindow: number;
+    windowMs: number;
+  };
+  /** Injectable clock for tests. Default: `Date.now`. */
+  _now?: () => number;
 }
 
 /** Maximum request body size accepted by the multiplexer. Matches the
@@ -135,6 +143,21 @@ export class McpHttpHandler {
   private readonly buckets = new Map<string, ServerBucket>();
   private readonly persistence: SessionPersistenceStore | undefined;
   private closed = false;
+  /**
+   * Per-bearer (= per-`ptyId`) sliding-window request timestamps. Each
+   * entry is the list of request-receipt epoch-ms values within the
+   * current `windowMs`. `_checkRateLimit` evicts entries older than
+   * `now - windowMs` and rejects when the remaining count would exceed
+   * `maxRequestsPerWindow`. #72 item 1.
+   *
+   * Memory is bounded by `maxRequestsPerWindow * ptyCount` numbers. At
+   * default 600/PTY and 32 PTYs (settings.pty.maxConcurrent default),
+   * that's ~150KB worst case. Acceptable.
+   */
+  private readonly _rlWindows = new Map<string, number[]>();
+  private readonly _rlMax: number;
+  private readonly _rlWindowMs: number;
+  private readonly _now: () => number;
 
   constructor(opts: McpHttpHandlerOpts) {
     this.serverName = opts.serverName;
@@ -144,6 +167,41 @@ export class McpHttpHandler {
     // stateless bucket has no per-PTY identity to bind to. Even if the
     // operator wires a store, we skip it for stateless servers.
     this.persistence = this.stateless ? undefined : opts.persistence;
+    this._rlMax = opts.rateLimit?.maxRequestsPerWindow ?? 0;
+    this._rlWindowMs = opts.rateLimit?.windowMs ?? 60_000;
+    this._now = opts._now ?? (() => Date.now());
+  }
+
+  /**
+   * Sliding-window check for `/mcp/<server>` requests under a given
+   * bearer (`ptyId`). Returns `null` when the request is allowed and
+   * records its timestamp; returns a `Retry-After` value (in seconds,
+   * rounded up, minimum 1) when the request must be rejected.
+   *
+   * When `_rlMax <= 0` the limit is disabled and every request is
+   * allowed without touching the window state. #72 item 1.
+   */
+  _checkRateLimit(ptyId: string): { rejected: false } | { rejected: true; retryAfterSec: number } {
+    if (this._rlMax <= 0) return { rejected: false };
+    const now = this._now();
+    const cutoff = now - this._rlWindowMs;
+    let win = this._rlWindows.get(ptyId);
+    if (!win) {
+      win = [];
+      this._rlWindows.set(ptyId, win);
+    }
+    // Evict timestamps outside the window. Cheap on a sorted list.
+    while (win.length > 0 && win[0]! < cutoff) win.shift();
+    if (win.length >= this._rlMax) {
+      // Retry-After = milliseconds until the oldest in-window request
+      // ages out, rounded up to seconds and floored at 1.
+      const oldest = win[0]!;
+      const waitMs = oldest + this._rlWindowMs - now;
+      const retryAfterSec = Math.max(1, Math.ceil(waitMs / 1000));
+      return { rejected: true, retryAfterSec };
+    }
+    win.push(now);
+    return { rejected: false };
   }
 
   /**
@@ -182,6 +240,36 @@ export class McpHttpHandler {
         });
       } catch {}
       return _errResponse(401, "invalid_bearer", "HMAC verification failed");
+    }
+
+    // ── Per-bearer rate limit (#72 item 1) ────────────────────────────
+    // Defense-in-depth: a leaked bearer is bounded by the rate limit
+    // even before the issuing PTY respawns and rotates the secret.
+    const rl = this._checkRateLimit(ptyId);
+    if (rl.rejected) {
+      try {
+        getMcpBridge().audit("multiplexer_rate_limited", {
+          server: this.serverName,
+          pty_id: ptyId,
+          max_per_window: this._rlMax,
+          window_ms: this._rlWindowMs,
+          retry_after_sec: rl.retryAfterSec,
+        });
+      } catch {}
+      return new Response(
+        JSON.stringify({
+          error: "rate_limited",
+          message: `request limit exceeded for pty ${ptyId} on /mcp/${this.serverName}`,
+          retry_after_seconds: rl.retryAfterSec,
+        }),
+        {
+          status: 429,
+          headers: {
+            "content-type": "application/json",
+            "retry-after": String(rl.retryAfterSec),
+          },
+        },
+      );
     }
 
     // ── Upstream readiness ────────────────────────────────────────────

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -342,6 +342,7 @@ export class McpMultiplexerPlugin {
             persistence: settings.stateless.includes(name)
               ? undefined
               : (this.persistence ?? undefined),
+            rateLimit: settings.rateLimit,
           });
           this.handlers.set(name, handler);
 


### PR DESCRIPTION
Closes #72 item 1.

## Motivation

`/api/plugin/*` has HMAC + 15-minute replay window. `/mcp/<server>` is bearer-only with no rate limit — a leaked bearer (core dump, log scrape, anything) permits full replay against the shared upstream MCP until the issuing PTY respawns and rotates the secret. The idle-reap + loopback-only + 0600-mode envelope holds for the broader threat model, but per-bearer rate limiting is the natural next defense layer (called out in the Security Audit deferred from #71 / tracked in #72).

## Design

New `settings.mcp.rateLimit.{maxRequestsPerWindow, windowMs}` config:
- Default **600 req / 60s** per ptyId (10/sec sustained — generous for tool-call traffic, tight enough to be useful).
- `maxRequestsPerWindow: 0` disables.
- `windowMs` floored at 100ms (sanity).

`McpHttpHandler` keeps a `Map<ptyId, number[]>` of request timestamps within the current window. On each request: evict entries older than `now - windowMs`, reject if remaining count would exceed the cap. Memory bound: `maxRequestsPerWindow × ptyCount` numbers (~150KB worst case at default 600/PTY × 32 PTYs).

Rejected requests:
- **HTTP 429** with `Retry-After: <seconds>` header (HTTP-standard — MCP clients can honour).
- JSON body `{ error: "rate_limited", retry_after_seconds, message }`.
- `multiplexer_rate_limited` audit event with `pty_id`, `max_per_window`, `window_ms`, `retry_after_sec`. **No bearer leaked.**

Layering:
- Body cap (Phase D #2) — first, before auth.
- Bearer verify (HMAC) — second.
- **Rate limit (this PR)** — third, AFTER auth so bad bearers still get 401 (no rate budget consumed) and BEFORE upstream dispatch so a rejected request never touches the shared MCP child.
- Upstream readiness check.

## Tests

Six new tests in `http-handler.test.ts` using an injectable `_now` for deterministic windowing:

- `disabled by default (no rateLimit opt → no cap)` — 50 calls succeed.
- `returns 429 + Retry-After once the per-window cap is exceeded` — pre-fix FAILS (request reaches transport), post-fix PASSES with 429.
- `does not consume upstream when rate-limited` — `proc.lastInvocationAt` unchanged on the rejected request.
- `window slides — old requests age out and new ones are allowed`.
- `rate limit is per-ptyId (a leaked bearer for suzy doesn't starve reg)`.
- `rate-limit check runs AFTER bearer verification (bad bearer → 401, not 429)`.

Verified pre-fix regression catches the bug.

Full multiplexer + proxy suites: **100 pass, 0 fail**.
Full-repo `bun run lint`: **zero errors**.

## Production note

Multiplexer is dormant on Hetzner today (`settings.mcp.shared: []`), so this code path is unreachable in production until task #26 (multiplexer activation with a real MCP set) lands. The unit-test coverage is the verification for this PR; live exercise comes with #26.

## Test plan
- [x] Unit tests green
- [x] Lint green
- [x] Verified regression catches pre-fix behavior
- [ ] Live smoke-test deferred to #72 / task #26 activation