### PR TITLE
perf(mcp-multiplexer): skip _readBody clone for large bodies (#72 item 11)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.30",
+      "version": "2.2.31",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.30",
+  "version": "2.2.31",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/http-handler.test.ts
@@ -559,3 +559,155 @@ describe("McpHttpHandler — multiplexer_invoke audit carries X-Claudeclaw-Ts (#
     revokeIdentity("suzy");
   });
 });
+
+// #72 item 11: skip the body-peek clone when the request body exceeds
+// PEEK_MAX_BYTES (4 KiB). Saves a full body duplicate + JSON-parse pass
+// for tool calls with large arguments (file contents, image attachments,
+// etc). The `rpc_method` audit field becomes undefined for those calls
+// — forensic-only loss, no security/correctness impact.
+describe("McpHttpHandler — body-peek threshold for audit (#72 item 11)", () => {
+  let proc: McpServerProcess | null = null;
+  let handler: McpHttpHandler | null = null;
+
+  beforeEach(async () => {
+    _resetIdentityStore();
+    proc = new McpServerProcess("test", makeServerConfig());
+    await proc.start();
+    handler = new McpHttpHandler({ serverName: "test", proc: proc! });
+  });
+
+  afterEach(async () => {
+    if (handler) await handler.stop();
+    if (proc) await proc.stop();
+    proc = null;
+    handler = null;
+    _resetIdentityStore();
+    _resetMcpBridge();
+  });
+
+  function captureAudits(events: Array<{ name: string; payload: Record<string, unknown> }>) {
+    _setMcpBridge({
+      audit: (name: string, payload: Record<string, unknown>) => {
+        events.push({ name, payload });
+      },
+      registerPluginTool: () => {},
+      unregisterPluginTool: () => {},
+      listTools: () => [],
+      invoke: async () => {
+        throw new Error("not in test");
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: minimal test bridge
+    } as any);
+  }
+
+  /** Build a Request with an explicit content-length so the peek logic
+   *  can short-circuit. The body JSON is constructed to be roughly
+   *  `targetSize` bytes (close enough for the 4 KiB threshold). */
+  function bigRpcRequest(targetBodyBytes: number, headers: Record<string, string>): Request {
+    // The method field is what _peekRpcMethod would extract — fill the
+    // rest with padding to push past PEEK_MAX_BYTES.
+    const padding = "x".repeat(Math.max(0, targetBodyBytes - 80));
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/list",
+      params: { padding },
+    });
+    return new Request("http://127.0.0.1:4632/mcp/test", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+        "content-length": String(body.length),
+        ...headers,
+      },
+      body,
+    });
+  }
+
+  it("includes rpc_method in audit when body is below the peek threshold", async () => {
+    const id = issueIdentity("suzy");
+    const events: Array<{ name: string; payload: Record<string, unknown> }> = [];
+    captureAudits(events);
+
+    // Default small request (~80 bytes JSON) — well under 4 KiB.
+    await handler!.handle(
+      rpcRequest(
+        { jsonrpc: "2.0", id: 1, method: "tools/list" },
+        { [PTY_ID_HEADER]: "suzy", [AUTH_HEADER]: id.headers[AUTH_HEADER] },
+      ),
+    );
+
+    const invoke = events.find((e) => e.name === "multiplexer_invoke");
+    expect(invoke).toBeDefined();
+    expect(invoke!.payload.rpc_method).toBe("tools/list");
+    revokeIdentity("suzy");
+  });
+
+  it("omits rpc_method (sets to undefined) when body exceeds PEEK_MAX_BYTES", async () => {
+    const id = issueIdentity("suzy");
+    const events: Array<{ name: string; payload: Record<string, unknown> }> = [];
+    captureAudits(events);
+
+    // 8 KiB body — comfortably above the 4 KiB peek threshold.
+    await handler!.handle(
+      bigRpcRequest(8192, {
+        [PTY_ID_HEADER]: "suzy",
+        [AUTH_HEADER]: id.headers[AUTH_HEADER],
+      }),
+    );
+
+    const invoke = events.find((e) => e.name === "multiplexer_invoke");
+    expect(invoke).toBeDefined();
+    // The clone+parse path was skipped → no method extracted.
+    expect(invoke!.payload.rpc_method).toBeUndefined();
+    // Everything else still recorded — server, pty_id, stateless,
+    // client_ts (when present) are all available without the body peek.
+    expect(invoke!.payload.server).toBe("test");
+    expect(invoke!.payload.pty_id).toBe("suzy");
+    revokeIdentity("suzy");
+  });
+
+  it("still includes rpc_method when content-length declared is just under threshold", async () => {
+    const id = issueIdentity("suzy");
+    const events: Array<{ name: string; payload: Record<string, unknown> }> = [];
+    captureAudits(events);
+
+    // 3 KiB body — under the 4 KiB cap, so the peek runs.
+    await handler!.handle(
+      bigRpcRequest(3000, {
+        [PTY_ID_HEADER]: "suzy",
+        [AUTH_HEADER]: id.headers[AUTH_HEADER],
+      }),
+    );
+
+    const invoke = events.find((e) => e.name === "multiplexer_invoke");
+    expect(invoke).toBeDefined();
+    expect(invoke!.payload.rpc_method).toBe("tools/list");
+    revokeIdentity("suzy");
+  });
+
+  it("the peek skip does not affect the audit fire path (only rpc_method is dropped)", async () => {
+    const id = issueIdentity("suzy");
+    const events: Array<{ name: string; payload: Record<string, unknown> }> = [];
+    captureAudits(events);
+
+    // 8 KiB body — peek will be skipped, but the rest of the dispatch
+    // path must continue normally. The `multiplexer_invoke` audit still
+    // fires (auth + rate-limit + bucket-init all reached); only
+    // `rpc_method` is absent.
+    await handler!.handle(
+      bigRpcRequest(8192, {
+        [PTY_ID_HEADER]: "suzy",
+        [AUTH_HEADER]: id.headers[AUTH_HEADER],
+      }),
+    );
+
+    const invoke = events.find((e) => e.name === "multiplexer_invoke");
+    expect(invoke).toBeDefined();
+    expect(invoke!.payload.server).toBe("test");
+    expect(invoke!.payload.pty_id).toBe("suzy");
+    expect(invoke!.payload.rpc_method).toBeUndefined();
+    revokeIdentity("suzy");
+  });
+});

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -73,15 +73,53 @@ export interface McpHttpHandlerOpts {
  *  would OOM the daemon. */
 const MAX_BODY_BYTES = 1_048_576; // 1 MiB
 
-/** Helper: read raw body bytes once. Phase D #2 (security): enforce a
- *  hard byte cap so a malicious or buggy client can't OOM the daemon
- *  with a multi-GB JSON POST. */
+/**
+ * Maximum body size we'll clone + JSON.parse for the audit-log peek
+ * (#72 item 11). Above this threshold we skip the peek entirely — the
+ * `rpc_method` audit field becomes undefined for that request, which
+ * is forensic-only (the auth + rate-limit + per-bucket dispatch paths
+ * are unaffected). Saves a full body duplicate + JSON-parse for tool
+ * calls with large arguments (file contents, image attachments, etc).
+ *
+ * 4KB is comfortably above the size of the JSON-RPC envelope for any
+ * realistic call (method names + ids + small args). Tool calls with
+ * non-trivial inputs cross this threshold quickly — those are the
+ * exact cases where the clone+parse matters for peak-memory pressure.
+ */
+const PEEK_MAX_BYTES = 4096;
+
+/**
+ * Helper: read JSON body for the audit-log peek. The SDK transport
+ * reparses the body itself from the original Request — this helper
+ * exists only so the audit path can grab `rpc_method` without
+ * consuming the body stream.
+ *
+ * Skip path (#72 item 11): when the declared `Content-Length` exceeds
+ * `PEEK_MAX_BYTES`, return `undefined` immediately. We avoid:
+ *   - `req.clone()` (full body duplication in memory)
+ *   - `cloned.json()` (a second JSON.parse pass over the same bytes
+ *     the SDK transport will already parse)
+ *
+ * The audit row for that request will carry `rpc_method: undefined`,
+ * which is fine — operators reading the audit log can still see the
+ * server name, ptyId, timestamp, etc. The bulk of multiplexer traffic
+ * (tool listings, small dispatches) is well under 4KB and continues
+ * to get the peek.
+ */
 async function _readBody(req: Request): Promise<unknown> {
-  // The SDK transport parses JSON itself from the Request — we just pass
-  // the raw Request through. This helper exists so the auth path can
-  // peek without consuming the body stream.
   const ct = req.headers.get("content-type") ?? "";
   if (!ct.toLowerCase().includes("json")) return undefined;
+  // Skip the clone+parse when the body is big enough to materially
+  // matter for peak memory. Without a declared Content-Length we
+  // can't cheaply size-check, so we fall through to the clone path
+  // — _enforceBodyCap already capped the absolute size at 1 MiB.
+  const declared = req.headers.get("content-length");
+  if (declared !== null) {
+    const n = Number(declared);
+    if (Number.isFinite(n) && n > PEEK_MAX_BYTES) {
+      return undefined;
+    }
+  }
   try {
     const cloned = req.clone();
     return await cloned.json();


### PR DESCRIPTION
Closes #72 item 11.

## Motivation

`_readBody` is called once per `/mcp/<server>` request to peek the JSON-RPC `method` field for the audit log. It clones the entire request body via `req.clone()` then `JSON.parse`s the clone. The SDK transport parses the body again for actual dispatch. For tool calls carrying non-trivial inputs (file contents, image attachments, etc), this doubles peak memory per request.

The audit `rpc_method` field is forensic-only — operators inspecting the audit log can still see `server`, `pty_id`, `client_ts`, etc. Dropping it for large bodies sacrifices no security or correctness.

## Fix

New `PEEK_MAX_BYTES = 4096` threshold. In `_readBody`:

```ts
const declared = req.headers.get("content-length");
if (declared !== null) {
  const n = Number(declared);
  if (Number.isFinite(n) && n > PEEK_MAX_BYTES) {
    return undefined;
  }
}
// fall through to clone+parse for small/unknown-size bodies
```

4 KiB is comfortably above the JSON-RPC envelope for any realistic call (method names + ids + small args). Tool calls with non-trivial inputs cross this threshold quickly — exactly the cases where the clone+parse matters for peak memory.

If `Content-Length` is absent (chunked transfer / HTTP/2), the code falls through to the existing clone path. `_enforceBodyCap` already caps the absolute body size at 1 MiB upstream, so the worst case is unchanged.

## Tests

Four new tests in `http-handler.test.ts`:

- `includes rpc_method in audit when body is below the peek threshold` — small RPC envelope still gets the peek.
- `omits rpc_method (sets to undefined) when body exceeds PEEK_MAX_BYTES` — 8 KiB body → peek skipped → `rpc_method: undefined`.
- `still includes rpc_method when content-length declared is just under threshold` — 3 KiB body → peek runs → `tools/list` recorded.
- `the peek skip does not affect the audit fire path (only rpc_method is dropped)` — server, pty_id, etc. still recorded for large bodies.

Verified pre-fix regression catches the missing skip path: removing the threshold check fails 2 of the 4 new tests.

Full mux suite: **101 pass, 0 fail**.
Full-repo `bun run lint`: **zero errors**.

## Out of scope

Codex's other option in the issue text — "extract via the SDK transport's hooks so the body is parsed once" — would require deeper coupling with the MCP SDK's transport internals. The size-threshold approach achieves the peak-memory goal with a 1-line predicate; the SDK-hook integration can be revisited if/when the SDK exposes a stable parsed-body event.

## Test plan
- [x] Unit tests green (23/23 in http-handler.test.ts)
- [x] Lint green
- [x] Verified regression catches the bug (2 of 4 new tests fail without the threshold check)