### PR TITLE
docs(mcp-multiplexer): surface coverage is tools-only (#72 item 12, doc path)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.31",
+      "version": "2.2.32",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.31",
+  "version": "2.2.32",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/README.md
+++ b/README.md
@@ -171,6 +171,17 @@ Net effect: you get the per-PTY process explosion the multiplexer was designed t
 - `stateless` — subset of `shared` for servers with no per-session state; one upstream session shared across all PTYs.
 - `rateLimit` — per-bearer (= per-PTY) sliding-window cap on `/mcp/<server>` requests. Defense-in-depth for a leaked bearer.
 
+#### Surface coverage: tools only (no resources / prompts / completions)
+
+The multiplexer currently proxies **`ListTools` + `CallTool` only**. MCP servers can also expose `resources/*`, `prompts/*`, and `completions/*` per the MCP spec — those surfaces are **not** forwarded through the multiplexer. If a shared server defines them, PTY claudes won't see them through the multiplexed `/mcp/<server>` route.
+
+**Practical impact:** none for the MCP servers we ship with by default (graphiti, codegraph, sentrux, etc. — all tool-only). Servers that depend on resource attachments (file-pinning workflows) or prompt templates won't surface that surface through a multiplexed mount.
+
+**Workarounds if you need resources / prompts from a specific server:**
+
+1. **Drop it from `settings.mcp.shared`** — claude will then spawn it per-PTY via the normal stdio path (the explosion concern applies; only worth it for the server that needs the extra surfaces).
+2. **Wait for the feature extension** — tracked as #72 item 12. Would require new `ListResourcesRequestSchema` / `ReadResourceRequestSchema` / `ListPromptsRequestSchema` / `GetPromptRequestSchema` handlers wired through the SDK transport. No design blockers, just unbuilt.
+
 #### References
 
 - Architecture: [`.planning/mcp-multiplexer/SPEC.md`](.planning/mcp-multiplexer/SPEC.md)


### PR DESCRIPTION
Closes #72 item 12 (doc path).

## What this PR does

Adds a "Surface coverage: tools only" section to the README under "MCP multiplexer", explaining that:

- The multiplexer currently proxies **`ListTools` + `CallTool` only**.
- `resources/*`, `prompts/*`, and `completions/*` per the MCP spec are NOT forwarded.
- If a shared server defines those surfaces they're invisible to PTY claudes via the multiplexed `/mcp/<server>` route.

Plus practical impact + workaround guidance for operators.

## Why doc-only

Item 12 of #72 left it operator's choice: feature extension OR doc. Shipping the doc now — no operator demand surfaced for resource/prompt forwarding, our default server set is tool-only (graphiti, codegraph, sentrux, etc.), and the README note prevents the silent-feature-missing footgun. The feature extension stays open as a ticket if/when a real use case shows up.

Code-only PR with no behavioural change.

## Test plan
- [x] No code changes; README addendum only
- [x] Lint green (markdown not lint-gated; touched files pass biome)