### PR TITLE
feat(mcp-multiplexer): warn on ~/.claude/mcp.json name collisions + README operator section (#72 item 7)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.27",
+      "version": "2.2.28",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.27",
+  "version": "2.2.28",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/README.md
+++ b/README.md
@@ -130,6 +130,54 @@ Hot-reload picks up `settings.json` changes within 30 seconds — no daemon rest
 
 ---
 
+### MCP multiplexer — shared MCP-server processes across PTYs
+
+**Tracking issue: [#72](https://github.com/TerrysPOV/ClaudeClaw-Plus/issues/72) · Lands across [#71](https://github.com/TerrysPOV/ClaudeClaw-Plus/pull/71), [#78](https://github.com/TerrysPOV/ClaudeClaw-Plus/pull/78), and a series of v1.1 hardening PRs (#91–#97)**
+
+The multiplexer hosts each shared MCP server child **once** and demultiplexes per-PTY traffic over a loopback HTTP route (`/mcp/<server>`). Each PTY claude gets a synthesized `--mcp-config` JSON pointing at that route with a per-PTY bearer + identity headers. Without this, every PTY would spawn its own copy of every MCP server — N × M subprocesses for N PTYs × M servers — which OOMs even a modest Hetzner box at moderate concurrency.
+
+#### Operator footgun: `mcp-proxy.json` ↔ `~/.claude/mcp.json` collisions
+
+claude's `--mcp-config` flag is **additive** to its own `~/.claude/mcp.json` discovery. The two configs MERGE by server name. If a server name appears in **both** `~/.config/claudeclaw/mcp-proxy.json` (or whichever path you configured) **and** `~/.claude/mcp.json`, claude will:
+
+1. **Spawn the stdio entry** from `~/.claude/mcp.json` on every PTY — one extra subprocess per PTY per colliding name.
+2. **Also make HTTP calls** to the multiplexer's `/mcp/<server>` for the same name from the synthesized config.
+
+Net effect: you get the per-PTY process explosion the multiplexer was designed to prevent, but for the colliding servers specifically — silently, with no visible error.
+
+**Fix:** for every server name you list in `settings.mcp.shared` (and define in `mcp-proxy.json`), **remove that name from `~/.claude/mcp.json`**. The multiplexer is now the single source of truth for those servers across PTY claudes.
+
+**Detection:** at startup, the multiplexer reads `~/.claude/mcp.json` (best-effort) and logs a `WARN [mcp-multiplexer]` line listing the colliding names. It also emits a `multiplexer_user_mcp_collision` audit event with `{path, collisions: [...]}` so dashboards can alert on it. The warning is observability — the multiplexer still starts, claude still spawns the duplicates, but you know what's happening.
+
+#### Settings block (defaults shown)
+
+```json
+"mcp": {
+  "shared": [],
+  "perPtyOnly": [],
+  "stateless": [],
+  "healthProbeIntervalMs": 30000,
+  "sessionPersistenceEnabled": true,
+  "sessionMaxAgeSeconds": 3600,
+  "sessionPersistencePath": "",
+  "rateLimit": {
+    "maxRequestsPerWindow": 600,
+    "windowMs": 60000
+  }
+}
+```
+
+- `shared` — server names (must also exist in `mcp-proxy.json`) the multiplexer hosts. Empty list = dormant; PTY claudes fall back to per-PTY stdio spawns (no protection from the explosion).
+- `stateless` — subset of `shared` for servers with no per-session state; one upstream session shared across all PTYs.
+- `rateLimit` — per-bearer (= per-PTY) sliding-window cap on `/mcp/<server>` requests. Defense-in-depth for a leaked bearer.
+
+#### References
+
+- Architecture: [`.planning/mcp-multiplexer/SPEC.md`](.planning/mcp-multiplexer/SPEC.md)
+- v1.1 follow-ups: [#72](https://github.com/TerrysPOV/ClaudeClaw-Plus/issues/72)
+
+---
+
 ### Policy Engine — fine-grained tool governance
 
 **[PR #71 — closed upstream — lives here](https://github.com/moazbuilds/claudeclaw/pull/71)**

--- a/src/plugins/mcp-multiplexer/__tests__/index.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/index.test.ts
@@ -888,3 +888,156 @@ describe("McpMultiplexerPlugin — session persistence wiring", () => {
     }
   });
 });
+
+// #72 item 7: claude's `--mcp-config` is ADDITIVE to its own
+// `~/.claude/mcp.json` discovery. If a name appears in BOTH, claude spawns
+// the stdio entry from ~/.claude/mcp.json IN ADDITION to making HTTP calls
+// to our multiplexed copy — one extra subprocess per PTY per colliding
+// server. The startup check warns operators so the misconfiguration
+// surfaces before they blame "the multiplexer leaking memory".
+describe("McpMultiplexerPlugin — operator-config collision (#72 item 7)", () => {
+  function writeUserMcpJson(dir: string, mcpServers: Record<string, unknown>): string {
+    const path = join(dir, ".claude-mcp.json");
+    writeFileSync(path, JSON.stringify({ mcpServers }, null, 2));
+    return path;
+  }
+
+  function makePluginWithUserJson(opts: { sharedNames: string[]; userMcpJsonPath?: string }) {
+    const cfgPath = writeProxyConfig(tmpDir, opts.sharedNames);
+    return new McpMultiplexerPlugin({
+      configPath: cfgPath,
+      settingsView: makeSettingsView({
+        webEnabled: true,
+        shared: opts.sharedNames,
+        healthProbeIntervalMs: 0,
+      }),
+      userMcpJsonPath: opts.userMcpJsonPath,
+    });
+  }
+
+  it("warns when a shared server name also appears in ~/.claude/mcp.json", () => {
+    const userPath = writeUserMcpJson(tmpDir, {
+      // Two collisions + one unrelated server.
+      alpha: { command: "node", args: ["alpha.js"] },
+      unrelated: { command: "node", args: ["unrelated.js"] },
+    });
+    const plugin = makePluginWithUserJson({
+      sharedNames: ["alpha"],
+      userMcpJsonPath: userPath,
+    });
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+
+    try {
+      (
+        plugin as unknown as { _warnOnUserMcpJsonCollision: (c: string[]) => void }
+      )._warnOnUserMcpJsonCollision(["alpha"]);
+    } finally {
+      console.warn = origWarn;
+    }
+
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("alpha");
+    expect(warnings[0]).toContain("mcp-multiplexer");
+    expect(warnings[0]).not.toContain("unrelated"); // non-colliding server isn't listed
+  });
+
+  it("does NOT warn when there are no name collisions", () => {
+    const userPath = writeUserMcpJson(tmpDir, {
+      "only-in-user-json": { command: "node", args: ["x.js"] },
+    });
+    const plugin = makePluginWithUserJson({
+      sharedNames: ["alpha"],
+      userMcpJsonPath: userPath,
+    });
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      (
+        plugin as unknown as { _warnOnUserMcpJsonCollision: (c: string[]) => void }
+      )._warnOnUserMcpJsonCollision(["alpha"]);
+    } finally {
+      console.warn = origWarn;
+    }
+
+    expect(warnings.length).toBe(0);
+  });
+
+  it("does NOT throw on a missing ~/.claude/mcp.json (legacy operator setup)", () => {
+    const missingPath = join(tmpDir, "definitely-not-here.json");
+    const plugin = makePluginWithUserJson({
+      sharedNames: ["alpha"],
+      userMcpJsonPath: missingPath,
+    });
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(" "));
+    };
+    try {
+      expect(() =>
+        (
+          plugin as unknown as { _warnOnUserMcpJsonCollision: (c: string[]) => void }
+        )._warnOnUserMcpJsonCollision(["alpha"]),
+      ).not.toThrow();
+    } finally {
+      console.warn = origWarn;
+    }
+    expect(warnings.length).toBe(0);
+  });
+
+  it("does NOT throw on a malformed ~/.claude/mcp.json", () => {
+    const malformedPath = join(tmpDir, "malformed.json");
+    writeFileSync(malformedPath, "{ not valid json");
+    const plugin = makePluginWithUserJson({
+      sharedNames: ["alpha"],
+      userMcpJsonPath: malformedPath,
+    });
+
+    expect(() =>
+      (
+        plugin as unknown as { _warnOnUserMcpJsonCollision: (c: string[]) => void }
+      )._warnOnUserMcpJsonCollision(["alpha"]),
+    ).not.toThrow();
+  });
+
+  it("emits audit event `multiplexer_user_mcp_collision` when a collision is detected", async () => {
+    const userPath = writeUserMcpJson(tmpDir, {
+      alpha: { command: "node", args: ["alpha.js"] },
+      beta: { command: "node", args: ["beta.js"] },
+    });
+    const plugin = makePluginWithUserJson({
+      sharedNames: ["alpha", "beta"],
+      userMcpJsonPath: userPath,
+    });
+
+    const audited: Array<{ event: string; payload: Record<string, unknown> }> = [];
+    const origAudit = getMcpBridge().audit.bind(getMcpBridge());
+    getMcpBridge().audit = (event: string, payload: Record<string, unknown>) => {
+      audited.push({ event, payload });
+      origAudit(event, payload);
+    };
+
+    try {
+      (
+        plugin as unknown as { _warnOnUserMcpJsonCollision: (c: string[]) => void }
+      )._warnOnUserMcpJsonCollision(["alpha", "beta"]);
+    } finally {
+      getMcpBridge().audit = origAudit;
+    }
+
+    const collision = audited.find((e) => e.event === "multiplexer_user_mcp_collision");
+    expect(collision).toBeDefined();
+    expect((collision!.payload.collisions as string[]).sort()).toEqual(["alpha", "beta"]);
+    expect(collision!.payload.path).toBe(userPath);
+  });
+});

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -174,6 +174,10 @@ export interface McpMultiplexerPluginOpts {
   /** GC tick interval in milliseconds. Default 1 hour. Tests pin this
    *  to a smaller value or 0 (disabled — drive via `_runGCTickForTests`). */
   gcTickMs?: number;
+  /** Test seam — override the path checked for `~/.claude/mcp.json`
+   *  collisions (#72 item 7). Production defaults to
+   *  `path.join(os.homedir(), ".claude", "mcp.json")`. */
+  userMcpJsonPath?: string;
 }
 
 export class McpMultiplexerPlugin {
@@ -205,6 +209,9 @@ export class McpMultiplexerPlugin {
   private persistence: SessionPersistenceStore | null = null;
   /** Periodic GC sweep. Null when persistence is dormant. */
   private gcTimer: ReturnType<typeof setInterval> | null = null;
+  /** #72 item 7: file to check for shared-name collisions at startup.
+   *  Defaults to `~/.claude/mcp.json`; tests can override. */
+  private readonly userMcpJsonPath: string;
 
   constructor(opts: McpMultiplexerPluginOpts = {}) {
     this.configPath = opts.configPath ?? join(homedir(), ".config", "claudeclaw", "mcp-proxy.json");
@@ -212,6 +219,7 @@ export class McpMultiplexerPlugin {
     this.settingsView = opts.settingsView ?? _readSettings;
     this.persistenceFactory = opts.persistenceFactory;
     this.gcTickMsOverride = opts.gcTickMs;
+    this.userMcpJsonPath = opts.userMcpJsonPath ?? join(homedir(), ".claude", "mcp.json");
   }
 
   async start(): Promise<void> {
@@ -397,6 +405,21 @@ export class McpMultiplexerPlugin {
     // post-settings-change.
     this.started = true;
 
+    // #72 item 7: operator footgun — the synthesized --mcp-config is
+    // ADDITIVE to claude's own `~/.claude/mcp.json` discovery. If a name
+    // appears in BOTH places, claude spawns the stdio version from
+    // ~/.claude/mcp.json IN ADDITION TO making HTTP calls to our shared
+    // multiplexed copy. The operator-visible symptom is an unexplained
+    // child process on every PTY for a server they thought was shared.
+    // Warn at startup so the misconfiguration surfaces immediately.
+    try {
+      this._warnOnUserMcpJsonCollision(claimed);
+    } catch {
+      // Best-effort. The check reads ~/.claude/mcp.json; any FS/JSON
+      // error MUST NOT block multiplexer startup — the warning is
+      // observability, not a gate.
+    }
+
     // Start the periodic health probe. Closes the silent-degradation gap
     // flagged on #64: when one shared MCP crashes all PTYs lose that tool
     // simultaneously, and without an active probe the operator only finds
@@ -464,6 +487,64 @@ export class McpMultiplexerPlugin {
       this.healthProbeTimer = null;
     }
     this.lastObservedStatus.clear();
+  }
+
+  // ── Operator-config-collision warning (#72 item 7) ────────────────────
+
+  /**
+   * The synthesized `--mcp-config` we pass to PTY claudes is ADDITIVE to
+   * claude's own `~/.claude/mcp.json` discovery — they merge by name with
+   * the per-invocation `--mcp-config` winning. If a name appears in BOTH
+   * places, claude spawns the stdio entry from `~/.claude/mcp.json` IN
+   * ADDITION TO making HTTP calls to our shared multiplexed copy. The
+   * operator-visible symptom is one extra child process per PTY for a
+   * server they thought was deduped behind the multiplexer.
+   *
+   * Warn at startup so the misconfiguration surfaces before operators
+   * blame "the multiplexer leaking memory". Best-effort: missing file,
+   * malformed JSON, or read errors all silently skip the check.
+   *
+   * Exposed as a public method (underscore-prefixed by convention) so
+   * unit tests can drive it without spinning up the whole `start()`
+   * pipeline. Production wires it from `start()` after claim.
+   */
+  _warnOnUserMcpJsonCollision(claimed: string[]): void {
+    if (claimed.length === 0) return;
+    // biome-ignore lint/suspicious/noExplicitAny: dynamic node:fs import
+    const { existsSync, readFileSync } = require("node:fs") as {
+      existsSync: (p: string) => boolean;
+      readFileSync: (p: string, enc: string) => string;
+    };
+    if (!existsSync(this.userMcpJsonPath)) return;
+    let parsed: unknown;
+    try {
+      const text = readFileSync(this.userMcpJsonPath, "utf8");
+      parsed = JSON.parse(text);
+    } catch {
+      return;
+    }
+    if (!parsed || typeof parsed !== "object") return;
+    const mcpServers = (parsed as { mcpServers?: unknown }).mcpServers;
+    if (!mcpServers || typeof mcpServers !== "object") return;
+    const userNames = Object.keys(mcpServers as Record<string, unknown>);
+    if (userNames.length === 0) return;
+    const userSet = new Set(userNames);
+    const collisions = claimed.filter((n) => userSet.has(n));
+    if (collisions.length === 0) return;
+    console.warn(
+      `[mcp-multiplexer] WARN: ${collisions.length} shared server name(s) ` +
+        `also appear in ${this.userMcpJsonPath}: ${collisions.join(", ")}. ` +
+        `claude WILL spawn the stdio entries from ${this.userMcpJsonPath} IN ` +
+        `ADDITION to making HTTP calls to the multiplexer. Remove the ` +
+        `colliding entries from ${this.userMcpJsonPath} to avoid duplicate ` +
+        `child processes per PTY.`,
+    );
+    try {
+      getMcpBridge().audit("multiplexer_user_mcp_collision", {
+        path: this.userMcpJsonPath,
+        collisions,
+      });
+    } catch {}
   }
 
   // ── Session-map persistence ─────────────────────────────────────────


### PR DESCRIPTION
Closes #72 item 7.

## Operator footgun

claude's `--mcp-config` is **additive** to its own `~/.claude/mcp.json` discovery — the two configs merge by server name. If the same name appears in BOTH `~/.config/claudeclaw/mcp-proxy.json` AND `~/.claude/mcp.json`, claude:

1. Spawns the stdio entry from `~/.claude/mcp.json` on every PTY (one extra subprocess per PTY per colliding name).
2. Also makes HTTP calls to the multiplexer's `/mcp/<server>` for the same name from the synthesized config.

Net: the per-PTY process explosion the multiplexer was designed to prevent — silently, with no error. Operators would attribute the extra processes to "the multiplexer leaking memory" rather than the merge.

Item 7 of #72 left it operator's choice: startup warning OR README. Shipping both belt-and-braces.

## Startup warning

`McpMultiplexerPlugin._warnOnUserMcpJsonCollision(claimed)` runs in `start()` right after the claim loop succeeds:

- Best-effort reads `~/.claude/mcp.json` (path injectable for tests).
- Parses the `mcpServers` map, intersects keys with the claimed set.
- On any overlap, emits **one** `WARN [mcp-multiplexer]` line listing the colliding names + path + remediation guidance.
- Emits a `multiplexer_user_mcp_collision` audit event with `{path, collisions}` so dashboards can alert.

Missing file, malformed JSON, FS errors all silently skip — the warning is observability, not a gate.

## README section

New "MCP multiplexer" subsection under "What's in Plus" with:
- One-paragraph overview.
- "Operator footgun" callout explaining the collision behaviour + remediation (remove colliding names from `~/.claude/mcp.json`).
- Settings block with defaults (`rateLimit` from #91, `sessionPersistence*` from #78, etc).
- Pointers to SPEC and #72 follow-up tracking.

## Tests

Five new tests in `mcp-multiplexer/__tests__/index.test.ts`:

- `warns when a shared server name also appears in ~/.claude/mcp.json`
- `does NOT warn when there are no name collisions`
- `does NOT throw on a missing ~/.claude/mcp.json (legacy operator setup)`
- `does NOT throw on a malformed ~/.claude/mcp.json`
- `emits audit event multiplexer_user_mcp_collision when a collision is detected`

Full mux suite: **92 pass, 0 fail** (was 87 before — 5 new).
Full-repo `bun run lint`: **zero errors**.

## Test plan
- [x] Unit tests green
- [x] Lint green
- [x] README change rendered locally (markdown only)