### PR TITLE
fix(runner): band-aid #105 — constrain PTY-mode replies to plain prose

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.33",
+      "version": "2.2.35",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.33",
+  "version": "2.2.35",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1175,6 +1175,26 @@ const DIR_SCOPE_PROMPT = [
   "If a request requires accessing files outside the project, refuse and explain why.",
 ].join("\n");
 
+/**
+ * Band-aid for #105 — see the call site in `run()` for full context.
+ *
+ * Constrains the model's user-facing reply to plain prose so the PTY
+ * sentinel-echo parser can extract textual content rather than TUI box
+ * chrome from rendered markdown blocks. Temporary; remove with the PTY
+ * runtime when the Bus runtime (epic #107, spec PR #106) becomes default.
+ */
+const PTY_OUTPUT_FORMAT_CONSTRAINT = [
+  "OUTPUT FORMAT CONSTRAINT (response surface limitation):",
+  "Your final user-facing reply MUST be plain prose. The reply is captured through a text-only transport that cannot render markdown.",
+  "Do NOT use in your final reply:",
+  "  - Backtick code fences (```...``` or single `...`) — write paths and commands plainly, e.g. /home/x/file.png NOT `/home/x/file.png`",
+  "  - Markdown bullets (`*`, `-`, `+`) at the start of lines",
+  "  - Numbered list items (`1.`, `2.`)",
+  "  - Block quotes (`>` at start of lines)",
+  "  - Horizontal rules (`---`)",
+  "This constraint applies ONLY to your final response text. You may still use markdown freely inside tool inputs and internal reasoning.",
+].join("\n");
+
 export async function ensureProjectClaudeMd(): Promise<void> {
   // Preflight-only initialization: never rewrite an existing project CLAUDE.md.
   if (existsSync(PROJECT_CLAUDE_MD)) return;
@@ -1703,6 +1723,25 @@ async function execClaude(
     if (memoryInstructions) appendParts.push(memoryInstructions);
 
     if (security.level !== "unrestricted") appendParts.push(DIR_SCOPE_PROMPT);
+
+    // Band-aid for #105 — the PTY sentinel-echo parser captures the TUI
+    // rendered form of the model's reply, not the underlying assistant text.
+    // When the model emits markdown structure (backticks, code fences, bullets,
+    // numbered lists, block quotes), the TUI renders them inside framed
+    // visual elements and the parser extracts box-chrome glyphs instead of
+    // textual content. Empirically observed: a reply of `Saved to
+    // `/path/to/file.png`` (clean in JSONL) came back through Discord as
+    // `*↓1`.
+    //
+    // Constrain the assistant output to plain prose when PTY parsing is the
+    // surface translation layer. This is a workaround, not a fix — the proper
+    // fix is the Bus runtime (issue #107 epic, spec PR #106) which reads the
+    // JSONL directly and doesn't depend on TUI rendering. Remove this block
+    // when `runtime: bus` becomes the default.
+    if (settings.pty.enabled) {
+      appendParts.push(PTY_OUTPUT_FORMAT_CONSTRAINT);
+    }
+
     if (appendParts.length > 0) {
       args.push("--append-system-prompt", appendParts.join("\n\n"));
     }


### PR DESCRIPTION
## Summary

Band-aid for #105. The PTY sentinel-echo parser captures the TUI-rendered form of model replies, not the underlying assistant text. Markdown block elements (backticks, code fences, bullets, numbered lists, block quotes) get rendered by the TUI inside framed visual boxes; the parser then extracts box chrome glyphs instead of textual content.

Adds a system-prompt clause when `settings.pty.enabled` is true, instructing the model to keep its final user-facing reply in plain prose. Markdown is still allowed inside tool inputs and internal reasoning — the constraint applies only to the response text.

## Evidence

The clean JSONL `assistant.text` from the failing DM run:

```
Saved to `/home/claw/project/example-com-screenshot.png`
```

What came back through Discord:

```
*

↓

1
```

— a bullet glyph, a scroll-indicator glyph, and a line-number glyph. Three runs of blank lines between them. Tool call succeeded, file written, session healthy.

## What this is, and what it isn't

**This is:** a temporary constraint that papers over the PTY parser's structural fragility by reducing what the parser has to handle correctly.

**This is not:** a fix. The parser will still break on the next TUI rendering change Anthropic ships, regardless of what the system prompt says. The structural fix is the Bus runtime — see epic #107 and spec PR #106. The JSONL contains the correct text every time; the Bus reads JSONL directly and never looks at TUI rendering.

## Scope

- One narrow code change in `src/runner.ts`.
- Conditional on `settings.pty.enabled` — operators running with PTY disabled (legacy `runClaudeStream` path only) are unaffected.
- The constraint is tagged in code comments as a band-aid for #105 with a pointer to remove when `runtime: bus` becomes default (per §10 Sprint 5 of the spec).

## Trade-offs

- **Pro:** Discord DM channel becomes usable today. Channel mode also benefits (the channel-side `Savedto/home/claw/...` we already saw was a near-miss — a slightly more markdown-heavy reply would have hit the same bug).
- **Con:** Model replies become less visually rich (no inline code-formatted paths, no bulleted enumerations in answers). The cost is fully recovered once the Bus ships and parses structured JSONL.
- **Con:** This is text the model has to internalise and follow. Bigger system prompts ≈ slightly higher token cost per turn. Negligible in absolute terms.

## Test plan

- [x] Build passes (`bunx biome check src/runner.ts` — no new errors)
- [x] Existing runner unit tests pass (`bun test src/__tests__/runner.test.ts --test-name-pattern "shouldStripSpawnEnvKey|oat01|withCleanProcessEnv"` → 15 pass / 0 fail)
- [x] Versions bumped (plugin + marketplace → 2.2.35)
- [ ] Hot-patch on Hetzner + re-run the #105 DM repro after this merges — expect plain-prose reply with the screenshot path written without backticks