### PR TITLE
fix(mcp-proxy): allowedTools re-check inside McpServerProcess.call (#72 item 3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.22",
+      "version": "2.2.23",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.22",
+  "version": "2.2.23",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/mcp_proxy_basic.test.ts
+++ b/src/__tests__/mcp_proxy_basic.test.ts
@@ -183,6 +183,90 @@ describe("McpServerProcess", () => {
   });
 });
 
+// #72 item 3: defense-in-depth allowlist check inside `McpServerProcess.call`.
+// The multiplexer layer already gates against `config.allowedTools`, but the
+// proxy must be hermetic without trusting upstream callers. A future caller
+// that reaches `proc.call(...)` bypassing the multiplexer gate must NOT be
+// able to invoke a disallowed tool.
+describe("McpServerProcess — allowedTools enforcement at call() (#72 item 3)", () => {
+  it("rejects a tool that's not in allowedTools without touching upstream", async () => {
+    const proc = new McpServerProcess("test", makeServerConfig());
+    try {
+      await proc.start();
+      // `secret_tool` is advertised by the upstream mock but excluded by
+      // `allowedTools: ["echo", "slow_tool"]`.
+      expect(proc.tools.map((t) => t.name)).not.toContain("secret_tool");
+      const before = proc.lastInvocationAt;
+      let err: Error | null = null;
+      try {
+        await proc.call("secret_tool", {});
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err).not.toBeNull();
+      expect(err!.message).toContain("secret_tool");
+      expect(err!.message).toContain("not in allowedTools");
+      // The proxy never reached the upstream child for the rejected call.
+      expect(proc.lastInvocationAt).toBe(before);
+    } finally {
+      await proc.stop();
+    }
+  });
+
+  it("rejects a tool name that the upstream never advertised", async () => {
+    const proc = new McpServerProcess("test", makeServerConfig());
+    try {
+      await proc.start();
+      const before = proc.lastInvocationAt;
+      let err: Error | null = null;
+      try {
+        await proc.call("totally_made_up_tool", {});
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err).not.toBeNull();
+      expect(err!.message).toContain("totally_made_up_tool");
+      expect(proc.lastInvocationAt).toBe(before);
+    } finally {
+      await proc.stop();
+    }
+  });
+
+  it("allows tools that ARE in the configured allowlist (no regression)", async () => {
+    const proc = new McpServerProcess("test", makeServerConfig());
+    try {
+      await proc.start();
+      const result = (await proc.call("echo", { message: "ok" })) as { echo: string };
+      expect(result.echo).toBe("ok");
+    } finally {
+      await proc.stop();
+    }
+  });
+
+  it("when allowedTools is undefined, the set is populated from upstream advertisement (still catches typos)", async () => {
+    // No allowedTools → upstream's full tool list is the allowlist.
+    const proc = new McpServerProcess("test", {
+      command: BUN_BIN,
+      args: ["run", MOCK_SERVER],
+    });
+    try {
+      await proc.start();
+      const advertised = proc.tools.map((t) => t.name);
+      expect(advertised.length).toBeGreaterThan(0);
+      // A name not in the advertisement must still be rejected.
+      let err: Error | null = null;
+      try {
+        await proc.call("definitely_not_an_advertised_tool", {});
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err).not.toBeNull();
+    } finally {
+      await proc.stop();
+    }
+  });
+});
+
 describe("McpServerProcess — startup failure cleanup (zombie prevention)", () => {
   it("closes transport when listTools throws during start()", async () => {
     // Spawn a server that exits immediately so client.connect/listTools will fail

--- a/src/plugins/mcp-proxy/server-process.ts
+++ b/src/plugins/mcp-proxy/server-process.ts
@@ -43,6 +43,22 @@ export class McpServerProcess {
   private restartTimer: ReturnType<typeof setTimeout> | null = null;
   // Generation counter: stale onclose/onerror handlers from old transports are discarded
   private generation = 0;
+  /**
+   * Defense-in-depth allowlist used by `call()` to gate tool dispatch
+   * (#72 item 3). The multiplexer layer already enforces this against
+   * the per-server `allowedTools` config, but `proc.call(...)` is
+   * exported and could be reached by future in-process callers that
+   * skip the multiplexer-level gate. The proxy must be hermetic without
+   * trusting upstream behaviour OR upstream callers.
+   *
+   * Populated at the end of `start()` from `this.tools` (which itself
+   * is already filtered against `config.allowedTools`). When
+   * `config.allowedTools` is undefined the set contains every tool the
+   * upstream advertised — `call()` still rejects bare typos and unknown
+   * names but doesn't restrict beyond what the operator allowed at
+   * startup.
+   */
+  private _allowedToolNames = new Set<string>();
 
   constructor(
     name: string,
@@ -128,6 +144,11 @@ export class McpServerProcess {
         description: t.description ?? "",
         inputSchema: (t.inputSchema as Record<string, unknown>) ?? {},
       }));
+    // #72 item 3: rebuild the per-call allowlist from the just-filtered
+    // tools. Restart paths re-enter `start()` so the set always reflects
+    // the upstream's CURRENT tool list intersected with the operator's
+    // configured allowlist.
+    this._allowedToolNames = new Set(this.tools.map((t) => t.name));
 
     this.status = "up";
     this.startedAt = new Date();
@@ -136,6 +157,18 @@ export class McpServerProcess {
   async call(tool: string, args: unknown, timeoutMs = DEFAULT_CALL_TIMEOUT_MS): Promise<unknown> {
     if (!this.client || this.status !== "up") {
       throw new Error(`Server ${this.name} is not ready (status: ${this.status})`);
+    }
+    // #72 item 3: defense-in-depth allowlist check. The multiplexer
+    // layer already gates against `config.allowedTools` before reaching
+    // here, but the proxy must be hermetic without trusting upstream
+    // callers. Reject before invocation so a future caller bypassing
+    // the multiplexer gate can't reach a disallowed tool — and the
+    // upstream child never sees the request.
+    if (!this._allowedToolNames.has(tool)) {
+      throw new Error(
+        `Tool '${tool}' is not in allowedTools for server '${this.name}' ` +
+          `(allowlist size=${this._allowedToolNames.size})`,
+      );
     }
     this.lastInvocationAt = new Date();
 


### PR DESCRIPTION
Closes #72 item 3.

## Motivation

The multiplexer layer already gates against `config.allowedTools` before reaching `proc.call(...)` (added in #71). But the proxy substrate must be hermetic without trusting upstream callers OR upstream behaviour. A future in-process caller that reaches `proc.call(...)` bypassing the multiplexer gate could otherwise invoke a disallowed tool, and the proxy would silently relay the request to the upstream MCP child.

Defense-in-depth: enforce the allowlist a second time, right at the boundary.

## Design

`McpServerProcess` now maintains `_allowedToolNames: Set<string>` populated at the end of `start()` from `this.tools` (already filtered against `config.allowedTools` upstream). `call()` checks the requested tool name against the set BEFORE invoking the upstream client.

- Restart paths re-enter `start()` so the set always reflects the upstream's CURRENT tool list intersected with the operator's configured allowlist.
- When `config.allowedTools` is undefined the set contains every tool the upstream advertised — `call()` still catches typos and unknown names but doesn't restrict beyond what the operator allowed at startup.
- Rejected calls throw a clear error (`Tool 'X' is not in allowedTools for server 'Y' (allowlist size=N)`) — no upstream invocation, no `lastInvocationAt` touched.

## Tests

Four new tests in `mcp_proxy_basic.test.ts`:

- `rejects a tool that's not in allowedTools without touching upstream` — pre-fix FAILS (upstream IS called and returns `Unknown tool: secret_tool`; the assertion that `lastInvocationAt` is unchanged catches the bug).
- `rejects a tool name that the upstream never advertised` — pre-fix FAILS (upstream is called; `lastInvocationAt` is set).
- `allows tools that ARE in the configured allowlist (no regression)`.
- `when allowedTools is undefined, the set is populated from upstream advertisement (still catches typos)`.

Verified regression catches the bug.

Full `mcp_proxy_basic.test.ts`: 12 pass, 0 fail.
Full mcp + multiplexer suites: 107 pass, 0 fail.
Full-repo `bun run lint`: zero errors.

## Production note

Multiplexer is dormant on Hetzner today (`settings.mcp.shared: []`), so this code path is exercised only by unit tests until task #26 activates real MCP servers behind the multiplexer. Defense-in-depth lands now so #26 ships against a hardened substrate.

## Test plan
- [x] Unit tests green
- [x] Lint green
- [x] Verified regression catches pre-fix behavior