### PR TITLE
fix(mcp): split crash + permanently-failed audit events (#72 item 4)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.23",
+      "version": "2.2.24",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.23",
+  "version": "2.2.24",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/mcp_proxy_basic.test.ts
+++ b/src/__tests__/mcp_proxy_basic.test.ts
@@ -5,7 +5,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { McpServerProcess } from "../plugins/mcp-proxy/server-process.js";
 import { McpProxyPlugin, _resetMcpProxy } from "../plugins/mcp-proxy/index.js";
-import { PluginMcpBridge, _resetMcpBridge } from "../plugins/mcp-bridge.js";
+import { PluginMcpBridge, _resetMcpBridge, _setMcpBridge } from "../plugins/mcp-bridge.js";
 import { _resetHttpGateway } from "../plugins/http-gateway.js";
 
 const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
@@ -263,6 +263,143 @@ describe("McpServerProcess — allowedTools enforcement at call() (#72 item 3)",
       expect(err).not.toBeNull();
     } finally {
       await proc.stop();
+    }
+  });
+});
+
+// #72 item 4: split crash + permanently-failed audit events so operators
+// don't have to inspect the `status` field of a single conflated event to
+// tell a transient (auto-recovering) crash apart from a terminal failure.
+describe("McpProxyPlugin — crash vs permanently-failed audit event split (#72 item 4)", () => {
+  // Capture every audit event the plugin emits during the test.
+  function captureAudits(events: Array<{ name: string; payload: unknown }>) {
+    _setMcpBridge({
+      // Minimal fake: only `audit` is exercised by `_onServerCrash`. Other
+      // bridge methods aren't called during this test path.
+      audit: (name: string, payload: unknown) => {
+        events.push({ name, payload });
+      },
+      // No-op the rest of the surface so TypeScript is happy and any
+      // accidental call doesn't break the test.
+      registerPluginTool: () => {},
+      unregisterPluginTool: () => {},
+      listTools: () => [],
+      invoke: async () => {
+        throw new Error("not implemented in test bridge");
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal test bridge
+    } as any);
+  }
+
+  type PluginPrivate = {
+    servers: Map<string, McpServerProcess>;
+    _onServerCrash(name: string, reason: string): void;
+  };
+
+  it("emits ONLY mcp_proxy_server_crashed when status is transient (e.g. 'restarting')", async () => {
+    const tokenPath = join(tmpDir, "split-test-1.token");
+    const configPath = join(tmpDir, "split-test-1.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        servers: { "test-server": { ...makeServerConfig(), enabled: true } },
+      }),
+      { mode: 0o600 },
+    );
+    const plugin = new McpProxyPlugin({ configPath, tokenPath });
+    await plugin.start();
+    try {
+      const events: Array<{ name: string; payload: unknown }> = [];
+      captureAudits(events);
+
+      const priv = plugin as unknown as PluginPrivate;
+      const proc = priv.servers.get("test-server");
+      expect(proc).toBeDefined();
+      // Simulate the auto-recovery loop still running.
+      (proc as unknown as { status: string }).status = "restarting";
+      priv._onServerCrash("test-server", "subprocess closed");
+
+      const names = events.map((e) => e.name);
+      expect(names).toContain("mcp_proxy_server_crashed");
+      expect(names).not.toContain("mcp_proxy_server_permanently_failed");
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("emits ONLY mcp_proxy_server_permanently_failed when status is 'failed'", async () => {
+    const tokenPath = join(tmpDir, "split-test-2.token");
+    const configPath = join(tmpDir, "split-test-2.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        servers: { "test-server": { ...makeServerConfig(), enabled: true } },
+      }),
+      { mode: 0o600 },
+    );
+    const plugin = new McpProxyPlugin({ configPath, tokenPath });
+    await plugin.start();
+    try {
+      const events: Array<{ name: string; payload: unknown }> = [];
+      captureAudits(events);
+
+      const priv = plugin as unknown as PluginPrivate;
+      const proc = priv.servers.get("test-server");
+      expect(proc).toBeDefined();
+      // Simulate the supervisor giving up.
+      (proc as unknown as { status: string }).status = "failed";
+      priv._onServerCrash("test-server", "exceeded max crashes in window");
+
+      const names = events.map((e) => e.name);
+      expect(names).toContain("mcp_proxy_server_permanently_failed");
+      // Pre-fix this test would fail: the old code emitted BOTH events
+      // for a permanent failure (the `mcp_proxy_server_crashed` event
+      // was always emitted, then `mcp_proxy_server_permanently_failed`
+      // was emitted in addition when status === "failed"). Operators
+      // had to dedup.
+      expect(names).not.toContain("mcp_proxy_server_crashed");
+    } finally {
+      await plugin.stop();
+    }
+  });
+
+  it("payload preserves {server, reason, status} on both event variants", async () => {
+    const tokenPath = join(tmpDir, "split-test-3.token");
+    const configPath = join(tmpDir, "split-test-3.json");
+    writeFileSync(
+      configPath,
+      JSON.stringify({
+        servers: { "test-server": { ...makeServerConfig(), enabled: true } },
+      }),
+      { mode: 0o600 },
+    );
+    const plugin = new McpProxyPlugin({ configPath, tokenPath });
+    await plugin.start();
+    try {
+      const events: Array<{ name: string; payload: unknown }> = [];
+      captureAudits(events);
+
+      const priv = plugin as unknown as PluginPrivate;
+      const proc = priv.servers.get("test-server");
+      expect(proc).toBeDefined();
+      (proc as unknown as { status: string }).status = "crashed";
+      priv._onServerCrash("test-server", "first crash");
+      (proc as unknown as { status: string }).status = "failed";
+      priv._onServerCrash("test-server", "final crash");
+
+      expect(events.length).toBe(2);
+      expect(events[0]!.payload).toEqual({
+        server: "test-server",
+        reason: "first crash",
+        status: "crashed",
+      });
+      expect(events[1]!.payload).toEqual({
+        server: "test-server",
+        reason: "final crash",
+        status: "failed",
+      });
+    } finally {
+      await plugin.stop();
     }
   });
 });

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -719,16 +719,32 @@ export class McpMultiplexerPlugin {
 
   private _onServerCrash(name: string, reason: string): void {
     const proc = this.servers.get(name);
+    const status = proc?.status ?? "unknown";
+    // #72 item 4: distinct events for transient crashes vs terminal
+    // failures so operators don't have to inspect the `status` field to
+    // differentiate. Mutually exclusive per incident:
+    //   - `status === "failed"` → `multiplexer_server_permanently_failed`
+    //   - otherwise              → `multiplexer_server_crashed` (auto-recovery
+    //                              loop is still running)
+    if (status === "failed") {
+      console.error(`[mcp-multiplexer] server '${name}' permanently failed: ${reason}`);
+      try {
+        getMcpBridge().audit("multiplexer_server_permanently_failed", {
+          server: name,
+          reason,
+          status,
+        });
+      } catch {}
+      return;
+    }
+    console.error(`[mcp-multiplexer] server '${name}' crashed: ${reason} — status: ${status}`);
     try {
       getMcpBridge().audit("multiplexer_server_crashed", {
         server: name,
         reason,
-        status: proc?.status ?? "unknown",
+        status,
       });
     } catch {}
-    console.error(
-      `[mcp-multiplexer] server '${name}' crashed: ${reason} — status: ${proc?.status ?? "unknown"}`,
-    );
   }
 
   private _registerBridgeCallbacks(serverName: string, proc: McpServerProcess): void {

--- a/src/plugins/mcp-proxy/index.ts
+++ b/src/plugins/mcp-proxy/index.ts
@@ -217,13 +217,34 @@ export class McpProxyPlugin {
     const proc = this.servers.get(name);
     if (!proc) return;
 
-    getMcpBridge().audit("mcp_proxy_server_crashed", { server: name, reason, status: proc.status });
-    console.error(`[mcp-proxy] Server '${name}' crashed: ${reason} — status: ${proc.status}`);
-
+    // #72 item 4: emit distinct events for transient crashes vs terminal
+    // failures so operators don't have to inspect the `status` field to
+    // differentiate. The two are MUTUALLY EXCLUSIVE per incident:
+    //   - `status === "failed"` → only `mcp_proxy_server_permanently_failed`
+    //   - otherwise              → only `mcp_proxy_server_crashed` (auto-recovery
+    //                              loop is still running)
+    // Both payloads keep the legacy `{server, reason, status}` shape so
+    // downstream dashboards / alert rules can keep filtering on
+    // either name without a payload-shape migration.
     if (proc.status === "failed") {
-      console.error(`[mcp-proxy] Server '${name}' permanently failed after too many crashes`);
-      getMcpBridge().audit("mcp_proxy_server_permanently_failed", { server: name });
+      console.error(`[mcp-proxy] Server '${name}' permanently failed: ${reason}`);
+      try {
+        getMcpBridge().audit("mcp_proxy_server_permanently_failed", {
+          server: name,
+          reason,
+          status: proc.status,
+        });
+      } catch {}
+      return;
     }
+    console.error(`[mcp-proxy] Server '${name}' crashed: ${reason} — status: ${proc.status}`);
+    try {
+      getMcpBridge().audit("mcp_proxy_server_crashed", {
+        server: name,
+        reason,
+        status: proc.status,
+      });
+    } catch {}
   }
 
   private async _invokeReasoned(fqn: string, args: unknown): Promise<unknown> {


### PR DESCRIPTION
Closes #72 item 4.

## Pre-fix behaviour

Both layers conflated transient crashes and terminal failures into a single `*_server_crashed` event. Operators had to inspect the `status` field of every event to tell auto-recovering crashes apart from terminal failures.

- **mcp-proxy** emitted `mcp_proxy_server_crashed` for **every** crash, then **also** emitted `mcp_proxy_server_permanently_failed` for terminal failures. Permanent failures fired BOTH events — alert rules grepping the JSONL had to dedup.
- **mcp-multiplexer** emitted only `multiplexer_server_crashed` with no per-status differentiation at all — same event name whether the auto-recovery loop was still running or had given up.

## Fix

Make the two variants MUTUALLY EXCLUSIVE per incident, in both layers:

| `proc.status`         | Event emitted                          |
|-----------------------|----------------------------------------|
| `"failed"`            | ONLY `*_server_permanently_failed`     |
| anything else         | ONLY `*_server_crashed`                |

Payloads keep the legacy `{server, reason, status}` shape so downstream dashboards / alert rules can keep filtering on either event name without a payload-shape migration. The `mcp_proxy_server_permanently_failed` payload gains `reason` and `status` (it previously only had `{server}` — easy win for forensics).

## Tests

Three new tests in `mcp_proxy_basic.test.ts` using a minimal in-process fake bridge that captures every `audit(name, payload)` call:

- `emits ONLY mcp_proxy_server_crashed when status is transient (e.g. 'restarting')` — exercises the recoverable branch.
- `emits ONLY mcp_proxy_server_permanently_failed when status is 'failed'` — pre-fix FAILS (legacy code emitted BOTH events for a permanent failure).
- `payload preserves {server, reason, status} on both event variants` — pre-fix FAILS (3 events fire instead of 2 for a crash+fail sequence).

Verified regression catches the pre-fix behaviour.

Full mcp + multiplexer suites: **122 pass, 0 fail**.
Full-repo `bun run lint`: **zero errors**.

## Test plan
- [x] Unit tests green
- [x] Lint green
- [x] Verified regression catches pre-fix behaviour