### PR TITLE
fix(mcp-multiplexer): dedup crash audit between _onServerCrash and _sampleHealth (#72 item 6)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.24",
+      "version": "2.2.25",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.24",
+  "version": "2.2.25",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/plugins/mcp-multiplexer/__tests__/index.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/index.test.ts
@@ -418,6 +418,120 @@ describe("McpMultiplexerPlugin — active path", () => {
       await plugin.stop();
     });
 
+    // #72 item 6: when `_onServerCrash` fires `multiplexer_server_crashed`
+    // immediately for an incident, the next `_sampleHealth` tick must
+    // NOT re-audit the same incident with `mcp_health_degraded`. Pre-fix
+    // both events fired for one crash and operators had to dedup. Post-
+    // fix `_onServerCrash` syncs `lastObservedStatus` so the next probe
+    // observes "no transition".
+    it("does NOT re-audit via _sampleHealth after _onServerCrash already fired (#72 item 6)", async () => {
+      const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+      const plugin = new McpMultiplexerPlugin({
+        configPath: cfgPath,
+        settingsView: makeSettingsView({
+          webEnabled: true,
+          shared: ["alpha"],
+          healthProbeIntervalMs: 0,
+        }),
+      });
+      await plugin.start();
+
+      // Seed the baseline so a status flip would otherwise register as a
+      // transition under the health probe.
+      const proc = (
+        plugin as unknown as {
+          servers: Map<string, { status: string }>;
+          lastObservedStatus: Map<string, string>;
+        }
+      ).servers.get("alpha")!;
+      (plugin as unknown as { lastObservedStatus: Map<string, string> }).lastObservedStatus.set(
+        "alpha",
+        proc.status,
+      );
+
+      // Simulate the upstream subprocess crashing — what
+      // McpServerProcess does when its child closes unexpectedly.
+      (proc as { status: string }).status = "crashed";
+
+      const audited: string[] = [];
+      const origAudit = getMcpBridge().audit.bind(getMcpBridge());
+      getMcpBridge().audit = (event: string, payload: Record<string, unknown>) => {
+        audited.push(event);
+        origAudit(event, payload);
+      };
+
+      try {
+        // Step 1: McpServerProcess fires the crash hook → multiplexer
+        // audits `multiplexer_server_crashed` immediately.
+        (plugin as unknown as { _onServerCrash: (n: string, r: string) => void })._onServerCrash(
+          "alpha",
+          "subprocess closed",
+        );
+        // Step 2: the periodic probe runs. With the dedup gate, it must
+        // observe "no transition" (lastObservedStatus already == "crashed")
+        // and NOT re-audit `mcp_health_degraded`.
+        (plugin as unknown as { _sampleHealthForTests: () => void })._sampleHealthForTests();
+      } finally {
+        getMcpBridge().audit = origAudit;
+      }
+
+      // The crash incident MUST surface exactly ONE event, not two.
+      expect(audited.filter((e) => e === "multiplexer_server_crashed")).toHaveLength(1);
+      expect(audited.filter((e) => e === "mcp_health_degraded")).toHaveLength(0);
+
+      await plugin.stop();
+    });
+
+    // Same gate for the permanently-failed branch added in #93 (#72 item 4).
+    it("does NOT re-audit via _sampleHealth after _onServerCrash fired permanently_failed", async () => {
+      const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
+      const plugin = new McpMultiplexerPlugin({
+        configPath: cfgPath,
+        settingsView: makeSettingsView({
+          webEnabled: true,
+          shared: ["alpha"],
+          healthProbeIntervalMs: 0,
+        }),
+      });
+      await plugin.start();
+
+      const proc = (
+        plugin as unknown as {
+          servers: Map<string, { status: string }>;
+          lastObservedStatus: Map<string, string>;
+        }
+      ).servers.get("alpha")!;
+      (plugin as unknown as { lastObservedStatus: Map<string, string> }).lastObservedStatus.set(
+        "alpha",
+        proc.status,
+      );
+      (proc as { status: string }).status = "failed";
+
+      const audited: string[] = [];
+      const origAudit = getMcpBridge().audit.bind(getMcpBridge());
+      getMcpBridge().audit = (event: string, payload: Record<string, unknown>) => {
+        audited.push(event);
+        origAudit(event, payload);
+      };
+
+      try {
+        (plugin as unknown as { _onServerCrash: (n: string, r: string) => void })._onServerCrash(
+          "alpha",
+          "exceeded max crashes",
+        );
+        (plugin as unknown as { _sampleHealthForTests: () => void })._sampleHealthForTests();
+      } finally {
+        getMcpBridge().audit = origAudit;
+      }
+
+      expect(audited.filter((e) => e === "multiplexer_server_permanently_failed")).toHaveLength(1);
+      expect(audited.filter((e) => e === "mcp_health_degraded")).toHaveLength(0);
+      // And the broader crash event is mutually exclusive (#72 item 4) — so it should NOT fire either.
+      expect(audited.filter((e) => e === "multiplexer_server_crashed")).toHaveLength(0);
+
+      await plugin.stop();
+    });
+
     it("does not emit duplicate events when status is stable across samples", async () => {
       const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
       const plugin = new McpMultiplexerPlugin({

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -735,6 +735,10 @@ export class McpMultiplexerPlugin {
           status,
         });
       } catch {}
+      // #72 item 6: align the health-probe view with what we just
+      // audited so the next `_sampleHealth` tick doesn't re-fire
+      // `mcp_health_degraded` for the same incident.
+      this.lastObservedStatus.set(name, status);
       return;
     }
     console.error(`[mcp-multiplexer] server '${name}' crashed: ${reason} — status: ${status}`);
@@ -745,6 +749,11 @@ export class McpMultiplexerPlugin {
         status,
       });
     } catch {}
