### PR TITLE
feat(mcp-multiplexer): include X-Claudeclaw-Ts in multiplexer_invoke audit (#72 item 5)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.25",
+      "version": "2.2.26",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.25",
+  "version": "2.2.26",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
@@ -8,7 +8,9 @@ import {
   _resetIdentityStore,
   AUTH_HEADER,
   PTY_ID_HEADER,
+  PTY_TS_HEADER,
 } from "../pty-identity.js";
+import { _resetMcpBridge, _setMcpBridge } from "../../mcp-bridge.js";
 
 const MOCK_SERVER = fileURLToPath(
   new URL("../../../__tests__/fixtures/mock-mcp-server.ts", import.meta.url),
@@ -441,5 +443,119 @@ describe("McpHttpHandler — per-bearer rate limit (#72 item 1)", () => {
       ),
     );
     expect(resp.status).toBe(401);
+  });
+});
+
+// #72 item 5: include the client-asserted X-Claudeclaw-Ts header in the
+// `multiplexer_invoke` audit payload so operators can correlate calls
+// back to a specific identity-issuance window (forensics, replay
+// detection across rotations).
+describe("McpHttpHandler — multiplexer_invoke audit carries X-Claudeclaw-Ts (#72 item 5)", () => {
+  let proc: McpServerProcess | null = null;
+  let handler: McpHttpHandler | null = null;
+
+  beforeEach(async () => {
+    _resetIdentityStore();
+    proc = new McpServerProcess("test", makeServerConfig());
+    await proc.start();
+    handler = new McpHttpHandler({ serverName: "test", proc: proc! });
+  });
+
+  afterEach(async () => {
+    if (handler) await handler.stop();
+    if (proc) await proc.stop();
+    proc = null;
+    handler = null;
+    _resetIdentityStore();
+    _resetMcpBridge();
+  });
+
+  function captureAudits(events: Array<{ name: string; payload: Record<string, unknown> }>) {
+    _setMcpBridge({
+      audit: (name: string, payload: Record<string, unknown>) => {
+        events.push({ name, payload });
+      },
+      registerPluginTool: () => {},
+      unregisterPluginTool: () => {},
+      listTools: () => [],
+      invoke: async () => {
+        throw new Error("not in test");
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal test bridge
+    } as any);
+  }
+
+  it("includes client_ts (parsed epoch ms) on successful auth", async () => {
+    const id = issueIdentity("suzy");
+    // `issueIdentity` populates headers with X-Claudeclaw-Ts = issuance ms.
+    const issuedAtRaw = id.headers[PTY_TS_HEADER];
+    expect(issuedAtRaw).toBeTruthy();
+    const issuedAt = Number(issuedAtRaw);
+
+    const events: Array<{ name: string; payload: Record<string, unknown> }> = [];
+    captureAudits(events);
+
+    await handler!.handle(
+      rpcRequest(
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        {
+          [PTY_ID_HEADER]: "suzy",
+          [AUTH_HEADER]: id.headers[AUTH_HEADER],
+          [PTY_TS_HEADER]: issuedAtRaw,
+        },
+      ),
+    );
+
+    const invoke = events.find((e) => e.name === "multiplexer_invoke");
+    expect(invoke).toBeDefined();
+    expect(invoke!.payload.client_ts).toBe(issuedAt);
+    expect(invoke!.payload.pty_id).toBe("suzy");
+    expect(invoke!.payload.server).toBe("test");
+    revokeIdentity("suzy");
+  });
+
+  it("client_ts is null when the header is missing (defensive — never throws)", async () => {
+    const id = issueIdentity("suzy");
+    const events: Array<{ name: string; payload: Record<string, unknown> }> = [];
+    captureAudits(events);
+
+    // Pass auth headers but omit X-Claudeclaw-Ts. Pre-#71 clients
+    // wouldn't send it; we shouldn't break on the missing field.
+    await handler!.handle(
+      rpcRequest(
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        {
+          [PTY_ID_HEADER]: "suzy",
+          [AUTH_HEADER]: id.headers[AUTH_HEADER],
+        },
+      ),
+    );
+
+    const invoke = events.find((e) => e.name === "multiplexer_invoke");
+    expect(invoke).toBeDefined();
+    expect(invoke!.payload.client_ts).toBeNull();
+    revokeIdentity("suzy");
+  });
+
+  it("client_ts is null when the header is non-numeric (malformed input)", async () => {
+    const id = issueIdentity("suzy");
+    const events: Array<{ name: string; payload: Record<string, unknown> }> = [];
+    captureAudits(events);
+
+    await handler!.handle(
+      rpcRequest(
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        {
+          [PTY_ID_HEADER]: "suzy",
+          [AUTH_HEADER]: id.headers[AUTH_HEADER],
+          [PTY_TS_HEADER]: "not-a-number",
+        },
+      ),
+    );
+
+    const invoke = events.find((e) => e.name === "multiplexer_invoke");
+    expect(invoke).toBeDefined();
+    expect(invoke!.payload.client_ts).toBeNull();
+    revokeIdentity("suzy");
   });
 });

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -25,7 +25,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprot
 import { randomUUID } from "node:crypto";
 import { getMcpBridge } from "../mcp-bridge.js";
 import type { McpServerProcess } from "../mcp-proxy/server-process.js";
-import { AUTH_HEADER, PTY_ID_HEADER, verifyBearer } from "./pty-identity.js";
+import { AUTH_HEADER, PTY_ID_HEADER, PTY_TS_HEADER, verifyBearer } from "./pty-identity.js";
 import type { SessionPersistenceStore } from "./session-persistence.js";
 
 /** Sentinel used when a server is declared stateless: all PTYs collapse
@@ -312,12 +312,21 @@ export class McpHttpHandler {
     // request stream (the transport needs to re-read it).
     const peek = await _readBody(safeReq);
 
+    // #72 item 5: include the client-asserted identity-issuance
+    // timestamp (`X-Claudeclaw-Ts`) in the invoke audit so the audit
+    // log can correlate calls back to the specific identity-issuance
+    // window. Stored as a number when parseable (epoch ms), null when
+    // the header is missing or malformed — never throws on bad input.
+    const tsRaw = safeReq.headers.get(PTY_TS_HEADER);
+    const tsNum = tsRaw != null && /^\d+$/.test(tsRaw) ? Number(tsRaw) : null;
+
     try {
       getMcpBridge().audit("multiplexer_invoke", {
         server: this.serverName,
         pty_id: ptyId,
         stateless: this.stateless,
         rpc_method: _peekRpcMethod(peek),
+        client_ts: tsNum,
       });
     } catch {}
 


### PR DESCRIPTION
Closes #72 item 5.

## Motivation

The identity issuer mints headers with `X-Claudeclaw-Ts` = epoch ms of issuance (see `pty-identity.ts:_toPublic`). Every request through `/mcp/<server>` carries it.

Pre-fix, the `multiplexer_invoke` audit recorded `{server, pty_id, stateless, rpc_method}` but dropped the client-asserted timestamp. Operators couldn't correlate a call back to a specific identity-issuance window when forensically replaying the audit log — e.g. "this invoke arrived at audit time T; which identity bucket did it come from?"

## Fix

Read `safeReq.headers.get(PTY_TS_HEADER)`, parse to a number when the value is a pure-digit string, store as `client_ts` in the payload. Malformed / missing header → `null` (never throws — the audit must not break the invoke pipeline).

```ts
const tsRaw = safeReq.headers.get(PTY_TS_HEADER);
const tsNum = tsRaw != null && /^\d+$/.test(tsRaw) ? Number(tsRaw) : null;

getMcpBridge().audit("multiplexer_invoke", {
  server: this.serverName,
  pty_id: ptyId,
  stateless: this.stateless,
  rpc_method: _peekRpcMethod(peek),
  client_ts: tsNum, // NEW
});
```

## Tests

Three new tests in `http-handler.test.ts` using a minimal in-process fake bridge that captures every `audit(name, payload)` call:

- `includes client_ts (parsed epoch ms) on successful auth` — pre-fix FAILS (`client_ts` is undefined in the payload).
- `client_ts is null when the header is missing (defensive — never throws)` — exercises the legacy-client path.
- `client_ts is null when the header is non-numeric (malformed input)` — exercises the bad-input path.

Verified regression catches the missing field — all 3 new tests fail without the change.

Full `mcp-multiplexer/__tests__`: **89 pass, 0 fail**.
Full-repo `bun run lint`: **zero errors**.

## Test plan
- [x] Unit tests green
- [x] Lint green
- [x] Verified regression catches pre-fix behaviour (missing/malformed inputs all handled)