### PR TITLE
feat(skills-tuner): DiscordAdapter for proposal approval

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.42",
+      "version": "2.2.44",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.42",
+  "version": "2.2.44",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/skills-tuner/discord-adapter.test.ts
+++ b/src/__tests__/skills-tuner/discord-adapter.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Tests for skills-tuner DiscordAdapter.
+ *
+ * Run with: bun test src/__tests__/skills-tuner/discord-adapter.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { DiscordAdapter, type DiscordAdapterConfig } from "../../skills-tuner/adapters/discord";
+import type { Proposal } from "../../skills-tuner/core/types";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
+  return {
+    id: 42,
+    cluster_id: "cluster-1",
+    subject: "skills",
+    kind: "create",
+    target_path: "/home/user/.claude/skills/foo.md",
+    alternatives: [
+      { id: "a", label: "Tight option", diff_or_content: "x", tradeoff: "fast but terse" },
+      { id: "b", label: "Verbose option", diff_or_content: "y", tradeoff: "longer but clearer" },
+    ],
+    pattern_signature: "sig-1",
+    created_at: new Date("2026-05-17T00:00:00Z"),
+    signature: "test-signature",
+    ...overrides,
+  } as Proposal;
+}
+
+function makeConfig(overrides: Partial<DiscordAdapterConfig> = {}): DiscordAdapterConfig {
+  return {
+    botToken: "test-token",
+    channelId: "1234567890",
+    baseUrl: "https://discord.test",
+    allowedUserIds: ["user-alice", "user-bob"],
+    ...overrides,
+  };
+}
+
+// fetch mock — captures calls and returns canned responses
+type CapturedCall = { url: string; init?: RequestInit };
+let capturedCalls: CapturedCall[];
+let nextResponse: { ok: boolean; status: number; body: string };
+const origFetch = globalThis.fetch;
+
+beforeEach(() => {
+  capturedCalls = [];
+  nextResponse = { ok: true, status: 200, body: '{"id":"msg-1"}' };
+  globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+    capturedCalls.push({ url: url.toString(), init });
+    return new Response(nextResponse.body, { status: nextResponse.status });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+});
+
+// ─── Constructor ─────────────────────────────────────────────────────────────
+
+describe("DiscordAdapter constructor", () => {
+  it("rejects empty allowedUserIds", () => {
+    expect(() => new DiscordAdapter(makeConfig({ allowedUserIds: [] }))).toThrow(
+      /at least one allowedUserId/,
+    );
+  });
+
+  it("rejects missing botToken", () => {
+    expect(() => new DiscordAdapter(makeConfig({ botToken: "" }))).toThrow(/requires botToken/);
+  });
+
+  it("rejects missing channelId", () => {
+    expect(() => new DiscordAdapter(makeConfig({ channelId: "" }))).toThrow(/requires channelId/);
+  });
+
+  it("accepts valid config", () => {
+    expect(() => new DiscordAdapter(makeConfig())).not.toThrow();
+  });
+});
+
+// ─── renderProposal ──────────────────────────────────────────────────────────
+
+describe("DiscordAdapter.renderProposal", () => {
+  it("posts to /channels/{channelId}/messages with Bot auth header", async () => {
+    const adapter = new DiscordAdapter(makeConfig());
+    await adapter.renderProposal(makeProposal());
+    expect(capturedCalls).toHaveLength(1);
+    const call = capturedCalls[0]!;
+    expect(call.url).toBe("https://discord.test/channels/1234567890/messages");
+    const headers = (call.init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bot test-token");
+    expect(headers["Content-Type"]).toBe("application/json");
+  });
+
+  it("never embeds botToken in the URL", async () => {
+    const adapter = new DiscordAdapter(makeConfig());
+    await adapter.renderProposal(makeProposal());
+    expect(capturedCalls[0]!.url).not.toContain("test-token");
+  });
+
+  it("builds an Apply button per alternative + Refuse/Edit row", async () => {
+    const adapter = new DiscordAdapter(makeConfig());
+    await adapter.renderProposal(makeProposal());
+    const body = JSON.parse(capturedCalls[0]!.init?.body as string);
+    expect(body.components).toHaveLength(2);
+    const applyRow = body.components[0];
+    expect(applyRow.type).toBe(1); // action row
+    expect(applyRow.components).toHaveLength(2); // 2 alternatives
+    expect(applyRow.components[0].custom_id).toBe("apply:42:a");
+    expect(applyRow.components[1].custom_id).toBe("apply:42:b");
+    const decisionRow = body.components[1];
+    expect(decisionRow.components.map((b: { custom_id: string }) => b.custom_id)).toEqual([
+      "refuse:42",
+      "edit:42",
+    ]);
+  });
+
+  it("truncates button labels exceeding Discord's 80-char limit", async () => {
+    const adapter = new DiscordAdapter(makeConfig());
+    const longLabel = "x".repeat(200);
+    await adapter.renderProposal(
+      makeProposal({
+        alternatives: [{ id: "a", label: longLabel, diff_or_content: "", tradeoff: "" }],
+      }),
+    );
+    const body = JSON.parse(capturedCalls[0]!.init?.body as string);
+    const label: string = body.components[0].components[0].label;
+    expect(label.length).toBeLessThanOrEqual(80);
+  });
+
+  it("throws with the HTTP status when Discord rejects the request", async () => {
+    nextResponse = { ok: false, status: 401, body: "Unauthorized" };
+    const adapter = new DiscordAdapter(makeConfig());
+    await expect(adapter.renderProposal(makeProposal())).rejects.toThrow(
+      /Discord createMessage failed: 401/,
+    );
+  });
+
+  it("does not leak the botToken in error messages", async () => {
+    nextResponse = { ok: false, status: 500, body: "some error" };
+    const adapter = new DiscordAdapter(makeConfig({ botToken: "secret-token-do-not-leak" }));
+    let err: Error | null = null;
+    try {
+      await adapter.renderProposal(makeProposal());
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).not.toBeNull();
+    expect(err!.message).not.toContain("secret-token-do-not-leak");
+  });
+});
+
+// ─── handleCallback ──────────────────────────────────────────────────────────
+
+describe("DiscordAdapter.handleCallback", () => {
+  it("rejects users not in allowedUserIds", async () => {
+    const adapter = new DiscordAdapter(makeConfig());
+    await expect(adapter.handleCallback("apply:1:a", "user-eve")).rejects.toThrow(
+      /not in allowedUserIds/,
+    );
+  });
+
+  it("accepts users in allowedUserIds and fires callback", async () => {
+    const seen: { proposalId: number; alternativeId?: string; action: string }[] = [];
+    const adapter = new DiscordAdapter(
+      makeConfig({
+        callbackHandler: async (p) => {
+          seen.push(p);
+        },
+      }),
+    );
+    await adapter.handleCallback("apply:42:a", "user-alice");
+    expect(seen).toEqual([{ proposalId: 42, alternativeId: "a", action: "apply" }]);
+  });
+
+  it("rejects malformed custom_id", async () => {
+    const adapter = new DiscordAdapter(makeConfig());
+    await expect(adapter.handleCallback("malformed", "user-alice")).rejects.toThrow(
+      /Discord callback malformed/,
+    );
+  });
+
+  it("rejects unknown action verb", async () => {
+    const adapter = new DiscordAdapter(makeConfig());
+    await expect(adapter.handleCallback("destroy:1", "user-alice")).rejects.toThrow(
+      /unknown action/,
+    );
+  });
+
+  it("rejects non-numeric proposalId", async () => {
+    const adapter = new DiscordAdapter(makeConfig());
+    await expect(adapter.handleCallback("apply:abc:x", "user-alice")).rejects.toThrow(
+      /invalid proposalId/,
+    );
+  });
+
+  it("rejects proposalId < 1", async () => {
+    const adapter = new DiscordAdapter(makeConfig());
+    await expect(adapter.handleCallback("apply:0:x", "user-alice")).rejects.toThrow(
+      /invalid proposalId/,
+    );
+  });
+
+  it("calls verifyProposalFn before firing callback when provided", async () => {
+    let verified: number | null = null;
+    let callbackFired = false;
+    const adapter = new DiscordAdapter(
+      makeConfig({
+        verifyProposalFn: async (id) => {
+          verified = id;
+          return true;
+        },
+        callbackHandler: async () => {
+          callbackFired = true;
+        },
+      }),
+    );
+    await adapter.handleCallback("apply:42:a", "user-alice");
+    expect(verified).toBe(42);
+    expect(callbackFired).toBe(true);
+  });
+
+  it("blocks the callback when verifyProposalFn returns false", async () => {
+    let callbackFired = false;
+    const adapter = new DiscordAdapter(
+      makeConfig({
+        verifyProposalFn: async () => false,
+        callbackHandler: async () => {
+          callbackFired = true;
+        },
+      }),
+    );
+    await expect(adapter.handleCallback("apply:42:a", "user-alice")).rejects.toThrow(
+      /verifyProposalFn rejected/,
+    );
+    expect(callbackFired).toBe(false);
+  });
+
+  it("parses refuse without alternativeId", async () => {
+    const seen: { proposalId: number; alternativeId?: string; action: string }[] = [];
+    const adapter = new DiscordAdapter(
+      makeConfig({
+        callbackHandler: async (p) => {
+          seen.push(p);
+        },
+      }),
+    );
+    await adapter.handleCallback("refuse:42", "user-alice");
+    expect(seen[0]).toEqual({ proposalId: 42, alternativeId: undefined, action: "refuse" });
+  });
+});
+
+// ─── formatProposalText ──────────────────────────────────────────────────────
+
+describe("DiscordAdapter.formatProposalText", () => {
+  it("includes proposal id, subject/kind, target path, alternatives", () => {
+    const adapter = new DiscordAdapter(makeConfig());
+    const txt = adapter.formatProposalText(makeProposal());
+    expect(txt).toContain("Proposal #42");
+    expect(txt).toContain("skills/create");
+    expect(txt).toContain("/home/user/.claude/skills/foo.md");
+    expect(txt).toContain("Tight option");
+    expect(txt).toContain("Verbose option");
+  });
+
+  it("substitutes 'no tradeoff' when tradeoff is empty", () => {
+    const adapter = new DiscordAdapter(makeConfig());
+    const txt = adapter.formatProposalText(
+      makeProposal({
+        alternatives: [{ id: "a", label: "Plain", diff_or_content: "", tradeoff: "" }],
+      }),
+    );
+    expect(txt).toContain("no tradeoff");
+  });
+});

--- a/src/skills-tuner/adapters/discord.ts
+++ b/src/skills-tuner/adapters/discord.ts
@@ -1,0 +1,171 @@
+import { Adapter } from "../core/interfaces.js";
+import type { Proposal } from "../core/types.js";
+import type { CallbackHandler } from "./base.js";
+
+export interface DiscordAdapterConfig {
+  /** Discord bot token. Sent only via Authorization header; never embedded in URLs. */
+  botToken: string;
+  /** Snowflake of the channel where proposals are rendered. */
+  channelId: string;
+  /** Override Discord REST base URL (test/mocking only). */
+  baseUrl?: string;
+  /** Fires when a user clicks a proposal action button. */
+  callbackHandler?: CallbackHandler;
+  /** Snowflake user IDs allowed to act on proposals. Empty list is rejected. */
+  allowedUserIds: string[];
+  /** Optional guard: verify the proposal still exists / belongs to user before acting. */
+  verifyProposalFn?: (proposalId: number) => Promise<boolean>;
+}
+
+// Discord component types / styles
+const COMPONENT_ACTION_ROW = 1;
+const COMPONENT_BUTTON = 2;
+const BUTTON_STYLE_PRIMARY = 1; // Apply alternatives
+const BUTTON_STYLE_SECONDARY = 2; // Edit
+const BUTTON_STYLE_DANGER = 4; // Refuse
+
+// Discord limits we enforce defensively
+const MAX_BUTTON_LABEL = 80;
+const MAX_CUSTOM_ID = 100;
+
+export class DiscordAdapter extends Adapter {
+  constructor(private cfg: DiscordAdapterConfig) {
+    super();
+    if (!cfg.allowedUserIds || cfg.allowedUserIds.length === 0) {
+      throw new Error("DiscordAdapter requires at least one allowedUserId");
+    }
+    if (!cfg.botToken) {
+      throw new Error("DiscordAdapter requires botToken");
+    }
+    if (!cfg.channelId) {
+      throw new Error("DiscordAdapter requires channelId");
+    }
+  }
+
+  async renderProposal(proposal: Proposal): Promise<void> {
+    const baseUrl = this.cfg.baseUrl ?? "https://discord.com/api/v10";
+    const content = this.formatProposalText(proposal);
+
+    // Action row 1: one Apply button per alternative (Discord allows ≤5 buttons/row;
+    // alternatives are capped at 3 by AlternativeSchema so this always fits).
+    const applyRow = {
+      type: COMPONENT_ACTION_ROW,
+      components: proposal.alternatives.map((alt) => ({
+        type: COMPONENT_BUTTON,
+        style: BUTTON_STYLE_PRIMARY,
+        label: truncate("Apply " + alt.id + ": " + alt.label, MAX_BUTTON_LABEL),
+        custom_id: truncate("apply:" + proposal.id + ":" + alt.id, MAX_CUSTOM_ID),
+      })),
+    };
+
+    // Action row 2: Refuse + Edit
+    const decisionRow = {
+      type: COMPONENT_ACTION_ROW,
+      components: [
+        {
+          type: COMPONENT_BUTTON,
+          style: BUTTON_STYLE_DANGER,
+          label: "Refuse",
+          custom_id: truncate("refuse:" + proposal.id, MAX_CUSTOM_ID),
+        },
+        {
+          type: COMPONENT_BUTTON,
+          style: BUTTON_STYLE_SECONDARY,
+          label: "Edit",
+          custom_id: truncate("edit:" + proposal.id, MAX_CUSTOM_ID),
+        },
+      ],
+    };
+
+    const res = await fetch(baseUrl + "/channels/" + this.cfg.channelId + "/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bot " + this.cfg.botToken,
+      },
+      body: JSON.stringify({
+        content,
+        components: [applyRow, decisionRow],
+      }),
+    });
+    if (!res.ok) {
+      // Read body for context but never echo the bot token. The body itself
+      // never contains the token (we sent it in a header).
+      throw new Error("Discord createMessage failed: " + res.status + " " + (await res.text()));
+    }
+  }
+
+  async renderApplyConfirmation(proposal: Proposal, alternativeId: string): Promise<void> {
+    const baseUrl = this.cfg.baseUrl ?? "https://discord.com/api/v10";
+    await fetch(baseUrl + "/channels/" + this.cfg.channelId + "/messages", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: "Bot " + this.cfg.botToken,
+      },
+      body: JSON.stringify({
+        content:
+          "Applied alt " +
+          alternativeId +
+          " on proposal #" +
+          proposal.id +
+          " (" +
+          proposal.subject +
+          ")",
+      }),
+    });
+  }
+
+  async handleCallback(customId: string, fromUserId: string): Promise<void> {
+    if (!this.cfg.allowedUserIds.includes(fromUserId)) {
+      throw new Error("User " + fromUserId + " not in allowedUserIds");
+    }
+    const parts = customId.split(":");
+    if (parts.length < 2) {
+      throw new Error(`Discord callback malformed: '${customId}' (expected action:id[:alt])`);
+    }
+    const action = parts[0] as "apply" | "refuse" | "edit";
+    if (!["apply", "refuse", "edit"].includes(action)) {
+      throw new Error(`Discord callback unknown action: '${action}'`);
+    }
+    const proposalId = Number.parseInt(parts[1]!, 10);
+    if (!Number.isFinite(proposalId) || proposalId < 1) {
+      throw new Error(`Discord callback invalid proposalId: '${parts[1]}' in '${customId}'`);
+    }
+    const alternativeId = parts[2];
+    if (this.cfg.verifyProposalFn) {
+      const valid = await this.cfg.verifyProposalFn(proposalId);
+      if (!valid) {
+        throw new Error(
+          "verifyProposalFn rejected proposal " + proposalId + " for user " + fromUserId,
+        );
+      }
+    }
+    if (this.cfg.callbackHandler) {
+      await this.cfg.callbackHandler({ proposalId, alternativeId, action });
+    }
+  }
+
+  formatProposalText(proposal: Proposal): string {
+    const altLines = proposal.alternatives
+      .map((a) => "**" + a.id + ".** " + a.label + "\n   _" + (a.tradeoff || "no tradeoff") + "_")
+      .join("\n\n");
+    return (
+      "**Proposal #" +
+      proposal.id +
+      "** - " +
+      proposal.subject +
+      "/" +
+      proposal.kind +
+      "\n\n" +
+      "Target: `" +
+      proposal.target_path +
+      "`\n\n" +
+      altLines
+    );
+  }
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max);
+}


