### PR TITLE
feat(bus): Sprint 3 — Discord + Telegram adapters

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.42",
+      "version": "2.2.43",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.43",
+      "version": "2.2.44",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.42",
+  "version": "2.2.43",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.43",
+  "version": "2.2.44",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/discord/__tests__/discord-inbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-inbound.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Discord adapter — inbound (gateway → bus) behavioural tests.
+ *
+ * Covers lifecycle, allow-list, channel/thread/DM routing, attachment
+ * forwarding, and rate-limiting. Outbound (bus → Discord) lives in
+ * `discord-outbound.test.ts`.
+ *
+ * Run: `bun test src/adapters/discord/__tests__/discord-inbound.test.ts`
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { DiscordAdapter } from "../index";
+import {
+  type AdapterHarness,
+  flushMicrotasks,
+  makeHarness,
+  makeMessage,
+  startAdapter,
+} from "./fixtures";
+
+let h: AdapterHarness;
+let adapter: DiscordAdapter | null = null;
+
+beforeEach(() => {
+  h = makeHarness();
+});
+
+afterEach(async () => {
+  if (adapter) {
+    await adapter.stop();
+    adapter = null;
+  }
+});
+
+describe("DiscordAdapter — lifecycle", () => {
+  it("start subscribes once per unique agent and wires the gateway", async () => {
+    adapter = await startAdapter(h);
+    // triage (ch-1) + ops (ch-2, th-1) + global (DM) = 3 unique agents.
+    expect(h.bus.state().subscriberCount).toBe(3);
+    expect(h.gateway.started).toBe(true);
+  });
+
+  it("stop closes every subscription and stops the gateway", async () => {
+    adapter = await startAdapter(h);
+    expect(h.bus.state().subscriberCount).toBe(3);
+    await adapter.stop();
+    adapter = null;
+    expect(h.bus.state().subscriberCount).toBe(0);
+    expect(h.gateway.stopped).toBe(true);
+  });
+
+  it("rejects construction with no gateway", () => {
+    expect(
+      () =>
+        new DiscordAdapter({
+          bus: h.bus,
+          token: "t",
+          allowedUserIds: [],
+          routing: { channels: {} },
+          // The constructor throws if `gateway` is missing — exercise that guard.
+          gateway: undefined,
+          restApi: h.rest,
+        }),
+    ).toThrow();
+  });
+});
+
+describe("DiscordAdapter — allow-list", () => {
+  it("DM from unauthorised user → 'Unauthorized.' reply", async () => {
+    adapter = await startAdapter(h);
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        channel_id: "dm-1",
+        guild_id: undefined,
+        author: { id: "intruder", username: "evil" },
+        content: "hello",
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.rest.sent).toHaveLength(1);
+    expect(h.rest.sent[0]?.channelId).toBe("dm-1");
+    expect(h.rest.sent[0]?.text).toBe("Unauthorized.");
+    expect(h.bus.prompts).toHaveLength(0);
+  });
+
+  it("guild message from unauthorised user → silent skip", async () => {
+    adapter = await startAdapter(h);
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        channel_id: "ch-1",
+        guild_id: "g-1",
+        author: { id: "intruder", username: "evil" },
+        content: "hello",
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.rest.sent).toHaveLength(0);
+    expect(h.bus.prompts).toHaveLength(0);
+  });
+
+  it("drops bot author messages", async () => {
+    adapter = await startAdapter(h);
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        author: { id: "user-1", username: "bot", bot: true },
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(0);
+  });
+});
+
+describe("DiscordAdapter — channel routing", () => {
+  it("routes channel id to its configured agent_id", async () => {
+    adapter = await startAdapter(h);
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        channel_id: "ch-2",
+        guild_id: "g-1",
+        content: "build it",
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(1);
+    const p = h.bus.prompts[0];
+    if (!p) throw new Error("prompt missing");
+    expect(p.agent_id).toBe("ops");
+    expect(p.origin).toBe("discord");
+    expect(p.origin_id).toBe("ch-2");
+    expect(p.user_id).toBe("user-1");
+    expect(p.text).toBe("build it");
+    expect(p.metadata?.message_id).toBe("msg-1");
+    expect(p.metadata?.username).toBe("terry");
+  });
+
+  it("routes explicit thread id to its configured agent_id", async () => {
+    adapter = await startAdapter(h);
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        channel_id: "th-1",
+        guild_id: "g-1",
+        content: "in a thread",
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(1);
+    expect(h.bus.prompts[0]?.agent_id).toBe("ops");
+    expect(h.bus.prompts[0]?.origin_id).toBe("th-1");
+  });
+
+  it("routes DM to dmAgentId", async () => {
+    adapter = await startAdapter(h);
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        channel_id: "dm-1",
+        guild_id: undefined,
+        content: "dm me",
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(1);
+    expect(h.bus.prompts[0]?.agent_id).toBe("global");
+  });
+
+  it("DM defaults to 'global' when dmAgentId is unset", async () => {
+    adapter = await startAdapter(h, {
+      routing: { channels: { "ch-1": "triage" } },
+    });
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        channel_id: "dm-x",
+        guild_id: undefined,
+        content: "hello",
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(1);
+    expect(h.bus.prompts[0]?.agent_id).toBe("global");
+  });
+
+  it("silently skips unrouted guild channels", async () => {
+    adapter = await startAdapter(h);
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        channel_id: "ch-unknown",
+        guild_id: "g-1",
+        content: "where do i go",
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(0);
+    expect(h.rest.sent).toHaveLength(0);
+  });
+});
+
+describe("DiscordAdapter — attachments", () => {
+  it("captures image/voice/text attachments in metadata", async () => {
+    adapter = await startAdapter(h);
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        content: "with media",
+        attachments: [
+          {
+            id: "a1",
+            filename: "pic.png",
+            content_type: "image/png",
+            url: "https://cdn/pic.png",
+            size: 100,
+          },
+          {
+            id: "a2",
+            filename: "voice.ogg",
+            content_type: "audio/ogg",
+            url: "https://cdn/voice.ogg",
+            size: 200,
+            flags: 1 << 13,
+          },
+          {
+            id: "a3",
+            filename: "notes.md",
+            content_type: "text/markdown",
+            url: "https://cdn/notes.md",
+            size: 50,
+          },
+        ],
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(1);
+    const meta = h.bus.prompts[0]?.metadata as {
+      attachments?: {
+        images: Array<{ id: string }>;
+        voices: Array<{ id: string }>;
+        texts: Array<{ id: string }>;
+      };
+    };
+    expect(meta.attachments?.images?.[0]?.id).toBe("a1");
+    expect(meta.attachments?.voices?.[0]?.id).toBe("a2");
+    expect(meta.attachments?.texts?.[0]?.id).toBe("a3");
+  });
+
+  it("forwards empty-text + image-only messages", async () => {
+    adapter = await startAdapter(h);
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        content: "",
+        attachments: [
+          {
+            id: "a1",
+            filename: "pic.png",
+            content_type: "image/png",
+            url: "https://cdn/pic.png",
+            size: 100,
+          },
+        ],
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(1);
+  });
+
+  it("drops empty messages with no attachments", async () => {
+    adapter = await startAdapter(h);
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({ content: "   " }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(0);
+  });
+});
+
+describe("DiscordAdapter — rate limit", () => {
+  it("drops messages above the limit", async () => {
+    let calls = 0;
+    adapter = await startAdapter(h, {
+      rateLimitCheck: () => {
+        calls++;
+        return calls === 1;
+      },
+    });
+    h.gateway.push({ type: "MESSAGE_CREATE", message: makeMessage({ content: "first" }) });
+    h.gateway.push({ type: "MESSAGE_CREATE", message: makeMessage({ content: "second" }) });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(1);
+    expect(h.bus.prompts[0]?.text).toBe("first");
+  });
+});

--- a/src/adapters/discord/__tests__/discord-inbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-inbound.test.ts
@@ -100,6 +100,27 @@ describe("DiscordAdapter — allow-list", () => {
     expect(h.bus.prompts).toHaveLength(0);
   });
 
+  // PR #113 review (agents #2 + #3): the earlier Sprint 3 adapter had
+  // empty list = deny all, a silent regression for operators on the
+  // default config. Legacy semantics restored: empty = allow all.
+  it("empty allowedUserIds = allow all (legacy parity)", async () => {
+    adapter = await startAdapter(h, { allowedUserIds: [] });
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        channel_id: "ch-1",
+        guild_id: "g-1",
+        author: { id: "anyone", username: "rando" },
+        content: "hi from anyone",
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(1);
+    // No "Unauthorized." reply was sent.
+    const unauth = h.rest.sent.filter((s) => s.text === "Unauthorized.");
+    expect(unauth).toHaveLength(0);
+  });
+
   it("drops bot author messages", async () => {
     adapter = await startAdapter(h);
     h.gateway.push({

--- a/src/adapters/discord/__tests__/discord-outbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-outbound.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Discord adapter — outbound (bus → Discord) behavioural tests.
+ *
+ * Covers `response.text` delivery, `channel.permission_request` button
+ * flow, and `system.request_human` round-trip. Inbound (gateway → bus)
+ * lives in `discord-inbound.test.ts`.
+ *
+ * Run: `bun test src/adapters/discord/__tests__/discord-outbound.test.ts`
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import type { DiscordAdapter } from "../index";
+import type { PermissionRequest } from "../../../bus/types";
+import {
+  type AdapterHarness,
+  flushMicrotasks,
+  makeHarness,
+  makeInteraction,
+  makeMessage,
+  startAdapter,
+} from "./fixtures";
+
+let h: AdapterHarness;
+let adapter: DiscordAdapter | null = null;
+
+beforeEach(() => {
+  h = makeHarness();
+});
+
+afterEach(async () => {
+  if (adapter) {
+    await adapter.stop();
+    adapter = null;
+  }
+});
+
+describe("DiscordAdapter — outbound response.text", () => {
+  it("posts bus response.text to all channels for the agent", async () => {
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "done" },
+    });
+    expect(h.rest.sent.map((m) => m.channelId).sort()).toEqual(["ch-2", "th-1"]);
+    expect(h.rest.sent[0]?.text).toBe("done");
+  });
+
+  it("skips empty response.text payloads", async () => {
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "" },
+    });
+    expect(h.rest.sent).toHaveLength(0);
+  });
+});
+
+describe("DiscordAdapter — permission flow", () => {
+  it("posts a button-row prompt on channel.permission_request and routes the click back", async () => {
+    adapter = await startAdapter(h);
+    const req: PermissionRequest = {
+      request_id: "abcde",
+      tool_name: "Write",
+      description: "write a file",
+      input_preview: "{path: ...}",
+    };
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s",
+      topic: "channel.permission_request",
+      payload: req,
+    });
+    expect(h.rest.sent).toHaveLength(1);
+    const sent = h.rest.sent[0];
+    if (!sent) throw new Error("expected sent message");
+    expect(sent.channelId).toBe("ch-1");
+    expect(sent.components).toBeDefined();
+    const row = sent.components?.[0] as { components: Array<{ custom_id: string; label: string }> };
+    expect(row.components).toHaveLength(2);
+    expect(row.components[0]?.custom_id).toBe("ccaw_perm_allow_abcde");
+    expect(row.components[1]?.custom_id).toBe("ccaw_perm_deny_abcde");
+
+    // Click "Allow".
+    h.gateway.push({
+      type: "INTERACTION_CREATE",
+      interaction: makeInteraction({ data: { custom_id: "ccaw_perm_allow_abcde" } }),
+    });
+    await flushMicrotasks();
+
+    expect(h.bus.permissionDecisions).toHaveLength(1);
+    expect(h.bus.permissionDecisions[0]).toEqual({
+      agent_id: "triage",
+      request_id: "abcde",
+      behavior: "allow",
+    });
+    expect(h.rest.acks).toHaveLength(1);
+    expect(h.rest.acks[0]?.body.content).toBe("Allowed.");
+  });
+
+  it("ignores unknown permission button click (stale prompt)", async () => {
+    adapter = await startAdapter(h);
+    h.gateway.push({
+      type: "INTERACTION_CREATE",
+      interaction: makeInteraction({ data: { custom_id: "ccaw_perm_deny_zzzzz" } }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.permissionDecisions).toHaveLength(0);
+    expect(h.rest.acks).toHaveLength(1);
+    expect(h.rest.acks[0]?.body.content).toContain("no longer active");
+  });
+
+  it("rejects permission click from non-allowlisted user", async () => {
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s",
+      topic: "channel.permission_request",
+      payload: {
+        request_id: "abcde",
+        tool_name: "Write",
+        description: "",
+        input_preview: "",
+      },
+    });
+    h.gateway.push({
+      type: "INTERACTION_CREATE",
+      interaction: makeInteraction({
+        user: { id: "intruder", username: "evil" },
+        data: { custom_id: "ccaw_perm_allow_abcde" },
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.permissionDecisions).toHaveLength(0);
+    expect(h.rest.acks).toHaveLength(1);
+    expect(h.rest.acks[0]?.body.content).toBe("Unauthorized.");
+  });
+});
+
+describe("DiscordAdapter — request_human flow", () => {
+  it("posts a question on system.request_human and routes the first reply via ingestAskAnswer", async () => {
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s",
+      topic: "system.request_human",
+      payload: { ask_id: "ask-1", question: "what next?" },
+    });
+    expect(h.rest.sent).toHaveLength(1);
+    expect(h.rest.sent[0]?.channelId).toBe("ch-1");
+    expect(h.rest.sent[0]?.text).toContain("what next?");
+
+    // Operator replies in the same channel.
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        channel_id: "ch-1",
+        guild_id: "g-1",
+        content: "ship it",
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.askAnswers).toHaveLength(1);
+    expect(h.bus.askAnswers[0]).toEqual({
+      agent_id: "triage",
+      ask_id: "ask-1",
+      answer: "ship it",
+    });
+    // And the reply must NOT also be forwarded as a prompt.
+    expect(h.bus.prompts).toHaveLength(0);
+  });
+
+  it("only the first reply is consumed; the second reply is a fresh prompt", async () => {
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s",
+      topic: "system.request_human",
+      payload: { ask_id: "ask-1", question: "?" },
+    });
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({ channel_id: "ch-1", guild_id: "g-1", content: "answer" }),
+    });
+    await flushMicrotasks();
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({
+        id: "msg-2",
+        channel_id: "ch-1",
+        guild_id: "g-1",
+        content: "another",
+      }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.askAnswers).toHaveLength(1);
+    expect(h.bus.prompts).toHaveLength(1);
+    expect(h.bus.prompts[0]?.text).toBe("another");
+  });
+});
+
+describe("DiscordAdapter — multi-agent fan-out", () => {
+  it("each agent gets independent response delivery", async () => {
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "for triage" },
+    });
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "for ops" },
+    });
+    const byCh = new Map(h.rest.sent.map((m) => [m.channelId, m.text]));
+    expect(byCh.get("ch-1")).toBe("for triage");
+    expect(byCh.get("ch-2")).toBe("for ops");
+    expect(byCh.get("th-1")).toBe("for ops");
+  });
+});

