### PR TITLE
chore(mcp): drop audit try/catch wrappers in production paths (#72 item 13)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.29",
+      "version": "2.2.30",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.29",
+  "version": "2.2.30",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/plugins/http-gateway.ts
+++ b/src/plugins/http-gateway.ts
@@ -411,9 +411,7 @@ export class PluginHttpGateway {
     try {
       getMcpBridge().unregisterPlugin(name);
     } catch {}
-    try {
-      getMcpBridge().audit("http_plugin_unregistered", { plugin: name, request_id: requestId });
-    } catch {}
+    getMcpBridge().audit("http_plugin_unregistered", { plugin: name, request_id: requestId });
     return json({ unregistered: name, request_id: requestId });
   }
 
@@ -537,12 +535,10 @@ export class PluginHttpGateway {
       inProcessHealthFn: opts.healthFn,
     });
 
-    try {
-      getMcpBridge().audit("in_process_plugin_registered", {
-        plugin: name,
-        tools_count: opts.tools.length,
-      });
-    } catch {}
+    getMcpBridge().audit("in_process_plugin_registered", {
+      plugin: name,
+      tools_count: opts.tools.length,
+    });
     return pluginToken;
   }
 

--- a/src/plugins/mcp-bridge.ts
+++ b/src/plugins/mcp-bridge.ts
@@ -224,12 +224,25 @@ export class PluginMcpBridge {
     return { type: "object", additionalProperties: true };
   }
 
+  /**
+   * Append an audit event to the JSONL log.
+   *
+   * **Contract (#72 item 13): this method MUST NOT throw.** Every
+   * failure mode — JSON-serialisation of a payload that contains
+   * circular refs, FS write errors on a full / read-only disk,
+   * permission errors, etc. — is swallowed by the inner try/catch.
+   * Callers are explicitly relieved of the burden of wrapping
+   * `getMcpBridge().audit(...)` in their own try/catch; doing so is
+   * dead code that exists in production paths only because callers
+   * were defensive before this contract was nailed down. As of #72
+   * item 13 all 20 caller-side wrappers were removed.
+   */
   audit(event: string, payload: Record<string, unknown>): void {
     try {
       const entry = JSON.stringify({ event, ts: new Date().toISOString(), ...payload }) + "\n";
       appendFileSync(this.auditPath, entry, { encoding: "utf8" });
     } catch {
-      // Audit failures must not break the bridge
+      // Audit failures must not break the bridge — see contract above.
     }
   }
 }

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -233,12 +233,10 @@ export class McpHttpHandler {
     }
     if (!bearer || !verifyBearer(ptyId, bearer)) {
       // Audit, but only the failure event — do not log the bearer itself.
-      try {
-        getMcpBridge().audit("multiplexer_auth_rejected", {
-          server: this.serverName,
-          pty_id: ptyId,
-        });
-      } catch {}
+      getMcpBridge().audit("multiplexer_auth_rejected", {
+        server: this.serverName,
+        pty_id: ptyId,
+      });
       return _errResponse(401, "invalid_bearer", "HMAC verification failed");
     }
 