### PR DESCRIPTION
## Summary

Adds `DiscordAdapter` to the skills-tuner adapter framework, alongside the existing `TelegramAdapter`. Lets the tuner ship proposal approval requests to a Discord channel with buttons for Apply / Refuse / Edit.

Follow-up to your ask about extending the recent adapter work to Discord and Slack — this is the Discord half. Slack to follow as a separate PR (needs HTTP callback endpoint plumbing for Block Kit `block_actions`, slightly more involved).

## What's in

- **`src/skills-tuner/adapters/discord.ts`** (171 LOC) — Mirror of `TelegramAdapter` with Discord-specific adaptations:
  - Discord Components V2 buttons (action rows + buttons, styles Primary / Danger / Secondary)
  - `custom_id` format matches Telegram's `callback_data` exactly: `apply:<proposalId>:<altId>` / `refuse:<proposalId>` / `edit:<proposalId>`
  - Allow-list of Discord snowflake IDs (`string[]`, since snowflakes exceed `Number.MAX_SAFE_INTEGER`)
  - Bot token sent only via `Authorization: Bot <token>` header — never embedded in URL
  - Defensive truncation to Discord limits (80 char label, 100 char custom_id)

- **`src/__tests__/skills-tuner/discord-adapter.test.ts`** (276 LOC, 21 cases / 36 assertions) — Covers constructor validation, `renderProposal` payload shape + auth header + no-token-leak in error messages, `handleCallback` allow-list / malformed customId / unknown action / invalid proposalId / `verifyProposalFn` happy + blocked paths, and `formatProposalText`.