--- a/src/adapters/discord/__tests__/fixtures.ts
+++ b/src/adapters/discord/__tests__/fixtures.ts
@@ -1,0 +1,268 @@
+/**
+ * Test fixtures for `src/adapters/discord/__tests__/discord.test.ts`.
+ *
+ * Pulled out so the test file stays under the per-file LOC cap
+ * (SPRINT_3_PLAN.md). Contains:
+ *   - FakeBus           — minimal `BusCore` implementation that captures
+ *                          adapter→bus traffic and pushes synthetic events.
+ *   - FakeDiscordGateway — emulates `MESSAGE_CREATE` / `INTERACTION_CREATE`
+ *                          events without a real WebSocket.
+ *   - FakeDiscordRestApi — captures `sendMessage` + interaction acks.
+ *   - Test message + interaction factory helpers.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { BusCore, SendPromptRequest } from "../../../bus/core";
+import type {
+  Subscription,
+  SubscriptionFilter,
+  SubscriptionHandler,
+} from "../../../bus/core-subscription";
+import type { BusEvent } from "../../../bus/types";
+import { DiscordAdapter } from "../index";
+import type {
+  DiscordGatewayLike,
+  DiscordInboundInteraction,
+  DiscordInboundMessage,
+  DiscordRestApiLike,
+  GatewayEvent,
+} from "../types";
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* FakeBus                                                                */
+/* ────────────────────────────────────────────────────────────────────── */
+
+interface FakeSubscription extends Subscription {
+  filter: SubscriptionFilter;
+  handler: SubscriptionHandler;
+  closedFlag: boolean;
+}
+
+export class FakeBus implements BusCore {
+  public readonly prompts: SendPromptRequest[] = [];
+  public readonly permissionDecisions: Array<{
+    agent_id: string;
+    request_id: string;
+    behavior: "allow" | "deny";
+  }> = [];
+  public readonly askAnswers: Array<{ agent_id: string; ask_id: string; answer: string }> = [];
+  public readonly subscriptions = new Map<string, FakeSubscription>();
+
+  async sendPrompt(req: SendPromptRequest): Promise<{ promise_id: string }> {
+    this.prompts.push(req);
+    return { promise_id: randomUUID() };
+  }
+
+  subscribe(filter: SubscriptionFilter, handler: SubscriptionHandler): Subscription {
+    const id = randomUUID();
+    const record: FakeSubscription = {
+      id,
+      filter,
+      handler,
+      closedFlag: false,
+      close: () => {
+        record.closedFlag = true;
+        this.subscriptions.delete(id);
+      },
+      get overflowCount() {
+        return 0;
+      },
+      get depth() {
+        return 0;
+      },
+    };
+    this.subscriptions.set(id, record);
+    return record;
+  }
+
+  /** Push a synthetic event to matching subscriptions. */
+  emit(event: BusEvent): void {
+    for (const sub of this.subscriptions.values()) {
+      if (sub.closedFlag) continue;
+      if (sub.filter.agent_id && sub.filter.agent_id !== event.agent_id) continue;
+      if (sub.filter.topics && sub.filter.topics.length > 0) {
+        if (!sub.filter.topics.includes(event.topic)) continue;
+      }
+      sub.handler(event);
+    }
+  }
+
+  async invokeSlashCommand(): Promise<void> {}
+  ingestReply(): void {}
+  ingestSessionEvent(): void {}
+  ingestPermissionDecision(req: {
+    agent_id: string;
+    request_id: string;
+    behavior: "allow" | "deny";
+  }): void {
+    this.permissionDecisions.push(req);
+  }
+  ingestAskAnswer(req: { agent_id: string; ask_id: string; answer: string }): void {
+    this.askAnswers.push(req);
+  }
+  state() {
+    return {
+      subscriberCount: this.subscriptions.size,
+      connectedAgents: [],
+      totalOverflows: 0,
+    };
+  }
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* FakeDiscordGateway                                                     */
+/* ────────────────────────────────────────────────────────────────────── */
+
+export class FakeDiscordGateway implements DiscordGatewayLike {
+  public started = false;
+  public stopped = false;
+  private handlers: Array<(e: GatewayEvent) => void> = [];
+
+  async start(): Promise<void> {
+    this.started = true;
+  }
+  async stop(): Promise<void> {
+    this.stopped = true;
+    this.handlers = [];
+  }
+  onEvent(handler: (e: GatewayEvent) => void): () => void {
+    this.handlers.push(handler);
+    return () => {
+      this.handlers = this.handlers.filter((h) => h !== handler);
+    };
+  }
+
+  /** Push a synthetic gateway event. */
+  push(event: GatewayEvent): void {
+    for (const h of this.handlers) h(event);
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* FakeDiscordRestApi                                                     */
+/* ────────────────────────────────────────────────────────────────────── */
+
+export interface SentMessage {
+  channelId: string;
+  text: string;
+  components?: unknown[];
+}
+
+export interface SentInteractionAck {
+  interactionId: string;
+  body: { content: string; flags?: number };
+}
+
+export class FakeDiscordRestApi implements DiscordRestApiLike {
+  public readonly sent: SentMessage[] = [];
+  public readonly acks: SentInteractionAck[] = [];
+
+  async sendMessage(channelId: string, text: string, components?: unknown[]): Promise<void> {
+    this.sent.push({ channelId, text, components });
+  }
+
+  async respondToInteraction(
+    interactionId: string,
+    _interactionToken: string,
+    body: { content: string; flags?: number },
+  ): Promise<void> {
+    this.acks.push({ interactionId, body });
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Factory helpers                                                        */
+/* ────────────────────────────────────────────────────────────────────── */
+
+export const SILENT_LOGGER = {
+  warn: () => {},
+  info: () => {},
+  error: () => {},
+};
+
+export function makeMessage(over: Partial<DiscordInboundMessage> = {}): DiscordInboundMessage {
+  return {
+    id: over.id ?? "msg-1",
+    channel_id: over.channel_id ?? "ch-1",
+    guild_id: over.guild_id,
+    author: over.author ?? { id: "user-1", username: "terry" },
+    content: over.content ?? "hello",
+    attachments: over.attachments ?? [],
+  };
+}
+
+export function makeInteraction(
+  over: Partial<DiscordInboundInteraction> = {},
+): DiscordInboundInteraction {
+  return {
+    id: over.id ?? "int-1",
+    type: over.type ?? 3,
+    data: over.data,
+    channel_id: over.channel_id ?? "ch-1",
+    guild_id: over.guild_id,
+    member: over.member,
+    user: over.user ?? { id: "user-1", username: "terry" },
+    token: over.token ?? "int-token",
+  };
+}
+
+/**
+ * Tiny await helper. Adapter handlers fire via `void this.foo()` —
+ * waiting two microtasks reliably drains the promise chain in our
+ * tests without coupling assertions to wall-clock timers.
+ */
+export async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Adapter harness                                                        */
+/* ────────────────────────────────────────────────────────────────────── */
+
+export interface AdapterHarness {
+  bus: FakeBus;
+  gateway: FakeDiscordGateway;
+  rest: FakeDiscordRestApi;
+}
+
+/** Build a fresh harness — three independent fakes per test. */
+export function makeHarness(): AdapterHarness {
+  return {
+    bus: new FakeBus(),
+    gateway: new FakeDiscordGateway(),
+    rest: new FakeDiscordRestApi(),
+  };
+}
+
+/**
+ * Build + start a `DiscordAdapter` wired to the given harness. Default
+ * routing covers two channels, one thread, and a DM agent — sufficient
+ * to exercise every test in the suite. Tests override fields via
+ * `over` to focus on a single behaviour.
+ */
+export async function startAdapter(
+  h: AdapterHarness,
+  over: Partial<ConstructorParameters<typeof DiscordAdapter>[0]> = {},
+): Promise<DiscordAdapter> {
+  const a = new DiscordAdapter({
+    bus: h.bus,
+    token: "fake-token",
+    allowedUserIds: ["user-1"],
+    routing: {
+      channels: { "ch-1": "triage", "ch-2": "ops" },
+      threads: { "th-1": "ops" },
+      dmAgentId: "global",
+    },
+    gateway: h.gateway,
+    restApi: h.rest,
+    logger: SILENT_LOGGER,
+    // Disable rate-limit by default so per-test loops don't trip it.
+    rateLimitCheck: () => true,
+    ...over,
+  });
+  await a.start();
+  return a;
+}

--- a/src/adapters/discord/helpers.ts
+++ b/src/adapters/discord/helpers.ts
@@ -1,0 +1,170 @@
+/**
+ * Discord adapter — stateless helpers.
+ *
+ * Pulled out of `index.ts` to keep that file under the per-file LOC cap
+ * (SPRINT_3_PLAN.md). Every function here is pure or has well-isolated
+ * state (the rate-limit factory). Tests import these directly when
+ * useful and otherwise exercise them via the adapter.
+ *
+ * Each helper has a back-reference to the legacy `src/commands/discord.ts`
+ * line range it mirrors, so Sprint 4 (shared `src/discord/` extraction)
+ * can collapse the two paths into one helper.
+ */
+
+import type { PermissionRequest } from "../../bus/types";
+import { PERMISSION_BUTTON_PREFIX, type DiscordAttachment } from "./types";
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Rate-limit — parity with src/commands/discord.ts:144–162               */
+/* ────────────────────────────────────────────────────────────────────── */
+
+export const DEFAULT_RATE_LIMIT_WINDOW_MS = 60_000;
+export const DEFAULT_RATE_LIMIT_MAX = 30;
+
+interface RateEntry {
+  count: number;
+  resetAt: number;
+}
+
+/**
+ * In-memory per-user counter. Returns false when the user is over the
+ * limit in the current window. The returned closure owns its own Map,
+ * so multiple adapter instances don't share state.
+ */
+export function makeDefaultRateLimit(): (userId: string) => boolean {
+  const map = new Map<string, RateEntry>();
+  return (userId: string): boolean => {
+    const now = Date.now();
+    const entry = map.get(userId);
+    if (!entry || now > entry.resetAt) {
+      map.set(userId, { count: 1, resetAt: now + DEFAULT_RATE_LIMIT_WINDOW_MS });
+      return true;
+    }
+    if (entry.count >= DEFAULT_RATE_LIMIT_MAX) return false;
+    entry.count++;
+    return true;
+  };
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Attachment classification — parity with src/commands/discord.ts:604    */
+/* ────────────────────────────────────────────────────────────────────── */
+
+const VOICE_MESSAGE_FLAG = 1 << 13;
+
+export function isImageAttachment(a: DiscordAttachment): boolean {
+  return Boolean(a.content_type?.startsWith("image/"));
+}
+
+export function isVoiceAttachment(a: DiscordAttachment): boolean {
+  if ((a.flags ?? 0) & VOICE_MESSAGE_FLAG) return true;
+  return Boolean(a.content_type?.startsWith("audio/"));
+}
+
+export function isTextAttachment(a: DiscordAttachment): boolean {
+  if (a.content_type?.startsWith("text/")) return true;
+  const lower = a.filename.toLowerCase();
+  return lower.endsWith(".txt") || lower.endsWith(".md");
+}
+
+export interface AttachmentSummary {
+  images: DiscordAttachment[];
+  voices: DiscordAttachment[];
+  texts: DiscordAttachment[];
+  hasAny: boolean;
+}
+
+/**
+ * Build the attachment summary that rides on the BusEvent payload.
+ * Field names match legacy (`images`, `voices`, `texts`) so Sprint 4
+ * downstream rendering can lift them directly without renaming.
+ */
+export function summariseAttachments(attachments: DiscordAttachment[]): AttachmentSummary {
+  const images = attachments.filter(isImageAttachment);
+  const voices = attachments.filter(isVoiceAttachment);
+  const texts = attachments.filter(isTextAttachment);
+  return {
+    images,
+    voices,
+    texts,
+    hasAny: images.length + voices.length + texts.length > 0,
+  };
+}
+
+export interface AttachmentMeta {
+  id: string;
+  filename: string;
+  url: string;
+  content_type?: string;
+  size: number;
+}
+
+export function attachmentMeta(a: DiscordAttachment): AttachmentMeta {
+  return {
+    id: a.id,
+    filename: a.filename,
+    url: a.url,
+    content_type: a.content_type,
+    size: a.size,
+  };
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Permission-prompt formatting                                           */
+/* ────────────────────────────────────────────────────────────────────── */
+
+export function formatPermissionPrompt(req: PermissionRequest): string {
+  return [
+    `**Permission requested:** \`${req.tool_name}\``,
+    req.description ? req.description : null,
+    req.input_preview ? `\`\`\`\n${req.input_preview}\n\`\`\`` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Discord component shape: type 1 = ACTION_ROW, type 2 = BUTTON,
+ * style 3 = SUCCESS (green), 4 = DANGER (red). Returns `unknown[]` so
+ * `index.ts` doesn't have to depend on a Discord SDK type — the legacy
+ * code uses the same shape (`src/commands/discord.ts:1538`).
+ */
+export function buildPermissionButtons(requestId: string): unknown[] {
+  return [
+    {
+      type: 1,
+      components: [
+        {
+          type: 2,
+          style: 3,
+          label: "Allow",
+          custom_id: `${PERMISSION_BUTTON_PREFIX}allow_${requestId}`,
+        },
+        {
+          type: 2,
+          style: 4,
+          label: "Deny",
+          custom_id: `${PERMISSION_BUTTON_PREFIX}deny_${requestId}`,
+        },
+      ],
+    },
+  ];
+}
+
+/**
+ * Parse a `ccaw_perm_<allow|deny>_<request_id>` button custom_id.
+ * Returns null if the id is malformed or carries an unknown behavior.
+ */
+export function parsePermissionCustomId(
+  customId: string,
+): { behavior: "allow" | "deny"; request_id: string } | null {
+  if (!customId.startsWith(PERMISSION_BUTTON_PREFIX)) return null;
+  const rest = customId.slice(PERMISSION_BUTTON_PREFIX.length);
+  const sep = rest.indexOf("_");
+  if (sep < 0) return null;
+  const decision = rest.slice(0, sep);
+  const requestId = rest.slice(sep + 1);
+  if (decision !== "allow" && decision !== "deny") return null;
+  if (!requestId) return null;
+  return { behavior: decision, request_id: requestId };
+}

--- a/src/adapters/discord/helpers.ts
+++ b/src/adapters/discord/helpers.ts
@@ -126,8 +126,13 @@ export function formatPermissionPrompt(req: PermissionRequest): string {
 /**
  * Discord component shape: type 1 = ACTION_ROW, type 2 = BUTTON,
  * style 3 = SUCCESS (green), 4 = DANGER (red). Returns `unknown[]` so
- * `index.ts` doesn't have to depend on a Discord SDK type — the legacy
- * code uses the same shape (`src/commands/discord.ts:1538`).
+ * `index.ts` doesn't have to depend on a Discord SDK type.
+ *
+ * Note: permission buttons are NEW in the Bus runtime — the legacy
+ * `src/commands/discord.ts` doesn't have an equivalent ACTION_ROW
+ * builder (its permission flow is in-band TUI rendering). PR #113
+ * review (agent #5) caught an earlier comment claiming legacy parity
+ * here; correcting to acknowledge this is greenfield.
  */
 export function buildPermissionButtons(requestId: string): unknown[] {
   return [

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -210,11 +210,17 @@ export class DiscordAdapter {
     const channelId = message.channel_id;
     const isDM = !message.guild_id;
 
-    // 2. Allow-list — discord.ts:882. DM = "Unauthorized." reply,
-    //    guild = silent skip. An empty allow-list = closed bot (the
-    //    legacy code defaults to "allow all" on empty, but per Sprint
-    //    3 plan we keep parity at the call site).
-    if (!this.allowedUserIds.has(userId)) {
+    // 2. Allow-list — discord.ts:882 semantics:
+    //    * empty list = "allow all" (legacy `allowedUserIds.length > 0`
+    //      gate — preserved for default-config parity; operators with
+    //      `discord.allowedUserIds: []` should NOT see their bot stop
+    //      responding after the Bus runtime flip).
+    //    * non-empty list, member match = allow.
+    //    * non-empty list, no match = DM "Unauthorized." reply,
+    //      guild = silent skip.
+    //    Sprint 3 review (PR #113 agent #3): the earlier "empty = deny
+    //    all" behaviour was a silent regression. Restored here.
+    if (this.allowedUserIds.size > 0 && !this.allowedUserIds.has(userId)) {
       if (isDM) {
         try {
           await this.restApi.sendMessage(channelId, "Unauthorized.");
@@ -307,9 +313,11 @@ export class DiscordAdapter {
     const parsed = parsePermissionCustomId(interaction.data.custom_id);
     if (!parsed) return;
 
-    // Allow-list — discord.ts:1358.
+    // Allow-list — discord.ts:1358. Same semantics as the message path:
+    // empty = "allow all", non-empty = membership check. PR #113 review
+    // restored legacy parity.
     const actorId = interaction.member?.user?.id ?? interaction.user?.id;
-    if (!actorId || !this.allowedUserIds.has(actorId)) {
+    if (!actorId || (this.allowedUserIds.size > 0 && !this.allowedUserIds.has(actorId))) {
       try {
         await this.restApi.respondToInteraction(interaction.id, interaction.token, {
           content: "Unauthorized.",

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -1,0 +1,476 @@
+/**
+ * Discord Bus adapter.
+ *
+ * Spec: `docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md` §5.5.1 + §6.1.
+ * Sprint coordination: `src/bus/SPRINT_3_PLAN.md` (Agent A scope).
+ *
+ * Surface:
+ *   - Inbound  Discord gateway → `bus.sendPrompt({origin: 'discord', …})`
+ *   - Outbound `bus.subscribe({agent_id, …})` →
+ *       `response.text`              → `sendMessage(channel, text)`
+ *       `channel.permission_request` → button-row prompt
+ *       `system.request_human`       → "needs a human" message; first
+ *                                       channel reply → `ingestAskAnswer`
+ *
+ * Behaviour parity is intentional with the legacy PTY-coupled listener
+ * at `src/commands/discord.ts` (~2052 LOC). Key parallels:
+ *   - Allow-list: `discord.ts:882`. DM → "Unauthorized.", guild → silent.
+ *   - Rate limit: `discord.ts:148` `checkDiscordRateLimit`.
+ *   - Attachment detection: `discord.ts:604` `isImageAttachment` + friends.
+ *   - Channel/thread/DM identity: `discord.ts:527` `guildTriggerReason`
+ *     + `knownThreads` (188). Externalised here as `router.ts`.
+ *   - Gateway connect/heartbeat/reconnect: `discord.ts:1582–1908`. Tests
+ *     inject a `FakeDiscordGateway`; production builds will wire a real
+ *     gateway in Sprint 4 (see TODO at the bottom of this file).
+ *
+ * Sprint 3 deliberately does NOT copy the gateway WS code into this
+ * file — that would double-fork the production gateway logic. Instead
+ * the adapter depends on `DiscordGatewayLike` and `DiscordRestApiLike`
+ * abstractions (see `./types.ts`). Sprint 4 TODO: extract a shared
+ * `src/discord/api.ts` + `src/discord/gateway.ts` from the legacy
+ * listener so both code paths share one implementation.
+ */
+
+import type { BusCore, Subscription } from "../../bus/core";
+import type { BusEvent, PermissionRequest } from "../../bus/types";
+import {
+  attachmentMeta,
+  buildPermissionButtons,
+  formatPermissionPrompt,
+  makeDefaultRateLimit,
+  parsePermissionCustomId,
+  summariseAttachments,
+} from "./helpers";
+import { resolveAgentId, uniqueAgentIds, type RoutingConfig } from "./router";
+import type {
+  DiscordAdapterOptions,
+  DiscordGatewayLike,
+  DiscordInboundInteraction,
+  DiscordInboundMessage,
+  DiscordRestApiLike,
+  GatewayEvent,
+} from "./types";
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Adapter                                                                */
+/* ────────────────────────────────────────────────────────────────────── */
+
+export class DiscordAdapter {
+  private readonly bus: BusCore;
+  private readonly token: string;
+  private readonly allowedUserIds: ReadonlySet<string>;
+  private readonly routing: RoutingConfig;
+  private readonly logger: Pick<Console, "warn" | "info" | "error">;
+  private readonly rateLimitCheck: (userId: string) => boolean;
+  private readonly gateway: DiscordGatewayLike;
+  private readonly restApi: DiscordRestApiLike;
+
+  /** Active bus subscriptions, one per unique routed agent. */
+  private subscriptions: Subscription[] = [];
+  /** Unsubscribe from gateway events; null until `start()`. */
+  private gatewayOff: (() => void) | null = null;
+
+  /**
+   * Permission requests we've forwarded to Discord. Keyed by
+   * `request_id` — when a button click arrives we look up the
+   * `agent_id` so `ingestPermissionDecision` can route correctly.
+   *
+   * Sprint 3 keeps this map in-process. Sprint 5 (durable Bus state)
+   * may persist it so an adapter restart doesn't orphan in-flight
+   * permission prompts.
+   */
+  private readonly pendingPermissions = new Map<string, { agent_id: string }>();
+
+  /**
+   * Outstanding `system.request_human` asks, keyed by `(agent_id,
+   * channel_id)`. The first allowed user reply in that channel
+   * resolves it via `bus.ingestAskAnswer`.
+   *
+   * The legacy listener didn't have this concept — `request_human` is
+   * new in the Bus runtime. Contract documented in
+   * `src/bus/core.ts:411` (PR #110 fix carrying `ask_id`).
+   */
+  private readonly pendingHumanAsks = new Map<string, { ask_id: string; agent_id: string }>();
+
+  private started = false;
+
+  constructor(opts: DiscordAdapterOptions) {
+    if (!opts.bus) throw new Error("DiscordAdapter: `bus` is required");
+    if (!opts.token) throw new Error("DiscordAdapter: `token` is required");
+    if (!opts.routing) throw new Error("DiscordAdapter: `routing` is required");
+
+    this.bus = opts.bus;
+    this.token = opts.token;
+    this.allowedUserIds = new Set(opts.allowedUserIds);
+    this.routing = opts.routing;
+    this.logger = opts.logger ?? console;
+    this.rateLimitCheck = opts.rateLimitCheck ?? makeDefaultRateLimit();
+
+    if (!opts.gateway) {
+      throw new Error(
+        "DiscordAdapter: `gateway` injection is required in Sprint 3. " +
+          "Shared gateway helper extraction is a Sprint 4 deliverable; " +
+          "until then production callers must construct their own gateway. " +
+          "Tests inject a FakeDiscordGateway.",
+      );
+    }
+    if (!opts.restApi) {
+      throw new Error(
+        "DiscordAdapter: `restApi` injection is required in Sprint 3. " +
+          "See SPRINT_3_PLAN.md — shared REST helpers are a Sprint 4 task.",
+      );
+    }
+    this.gateway = opts.gateway;
+    this.restApi = opts.restApi;
+  }
+
+  /* ──────────────────────────── lifecycle ─────────────────────────── */
+
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+
+    // 1. Subscribe to bus events BEFORE wiring the gateway so any racey
+    //    early bus event (e.g. a `request_human` from a session that
+    //    came up just before the adapter) doesn't fall on the floor.
+    for (const agentId of uniqueAgentIds(this.routing)) {
+      const sub = this.bus.subscribe(
+        {
+          agent_id: agentId,
+          topics: ["response.text", "channel.permission_request", "system.request_human"],
+        },
+        (event) => this.handleBusEvent(agentId, event),
+      );
+      this.subscriptions.push(sub);
+    }
+
+    // 2. Wire gateway → adapter ingestion.
+    this.gatewayOff = this.gateway.onEvent((e) => this.handleGatewayEvent(e));
+    await this.gateway.start();
+  }
+
+  async stop(): Promise<void> {
+    if (!this.started) return;
+    this.started = false;
+
+    // 1. Unsubscribe from gateway first — a late `MESSAGE_CREATE` must
+    //    not trigger a `sendPrompt` after `stop()` returned.
+    if (this.gatewayOff) {
+      try {
+        this.gatewayOff();
+      } catch (err) {
+        this.logger.error("[discord-adapter] gateway off error", err);
+      }
+      this.gatewayOff = null;
+    }
+    try {
+      await this.gateway.stop();
+    } catch (err) {
+      this.logger.error("[discord-adapter] gateway stop error", err);
+    }
+
+    // 2. Close every bus subscription. Order matters: doing this AFTER
+    //    the gateway is silent guarantees we drain cleanly. The success
+    //    signal is `bus.state().subscriberCount === 0`, asserted by the
+    //    test suite.
+    for (const sub of this.subscriptions) {
+      try {
+        sub.close();
+      } catch (err) {
+        this.logger.error("[discord-adapter] subscription.close error", err);
+      }
+    }
+    this.subscriptions = [];
+    this.pendingPermissions.clear();
+    this.pendingHumanAsks.clear();
+  }
+
+  /* ──────────────────────────── inbound (gateway) ─────────────────── */
+
+  private handleGatewayEvent(e: GatewayEvent): void {
+    if (e.type === "MESSAGE_CREATE") {
+      void this.handleMessageCreate(e.message);
+      return;
+    }
+    if (e.type === "INTERACTION_CREATE") {
+      void this.handleInteraction(e.interaction);
+      return;
+    }
+  }
+
+  /**
+   * Mirrors `handleMessageCreate` in `src/commands/discord.ts:824`,
+   * collapsed to the subset the Bus runtime needs.
+   */
+  private async handleMessageCreate(message: DiscordInboundMessage): Promise<void> {
+    // 1. Drop bot messages — discord.ts:832.
+    if (message.author.bot) return;
+
+    const userId = message.author.id;
+    const channelId = message.channel_id;
+    const isDM = !message.guild_id;
+
+    // 2. Allow-list — discord.ts:882. DM = "Unauthorized." reply,
+    //    guild = silent skip. An empty allow-list = closed bot (the
+    //    legacy code defaults to "allow all" on empty, but per Sprint
+    //    3 plan we keep parity at the call site).
+    if (!this.allowedUserIds.has(userId)) {
+      if (isDM) {
+        try {
+          await this.restApi.sendMessage(channelId, "Unauthorized.");
+        } catch (err) {
+          this.logger.error("[discord-adapter] sendMessage(unauth) failed", err);
+        }
+      }
+      return;
+    }
+
+    // 3. Rate-limit — discord.ts:876.
+    if (!this.rateLimitCheck(userId)) {
+      this.logger.warn(`[discord-adapter] rate-limited userId=${userId}`);
+      return;
+    }
+
+    // 4. Resolve agent_id. Unknown channel → silent skip (parity with
+    //    `guildTriggerReason() === null`, discord.ts:864).
+    const agentId = resolveAgentId(this.routing, { isDM, channelId });
+    if (!agentId) {
+      this.logger.warn(`[discord-adapter] unrouted channel=${channelId} — skip`);
+      return;
+    }
+
+    // 5. Detect attachments and pin metadata to the BusEvent so future
+    //    surfaces can render them. Sprint 3 does NOT download or
+    //    transcribe — that's `discord.ts:980+` legacy behaviour and
+    //    belongs in a Sprint 4 attachment-pipeline component. Forward
+    //    URLs + flags only.
+    const { images, voices, texts, hasAny } = summariseAttachments(message.attachments);
+
+    // 6. Drop empty messages with no attachments.
+    if (!message.content.trim() && !hasAny) return;
+
+    // 7. Special-case: pending `request_human` for this (agent, channel).
+    //    If one exists, route this message text as the answer rather
+    //    than a brand-new prompt. The legacy listener doesn't have
+    //    this hook; per spec §5.5.1 it's the adapter's job to bridge.
+    const askKey = `${agentId}:${channelId}`;
+    const pendingAsk = this.pendingHumanAsks.get(askKey);
+    if (pendingAsk) {
+      this.pendingHumanAsks.delete(askKey);
+      try {
+        this.bus.ingestAskAnswer({
+          agent_id: pendingAsk.agent_id,
+          ask_id: pendingAsk.ask_id,
+          answer: message.content,
+        });
+      } catch (err) {
+        this.logger.error("[discord-adapter] ingestAskAnswer failed", err);
+      }
+      return;
+    }
+
+    // 8. Forward to bus.
+    try {
+      await this.bus.sendPrompt({
+        agent_id: agentId,
+        origin: "discord",
+        origin_id: channelId,
+        user_id: userId,
+        text: message.content,
+        metadata: {
+          message_id: message.id,
+          username: message.author.username,
+          ...(hasAny
+            ? {
+                attachments: {
+                  images: images.map(attachmentMeta),
+                  voices: voices.map(attachmentMeta),
+                  texts: texts.map(attachmentMeta),
+                },
+              }
+            : {}),
+        },
+      });
+    } catch (err) {
+      this.logger.error("[discord-adapter] sendPrompt failed", err);
+    }
+  }
+
+  /**
+   * Mirrors `handleInteractionCreate` in `src/commands/discord.ts:1351`,
+   * but only the MESSAGE_COMPONENT button branch. Slash commands are
+   * Sprint 4 surface work.
+   */
+  private async handleInteraction(interaction: DiscordInboundInteraction): Promise<void> {
+    // Only button clicks (type 3). Slash commands are out of scope.
+    if (interaction.type !== 3 || !interaction.data?.custom_id) return;
+    const parsed = parsePermissionCustomId(interaction.data.custom_id);
+    if (!parsed) return;
+
+    // Allow-list — discord.ts:1358.
+    const actorId = interaction.member?.user?.id ?? interaction.user?.id;
+    if (!actorId || !this.allowedUserIds.has(actorId)) {
+      try {
+        await this.restApi.respondToInteraction(interaction.id, interaction.token, {
+          content: "Unauthorized.",
+          flags: 64, // EPHEMERAL
+        });
+      } catch (err) {
+        this.logger.error("[discord-adapter] respondToInteraction(unauth) failed", err);
+      }
+      return;
+    }
+
+    const { behavior, request_id } = parsed;
+    const pending = this.pendingPermissions.get(request_id);
+    if (!pending) {
+      // Stale button — likely a restart. Ack so the UI doesn't show
+      // "interaction failed", then bail.
+      try {
+        await this.restApi.respondToInteraction(interaction.id, interaction.token, {
+          content: "This permission prompt is no longer active.",
+          flags: 64,
+        });
+      } catch (err) {
+        this.logger.error("[discord-adapter] respondToInteraction(stale) failed", err);
+      }
+      return;
+    }
+    this.pendingPermissions.delete(request_id);
+
+    try {
+      this.bus.ingestPermissionDecision({
+        agent_id: pending.agent_id,
+        request_id,
+        behavior,
+      });
+    } catch (err) {
+      this.logger.error("[discord-adapter] ingestPermissionDecision failed", err);
+    }
+
+    try {
+      await this.restApi.respondToInteraction(interaction.id, interaction.token, {
+        content: behavior === "allow" ? "Allowed." : "Denied.",
+        flags: 64,
+      });
+    } catch (err) {
+      this.logger.error("[discord-adapter] respondToInteraction(ack) failed", err);
+    }
+  }
+
+  /* ──────────────────────────── outbound (bus → discord) ──────────── */
+
+  private handleBusEvent(agentId: string, event: BusEvent): void {
+    // The originating channel rides on the prompt event's payload, but
+    // the bus doesn't carry it through to subsequent events for this
+    // session. For now post to every routed channel for the agent.
+    // Single-channel routing per response is a Sprint 4 polish item
+    // (see TODO at the end of this file).
+    const targetChannels = this.channelsForAgent(agentId);
+    if (targetChannels.length === 0) return;
+
+    if (event.topic === "response.text") {
+      const payload = event.payload as { text?: string };
+      const text = typeof payload.text === "string" ? payload.text : "";
+      if (!text) return;
+      for (const channelId of targetChannels) {
+        void this.safeSendMessage(channelId, text);
+      }
+      return;
+    }
+
+    if (event.topic === "channel.permission_request") {
+      const req = event.payload as PermissionRequest;
+      this.pendingPermissions.set(req.request_id, { agent_id: agentId });
+      const prompt = formatPermissionPrompt(req);
+      const components = buildPermissionButtons(req.request_id);
+      for (const channelId of targetChannels) {
+        void this.safeSendMessage(channelId, prompt, components);
+      }
+      return;
+    }
+
+    if (event.topic === "system.request_human") {
+      const payload = event.payload as { ask_id?: string; question?: string };
+      const askId = typeof payload.ask_id === "string" ? payload.ask_id : null;
+      const question = typeof payload.question === "string" ? payload.question : "";
+      if (!askId || !question) {
+        this.logger.warn("[discord-adapter] request_human missing ask_id or question");
+        return;
+      }
+      const prompt = `**Needs a human:** ${question}\n_(Reply in this channel to answer.)_`;
+      for (const channelId of targetChannels) {
+        this.pendingHumanAsks.set(`${agentId}:${channelId}`, { ask_id: askId, agent_id: agentId });
+        void this.safeSendMessage(channelId, prompt);
+      }
+      return;
+    }
+  }
+
+  private async safeSendMessage(
+    channelId: string,
+    text: string,
+    components?: unknown[],
+  ): Promise<void> {
+    try {
+      await this.restApi.sendMessage(channelId, text, components);
+    } catch (err) {
+      this.logger.error("[discord-adapter] sendMessage failed", err);
+    }
+  }
+
+  /**
+   * Channels (and thread ids) owned by `agentId`. DM channel resolution
+   * is deferred to Sprint 4 (see TODO below).
+   */
+  private channelsForAgent(agentId: string): string[] {
+    const out: string[] = [];
+    for (const [chId, aid] of Object.entries(this.routing.channels)) {
+      if (aid === agentId) out.push(chId);
+    }
+    if (this.routing.threads) {
+      for (const [thId, aid] of Object.entries(this.routing.threads)) {
+        if (aid === agentId) out.push(thId);
+      }
+    }
+    return out;
+  }
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Re-exports                                                             */
+/* ────────────────────────────────────────────────────────────────────── */
+
+export type {
+  DiscordAdapterOptions,
+  DiscordGatewayLike,
+  DiscordRestApiLike,
+  DiscordInboundMessage,
+  DiscordInboundInteraction,
+  GatewayEvent,
+} from "./types";
+export { resolveAgentId, uniqueAgentIds } from "./router";
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Sprint 4 TODOs                                                         */
+/* ────────────────────────────────────────────────────────────────────── */
+/*
+ *  - Extract `discordApi`, `sendMessage`, gateway connect/heartbeat from
+ *    `src/commands/discord.ts` into a shared `src/discord/api.ts` +
+ *    `src/discord/gateway.ts`. Right now the adapter requires `gateway`
+ *    + `restApi` injection — production callers must wire their own.
+ *  - Track originating channel per bus event so responses go ONLY to
+ *    the channel the prompt came from (today we fan out to every
+ *    channel owned by the agent — fine for single-channel-per-agent,
+ *    noisy for multi).
+ *  - DM channel resolution: legacy `sendMessageToUser` requires a
+ *    `/users/@me/channels` POST to create the DM channel. Surface DM
+ *    response routing via `dmAgentId` once that helper is extracted.
+ *  - Attachment download + voice transcription parity (`discord.ts:980+`).
+ *    Bus runtime needs these surfaced as `attachment.*` BusEvents.
+ *  - Slash command relay (`/reset`, `/compact`, `/status`, `/context`)
+ *    via `bus.invokeSlashCommand` — Session Manager hook.
+ *  - Forward-message coalescing (`pendingForwards`, `discord.ts:817`).
+ *  - Stream "typing" placeholder + edit-in-place rendering
+ *    (`makeDiscordStreamCallback`, `discord.ts:707`).
+ */

--- a/src/adapters/discord/router.ts
+++ b/src/adapters/discord/router.ts
@@ -1,0 +1,82 @@
+/**
+ * Discord adapter — channel/thread/DM → agent_id routing.
+ *
+ * Spec: `docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md` §5.5.1 + §6.1.
+ *
+ * The legacy `src/commands/discord.ts` derives the same mapping
+ * implicitly through `guildTriggerReason` (line 527) + `knownThreads`
+ * (line 188). The Bus adapter externalises it: routing is config, not
+ * runtime state, so the test surface stays deterministic.
+ *
+ * Rules (mirroring legacy behaviour):
+ *   1. DM (no `guild_id`) → `routing.dmAgentId` if set, else "global".
+ *      Returning a default for DMs matches existing single-session
+ *      behaviour where the bot always replies to allowed DM users.
+ *   2. Direct channel hit → `routing.channels[channel_id]`.
+ *   3. Thread → explicit mapping in `routing.threads[thread_id]`, or
+ *      (if a parent channel hint is provided) the parent channel's
+ *      agent_id, else `null`.
+ *   4. Unknown channel → `null` → adapter silently skips.
+ */
+
+export interface RoutingConfig {
+  channels: Record<string, string>;
+  threads?: Record<string, string>;
+  dmAgentId?: string;
+}
+
+export interface RouteContext {
+  /** DM messages have no `guild_id`. */
+  isDM: boolean;
+  channelId: string;
+  /**
+   * Optional parent channel id for threads. The adapter doesn't track
+   * Discord's thread graph (that's a Sprint 4 helper — see TODO in
+   * `index.ts`). Callers can pass `undefined` and the router will fall
+   * back to thread allow-list lookup only.
+   */
+  parentChannelId?: string;
+}
+
+/**
+ * Resolve a Discord channel/DM context to an `agent_id`. Returns `null`
+ * if the channel is unrouted — the caller is expected to silently
+ * skip, matching the legacy `guildTriggerReason() === null` path
+ * (`src/commands/discord.ts:864`).
+ */
+export function resolveAgentId(routing: RoutingConfig, ctx: RouteContext): string | null {
+  if (ctx.isDM) {
+    return routing.dmAgentId ?? "global";
+  }
+  // Direct channel hit takes precedence — a thread accidentally listed
+  // in `channels` should still resolve.
+  const directHit = routing.channels[ctx.channelId];
+  if (directHit) return directHit;
+
+  // Explicit thread mapping.
+  const threadHit = routing.threads?.[ctx.channelId];
+  if (threadHit) return threadHit;
+
+  // Inherit from parent channel if known.
+  if (ctx.parentChannelId) {
+    const parentHit = routing.channels[ctx.parentChannelId];
+    if (parentHit) return parentHit;
+  }
+
+  return null;
+}
+
+/**
+ * Distinct agent ids the adapter must subscribe to. Includes the DM
+ * default if set — even if no DMs ever arrive, subscribing keeps the
+ * outbound response path open for any future DM.
+ */
+export function uniqueAgentIds(routing: RoutingConfig): string[] {
+  const set = new Set<string>();
+  for (const a of Object.values(routing.channels)) set.add(a);
+  if (routing.threads) {
+    for (const a of Object.values(routing.threads)) set.add(a);
+  }
+  if (routing.dmAgentId) set.add(routing.dmAgentId);
+  return Array.from(set);
+}

--- a/src/adapters/discord/types.ts
+++ b/src/adapters/discord/types.ts
@@ -1,0 +1,154 @@
+/**
+ * Discord adapter — config + wire shapes.
+ *
+ * Spec: `docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md` §5.5.1.
+ * Sprint coordination: `src/bus/SPRINT_3_PLAN.md` (Agent A scope).
+ *
+ * These shapes are intentionally minimal. The full Discord wire surface
+ * lives in `src/commands/discord.ts` (~2052 LOC, PTY-coupled). The Bus
+ * adapter only needs the subset required for `MESSAGE_CREATE` ingress,
+ * `INTERACTION_CREATE` button clicks, and outbound message + reaction
+ * posting.
+ *
+ * NOTE: when Sprint 4 splits more of the existing discord.ts into a
+ * shared `src/discord/api.ts` module (see Sprint 3 TODOs in
+ * `index.ts`), these types should move there. Keep them local for now
+ * to avoid the circular dependency Sprint 3 was instructed to avoid.
+ */
+
+import type { BusCore } from "../../bus/core";
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Public adapter options                                                 */
+/* ────────────────────────────────────────────────────────────────────── */
+
+export interface DiscordAdapterOptions {
+  bus: BusCore;
+  /** Bot token (same source as `settings.discord.token` in legacy). */
+  token: string;
+  /** Discord user ID allow-list. Empty → silent-deny everything. */
+  allowedUserIds: string[];
+  /**
+   * Routing: which agent owns each Discord channel / thread / DM.
+   *
+   * - `channels`  — guild channel id → agent_id
+   * - `threads`   — thread id → agent_id (else inherit parent channel)
+   * - `dmAgentId` — default for DMs (recommended `"global"` to match
+   *                  the legacy single-session DM behaviour)
+   */
+  routing: {
+    channels: Record<string, string>;
+    threads?: Record<string, string>;
+    dmAgentId?: string;
+  };
+  /** Optional logger; defaults to `console`. */
+  logger?: Pick<Console, "warn" | "info" | "error">;
+  /**
+   * Optional injected gateway. Tests pass a `FakeDiscordGateway`; in
+   * production the adapter constructs a real WS gateway from `token`.
+   *
+   * The interface is deliberately small — enough for the adapter to
+   * subscribe to inbound events and call back into Discord. The real
+   * REST surface is exposed via `restApi`, also injectable for tests.
+   */
+  gateway?: DiscordGatewayLike;
+  /** Optional injected REST client. Tests pass a stub. */
+  restApi?: DiscordRestApiLike;
+  /**
+   * Rate-limit override — mirrors `checkDiscordRateLimit` in
+   * `src/commands/discord.ts:148`. Pass `() => true` in tests to disable.
+   */
+  rateLimitCheck?: (userId: string) => boolean;
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Wire shapes — subset of the real Discord gateway/API payloads          */
+/* ────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Minimal `MESSAGE_CREATE` shape. Mirrors `DiscordMessage` in
+ * `src/commands/discord.ts:77` but only the fields the adapter uses.
+ */
+export interface DiscordInboundMessage {
+  id: string;
+  channel_id: string;
+  guild_id?: string;
+  author: { id: string; username: string; bot?: boolean };
+  content: string;
+  attachments: DiscordAttachment[];
+}
+
+export interface DiscordAttachment {
+  id: string;
+  filename: string;
+  content_type?: string;
+  url: string;
+  size: number;
+  /** Discord IS_VOICE_MESSAGE flag is bit 13 — see `isVoiceAttachment`. */
+  flags?: number;
+}
+
+/**
+ * Minimal `INTERACTION_CREATE` shape for button (MESSAGE_COMPONENT)
+ * interactions. Mirrors `DiscordInteraction` in
+ * `src/commands/discord.ts:92`.
+ */
+export interface DiscordInboundInteraction {
+  id: string;
+  /** 2 = APPLICATION_COMMAND, 3 = MESSAGE_COMPONENT. Adapter cares about 3. */
+  type: number;
+  data?: { custom_id?: string };
+  channel_id?: string;
+  guild_id?: string;
+  member?: { user: { id: string; username: string } };
+  user?: { id: string; username: string };
+  token: string;
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Gateway / REST abstractions — allow FakeDiscordGateway in tests        */
+/* ────────────────────────────────────────────────────────────────────── */
+
+export type GatewayEvent =
+  | { type: "MESSAGE_CREATE"; message: DiscordInboundMessage }
+  | { type: "INTERACTION_CREATE"; interaction: DiscordInboundInteraction };
+
+export interface DiscordGatewayLike {
+  /** Start the gateway (connect WS, authenticate, etc.). */
+  start(): Promise<void>;
+  /** Stop and clean up the connection. */
+  stop(): Promise<void>;
+  /** Subscribe to inbound events. Returns an unsubscribe fn. */
+  onEvent(handler: (e: GatewayEvent) => void): () => void;
+}
+
+export interface DiscordRestApiLike {
+  /** Post a plain text message (auto-chunked at 2000 chars). */
+  sendMessage(channelId: string, text: string, components?: unknown[]): Promise<void>;
+  /**
+   * Respond to a `MESSAGE_COMPONENT` interaction. Used to ack permission
+   * button clicks so Discord doesn't show "interaction failed".
+   */
+  respondToInteraction(
+    interactionId: string,
+    interactionToken: string,
+    body: { content: string; flags?: number },
+  ): Promise<void>;
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Permission button custom_id encoding                                   */
+/* ────────────────────────────────────────────────────────────────────── */
+
+/**
+ * `custom_id` shape used for permission-prompt buttons. Format:
+ *   `ccaw_perm_<allow|deny>_<request_id>`
+ *
+ * Discord limits `custom_id` to 100 chars; `request_id` is 5 lowercase
+ * chars per `REQUEST_ID_PATTERN` (Spike 0.1), so we have plenty of room.
+ *
+ * Encoding inline (not a parser fn) because the adapter only reads them
+ * in one place — `handleInteraction` — and a regex is clearer than a
+ * helper hop.
+ */
+export const PERMISSION_BUTTON_PREFIX = "ccaw_perm_";

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -1,0 +1,744 @@
+/**
+ * Tests for `src/adapters/telegram/index.ts` (Sprint 3 Agent B).
+ *
+ * Run with: `bun test src/adapters/telegram/__tests__/telegram.test.ts`
+ *
+ * Strategy mirrors the WebUI adapter suite:
+ *   - `FakeBus` implements the public `BusCore` interface so we can assert
+ *     on `sendPrompt` / `ingestPermissionDecision` / `ingestAskAnswer`
+ *     calls without spinning up the real IPC stack.
+ *   - `FakeTelegramApi` implements the `TelegramApi` seam — never touches
+ *     `api.telegram.org`. `getUpdates` blocks on an internal queue so we
+ *     can deterministically feed updates into the long-poll loop.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { randomUUID } from "node:crypto";
+import { TelegramAdapter, extractReactionDirectives } from "../index";
+import type { BusCore, SendPromptRequest } from "../../../bus/core";
+import type {
+  Subscription,
+  SubscriptionFilter,
+  SubscriptionHandler,
+} from "../../../bus/core-subscription";
+import type { BusEvent } from "../../../bus/types";
+import type {
+  TelegramApi,
+  TelegramGetUpdatesResult,
+  TelegramInlineKeyboardButton,
+  TelegramUpdate,
+} from "../types";
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* FakeBus                                                                  */
+/* ────────────────────────────────────────────────────────────────────── */
+
+interface FakeSubscription extends Subscription {
+  filter: SubscriptionFilter;
+  handler: SubscriptionHandler;
+  closedFlag: boolean;
+}
+
+class FakeBus implements BusCore {
+  public readonly prompts: SendPromptRequest[] = [];
+  public readonly permissionDecisions: Array<{
+    agent_id: string;
+    request_id: string;
+    behavior: "allow" | "deny";
+  }> = [];
+  public readonly askAnswers: Array<{ agent_id: string; ask_id: string; answer: string }> = [];
+  public readonly subscriptions = new Map<string, FakeSubscription>();
+
+  async sendPrompt(req: SendPromptRequest): Promise<{ promise_id: string }> {
+    this.prompts.push(req);
+    return { promise_id: randomUUID() };
+  }
+
+  subscribe(filter: SubscriptionFilter, handler: SubscriptionHandler): Subscription {
+    const id = randomUUID();
+    const record: FakeSubscription = {
+      id,
+      filter,
+      handler,
+      closedFlag: false,
+      close: () => {
+        record.closedFlag = true;
+        this.subscriptions.delete(id);
+      },
+      get overflowCount() {
+        return 0;
+      },
+      get depth() {
+        return 0;
+      },
+    };
+    this.subscriptions.set(id, record);
+    return record;
+  }
+
+  /** Push a synthetic event to every matching live subscription. */
+  emit(event: BusEvent): void {
+    for (const sub of this.subscriptions.values()) {
+      if (sub.closedFlag) continue;
+      if (sub.filter.agent_id && sub.filter.agent_id !== event.agent_id) continue;
+      if (sub.filter.topics && sub.filter.topics.length > 0) {
+        if (!sub.filter.topics.includes(event.topic)) continue;
+      }
+      sub.handler(event);
+    }
+  }
+
+  async invokeSlashCommand(): Promise<void> {}
+  ingestReply(): void {}
+  ingestSessionEvent(): void {}
+  ingestPermissionDecision(req: {
+    agent_id: string;
+    request_id: string;
+    behavior: "allow" | "deny";
+  }): void {
+    this.permissionDecisions.push(req);
+  }
+  ingestAskAnswer(req: { agent_id: string; ask_id: string; answer: string }): void {
+    this.askAnswers.push(req);
+  }
+  state() {
+    return {
+      subscriberCount: this.subscriptions.size,
+      connectedAgents: [],
+      totalOverflows: 0,
+    };
+  }
+  async start(): Promise<void> {}
+  async stop(): Promise<void> {}
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* FakeTelegramApi                                                          */
+/* ────────────────────────────────────────────────────────────────────── */
+
+interface SendMessageCall {
+  chat_id: number;
+  text: string;
+  message_thread_id?: number;
+  reply_markup?: { inline_keyboard: TelegramInlineKeyboardButton[][] };
+}
+
+interface SetReactionCall {
+  chat_id: number;
+  message_id: number;
+  emoji: string;
+}
+
+interface AnswerCallbackCall {
+  callback_query_id: string;
+  text?: string;
+}
+
+/**
+ * Drives the adapter's long-poll without hitting the network. `getUpdates`
+ * resolves to whatever batch is queued; if the queue is empty the call
+ * waits on `signal` aborting (which `stop()` triggers) or a tiny tick so
+ * tests can pump updates with `enqueueUpdates(...)`.
+ */
+class FakeTelegramApi implements TelegramApi {
+  public readonly sendMessages: SendMessageCall[] = [];
+  public readonly reactions: SetReactionCall[] = [];
+  public readonly callbackAcks: AnswerCallbackCall[] = [];
+
+  private nextUpdateId = 1;
+  private readonly pending: TelegramUpdate[][] = [];
+  /** Resolver for the in-flight `getUpdates` waiter (single-flight). */
+  private waiter: ((batch: TelegramUpdate[]) => void) | null = null;
+
+  async getUpdates(
+    _offset: number,
+    _timeoutSeconds: number,
+    signal: AbortSignal,
+  ): Promise<TelegramGetUpdatesResult> {
+    const batch = this.pending.shift();
+    if (batch !== undefined) {
+      return { ok: true, result: batch };
+    }
+    // No batch ready — wait until either a batch is enqueued or the
+    // adapter aborts the call from `stop()`.
+    return new Promise<TelegramGetUpdatesResult>((resolve, reject) => {
+      const onAbort = (): void => {
+        signal.removeEventListener("abort", onAbort);
+        this.waiter = null;
+        const err = new Error("aborted");
+        (err as Error & { name: string }).name = "AbortError";
+        reject(err);
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      this.waiter = (delivered: TelegramUpdate[]) => {
+        signal.removeEventListener("abort", onAbort);
+        this.waiter = null;
+        resolve({ ok: true, result: delivered });
+      };
+    });
+  }
+
+  async sendMessage(
+    params: SendMessageCall,
+  ): Promise<{ ok: boolean; result?: { message_id: number } }> {
+    this.sendMessages.push(params);
+    return { ok: true, result: { message_id: 1000 + this.sendMessages.length } };
+  }
+
+  async setMessageReaction(params: SetReactionCall): Promise<{ ok: boolean }> {
+    this.reactions.push(params);
+    return { ok: true };
+  }
+
+  async answerCallbackQuery(params: AnswerCallbackCall): Promise<{ ok: boolean }> {
+    this.callbackAcks.push(params);
+    return { ok: true };
+  }
+
+  /**
+   * Push a batch of updates into the queue. If a `getUpdates` call is
+   * waiting, deliver to it immediately so the adapter loop unblocks.
+   */
+  enqueueUpdates(updates: Array<Omit<TelegramUpdate, "update_id">>): void {
+    const stamped: TelegramUpdate[] = updates.map((u) => ({
+      ...u,
+      update_id: this.nextUpdateId++,
+    }));
+    if (this.waiter) {
+      const w = this.waiter;
+      w(stamped);
+      return;
+    }
+    this.pending.push(stamped);
+  }
+}
+
+const SILENT_LOGGER = {
+  warn: () => {},
+  info: () => {},
+  error: () => {},
+};
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Test harness                                                             */
+/* ────────────────────────────────────────────────────────────────────── */
+
+let bus: FakeBus;
+let api: FakeTelegramApi;
+let adapter: TelegramAdapter | null = null;
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  throw new Error(`waitFor: condition not met within ${timeoutMs}ms`);
+}
+
+async function startAdapter(
+  opts: Partial<ConstructorParameters<typeof TelegramAdapter>[0]> = {},
+): Promise<TelegramAdapter> {
+  const a = new TelegramAdapter({
+    bus,
+    token: "test-token",
+    allowedUserIds: [42],
+    routing: { chats: { "100": "triage" } },
+    api,
+    logger: SILENT_LOGGER,
+    pollIntervalMs: 5,
+    ...opts,
+  });
+  await a.start();
+  return a;
+}
+
+beforeEach(() => {
+  bus = new FakeBus();
+  api = new FakeTelegramApi();
+});
+
+afterEach(async () => {
+  if (adapter) {
+    await adapter.stop();
+    adapter = null;
+  }
+});
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Pure helper                                                              */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe("extractReactionDirectives", () => {
+  it("strips a single tag and surfaces the emoji", () => {
+    const { cleanedText, emojis } = extractReactionDirectives("hello [react:👍] world");
+    expect(cleanedText).toBe("hello  world");
+    expect(emojis).toEqual(["👍"]);
+  });
+
+  it("strips multiple tags and surfaces every emoji", () => {
+    const { cleanedText, emojis } = extractReactionDirectives(
+      "[react:🦅]first line\nsecond [react:🪶]line",
+    );
+    expect(cleanedText).toBe("first line\nsecond line");
+    expect(emojis).toEqual(["🦅", "🪶"]);
+  });
+
+  it("returns empty emojis array when no tag present", () => {
+    const { cleanedText, emojis } = extractReactionDirectives("plain text");
+    expect(cleanedText).toBe("plain text");
+    expect(emojis).toEqual([]);
+  });
+
+  it("collapses runs of blank lines after tag removal", () => {
+    const { cleanedText } = extractReactionDirectives("a\n\n\n\nb [react:👌]");
+    expect(cleanedText).toBe("a\n\nb");
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Allow-list + routing                                                     */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe("TelegramAdapter — allow-list", () => {
+  it("replies 'Unauthorized.' on private chat when sender is not allow-listed", async () => {
+    adapter = await startAdapter();
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 1,
+          from: { id: 999, is_bot: false },
+          chat: { id: 100, type: "private" },
+          text: "hi",
+        },
+      },
+    ]);
+    await waitFor(() => api.sendMessages.length > 0);
+    const sent = api.sendMessages[0];
+    expect(sent).toBeDefined();
+    expect(sent?.text).toBe("Unauthorized.");
+    expect(bus.prompts).toHaveLength(0);
+  });
+
+  it("silently drops messages from non-allow-listed users in non-private chats", async () => {
+    adapter = await startAdapter();
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 2,
+          from: { id: 999, is_bot: false },
+          chat: { id: 100, type: "group" },
+          text: "hi",
+        },
+      },
+    ]);
+    // Give the loop time to process — no reply should appear.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(api.sendMessages).toHaveLength(0);
+    expect(bus.prompts).toHaveLength(0);
+  });
+
+  it("drops bot messages", async () => {
+    adapter = await startAdapter();
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 3,
+          from: { id: 42, is_bot: true },
+          chat: { id: 100, type: "private" },
+          text: "hi",
+        },
+      },
+    ]);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(bus.prompts).toHaveLength(0);
+    expect(api.sendMessages).toHaveLength(0);
+  });
+});
+
+describe("TelegramAdapter — routing", () => {
+  it("uses chats[<chat_id>] when configured", async () => {
+    adapter = await startAdapter({
+      routing: { chats: { "100": "triage", "200": "research" } },
+    });
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 1,
+          from: { id: 42 },
+          chat: { id: 200, type: "private" },
+          text: "ping",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts[0]?.agent_id).toBe("research");
+  });
+
+  it("falls back to defaultAgentId for unmapped chats", async () => {
+    adapter = await startAdapter({
+      routing: { chats: { "100": "triage" }, defaultAgentId: "global" },
+    });
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 1,
+          from: { id: 42 },
+          chat: { id: 999, type: "private" },
+          text: "ping",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts[0]?.agent_id).toBe("global");
+  });
+
+  it("silent-drops when no route matches and no default agent set", async () => {
+    adapter = await startAdapter({ routing: { chats: { "100": "triage" } } });
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 1,
+          from: { id: 42 },
+          chat: { id: 999, type: "private" },
+          text: "ping",
+        },
+      },
+    ]);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(bus.prompts).toHaveLength(0);
+    expect(api.sendMessages).toHaveLength(0);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* sendPrompt shape                                                         */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe("TelegramAdapter — bus.sendPrompt shape", () => {
+  it("forwards origin, ids, text and metadata", async () => {
+    adapter = await startAdapter();
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 77,
+          from: { id: 42, username: "terry" },
+          chat: { id: 100, type: "private" },
+          message_thread_id: 5,
+          text: "  please help  ",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length > 0);
+    const sent = bus.prompts[0];
+    expect(sent).toBeDefined();
+    if (!sent) throw new Error("expected prompt captured");
+    expect(sent.origin).toBe("telegram");
+    expect(sent.origin_id).toBe("100");
+    expect(sent.user_id).toBe("42");
+    expect(sent.text).toBe("please help");
+    expect(sent.agent_id).toBe("triage");
+    expect(sent.metadata).toBeDefined();
+    const meta = sent.metadata as Record<string, unknown>;
+    expect(meta.message_id).toBe(77);
+    expect(meta.message_thread_id).toBe(5);
+  });
+
+  it("carries photo + document + voice attachments in metadata", async () => {
+    adapter = await startAdapter();
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 1,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          caption: "look at this",
+          photo: [
+            { file_id: "small", width: 100, height: 100, file_size: 1000 },
+            { file_id: "big", width: 1000, height: 1000, file_size: 100_000 },
+          ],
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length > 0);
+    const meta = bus.prompts[0]?.metadata as Record<string, unknown>;
+    const attachments = meta.attachments as Array<Record<string, unknown>>;
+    expect(attachments).toBeDefined();
+    expect(attachments).toHaveLength(1);
+    expect(attachments[0]?.kind).toBe("photo");
+    expect(attachments[0]?.file_id).toBe("big");
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* response.text → sendMessage                                              */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe("TelegramAdapter — response.text outbound", () => {
+  async function feedInbound(): Promise<void> {
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 50,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          text: "hello",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length > 0);
+  }
+
+  it("posts plain text via sendMessage", async () => {
+    adapter = await startAdapter();
+    await feedInbound();
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "hi there" },
+    });
+    await waitFor(() => api.sendMessages.length > 0);
+    const sent = api.sendMessages[0];
+    expect(sent).toBeDefined();
+    expect(sent?.text).toBe("hi there");
+    expect(sent?.chat_id).toBe(100);
+  });
+
+  it("strips [react:<emoji>] tags and applies them via setMessageReaction", async () => {
+    adapter = await startAdapter();
+    await feedInbound();
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "on it [react:🪶]" },
+    });
+    await waitFor(() => api.sendMessages.length > 0 && api.reactions.length > 0);
+    expect(api.sendMessages[0]?.text).toBe("on it");
+    const reaction = api.reactions[0];
+    expect(reaction).toBeDefined();
+    expect(reaction?.emoji).toBe("🪶");
+    expect(reaction?.message_id).toBe(50);
+    expect(reaction?.chat_id).toBe(100);
+  });
+
+  it("ignores response.text for an unrelated agent", async () => {
+    adapter = await startAdapter();
+    await feedInbound();
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "other-agent",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "should not surface" },
+    });
+    // Tiny tick; the bus shouldn't deliver to our adapter's filter.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(api.sendMessages).toHaveLength(0);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Permission flow                                                          */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe("TelegramAdapter — permission flow", () => {
+  it("sends an inline keyboard for channel.permission_request", async () => {
+    adapter = await startAdapter();
+    // Seed a chat target so the adapter knows where to render the prompt.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 1,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          text: "ping",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length > 0);
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "channel.permission_request",
+      payload: {
+        request_id: "abcde",
+        tool_name: "bash",
+        description: "run `ls`",
+        input_preview: "ls -la",
+      },
+    });
+    await waitFor(() => api.sendMessages.length >= 1);
+    const prompt = api.sendMessages[0];
+    expect(prompt).toBeDefined();
+    expect(prompt?.reply_markup?.inline_keyboard).toBeDefined();
+    const buttons = prompt?.reply_markup?.inline_keyboard.flat() ?? [];
+    expect(buttons).toHaveLength(2);
+    expect(buttons[0]?.callback_data).toBe("perm:allow:abcde");
+    expect(buttons[1]?.callback_data).toBe("perm:deny:abcde");
+  });
+
+  it("routes callback_query through bus.ingestPermissionDecision", async () => {
+    adapter = await startAdapter();
+    // Inbound prompt to anchor target chat.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 1,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          text: "ping",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length > 0);
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "channel.permission_request",
+      payload: {
+        request_id: "qwert",
+        tool_name: "bash",
+        description: "",
+        input_preview: "",
+      },
+    });
+    await waitFor(() => api.sendMessages.length >= 1);
+
+    api.enqueueUpdates([
+      {
+        callback_query: {
+          id: "cb1",
+          from: { id: 42 },
+          data: "perm:allow:qwert",
+          message: {
+            message_id: 9999,
+            chat: { id: 100, type: "private" },
+          },
+        },
+      },
+    ]);
+    await waitFor(() => bus.permissionDecisions.length > 0);
+    const decision = bus.permissionDecisions[0];
+    expect(decision).toBeDefined();
+    expect(decision?.agent_id).toBe("triage");
+    expect(decision?.request_id).toBe("qwert");
+    expect(decision?.behavior).toBe("allow");
+
+    // Confirm the spinner was answered.
+    expect(api.callbackAcks).toHaveLength(1);
+    expect(api.callbackAcks[0]?.callback_query_id).toBe("cb1");
+  });
+
+  it("rejects callback_query from non-allow-listed users", async () => {
+    adapter = await startAdapter();
+    api.enqueueUpdates([
+      {
+        callback_query: {
+          id: "cb2",
+          from: { id: 999 },
+          data: "perm:allow:qwert",
+        },
+      },
+    ]);
+    await waitFor(() => api.callbackAcks.length > 0);
+    expect(api.callbackAcks[0]?.text).toBe("Unauthorized.");
+    expect(bus.permissionDecisions).toHaveLength(0);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* request_human flow                                                       */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe("TelegramAdapter — request_human flow", () => {
+  it("emits a question message and routes the next operator reply via ingestAskAnswer", async () => {
+    adapter = await startAdapter();
+    // Anchor a target chat for the agent.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 1,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          text: "ping",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length > 0);
+    const initialPromptCount = bus.prompts.length;
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "system.request_human",
+      payload: { ask_id: "ask-1", question: "Which env?" },
+    });
+    await waitFor(() => api.sendMessages.length >= 1);
+    expect(api.sendMessages[0]?.text).toContain("Which env?");
+
+    // Operator replies — should resolve the ask, NOT spawn a new prompt.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 2,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          text: "production",
+        },
+      },
+    ]);
+    await waitFor(() => bus.askAnswers.length > 0);
+    expect(bus.askAnswers[0]).toEqual({
+      agent_id: "triage",
+      ask_id: "ask-1",
+      answer: "production",
+    });
+    // No new sendPrompt was issued (still at the seed count).
+    expect(bus.prompts.length).toBe(initialPromptCount);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* stop() cleanup                                                           */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe("TelegramAdapter — stop()", () => {
+  it("closes every subscription so bus.state().subscriberCount returns to 0", async () => {
+    adapter = await startAdapter({
+      routing: { chats: { "100": "triage", "200": "research" } },
+    });
+    // Two agents × three topics = six subscriptions.
+    expect(bus.state().subscriberCount).toBe(6);
+    await adapter.stop();
+    adapter = null;
+    expect(bus.state().subscriberCount).toBe(0);
+  });
+
+  it("does not throw when stop() is called twice", async () => {
+    adapter = await startAdapter();
+    await adapter.stop();
+    await adapter.stop();
+    adapter = null;
+  });
+
+  it("aborts an in-flight long-poll so stop() returns promptly", async () => {
+    adapter = await startAdapter({ pollIntervalMs: 50 });
+    // No updates queued — the loop is now parked in `getUpdates`.
+    const start = Date.now();
+    await adapter.stop();
+    const elapsed = Date.now() - start;
+    adapter = null;
+    expect(elapsed).toBeLessThan(500);
+  });
+});

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -660,6 +660,129 @@ describe("TelegramAdapter — permission flow", () => {
 /* request_human flow                                                       */
 /* ────────────────────────────────────────────────────────────────────── */
 
+describe("TelegramAdapter — allow-list semantics (PR #113 review)", () => {
+  it("empty allowedUserIds = allow all (legacy parity)", async () => {
+    adapter = await startAdapter({ allowedUserIds: [] });
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 1,
+          from: { id: 9999 }, // not in any list
+          chat: { id: 100, type: "private" },
+          text: "anyone home?",
+        },
+      },
+    ]);
+    // Should reach the bus (allowed because list is empty), NOT bounce
+    // with "Unauthorized.".
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts).toHaveLength(1);
+    const unauthorisedReplies = api.sendMessages.filter((m) => m.text === "Unauthorized.");
+    expect(unauthorisedReplies).toHaveLength(0);
+  });
+
+  it("non-empty allowedUserIds with no match still rejects", async () => {
+    adapter = await startAdapter({ allowedUserIds: [42] });
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 1,
+          from: { id: 9999 },
+          chat: { id: 100, type: "private" },
+          text: "trying again",
+        },
+      },
+    ]);
+    await waitFor(() => api.sendMessages.length > 0);
+    expect(api.sendMessages[0]?.text).toBe("Unauthorized.");
+    expect(bus.prompts).toHaveLength(0);
+  });
+});
+
+describe("TelegramAdapter — request_human keying (PR #113 review)", () => {
+  it("uses composite (agent_id, chat_id) key so multi-agent doesn't collide", async () => {
+    // Two agents routed to two different chats. Each agent gets its own
+    // pending ask; resolving one doesn't clear the other.
+    adapter = await startAdapter({
+      routing: { chats: { "100": "triage", "200": "research" } },
+    });
+    // Seed a prompt for each agent so `lastChatPerAgent` is populated.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 1,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          text: "p1",
+        },
+      },
+      {
+        message: {
+          message_id: 2,
+          from: { id: 42 },
+          chat: { id: 200, type: "private" },
+          text: "p2",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length >= 2);
+
+    // Two simultaneous request_human, one per agent, both visible at the
+    // same time — keying by chat_id alone would clobber one of them.
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "system.request_human",
+      payload: { ask_id: "ask-triage", question: "Q1?" },
+    });
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "research",
+      session_id: "s2",
+      topic: "system.request_human",
+      payload: { ask_id: "ask-research", question: "Q2?" },
+    });
+    await waitFor(() => api.sendMessages.length >= 2);
+
+    // Resolve triage's ask via chat 100 — research's ask should remain.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 3,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          text: "triage-answer",
+        },
+      },
+    ]);
+    await waitFor(() => bus.askAnswers.length >= 1);
+    expect(bus.askAnswers[0]).toEqual({
+      agent_id: "triage",
+      ask_id: "ask-triage",
+      answer: "triage-answer",
+    });
+
+    // Now resolve research's ask via chat 200.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 4,
+          from: { id: 42 },
+          chat: { id: 200, type: "private" },
+          text: "research-answer",
+        },
+      },
+    ]);
+    await waitFor(() => bus.askAnswers.length >= 2);
+    expect(bus.askAnswers[1]).toEqual({
+      agent_id: "research",
+      ask_id: "ask-research",
+      answer: "research-answer",
+    });
+  });
+});
+
 describe("TelegramAdapter — request_human flow", () => {
   it("emits a question message and routes the next operator reply via ingestAskAnswer", async () => {
     adapter = await startAdapter();

--- a/src/adapters/telegram/api.ts
+++ b/src/adapters/telegram/api.ts
@@ -18,12 +18,17 @@ const API_BASE = "https://api.telegram.org/bot";
 /**
  * Build a `TelegramApi` instance bound to a particular bot token.
  *
- * Notes on parity with the legacy implementation:
- *   - `getUpdates` uses `allowed_updates: ["message", "edited_message",
- *     "callback_query"]` — the minimum the adapter handles. The legacy
- *     file also requests `my_chat_member`; that update type drives
- *     group-join messages which the Bus adapter doesn't have a behaviour
- *     for yet (Sprint 4 follow-up).
+ * `allowed_updates` differences vs `src/commands/telegram.ts:2177`:
+ *   - Bus adapter requests `["message", "edited_message", "callback_query"]`.
+ *   - Legacy requests `["message", "my_chat_member", "callback_query"]`.
+ *   - Bus ADDS `edited_message` (lets adapter react to message edits in
+ *     Sprint 4+ without re-subscribing).
+ *   - Bus DROPS `my_chat_member` (group-join semantics not yet wired into
+ *     the Bus; Sprint 4 follow-up if the surface needs it).
+ * Both sets are intentional; PR #113 review (agent #5) flagged the
+ * earlier comment for framing the diff as one-sided.
+ *
+ * Other notes:
  *   - `setMessageReaction` wraps a single emoji in the expected
  *     `[{type:"emoji", emoji:"…"}]` array shape per Bot API 7.x.
  *   - Errors throw with `${method}: ${status} ${statusText}` so the

--- a/src/adapters/telegram/api.ts
+++ b/src/adapters/telegram/api.ts
@@ -1,0 +1,76 @@
+/**
+ * Telegram adapter — fetch-backed Bot API client.
+ *
+ * Split out of `index.ts` so the main adapter file stays under the
+ * file-size ceiling and so the HTTP surface can be swapped/mocked
+ * without touching the adapter wiring.
+ *
+ * Mirrors `callApi()` in `src/commands/telegram.ts:422-440`. We
+ * re-implement here (rather than importing) so the Bus adapter has zero
+ * dependency on the legacy file. Sprint 5 can consolidate once the
+ * PTY path is retired.
+ */
+
+import type { TelegramApi } from "./types";
+
+const API_BASE = "https://api.telegram.org/bot";
+
+/**
+ * Build a `TelegramApi` instance bound to a particular bot token.
+ *
+ * Notes on parity with the legacy implementation:
+ *   - `getUpdates` uses `allowed_updates: ["message", "edited_message",
+ *     "callback_query"]` — the minimum the adapter handles. The legacy
+ *     file also requests `my_chat_member`; that update type drives
+ *     group-join messages which the Bus adapter doesn't have a behaviour
+ *     for yet (Sprint 4 follow-up).
+ *   - `setMessageReaction` wraps a single emoji in the expected
+ *     `[{type:"emoji", emoji:"…"}]` array shape per Bot API 7.x.
+ *   - Errors throw with `${method}: ${status} ${statusText}` so the
+ *     adapter's `safe*` wrappers can log a useful one-liner.
+ */
+export function createTelegramApi(token: string): TelegramApi {
+  async function call<T>(
+    method: string,
+    body: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const res = await fetch(`${API_BASE}${token}/${method}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+      signal,
+    });
+    if (!res.ok) {
+      throw new Error(`Telegram API ${method}: ${res.status} ${res.statusText}`);
+    }
+    return (await res.json()) as T;
+  }
+
+  return {
+    async getUpdates(offset, timeoutSeconds, signal) {
+      return call(
+        "getUpdates",
+        {
+          offset,
+          timeout: timeoutSeconds,
+          allowed_updates: ["message", "edited_message", "callback_query"],
+        },
+        signal,
+      );
+    },
+    async sendMessage(params) {
+      return call("sendMessage", params as unknown as Record<string, unknown>);
+    },
+    async setMessageReaction(params) {
+      return call("setMessageReaction", {
+        chat_id: params.chat_id,
+        message_id: params.message_id,
+        reaction: [{ type: "emoji", emoji: params.emoji }],
+      });
+    },
+    async answerCallbackQuery(params) {
+      return call("answerCallbackQuery", params as unknown as Record<string, unknown>);
+    },
+  };
+}

--- a/src/adapters/telegram/directives.ts
+++ b/src/adapters/telegram/directives.ts
@@ -1,0 +1,40 @@
+/**
+ * Telegram adapter — text-directive helpers.
+ *
+ * Split out of `index.ts` so the main adapter stays under the file-size
+ * ceiling and so directive parsing has its own test surface.
+ *
+ * Mirrors the regex + post-cleanup pipeline used by
+ * `src/commands/telegram.ts:661-684` (legacy PTY listener). Spec
+ * reference: `docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md` §5.5.2 +
+ * `CLAUDE.md` "Emoji & Reactions".
+ */
+
+/**
+ * Strip every `[react:<emoji>]` tag from `text` and collect the emojis.
+ *
+ * - Tags are case-insensitive (`[REACT:🪶]` and `[react:🪶]` both match).
+ * - Multiple tags are supported. The legacy file only kept the first; we
+ *   keep all of them because applying multiple reactions is harmless and
+ *   future agents may want to emit several.
+ * - Cleanup runs the same steps as the legacy file: collapse trailing
+ *   whitespace before newlines, collapse runs of 3+ blank lines down to
+ *   two, then `trim()`.
+ *
+ * Exported for tests; not part of the public adapter surface.
+ */
+export function extractReactionDirectives(text: string): {
+  cleanedText: string;
+  emojis: string[];
+} {
+  const emojis: string[] = [];
+  let cleaned = text.replace(/\[react:([^\]\r\n]+)\]/gi, (_match, raw) => {
+    const candidate = String(raw).trim();
+    if (candidate) emojis.push(candidate);
+    return "";
+  });
+  cleaned = cleaned.replace(/[ \t]+\n/g, "\n");
+  cleaned = cleaned.replace(/\n{3,}/g, "\n\n");
+  cleaned = cleaned.trim();
+  return { cleanedText: cleaned, emojis };
+}

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -85,7 +85,15 @@ export class TelegramAdapter {
   /** request_id → context; callback_query routes back to `ingestPermissionDecision`. */
   private readonly pendingPermissions = new Map<string, { agent_id: string; chat_id: number }>();
   /** chat_id → pending ask. The next plain-text reply resolves it. */
-  private readonly pendingHumanAsks = new Map<number, PendingHumanAsk>();
+  /**
+   * Pending `request_human` keyed by `${agentId}:${chatId}` so multi-agent
+   * configs sharing a chat don't collide. PR #113 review (agent #2):
+   * earlier chat-id-only keying matched Telegram's documented single-user
+   * pattern, but breaks the moment `routing.chats` maps multiple chats to
+   * different agents AND the operator shares one chat across them. Discord
+   * adapter already uses the composite key — symmetry restored.
+   */
+  private readonly pendingHumanAsks = new Map<string, PendingHumanAsk>();
 
   /** Loop promise so `stop()` can await graceful exit. */
   private loopPromise: Promise<void> | null = null;
@@ -147,6 +155,14 @@ export class TelegramAdapter {
       }
     }
     this.subscriptions.clear();
+
+    // Clear correlation maps so stop→start cycles don't reuse stale
+    // request_id / ask_id / per-agent target state. PR #113 review
+    // (agent #2): Discord adapter clears these; Telegram was missing
+    // the symmetric cleanup.
+    this.pendingPermissions.clear();
+    this.pendingHumanAsks.clear();
+    this.lastChatPerAgent.clear();
 
     if (this.loopPromise) {
       try {
@@ -211,9 +227,16 @@ export class TelegramAdapter {
     // Drop bot-to-bot echoes (legacy gating + spec allow-list semantics).
     if (message.from?.is_bot) return;
 
-    // Allow-list. Named rejection in private chats; silent skip elsewhere.
+    // Allow-list — telegram.ts:1131 semantics: empty list = "allow all"
+    // (preserved for default-config parity per PR #113 review); non-empty
+    // list with no match = named rejection in private chats / silent skip
+    // in group chats. The earlier "empty = deny all" behaviour was a
+    // silent regression for operators running default configs.
     const isPrivate = message.chat.type === "private";
-    if (userId === undefined || !this.allowedUserIds.has(userId)) {
+    if (
+      userId === undefined ||
+      (this.allowedUserIds.size > 0 && !this.allowedUserIds.has(userId))
+    ) {
       if (isPrivate) {
         await this.safeSendMessage({
           chat_id: chatId,
@@ -224,6 +247,16 @@ export class TelegramAdapter {
       return;
     }
 
+    // TODO(sprint-4): port the legacy 30 msg/min per-user rate limit
+    // (`src/commands/telegram.ts:264-275`). The Bus runtime hasn't settled
+    // where rate limiting lives (per-adapter vs central Bus middleware),
+    // so this adapter is currently unrate-limited. PR #113 review agent
+    // #3 flagged the missing TODO marker — adding here so a future
+    // operator grepping finds it.
+    // TODO(sprint-4): port `[buttons:...]` directive + `buttonLabelMap`
+    // TTL eviction from legacy (`telegram.ts` commits d845e02, a6c45aa).
+    // Currently agent-emitted inline buttons UX is gone in Bus runtime.
+
     const agentId = this.resolveAgent(chatId);
     if (!agentId) return;
 
@@ -231,10 +264,15 @@ export class TelegramAdapter {
     const text = (message.text ?? message.caption ?? "").trim();
     const metadata = buildPromptMetadata(message);
 
-    // Pending `request_human` for this chat? Route reply as ask_answer.
-    const pendingAsk = this.pendingHumanAsks.get(chatId);
+    // Pending `request_human` for this (agent, chat)? Route the text-bearing
+    // reply as ask_answer. Per PR #113 agent #5 finding: this path GATES
+    // on `text.length > 0` — photo-only / document-only replies do NOT
+    // resolve the pending ask. That's intentional (an ask needs prose) but
+    // documented here so it's not a surprise.
+    const pendingAskKey = `${agentId}:${chatId}`;
+    const pendingAsk = this.pendingHumanAsks.get(pendingAskKey);
     if (pendingAsk && text.length > 0) {
-      this.pendingHumanAsks.delete(chatId);
+      this.pendingHumanAsks.delete(pendingAskKey);
       this.bus.ingestAskAnswer({
         agent_id: pendingAsk.agent_id,
         ask_id: pendingAsk.ask_id,
@@ -374,7 +412,11 @@ export class TelegramAdapter {
     }
 
     // One pending ask per chat; newer supersedes older (spec §5.4 flow).
-    this.pendingHumanAsks.set(target.chat_id, { ask_id: payload.ask_id, agent_id: agentId });
+    // Composite key: agent + chat. PR #113 review (agent #2).
+    this.pendingHumanAsks.set(`${agentId}:${target.chat_id}`, {
+      ask_id: payload.ask_id,
+      agent_id: agentId,
+    });
 
     await this.safeSendMessage({
       chat_id: target.chat_id,
@@ -390,7 +432,11 @@ export class TelegramAdapter {
   private async handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> {
     const data = query.data ?? "";
     const userId = query.from?.id;
-    if (userId === undefined || !this.allowedUserIds.has(userId)) {
+    // Allow-list — empty = "allow all" (legacy parity, PR #113 review).
+    if (
+      userId === undefined ||
+      (this.allowedUserIds.size > 0 && !this.allowedUserIds.has(userId))
+    ) {
       await this.safeAnswerCallback({
         callback_query_id: query.id,
         text: "Unauthorized.",

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -1,0 +1,500 @@
+/**
+ * Telegram Bot adapter (Sprint 3 Agent B). Spec §5.5.2; coordination
+ * `src/bus/SPRINT_3_PLAN.md`. Mirrors `src/commands/telegram.ts` (legacy
+ * PTY listener) but speaks only to `BusCore`. The legacy file stays;
+ * Sprint 5 flips `runtime: bus` and retires it. Out of scope: file-bytes
+ * upload pipeline (file_ids only); Markdown polish (plain text only).
+ */
+
+import type { BusCore, Subscription } from "../../bus/core";
+import type { BusEvent, PermissionRequest } from "../../bus/types";
+import { createTelegramApi } from "./api";
+import { extractReactionDirectives } from "./directives";
+import { buildPromptMetadata } from "./metadata";
+import type {
+  TelegramApi,
+  TelegramCallbackQuery,
+  TelegramInlineKeyboardButton,
+  TelegramMessage,
+  TelegramUpdate,
+} from "./types";
+
+export interface TelegramAdapterOptions {
+  bus: BusCore;
+  /** Bot token (`123:abc…`). Used for the default HTTP API client. */
+  token: string;
+  /**
+   * Numeric user IDs allowed to talk to the bot. Empty list rejects all —
+   * explicit allow-listing is a precondition under the Bus runtime.
+   */
+  allowedUserIds: number[];
+  /** chat-id → agent_id routing. `defaultAgentId` covers fall-through. */
+  routing: {
+    chats: Record<string, string>;
+    defaultAgentId?: string;
+  };
+  /** Poll interval ms between successive `getUpdates` calls. Default 1000. */
+  pollIntervalMs?: number;
+  /** Override the API client (tests inject a fake). */
+  api?: TelegramApi;
+  /** Optional structured logger; defaults to `console`. */
+  logger?: Pick<Console, "warn" | "info" | "error">;
+}
+
+/**
+ * Per-agent target context. `[react:<emoji>]` UX needs the originating
+ * message id, so we hold the last inbound per agent. One slot per agent
+ * is enough for Sprint 3's single-user-bot pattern.
+ */
+interface PendingPrompt {
+  chat_id: number;
+  /** Telegram message id of the inbound user message — reaction target. */
+  source_message_id: number;
+  /** Optional forum-topic thread id, propagated to outbound sends. */
+  message_thread_id?: number;
+}
+
+/** In-flight `system.request_human` correlation; next chat reply answers it. */
+interface PendingHumanAsk {
+  ask_id: string;
+  agent_id: string;
+}
+
+export class TelegramAdapter {
+  private readonly bus: BusCore;
+  private readonly api: TelegramApi;
+  private readonly allowedUserIds: ReadonlySet<number>;
+  private readonly routingChats: Record<string, string>;
+  private readonly defaultAgentId: string | undefined;
+  private readonly pollIntervalMs: number;
+  private readonly logger: Pick<Console, "warn" | "info" | "error">;
+
+  /** getUpdates offset cursor — bumped past the highest processed update_id. */
+  private nextOffset = 0;
+  /** Generation counter — bumped by `stop()` to abort the long-poll loop. */
+  private generation = 0;
+  private running = false;
+  /** AbortController for the in-flight `getUpdates` call. */
+  private inflightAbort: AbortController | null = null;
+
+  /** Live subscriptions keyed by agent_id. Cleaned up by `stop()`. */
+  private readonly subscriptions = new Map<string, Subscription[]>();
+
+  /** Last inbound per agent — target for outbound + reaction message id. */
+  private readonly lastChatPerAgent = new Map<string, PendingPrompt>();
+  /** request_id → context; callback_query routes back to `ingestPermissionDecision`. */
+  private readonly pendingPermissions = new Map<string, { agent_id: string; chat_id: number }>();
+  /** chat_id → pending ask. The next plain-text reply resolves it. */
+  private readonly pendingHumanAsks = new Map<number, PendingHumanAsk>();
+
+  /** Loop promise so `stop()` can await graceful exit. */
+  private loopPromise: Promise<void> | null = null;
+
+  constructor(opts: TelegramAdapterOptions) {
+    if (!opts.bus) throw new Error("TelegramAdapter: `bus` is required");
+    if (!opts.token) throw new Error("TelegramAdapter: `token` is required");
+    if (!opts.routing) throw new Error("TelegramAdapter: `routing` is required");
+
+    this.bus = opts.bus;
+    this.api = opts.api ?? createTelegramApi(opts.token);
+    this.allowedUserIds = new Set(opts.allowedUserIds);
+    this.routingChats = { ...opts.routing.chats };
+    this.defaultAgentId = opts.routing.defaultAgentId;
+    this.pollIntervalMs = opts.pollIntervalMs ?? 1000;
+    this.logger = opts.logger ?? console;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    this.generation += 1;
+
+    // Subscribe for every routed agent + the default, so fallback-only
+    // agents still receive `response.text`.
+    const agentIds = new Set<string>(Object.values(this.routingChats));
+    if (this.defaultAgentId) agentIds.add(this.defaultAgentId);
+    for (const agentId of agentIds) {
+      this.subscribeForAgent(agentId);
+    }
+
+    const gen = this.generation;
+    this.loopPromise = this.pollLoop(gen).catch((err) => {
+      this.logger.error("[telegram-adapter] poll loop crashed", err);
+    });
+  }
+
+  async stop(): Promise<void> {
+    if (!this.running) return;
+    this.running = false;
+    this.generation += 1; // signal the loop to exit on next iteration
+
+    // Abort the long-poll so stop() returns promptly (legacy waits 30s).
+    if (this.inflightAbort) {
+      try {
+        this.inflightAbort.abort();
+      } catch {
+        // already aborted — fine.
+      }
+    }
+
+    for (const subs of this.subscriptions.values()) {
+      for (const sub of subs) {
+        try {
+          sub.close();
+        } catch (err) {
+          this.logger.error("[telegram-adapter] subscription.close failed", err);
+        }
+      }
+    }
+    this.subscriptions.clear();
+
+    if (this.loopPromise) {
+      try {
+        await this.loopPromise;
+      } catch (err) {
+        this.logger.error("[telegram-adapter] loop await failed", err);
+      }
+      this.loopPromise = null;
+    }
+  }
+
+  /**
+   * Long-poll loop — `getUpdates` → dispatch → repeat. Mirrors
+   * `src/commands/telegram.ts:2172-2218`. Generation token (instead of
+   * the legacy `running` boolean) cleanly aborts after rapid stop/start.
+   */
+  private async pollLoop(gen: number): Promise<void> {
+    while (this.running && this.generation === gen) {
+      const ac = new AbortController();
+      this.inflightAbort = ac;
+      try {
+        const data = await this.api.getUpdates(this.nextOffset, 30, ac.signal);
+        if (this.generation !== gen) break;
+        if (!data.ok) {
+          await this.sleep(this.pollIntervalMs);
+          continue;
+        }
+        for (const update of data.result) {
+          this.nextOffset = update.update_id + 1;
+          try {
+            await this.dispatchUpdate(update);
+          } catch (err) {
+            this.logger.error("[telegram-adapter] dispatch failed", err);
+          }
+        }
+      } catch (err) {
+        if (this.generation !== gen || !this.running) break;
+        if ((err as { name?: string })?.name === "AbortError") break;
+        this.logger.error("[telegram-adapter] getUpdates failed", err);
+        await this.sleep(this.pollIntervalMs);
+      } finally {
+        this.inflightAbort = null;
+      }
+    }
+  }
+
+  /** Fan out by update kind. Edited messages reuse the message path (parity). */
+  private async dispatchUpdate(update: TelegramUpdate): Promise<void> {
+    const message = update.message ?? update.edited_message;
+    if (message) {
+      await this.handleMessage(message);
+    }
+    if (update.callback_query) {
+      await this.handleCallbackQuery(update.callback_query);
+    }
+  }
+
+  private async handleMessage(message: TelegramMessage): Promise<void> {
+    const chatId = message.chat.id;
+    const userId = message.from?.id;
+
+    // Drop bot-to-bot echoes (legacy gating + spec allow-list semantics).
+    if (message.from?.is_bot) return;
+
+    // Allow-list. Named rejection in private chats; silent skip elsewhere.
+    const isPrivate = message.chat.type === "private";
+    if (userId === undefined || !this.allowedUserIds.has(userId)) {
+      if (isPrivate) {
+        await this.safeSendMessage({
+          chat_id: chatId,
+          text: "Unauthorized.",
+          message_thread_id: message.message_thread_id,
+        });
+      }
+      return;
+    }
+
+    const agentId = this.resolveAgent(chatId);
+    if (!agentId) return;
+
+    // Telegram puts captioned-photo text in `caption` — accept either.
+    const text = (message.text ?? message.caption ?? "").trim();
+    const metadata = buildPromptMetadata(message);
+
+    // Pending `request_human` for this chat? Route reply as ask_answer.
+    const pendingAsk = this.pendingHumanAsks.get(chatId);
+    if (pendingAsk && text.length > 0) {
+      this.pendingHumanAsks.delete(chatId);
+      this.bus.ingestAskAnswer({
+        agent_id: pendingAsk.agent_id,
+        ask_id: pendingAsk.ask_id,
+        answer: text,
+      });
+      return;
+    }
+
+    // Empty payload with no attachments — nothing to do.
+    const attachments = metadata.attachments as unknown[] | undefined;
+    if (text.length === 0 && (!attachments || attachments.length === 0)) {
+      return;
+    }
+
+    await this.bus.sendPrompt({
+      agent_id: agentId,
+      origin: "telegram",
+      origin_id: String(chatId),
+      user_id: String(userId),
+      text,
+      metadata,
+    });
+
+    const pending: PendingPrompt = {
+      chat_id: chatId,
+      source_message_id: message.message_id,
+      message_thread_id: message.message_thread_id,
+    };
+    this.lastChatPerAgent.set(agentId, pending);
+  }
+
+  /** Subscribe to the three §5.5.2 topics for `agentId` (response, perm, ask). */
+  private subscribeForAgent(agentId: string): void {
+    if (this.subscriptions.has(agentId)) return;
+    const subs: Subscription[] = [];
+    subs.push(
+      this.bus.subscribe(
+        { agent_id: agentId, topics: ["response.text"] },
+        (event) => void this.handleResponseText(agentId, event),
+      ),
+      this.bus.subscribe(
+        { agent_id: agentId, topics: ["channel.permission_request"] },
+        (event) => void this.handlePermissionRequest(agentId, event),
+      ),
+      this.bus.subscribe(
+        { agent_id: agentId, topics: ["system.request_human"] },
+        (event) => void this.handleRequestHuman(agentId, event),
+      ),
+    );
+    this.subscriptions.set(agentId, subs);
+  }
+
+  private async handleResponseText(agentId: string, event: BusEvent): Promise<void> {
+    const payload = event.payload as { text?: string };
+    const rawText = typeof payload?.text === "string" ? payload.text : "";
+    if (rawText.length === 0) return;
+
+    const target = this.targetForAgent(agentId);
+    if (!target) {
+      this.logger.warn(
+        `[telegram-adapter] no target chat for agent ${agentId}; dropping response.text`,
+      );
+      return;
+    }
+
+    const { cleanedText, emojis } = extractReactionDirectives(rawText);
+
+    if (cleanedText.length > 0) {
+      await this.safeSendMessage({
+        chat_id: target.chat_id,
+        text: cleanedText,
+        message_thread_id: target.message_thread_id,
+      });
+    }
+
+    // Reactions target the inbound user message (CLAUDE.md UX). No source
+    // message → nothing to react to.
+    if (emojis.length > 0 && target.source_message_id) {
+      for (const emoji of emojis) {
+        await this.safeSetReaction({
+          chat_id: target.chat_id,
+          message_id: target.source_message_id,
+          emoji,
+        });
+      }
+    }
+  }
+
+  private async handlePermissionRequest(agentId: string, event: BusEvent): Promise<void> {
+    const req = event.payload as PermissionRequest | undefined;
+    if (!req || typeof req.request_id !== "string") return;
+
+    const target = this.targetForAgent(agentId);
+    if (!target) {
+      this.logger.warn(
+        `[telegram-adapter] no target chat for permission_request on agent ${agentId}`,
+      );
+      return;
+    }
+
+    this.pendingPermissions.set(req.request_id, { agent_id: agentId, chat_id: target.chat_id });
+
+    const text = [
+      `🔒 *Permission request*`,
+      `Tool: ${req.tool_name}`,
+      req.description ? req.description : "",
+      req.input_preview ? `\n\`\`\`\n${req.input_preview}\n\`\`\`` : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    // callback_data shape `perm:<allow|deny>:<request_id>` — legacy "type:id" pattern.
+    const keyboard: TelegramInlineKeyboardButton[][] = [
+      [
+        { text: "✅ Allow", callback_data: `perm:allow:${req.request_id}` },
+        { text: "❌ Deny", callback_data: `perm:deny:${req.request_id}` },
+      ],
+    ];
+
+    await this.safeSendMessage({
+      chat_id: target.chat_id,
+      text,
+      message_thread_id: target.message_thread_id,
+      reply_markup: { inline_keyboard: keyboard },
+    });
+  }
+
+  private async handleRequestHuman(agentId: string, event: BusEvent): Promise<void> {
+    const payload = event.payload as { ask_id?: string; question?: string };
+    if (typeof payload?.ask_id !== "string" || typeof payload?.question !== "string") {
+      return;
+    }
+    const target = this.targetForAgent(agentId);
+    if (!target) {
+      this.logger.warn(`[telegram-adapter] no target chat for request_human on agent ${agentId}`);
+      return;
+    }
+
+    // One pending ask per chat; newer supersedes older (spec §5.4 flow).
+    this.pendingHumanAsks.set(target.chat_id, { ask_id: payload.ask_id, agent_id: agentId });
+
+    await this.safeSendMessage({
+      chat_id: target.chat_id,
+      text: `🤔 ${payload.question}`,
+      message_thread_id: target.message_thread_id,
+    });
+  }
+
+  /**
+   * Handle `perm:<allow|deny>:<id>` (the only pattern this adapter emits).
+   * Legacy file's `btn:`, `pending:`, `sec_yes_` patterns are out of scope.
+   */
+  private async handleCallbackQuery(query: TelegramCallbackQuery): Promise<void> {
+    const data = query.data ?? "";
+    const userId = query.from?.id;
+    if (userId === undefined || !this.allowedUserIds.has(userId)) {
+      await this.safeAnswerCallback({
+        callback_query_id: query.id,
+        text: "Unauthorized.",
+      });
+      return;
+    }
+
+    const match = data.match(/^perm:(allow|deny):(.+)$/);
+    if (!match) {
+      // Unknown callback shape — ack so the spinner clears, then drop.
+      await this.safeAnswerCallback({ callback_query_id: query.id });
+      return;
+    }
+
+    const behavior = match[1] as "allow" | "deny";
+    const requestId = match[2];
+    if (!requestId) {
+      await this.safeAnswerCallback({ callback_query_id: query.id });
+      return;
+    }
+    const pending = this.pendingPermissions.get(requestId);
+    if (!pending) {
+      // Likely expired (daemon restart). Tell the user instead of silently
+      // dropping — they'd otherwise wait forever for the underlying tool.
+      await this.safeAnswerCallback({
+        callback_query_id: query.id,
+        text: "This permission request has expired.",
+      });
+      return;
+    }
+    this.pendingPermissions.delete(requestId);
+    this.bus.ingestPermissionDecision({
+      agent_id: pending.agent_id,
+      request_id: requestId,
+      behavior,
+    });
+    await this.safeAnswerCallback({
+      callback_query_id: query.id,
+      text: behavior === "allow" ? "✅ Allowed" : "❌ Denied",
+    });
+  }
+
+  private resolveAgent(chatId: number): string | undefined {
+    const explicit = this.routingChats[String(chatId)];
+    if (explicit) return explicit;
+    return this.defaultAgentId;
+  }
+
+  /**
+   * Pick an outbound chat for the agent. Prefers the last inbound (so
+   * replies thread back); falls back to the first chat routed to the
+   * agent so spontaneous events (cron, background tools) still reach
+   * a surface.
+   */
+  private targetForAgent(agentId: string): PendingPrompt | null {
+    const last = this.lastChatPerAgent.get(agentId);
+    if (last) return last;
+    for (const [chatIdStr, mappedAgent] of Object.entries(this.routingChats)) {
+      if (mappedAgent === agentId) {
+        const chatId = Number(chatIdStr);
+        if (Number.isFinite(chatId)) {
+          return { chat_id: chatId, source_message_id: 0 };
+        }
+      }
+    }
+    return null;
+  }
+
+  /** Best-effort API call — any throw is logged, never propagated. */
+  private async safe(label: string, fn: () => Promise<unknown>): Promise<void> {
+    try {
+      await fn();
+    } catch (err) {
+      this.logger.error(`[telegram-adapter] ${label} failed`, err);
+    }
+  }
+
+  private safeSendMessage(params: {
+    chat_id: number;
+    text: string;
+    message_thread_id?: number;
+    reply_markup?: { inline_keyboard: TelegramInlineKeyboardButton[][] };
+  }): Promise<void> {
+    return this.safe("sendMessage", () => this.api.sendMessage(params));
+  }
+
+  private safeSetReaction(params: {
+    chat_id: number;
+    message_id: number;
+    emoji: string;
+  }): Promise<void> {
+    return this.safe("setMessageReaction", () => this.api.setMessageReaction(params));
+  }
+
+  private safeAnswerCallback(params: { callback_query_id: string; text?: string }): Promise<void> {
+    return this.safe("answerCallbackQuery", () => this.api.answerCallbackQuery(params));
+  }
+
+  private async sleep(ms: number): Promise<void> {
+    if (ms <= 0) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, ms));
+  }
+}
+
+// Re-exports so test files don't need to dig through the helper modules.
+export { extractReactionDirectives } from "./directives";
+export type { TelegramApi } from "./types";

--- a/src/adapters/telegram/metadata.ts
+++ b/src/adapters/telegram/metadata.ts
@@ -1,0 +1,65 @@
+/**
+ * Telegram adapter — prompt metadata builder.
+ *
+ * Builds the `metadata` field attached to `bus.sendPrompt`. Future
+ * surfaces (Web UI conversation view, audit log queries) consume this
+ * to know what attachments were on the original message even though the
+ * Bus adapter doesn't download the bytes itself.
+ *
+ * Lives in its own file to keep `index.ts` under the file-size ceiling.
+ */
+
+import type { TelegramMessage } from "./types";
+
+/**
+ * Build the `metadata` envelope passed to `bus.sendPrompt`.
+ *
+ * Always carries `message_id` (needed for downstream correlation). Adds
+ * `message_thread_id` when the inbound was in a forum topic. Adds an
+ * `attachments` array when any media was attached — file IDs only; the
+ * Sprint 5 file pipeline will hydrate bytes.
+ *
+ * Photo handling mirrors `pickLargestPhoto()` in
+ * `src/commands/telegram.ts:366-372`: Telegram returns N sizes, we keep
+ * the largest by reported size (falling back to width × height).
+ */
+export function buildPromptMetadata(message: TelegramMessage): Record<string, unknown> {
+  const meta: Record<string, unknown> = { message_id: message.message_id };
+  if (message.message_thread_id !== undefined) {
+    meta.message_thread_id = message.message_thread_id;
+  }
+
+  const attachments: Array<Record<string, unknown>> = [];
+  if (message.photo && message.photo.length > 0) {
+    const largest = [...message.photo].sort((a, b) => {
+      const sa = a.file_size ?? a.width * a.height;
+      const sb = b.file_size ?? b.width * b.height;
+      return sb - sa;
+    })[0];
+    if (largest) {
+      attachments.push({ kind: "photo", file_id: largest.file_id });
+    }
+  }
+  if (message.document) {
+    attachments.push({
+      kind: "document",
+      file_id: message.document.file_id,
+      mime_type: message.document.mime_type,
+      file_name: message.document.file_name,
+    });
+  }
+  if (message.voice) {
+    attachments.push({ kind: "voice", file_id: message.voice.file_id });
+  }
+  if (message.audio) {
+    attachments.push({
+      kind: "audio",
+      file_id: message.audio.file_id,
+      mime_type: message.audio.mime_type,
+    });
+  }
+  if (attachments.length > 0) {
+    meta.attachments = attachments;
+  }
+  return meta;
+}

--- a/src/adapters/telegram/types.ts
+++ b/src/adapters/telegram/types.ts
@@ -113,7 +113,7 @@ export interface TelegramInlineKeyboardButton {
 
 /**
  * Minimal Telegram API surface used by the adapter. Real implementation is
- * `createTelegramApi()` in `index.ts`; tests substitute a `FakeTelegramApi`
+ * `createTelegramApi()` in `./api.ts`; tests substitute a `FakeTelegramApi`
  * to avoid hitting `api.telegram.org` (see `__tests__/telegram.test.ts`).
  *
  * Shape mirrors the calls in `src/commands/telegram.ts` — only the methods

--- a/src/adapters/telegram/types.ts
+++ b/src/adapters/telegram/types.ts
@@ -1,0 +1,145 @@
+/**
+ * Telegram adapter — config + wire-shape types.
+ *
+ * Spec: `docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md` §5.5.2.
+ * Coordination: `src/bus/SPRINT_3_PLAN.md` Agent B scope.
+ *
+ * These mirror the subset of the Telegram Bot API the existing PTY-coupled
+ * listener at `src/commands/telegram.ts` uses. We re-declare them here
+ * (rather than import from `src/commands/telegram.ts`) so the adapter is
+ * decoupled from the legacy file — Sprint 5 will retire that path entirely
+ * for `runtime: bus`. Field names track the upstream Bot API verbatim.
+ */
+
+/* ──────────────────────────────────────────────────────────────────────── */
+/* Bot-API wire shapes                                                       */
+/* ──────────────────────────────────────────────────────────────────────── */
+
+export interface TelegramUser {
+  id: number;
+  first_name?: string;
+  username?: string;
+  is_bot?: boolean;
+}
+
+export interface TelegramChat {
+  id: number;
+  /**
+   * Telegram-side chat type. The Bus adapter accepts every type the existing
+   * single-user-bot pattern accepts (`private`, `group`, `supergroup`).
+   */
+  type: string;
+}
+
+export interface TelegramMessageEntity {
+  type: string;
+  offset: number;
+  length: number;
+}
+
+export interface TelegramPhotoSize {
+  file_id: string;
+  width: number;
+  height: number;
+  file_size?: number;
+}
+
+export interface TelegramDocument {
+  file_id: string;
+  file_name?: string;
+  mime_type?: string;
+  file_size?: number;
+}
+
+export interface TelegramVoice {
+  file_id: string;
+  mime_type?: string;
+  duration?: number;
+  file_size?: number;
+}
+
+export interface TelegramAudio {
+  file_id: string;
+  mime_type?: string;
+  duration?: number;
+  file_name?: string;
+  file_size?: number;
+}
+
+export interface TelegramMessage {
+  message_id: number;
+  from?: TelegramUser;
+  chat: TelegramChat;
+  /** Optional — only set for forum/topic threads. */
+  message_thread_id?: number;
+  text?: string;
+  caption?: string;
+  entities?: TelegramMessageEntity[];
+  caption_entities?: TelegramMessageEntity[];
+  photo?: TelegramPhotoSize[];
+  document?: TelegramDocument;
+  voice?: TelegramVoice;
+  audio?: TelegramAudio;
+}
+
+export interface TelegramCallbackQuery {
+  id: string;
+  from: TelegramUser;
+  message?: TelegramMessage;
+  /** Opaque payload set by the inline-keyboard button. */
+  data?: string;
+}
+
+export interface TelegramUpdate {
+  update_id: number;
+  message?: TelegramMessage;
+  edited_message?: TelegramMessage;
+  callback_query?: TelegramCallbackQuery;
+}
+
+export interface TelegramGetUpdatesResult {
+  ok: boolean;
+  result: TelegramUpdate[];
+}
+
+export interface TelegramInlineKeyboardButton {
+  text: string;
+  callback_data: string;
+}
+
+/* ──────────────────────────────────────────────────────────────────────── */
+/* Bot-API surface the adapter calls (interface seam for tests)              */
+/* ──────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Minimal Telegram API surface used by the adapter. Real implementation is
+ * `createTelegramApi()` in `index.ts`; tests substitute a `FakeTelegramApi`
+ * to avoid hitting `api.telegram.org` (see `__tests__/telegram.test.ts`).
+ *
+ * Shape mirrors the calls in `src/commands/telegram.ts` — only the methods
+ * the adapter actually invokes are declared.
+ */
+export interface TelegramApi {
+  /** Long-poll `getUpdates`. `signal` lets `stop()` abort an in-flight wait. */
+  getUpdates(
+    offset: number,
+    timeoutSeconds: number,
+    signal: AbortSignal,
+  ): Promise<TelegramGetUpdatesResult>;
+  sendMessage(params: {
+    chat_id: number;
+    text: string;
+    message_thread_id?: number;
+    reply_markup?: { inline_keyboard: TelegramInlineKeyboardButton[][] };
+  }): Promise<{ ok: boolean; result?: { message_id: number } }>;
+  /** Sets a single emoji reaction on a message (mirrors §5.5.2 reaction model). */
+  setMessageReaction(params: {
+    chat_id: number;
+    message_id: number;
+    emoji: string;
+  }): Promise<{ ok: boolean }>;
+  answerCallbackQuery(params: {
+    callback_query_id: string;
+    text?: string;
+  }): Promise<{ ok: boolean }>;
+}


### PR DESCRIPTION
## Summary

Sprint 3 per spec §10 (epic #107). Adds the first two chat-surface Bus adapters that subscribe to BusEvents and forward platform messages into \`bus.sendPrompt\`. Both follow the WebUI adapter pattern from Sprint 2 (#111).

**Bus runtime is still a no-op** until Sprint 5 flips \`runtime: bus\`. The existing PTY-coupled \`src/commands/discord.ts\` (2052 LOC) and \`src/commands/telegram.ts\` (2409 LOC) are **untouched** — they remain the active path under \`runtime: pty\`.

## What changed

11 new files under \`src/adapters/discord/\` and \`src/adapters/telegram/\`:

| File | LOC | Role |
|---|---:|---|
| \`src/adapters/discord/index.ts\` | 476 | DiscordAdapter — gateway lifecycle, MESSAGE_CREATE + INTERACTION_CREATE, bus fan-out |
| \`src/adapters/discord/types.ts\` | 154 | Gateway + REST API injection seams |
| \`src/adapters/discord/router.ts\` | 82 | channel/thread/DM → agent_id |
| \`src/adapters/discord/helpers.ts\` | 170 | rate-limit, attachment classifiers, permission-button format |
| \`src/adapters/telegram/index.ts\` | 500 | TelegramAdapter — long-poll loop, callback_query handling |
| \`src/adapters/telegram/types.ts\` | 145 | Bot API shapes + injection seam |
| \`src/adapters/telegram/api.ts\` | 76 | fetch-backed prod API |
| \`src/adapters/telegram/directives.ts\` | 40 | \`[react:emoji]\` tag parser |
| \`src/adapters/telegram/metadata.ts\` | 65 | attachment envelope |

Plus 4 test files: 45 new tests.

## Test plan

- [x] \`bun test src/adapters/ src/bus/\` — 159 pass / 1 skip / 0 fail / 457 assertions
- [x] \`bunx biome check src/adapters/ src/bus/\` — clean
- [x] No reachability from \`src/runner.ts\`, \`src/commands/start.ts\`, or any legacy entrypoint — adapter code is unreachable until Sprint 5
- [x] Versions bumped to 2.2.43

## Behaviour parity verified vs legacy files (NOT MODIFIED)

- Bot-message drop
- Allow-list (Discord DM "Unauthorized" / guild silent; Telegram private/group equivalent)
- Channel/thread/DM routing (Discord); chat routing + defaultAgentId fallback (Telegram)
- \`bus.sendPrompt\` shape: origin, origin_id, user_id, text, metadata
- \`response.text\` round-trip
- \`channel.permission_request\` → platform buttons → \`ingestPermissionDecision\`
- \`system.request_human\` → operator reply → \`ingestAskAnswer\`
- Telegram \`[react:<emoji>]\` tag extraction: stripped from user-facing text, applied as native reactions via \`setMessageReaction\`
- Subscription cleanup on \`stop()\` (verified via \`bus.state().subscriberCount === 0\`)

## Sprint 4 extraction candidates (flagged by both agents)

Both agents copied behaviour from the legacy files because nothing in them is exported. Sprint 4 should lift these into shared modules so the legacy path and the Bus adapters stop duplicating:

- \`src/discord/api.ts\` ← \`discordApi\`, \`sendMessage\`, \`sendReaction\`, \`respondToInteraction\`
- \`src/discord/gateway.ts\` ← \`connectGateway\` + heartbeat + reconnect + DISPATCH demux
- \`src/discord/attachments.ts\` ← \`is{Image,Voice,Text}Attachment\`
- \`src/discord/rate-limit.ts\` ← \`checkDiscordRateLimit\`
- Telegram \`callApi\` / \`getUpdates\` / \`sendMessage\` / \`setMessageReaction\` HTTP wiring
- \`markdownToTelegramHtml\` parity
- \`src/bus/__tests__/test-helpers.ts\` ← lift the duplicated \`FakeBus\` from webui + discord + telegram fixtures

## Sprint 4 reconciliation

Permission callback_data formats are inconsistent across the two adapters:

- Discord: \`ccaw_perm_<allow|deny>_<request_id>\`
- Telegram: \`perm:<allow|deny>:<id>\`

Independent parsers, not a bug — but a Sprint 4 mini-task should pick one format.

## Deferred to later sprints (TODO-tagged in code)

- Originating-channel tracking — \`response.text\` currently fans to ALL routed channels for an agent. Needs per-\`(agent_id, session_id)\` last-channel map.
- DM response routing for Discord (\`/users/@me/channels\`)
- Voice/image/document download + transcription (Whisper) — metadata-only today
- Slash commands (\`/reset /compact /status /context /start\`) via \`bus.invokeSlashCommand\` Session Manager seam
- Discord: forward-message coalescing (\`pendingForwards\`)
- Discord: streaming "typing" placeholder + edit-in-place (acceptable loss per spec §5.5.4)
- Telegram: file-bytes upload pipeline (Sprint 5)
- Telegram: HTML/Markdown rendering polish
- Rate-limit shape unification (Telegram didn't port legacy; Bus hasn't decided where rate limiting lives)
- Response directives (\`[buttons:...]\`, \`[voice:...]\`, \`[send-file:...]\`)
- \`my_chat_member\` group-join handling (Telegram)

## Reviewer notes

- Commit uses \`SKIP_SIMPLIFY=1\` — same rationale as prior sprints.
- The "Sprint 4 extraction" list represents technical debt this PR consciously accepts to keep the legacy path untouched. Reviewers may want to pull one or two of those out into separate PRs before Sprint 4 if the duplication makes review uncomfortable.
- Like prior sprints, **merging this has zero behavioural effect on running daemons** — Bus runtime is config-gated.