@@ -247,15 +245,13 @@ export class McpHttpHandler {
     // even before the issuing PTY respawns and rotates the secret.
     const rl = this._checkRateLimit(ptyId);
     if (rl.rejected) {
-      try {
-        getMcpBridge().audit("multiplexer_rate_limited", {
-          server: this.serverName,
-          pty_id: ptyId,
-          max_per_window: this._rlMax,
-          window_ms: this._rlWindowMs,
-          retry_after_sec: rl.retryAfterSec,
-        });
-      } catch {}
+      getMcpBridge().audit("multiplexer_rate_limited", {
+        server: this.serverName,
+        pty_id: ptyId,
+        max_per_window: this._rlMax,
+        window_ms: this._rlWindowMs,
+        retry_after_sec: rl.retryAfterSec,
+      });
       return new Response(
         JSON.stringify({
           error: "rate_limited",
@@ -320,15 +316,13 @@ export class McpHttpHandler {
     const tsRaw = safeReq.headers.get(PTY_TS_HEADER);
     const tsNum = tsRaw != null && /^\d+$/.test(tsRaw) ? Number(tsRaw) : null;
 
-    try {
-      getMcpBridge().audit("multiplexer_invoke", {
-        server: this.serverName,
-        pty_id: ptyId,
-        stateless: this.stateless,
-        rpc_method: _peekRpcMethod(peek),
-        client_ts: tsNum,
-      });
-    } catch {}
+    getMcpBridge().audit("multiplexer_invoke", {
+      server: this.serverName,
+      pty_id: ptyId,
+      stateless: this.stateless,
+      rpc_method: _peekRpcMethod(peek),
+      client_ts: tsNum,
+    });
 
     // Hand off to the SDK transport. It will read the body, dispatch
     // to the registered handlers on the SDK Server, and return a
@@ -502,13 +496,11 @@ export class McpHttpHandler {
     sdkServer.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
       if (!allowedNames.has(name)) {
-        try {
-          getMcpBridge().audit("multiplexer_tool_rejected", {
-            server: this.serverName,
-            tool: name,
-            reason: "not_in_allowed_set",
-          });
-        } catch {}
+        getMcpBridge().audit("multiplexer_tool_rejected", {
+          server: this.serverName,
+          tool: name,
+          reason: "not_in_allowed_set",
+        });
         return {
           content: [
             {

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -235,11 +235,9 @@ export class McpMultiplexerPlugin {
       console.error(
         `[mcp-multiplexer] dormant — gateway host '${settings.webHost}' is non-loopback; refusing to expose MCP routes externally.`,
       );
-      try {
-        getMcpBridge().audit("multiplexer_refused_non_loopback", {
-          host: settings.webHost,
-        });
-      } catch {}
+      getMcpBridge().audit("multiplexer_refused_non_loopback", {
+        host: settings.webHost,
+      });
       return;
     }
 
@@ -247,17 +245,13 @@ export class McpMultiplexerPlugin {
       console.error(
         "[mcp-multiplexer] dormant — settings.web.enabled is false; multiplexer requires the HTTP gateway.",
       );
-      try {
-        getMcpBridge().audit("multiplexer_dormant_web_disabled", {});
-      } catch {}
+      getMcpBridge().audit("multiplexer_dormant_web_disabled", {});
       return;
     }
 
     if (settings.shared.length === 0) {
       console.error("[mcp-multiplexer] dormant — settings.mcp.shared is empty.");
-      try {
-        getMcpBridge().audit("multiplexer_dormant_empty_shared", {});
-      } catch {}
+      getMcpBridge().audit("multiplexer_dormant_empty_shared", {});
       return;
     }
 
@@ -276,9 +270,7 @@ export class McpMultiplexerPlugin {
       console.error(
         `[mcp-multiplexer] dormant — could not load ${this.configPath}; no shared servers will be spawned.`,
       );
-      try {
-        getMcpBridge().audit("multiplexer_no_config", { path: this.configPath });
-      } catch {}
+      getMcpBridge().audit("multiplexer_no_config", { path: this.configPath });
       // Clear the cache we set above so isActive() + bridgeBaseUrl() are
       // consistent ("plugin is not running" → "URL is default placeholder").
       this.cachedSharedNames = [];
@@ -364,13 +356,11 @@ export class McpMultiplexerPlugin {
           console.error(
             `[mcp-multiplexer] spawned ${name} pid ${this._pidOf(proc)} — ${proc.tools.length} tools`,
           );
-          try {
-            getMcpBridge().audit("multiplexer_server_ready", {
-              server: name,
-              stateless: settings.stateless.includes(name),
-              tools: proc.tools.length,
-            });
-          } catch {}
+          getMcpBridge().audit("multiplexer_server_ready", {
+            server: name,
+            stateless: settings.stateless.includes(name),
+            tools: proc.tools.length,
+          });
         } catch (err) {
           console.error(
             `[mcp-multiplexer] failed to start '${name}': ${
@@ -539,12 +529,10 @@ export class McpMultiplexerPlugin {
         `colliding entries from ${this.userMcpJsonPath} to avoid duplicate ` +
         `child processes per PTY.`,
     );
-    try {
-      getMcpBridge().audit("multiplexer_user_mcp_collision", {
-        path: this.userMcpJsonPath,
-        collisions,
-      });
-    } catch {}
+    getMcpBridge().audit("multiplexer_user_mcp_collision", {
+      path: this.userMcpJsonPath,
+      collisions,
+    });
   }
 
   // ── Session-map persistence ─────────────────────────────────────────
@@ -710,14 +698,12 @@ export class McpMultiplexerPlugin {
       const uptimeS = proc.startedAt
         ? Math.floor((Date.now() - proc.startedAt.getTime()) / 1000)
         : null;
-      try {
-        getMcpBridge().audit(degraded ? "mcp_health_degraded" : "mcp_health_transition", {
-          server: name,
-          previous_status: prev ?? "unknown",
-          current_status: curr,
-          uptime_s: uptimeS,
-        });
-      } catch {}
+      getMcpBridge().audit(degraded ? "mcp_health_degraded" : "mcp_health_transition", {
+        server: name,
+        previous_status: prev ?? "unknown",
+        current_status: curr,
+        uptime_s: uptimeS,
+      });
       const line = `[mcp-multiplexer] HEALTH ${name}: ${prev ?? "unknown"} → ${curr}${degraded ? " (DEGRADED)" : ""}`;
       if (degraded) console.warn(line);
       else console.log(line);
@@ -763,12 +749,10 @@ export class McpMultiplexerPlugin {
 
   issueIdentity(ptyId: string): PtyIdentity {
     const id = _issueIdentity(ptyId);
-    try {
-      getMcpBridge().audit("multiplexer_identity_issued", {
-        pty_id: ptyId,
-        issued_at: id.issuedAt,
-      });
-    } catch {}
+    getMcpBridge().audit("multiplexer_identity_issued", {
+      pty_id: ptyId,
+      issued_at: id.issuedAt,
+    });
     return id;
   }
 
@@ -776,9 +760,7 @@ export class McpMultiplexerPlugin {
     const removed = _revokeIdentity(ptyId);
     await Promise.allSettled([...this.handlers.values()].map((h) => h.releasePty(ptyId)));
     if (removed) {
-      try {
-        getMcpBridge().audit("multiplexer_identity_released", { pty_id: ptyId });
-      } catch {}
+      getMcpBridge().audit("multiplexer_identity_released", { pty_id: ptyId });
     }
   }
 
@@ -831,13 +813,11 @@ export class McpMultiplexerPlugin {
     //                              loop is still running)
     if (status === "failed") {
       console.error(`[mcp-multiplexer] server '${name}' permanently failed: ${reason}`);
-      try {
-        getMcpBridge().audit("multiplexer_server_permanently_failed", {
-          server: name,
-          reason,
-          status,
-        });
-      } catch {}
+      getMcpBridge().audit("multiplexer_server_permanently_failed", {
+        server: name,
+        reason,
+        status,
+      });
       // #72 item 6: align the health-probe view with what we just
       // audited so the next `_sampleHealth` tick doesn't re-fire
       // `mcp_health_degraded` for the same incident.
@@ -845,13 +825,11 @@ export class McpMultiplexerPlugin {
       return;
     }
     console.error(`[mcp-multiplexer] server '${name}' crashed: ${reason} — status: ${status}`);
-    try {
-      getMcpBridge().audit("multiplexer_server_crashed", {
-        server: name,
-        reason,
-        status,
-      });
-    } catch {}
+    getMcpBridge().audit("multiplexer_server_crashed", {
+      server: name,
+      reason,
+      status,
+    });
     // #72 item 6: same dedup gate as the permanently-failed branch
     // above — sync `lastObservedStatus` so the next probe tick treats
     // this incident as already-audited and only fires on a subsequent

--- a/src/plugins/mcp-multiplexer/session-persistence.ts
+++ b/src/plugins/mcp-multiplexer/session-persistence.ts
@@ -95,13 +95,14 @@ function _hashFor(serverName: string, ptyId: string, sessionId: string): string 
   return createHash("sha256").update(`${serverName}:${ptyId}:${sessionId}`).digest("hex");
 }
 
-/** Fire an audit event, swallowing any failure (audits must never break us). */
+/**
+ * Fire an audit event. The bridge contract (#72 item 13) guarantees
+ * `audit()` never throws — failures are swallowed inside the bridge
+ * itself with a JSON-serialise try/catch + FS-append swallow. The
+ * caller-side wrapper that used to live here was dead defense.
+ */
 function _audit(event: string, payload: Record<string, unknown>): void {
-  try {
-    getMcpBridge().audit(event, payload);
-  } catch {
-    // intentionally swallowed — persistence layer must never throw from audit
-  }
+  getMcpBridge().audit(event, payload);
 }
 
 /** Type-guard for a parsed PersistedFile. */

--- a/src/plugins/mcp-proxy/index.ts
+++ b/src/plugins/mcp-proxy/index.ts
@@ -99,9 +99,7 @@ export class McpProxyPlugin {
       console.error(
         `[mcp-proxy] skipping ${skipped.length} server(s) claimed by multiplexer: ${skipped.join(", ")}`,
       );
-      try {
-        getMcpBridge().audit("mcp_proxy_skip_shared", { servers: skipped });
-      } catch {}
+      getMcpBridge().audit("mcp_proxy_skip_shared", { servers: skipped });
     }
     const allTools: { name: string; description: string; schema: Record<string, unknown> }[] = [];
 
@@ -228,23 +226,19 @@ export class McpProxyPlugin {
     // either name without a payload-shape migration.
     if (proc.status === "failed") {
       console.error(`[mcp-proxy] Server '${name}' permanently failed: ${reason}`);
-      try {
-        getMcpBridge().audit("mcp_proxy_server_permanently_failed", {
-          server: name,
-          reason,
-          status: proc.status,
-        });
-      } catch {}
-      return;
-    }
-    console.error(`[mcp-proxy] Server '${name}' crashed: ${reason} — status: ${proc.status}`);
-    try {
-      getMcpBridge().audit("mcp_proxy_server_crashed", {
+      getMcpBridge().audit("mcp_proxy_server_permanently_failed", {
         server: name,
         reason,
         status: proc.status,
       });
-    } catch {}
+      return;
+    }
+    console.error(`[mcp-proxy] Server '${name}' crashed: ${reason} — status: ${proc.status}`);
+    getMcpBridge().audit("mcp_proxy_server_crashed", {
+      server: name,
+      reason,
+      status: proc.status,
+    });
   }
 
   private async _invokeReasoned(fqn: string, args: unknown): Promise<unknown> {


### PR DESCRIPTION
Closes #72 item 13.

## Motivation

`PluginMcpBridge.audit()` already wraps its `appendFileSync` in a try/catch with the comment _"Audit failures must not break the bridge"_. Caller-side try/catch around `getMcpBridge().audit(...)` is dead defense — the bridge guarantees no throw.

Twenty such wrappers had accumulated across the multiplexer + proxy + gateway substrate. They add noise to grep/diff output and imply (incorrectly) that callers need to handle audit errors.

## Changes

**1. Bridge contract docblock.** Added a JSDoc block on `audit()` explicitly stating _"this method MUST NOT throw"_ and pointing callers at this PR for the historical context. Future contributors reading the bridge see the contract; future code review can call out new wrappers as dead defense.

**2. 20 try/catch wrappers removed** across:

| File | Sites removed |
|---|---|
| `mcp-multiplexer/index.ts` | 11 |
| `mcp-multiplexer/http-handler.ts` | 4 |
| `mcp-proxy/index.ts` | 3 |
| `http-gateway.ts` | 2 |

**3. `session-persistence.ts:_audit` helper** — the inner wrap was the same dead defense. Helper still exists so callers keep the short `_audit(event, payload)` form, but the try/catch is gone.

## Mechanical correctness

The regex used to find audit-only wrappers was:

```ts
try {
  getMcpBridge().audit(...);  // arbitrary balanced parens, multi-line ok
} catch {}
```

It only matches when the ONLY substantive content inside the `try` block is the bare audit call. Other `try/catch` swallows in these files (dispose paths, FS races, transport teardown) are untouched — they swallow real errors for valid reasons.

## Tests

The existing audit-forensics suite (`mcp_proxy_audit_forensics.test.ts`) verifies a malformed audit path still doesn't break invocations — that's the bridge-side contract this PR depends on. No new tests; removing dead defensive code can't change observable behaviour.

Full mux + proxy + integration suite: **134 pass, 0 fail**.
Full-repo `bun run lint`: **zero errors**.

## Test plan
- [x] Unit + integration tests green
- [x] Lint green
- [x] Bridge contract is documented + tested (audit-forensics suite)