### PR TITLE
fix(runner): explicit chmodSync(0o600) on synthesised mcp-config (#72 item 2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.26",
+      "version": "2.2.27",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.26",
+  "version": "2.2.27",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/pty-mcp-config-writer.test.ts
+++ b/src/__tests__/pty-mcp-config-writer.test.ts
@@ -206,6 +206,39 @@ describe("writeConfigForPty — filesystem hygiene", () => {
     expect(st.mode & 0o400).toBeGreaterThan(0); // at least owner-readable
   });
 
+  // #72 item 2: belt-and-braces — even if a prior turn left the file
+  // group/world-readable (operator manual chmod, permissive umask
+  // interaction with a non-POSIX write path, ...), the next write must
+  // clamp it back to 0600. Pre-fix the writer relied on writeFileSync's
+  // mode param which is IGNORED on overwrite on most platforms, so the
+  // bad perms persisted across re-writes — leaking the bearer to any
+  // local user.
+  it("re-clamps file mode to 0600 even if a prior write was world-readable", async () => {
+    const cwd = makeCwd("file-mode-reclamp");
+    const inp = baseInput({
+      ptyId: "x",
+      cwd,
+      sharedServers: [{ name: "graphiti" }],
+    });
+
+    // First write: 0600 expected.
+    const r1 = writeConfigForPty(inp);
+    expect(statSync(r1.path).mode & 0o077).toBe(0);
+
+    // Simulate an attacker / misbehaving process / operator manual
+    // chmod that widens perms.
+    const { chmodSync } = await import("node:fs");
+    chmodSync(r1.path, 0o644);
+    expect(statSync(r1.path).mode & 0o077).not.toBe(0);
+
+    // Next call to the writer MUST clamp back to 0600. Without the
+    // explicit chmod in the writer, this assertion would fail because
+    // writeFileSync's `mode` option is no-op on overwrite.
+    const r2 = writeConfigForPty(inp);
+    expect(r2.path).toBe(r1.path);
+    expect(statSync(r2.path).mode & 0o077).toBe(0);
+  });
+
   it("is idempotent — second call with same input overwrites the file", () => {
     const cwd = makeCwd("idempotent");
     const inp = baseInput({

--- a/src/runner/pty-mcp-config-writer.ts
+++ b/src/runner/pty-mcp-config-writer.ts
@@ -17,7 +17,7 @@
  * the identity; the writer splats `identity.headers` verbatim into the
  * synthesized JSON.
  */
-import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
 import type { PtyIdentity } from "../plugins/mcp-multiplexer/pty-identity";
@@ -168,17 +168,26 @@ export function writeConfigForPty(input: WriteConfigInput): WriteConfigResult {
     mkdirSync(dir, { recursive: true, mode: DIR_MODE });
   }
 
-  // Write atomically-ish: writeFileSync with mode 0600. If the file already
-  // exists, the mode flag is ignored on most platforms — we re-write the
-  // bytes but the perms stay as they were. We don't chmod separately
-  // because:
-  //   (a) the file we created in a prior turn already has 0600 from this
-  //       writer, so it's already correct;
-  //   (b) if an operator manually changed the mode we don't fight them.
+  // Write atomically-ish: writeFileSync with mode 0600. The `mode` option
+  // is only honoured on FILE CREATE — on overwrite, perms stay as-is on
+  // most platforms, AND a permissive umask can still widen the bits at
+  // create time depending on libc behaviour. Belt-and-braces (#72 item 2):
+  // explicit chmodSync after the write forces 0600 regardless of umask,
+  // platform quirk, or prior operator manual chmod. This file holds the
+  // synthesized `--mcp-config` including the per-PTY bearer Authorization
+  // header — leaking it to other local users would let any of them
+  // impersonate the PTY against `/mcp/<server>` until the bearer rotates.
   writeFileSync(path, JSON.stringify(payload, null, 2) + "\n", {
     mode: FILE_MODE,
     encoding: "utf8",
   });
+  try {
+    chmodSync(path, FILE_MODE);
+  } catch {
+    // Best-effort. On filesystems without permission semantics
+    // (e.g. some test FUSE mounts) chmod throws; we already wrote the
+    // file with the requested mode, so swallow and move on.
+  }
 
   return { path };
 }


### PR DESCRIPTION
Closes #72 item 2.

## Motivation

`writeFileSync`'s `mode` option is only honoured on **FILE CREATE** — on overwrite the perms stay as-is on most platforms. A permissive umask can also widen the bits at create time depending on libc behaviour.

The synthesized `${cwd}/.claudeclaw/mcp-pty-${ptyId}.json` holds the per-PTY bearer Authorization header. Leaking it to other local users would let any of them impersonate the PTY against `/mcp/<server>` until the bearer rotates on respawn.

Belt-and-braces: clamp to 0600 unconditionally after every write.

## Fix

Add `chmodSync(path, FILE_MODE)` after `writeFileSync`, swallowing errors as best-effort (some test FUSE mounts throw because the FS has no permission semantics).

The previous "don't fight operator manual chmod" rationale was wrong: an operator chmodding this file to 0644 is leaking secrets, not intentionally setting different perms. The whole point of this file is bearer secrecy. Comment updated.

## Regression test

`re-clamps file mode to 0600 even if a prior write was world-readable` in `pty-mcp-config-writer.test.ts`:

1. First write — verify 0600.
2. Manually `chmodSync(path, 0o644)` to simulate widening.
3. Call writer again with same input.
4. Assert `mode & 0o077 === 0`.

Pre-fix FAILS: `Expected: 0  Received: 36` (0o44, i.e. world+group readable). Post-fix PASSES.

Full `pty-mcp-config-writer.test.ts`: **18 pass, 0 fail**.
Full-repo `bun run lint`: **zero errors**.

## Test plan
- [x] Unit tests green
- [x] Lint green
- [x] Verified regression catches pre-fix behaviour