### PR TITLE
fix(runner): preserve long-lived sk-ant-oat01-* OAuth tokens for PTY claudes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.32",
+      "version": "2.2.33",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.32",
+  "version": "2.2.33",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/runner.test.ts
+++ b/src/__tests__/runner.test.ts
@@ -346,3 +346,152 @@ describe("withCleanProcessEnv", () => {
     }
   }, 5000);
 });
+
+// ─── shouldStripSpawnEnvKey (long-lived OAuth token exception) ──────────────
+//
+// Regression cover for the Hetzner activation flow. The original strip list
+// removed CLAUDE_CODE_OAUTH_TOKEN unconditionally to prevent short-lived
+// OAuth tokens (which expire ~daily and have no refresh path in PTY-mode
+// claudes) from being silently inherited by long-running PTY processes.
+// Long-lived `sk-ant-oat01-*` tokens minted via `claude setup-token` have a
+// 1-year hard expiry and a different leak profile — operators wire them
+// intentionally and want them to flow through to spawned claudes. This
+// helper carves out that single exception while leaving every other strip
+// (ANTHROPIC_API_KEY, CLAUDECODE, etc.) unconditional.
+describe("shouldStripSpawnEnvKey (long-lived OAuth exception)", () => {
+  it("keeps sk-ant-oat01-* OAuth tokens (returns false)", () => {
+    expect(
+      runnerMod.shouldStripSpawnEnvKey(
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "sk-ant-oat01-abc123_realistic-token-shape",
+      ),
+    ).toBe(false);
+  });
+
+  it("strips short-lived (non-oat01) OAuth tokens", () => {
+    expect(runnerMod.shouldStripSpawnEnvKey("CLAUDE_CODE_OAUTH_TOKEN", "some-session-oauth")).toBe(
+      true,
+    );
+    expect(
+      runnerMod.shouldStripSpawnEnvKey("CLAUDE_CODE_OAUTH_TOKEN", "sk-ant-something-else"),
+    ).toBe(true);
+  });
+
+  it("strips ANTHROPIC_API_KEY even if it happens to look oat01-ish", () => {
+    expect(
+      runnerMod.shouldStripSpawnEnvKey("ANTHROPIC_API_KEY", "sk-ant-oat01-not-the-right-key"),
+    ).toBe(true);
+  });
+
+  it("strips other strip-list keys unconditionally", () => {
+    expect(runnerMod.shouldStripSpawnEnvKey("CLAUDECODE", "1")).toBe(true);
+    expect(runnerMod.shouldStripSpawnEnvKey("CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST", "true")).toBe(
+      true,
+    );
+  });
+
+  it("strips when value is undefined or empty (no false-positive keep)", () => {
+    expect(runnerMod.shouldStripSpawnEnvKey("CLAUDE_CODE_OAUTH_TOKEN", undefined)).toBe(true);
+    expect(runnerMod.shouldStripSpawnEnvKey("CLAUDE_CODE_OAUTH_TOKEN", "")).toBe(true);
+  });
+});
+
+describe("cleanSpawnEnv (oat01 exception wiring)", () => {
+  function withTempEnv<T>(seed: Record<string, string | undefined>, fn: () => T): T {
+    const snapshot: Record<string, string | undefined> = {};
+    for (const k of Object.keys(seed)) snapshot[k] = process.env[k];
+    for (const [k, v] of Object.entries(seed)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    try {
+      return fn();
+    } finally {
+      for (const [k, v] of Object.entries(snapshot)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
+  }
+
+  it("keeps long-lived CLAUDE_CODE_OAUTH_TOKEN in the output env", () => {
+    withTempEnv(
+      {
+        CLAUDE_CODE_OAUTH_TOKEN: "sk-ant-oat01-test-long-lived",
+        ANTHROPIC_API_KEY: "sk-ant-api03-should-still-strip",
+        CLAUDECODE: "1",
+      },
+      () => {
+        const out = runnerMod.cleanSpawnEnv();
+        expect(out.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-test-long-lived");
+        expect(out.ANTHROPIC_API_KEY).toBeUndefined();
+        expect(out.CLAUDECODE).toBeUndefined();
+      },
+    );
+  });
+
+  it("strips CLAUDE_CODE_OAUTH_TOKEN when not in oat01 shape", () => {
+    withTempEnv(
+      {
+        CLAUDE_CODE_OAUTH_TOKEN: "ephemeral-session-token",
+      },
+      () => {
+        const out = runnerMod.cleanSpawnEnv();
+        expect(out.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+      },
+    );
+  });
+});
+
+describe("withCleanProcessEnv (oat01 exception wiring)", () => {
+  const STRIP_KEYS = [
+    "ANTHROPIC_API_KEY",
+    "CLAUDECODE",
+    "CLAUDE_CODE_OAUTH_TOKEN",
+    "CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST",
+  ] as const;
+
+  function snap(): Record<string, string | undefined> {
+    const out: Record<string, string | undefined> = {};
+    for (const k of STRIP_KEYS) out[k] = process.env[k];
+    return out;
+  }
+
+  function rest(s: Record<string, string | undefined>): void {
+    for (const [k, v] of Object.entries(s)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+
+  it("leaves sk-ant-oat01-* OAuth tokens visible to fn (does not strip)", () => {
+    const original = snap();
+    try {
+      const LONG_LIVED = "sk-ant-oat01-keep-me-visible";
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = LONG_LIVED;
+      process.env.ANTHROPIC_API_KEY = "sk-ant-api03-still-stripped";
+      const seen = runnerMod.withCleanProcessEnv(() => ({
+        oauth: process.env.CLAUDE_CODE_OAUTH_TOKEN,
+        api: process.env.ANTHROPIC_API_KEY,
+      }));
+      expect(seen.oauth).toBe(LONG_LIVED);
+      expect(seen.api).toBeUndefined();
+      expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe(LONG_LIVED);
+    } finally {
+      rest(original);
+    }
+  });
+
+  it("still strips short-lived (non-oat01) OAuth tokens", () => {
+    const original = snap();
+    try {
+      process.env.CLAUDE_CODE_OAUTH_TOKEN = "session-style-token";
+      runnerMod.withCleanProcessEnv(() => {
+        expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBeUndefined();
+      });
+      expect(process.env.CLAUDE_CODE_OAUTH_TOKEN).toBe("session-style-token");
+    } finally {
+      rest(original);
+    }
+  });
+});

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -199,6 +199,14 @@ const COMPACT_TIMEOUT_ENABLED = true;
  * Canonical strip list shared by `cleanSpawnEnv` and `withCleanProcessEnv`.
  * Keep these in sync — both helpers MUST agree, or one will reintroduce a
  * leak the other prevents.
+ *
+ * Exception: `CLAUDE_CODE_OAUTH_TOKEN` values that start with `sk-ant-oat01-`
+ * are 1-year long-lived tokens minted via `claude setup-token`. These do NOT
+ * carry the frozen-session refresh-failure risk that motivated stripping
+ * short-lived OAuth tokens, so they are preserved into spawned PTY claudes
+ * (intentional: operators wire the token via the daemon env file and expect
+ * it to flow through to the subscription-pool claudes). The exception is
+ * implemented by `shouldStripSpawnEnvKey` below.
  */
 const SPAWN_ENV_STRIP_KEYS = [
   "CLAUDECODE",
@@ -207,11 +215,27 @@ const SPAWN_ENV_STRIP_KEYS = [
   "ANTHROPIC_API_KEY", // see comment above — prevents accidental API-key billing
 ] as const;
 
+/**
+ * Decide whether a strip-list key should actually be stripped for the given
+ * value. Long-lived `sk-ant-oat01-*` OAuth tokens are kept; everything else
+ * on the strip list is removed unconditionally.
+ */
+export function shouldStripSpawnEnvKey(key: string, value: string | undefined): boolean {
+  if (
+    key === "CLAUDE_CODE_OAUTH_TOKEN" &&
+    typeof value === "string" &&
+    value.startsWith("sk-ant-oat01-")
+  ) {
+    return false;
+  }
+  return true;
+}
+
 export function cleanSpawnEnv(): Record<string, string> {
   const stripped = new Set<string>(SPAWN_ENV_STRIP_KEYS);
   const out: Record<string, string> = {};
   for (const [key, value] of Object.entries(process.env)) {
-    if (stripped.has(key)) continue;
+    if (stripped.has(key) && shouldStripSpawnEnvKey(key, value)) continue;
     if (typeof value === "string") out[key] = value;
   }
   return out;
@@ -303,7 +327,13 @@ export function withCleanProcessEnv<T>(fn: () => T): T {
   loadLibc();
   const restore: Record<string, string | undefined> = {};
   for (const k of SPAWN_ENV_STRIP_KEYS) {
-    restore[k] = process.env[k];
+    const currentValue = process.env[k];
+    // Skip the strip entirely for keys whose current value is exempt
+    // (e.g. long-lived `sk-ant-oat01-*` OAuth tokens). Leaving `restore[k]`
+    // unset means the finally-block does not touch JS env or libc environ
+    // for this key — it stays as-is throughout `fn`'s execution.
+    if (!shouldStripSpawnEnvKey(k, currentValue)) continue;
+    restore[k] = currentValue;
     // 1. JS-side delete so anything checking process.env directly sees it gone.
     delete process.env[k];
     // 2. libc unsetenv so anything reading via `environ` (bun-pty's Rust


### PR DESCRIPTION
## Summary

The PTY env strip was designed against short-lived OAuth tokens (expire ~daily, no refresh path in long-running PTY claudes). Long-lived `sk-ant-oat01-*` tokens minted via `claude setup-token` have a 1-year hard expiry and a different leak profile — operators wire them intentionally and want them to flow through to subscription-pool claudes.

This carves out a single exception in a new `shouldStripSpawnEnvKey` helper: keep `CLAUDE_CODE_OAUTH_TOKEN` when value starts with `sk-ant-oat01-`. Every other strip-list key (`ANTHROPIC_API_KEY`, `CLAUDECODE`, `CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST`) and every other shape of OAuth token still strips unconditionally.

Wired in both `cleanSpawnEnv` (the env Record handed to `bun-pty`) and `withCleanProcessEnv` (the JS env + libc `environ` strip around the synchronous FFI spawn) so the caller view and the fork+exec child view stay consistent.

## Why now

Hetzner activation of the MCP multiplexer (#72 follow-up task #26) needed PTY claudes that could actually auth. Session OAuth on the daemon had expired (filed as #102 for auto-refresh) and the only realistic stopgap was a long-lived token. With the strip in place, the long-lived token was deleted before reaching the spawned claude — every model call 401'd.

## Validation

Hot-patched on Hetzner first, then ran both smoke tests through Discord against the live multiplexer:

- **everything.echo (stateless)**: `Echo: hello multiplexer` — single round-trip through `/mcp/everything` with per-PTY HMAC bearer
- **playwright.screenshot (stateful)**: 18,788-byte PNG written, browser session held inside the shared playwright child process across the multiplexer's HTTP bridge

Same PTY session handled both servers. Shared MCP children stayed alive across calls (no per-PTY spawn).

## Test plan

- [x] New unit tests added in `src/__tests__/runner.test.ts`:
  - `shouldStripSpawnEnvKey`: keeps `sk-ant-oat01-*`, strips other token shapes, strips other strip-list keys, treats undefined/empty as strip
  - `cleanSpawnEnv (oat01 exception wiring)`: long-lived token survives, other keys still gone
  - `withCleanProcessEnv (oat01 exception wiring)`: long-lived token visible to `fn`, short-lived token still stripped
- [x] All 9 new tests pass: `bun test src/__tests__/runner.test.ts --test-name-pattern "(shouldStripSpawnEnvKey|oat01)"` → `9 pass / 0 fail`
- [x] Biome lint clean on changed files (`bunx biome check src/runner.ts src/__tests__/runner.test.ts` → 0 errors)
- [x] Full-repo lint (`bun run lint`) error count: **1 → 0** (pre-existing error fixed by formatter on the new test code; warning/info baseline unchanged)
- [x] Plugin + marketplace versions bumped to `2.2.33`
- [x] End-to-end smoke tests on Hetzner production (see "Validation" above)