+    // #72 item 6: same dedup gate as the permanently-failed branch
+    // above — sync `lastObservedStatus` so the next probe tick treats
+    // this incident as already-audited and only fires on a subsequent
+    // status transition (e.g. crashed → restarting → up).
+    this.lastObservedStatus.set(name, status);
   }
 
   private _registerBridgeCallbacks(serverName: string, proc: McpServerProcess): void {


### PR DESCRIPTION
Closes #72 item 6.

## Pre-fix behaviour

When an upstream MCP child crashed, two audit events fired for the same incident:

1. `McpServerProcess.onCrash` callback → `_onServerCrash` immediately audits `multiplexer_server_crashed` (or `multiplexer_server_permanently_failed` post-#93).
2. On the next health-probe tick, `_sampleHealth` observes the status transition `up` → `crashed` (or `failed`) and audits `mcp_health_degraded`.

Operators wiring alert rules / dashboards had to dedup one incident across two events. Either we documented this as a deliberate "immediate + confirmation" pattern, or we collapsed it. Going with collapse.

## Fix

`_onServerCrash` now syncs `lastObservedStatus.set(name, status)` on **both** branches (transient crash AND permanent failure). The next `_sampleHealth` tick sees `prev === curr` and skips the audit — the crash is reported once, by the path that knows the most about it (`reason` from the close handler).

If the status subsequently changes (e.g. `crashed` → `restarting` → `up`), the probe correctly fires the recovery transition — only the first "crash detected" duplicate is collapsed.

## Tests

Two new tests in `mcp-multiplexer/__tests__/index.test.ts`:

- `does NOT re-audit via _sampleHealth after _onServerCrash already fired (#72 item 6)` — pre-fix FAILS (`mcp_health_degraded` fires in addition to `multiplexer_server_crashed`).
- `does NOT re-audit via _sampleHealth after _onServerCrash fired permanently_failed` — covers the #93 split branch.

Verified pre-fix regression catches both bugs.

Full mcp-multiplexer + integration suites: **94 pass, 0 fail**.
Full-repo `bun run lint`: **zero errors**.

## Test plan
- [x] Unit tests green
- [x] Lint green
- [x] Verified regression catches pre-fix behaviour for both event variants