- Bumps plugin + marketplace to **2.2.44**.

## Boundary

**Outbound-only adapter.** The caller is responsible for wiring Discord gateway `INTERACTION_CREATE` events into `adapter.handleCallback(customId, fromUserId)`. Same shape as the Telegram side (the existing TG callback_query listener lives outside the adapter too).

## Pre-push validation

| Check | Result |
|---|---|
| `bun run lint` (biome check) | 0 errors (906 pre-existing warnings, unchanged from main) |
| `bun build src/index.ts --target bun` smoke | Bundled 329 modules in 49ms |
| New unit tests | **21 pass / 0 fail / 36 expect() calls** |
| Full test suite regression | 1151 pass on branch vs 1130 on pure main (delta = +21 new tests). 65 pre-existing failures on main, **0 new failures** introduced by the branch. |
| `/security-review` | No findings. Token-handling is an improvement over Telegram (header vs URL). |

Captured on Ubuntu 24.04 x86_64 with `bun 1.3.11`.

## Follow-ups (out of scope)

- Slack adapter — separate PR. Needs a webhook/Events API endpoint for `block_actions` since Slack interactive callbacks aren't on the gateway.
- The two non-test gaps inherited from `TelegramAdapter` (silent failure in `renderApplyConfirmation`, no retry/backoff) — left as-is to keep this PR a clean parity port. Happy to address both adapters in a follow-up if you want.