### PR TITLE
feat(skills-tuner): SlackAdapter for proposal approval

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.44",
+      "version": "2.2.45",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.44",
+  "version": "2.2.45",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/skills-tuner/slack-adapter.test.ts
+++ b/src/__tests__/skills-tuner/slack-adapter.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for skills-tuner SlackAdapter.
+ *
+ * Run with: bun test src/__tests__/skills-tuner/slack-adapter.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { SlackAdapter, type SlackAdapterConfig } from "../../skills-tuner/adapters/slack";
+import type { Proposal } from "../../skills-tuner/core/types";
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+function makeProposal(overrides: Partial<Proposal> = {}): Proposal {
+  return {
+    id: 42,
+    cluster_id: "cluster-1",
+    subject: "skills",
+    kind: "create",
+    target_path: "/home/user/.claude/skills/foo.md",
+    alternatives: [
+      { id: "a", label: "Tight option", diff_or_content: "x", tradeoff: "fast but terse" },
+      { id: "b", label: "Verbose option", diff_or_content: "y", tradeoff: "longer but clearer" },
+    ],
+    pattern_signature: "sig-1",
+    created_at: new Date("2026-05-17T00:00:00Z"),
+    signature: "test-signature",
+    ...overrides,
+  } as Proposal;
+}
+
+function makeConfig(overrides: Partial<SlackAdapterConfig> = {}): SlackAdapterConfig {
+  return {
+    botToken: "xoxb-test-token",
+    channelId: "C0123456",
+    baseUrl: "https://slack.test/api",
+    allowedUserIds: ["U_ALICE", "U_BOB"],
+    ...overrides,
+  };
+}
+
+// fetch mock — captures calls and returns canned responses
+type CapturedCall = { url: string; init?: RequestInit };
+let capturedCalls: CapturedCall[];
+let nextResponse: { ok: boolean; status: number; body: string };
+const origFetch = globalThis.fetch;
+
+beforeEach(() => {
+  capturedCalls = [];
+  nextResponse = { ok: true, status: 200, body: '{"ok":true,"ts":"1700000000.000100"}' };
+  globalThis.fetch = mock(async (url: string | URL | Request, init?: RequestInit) => {
+    capturedCalls.push({ url: url.toString(), init });
+    return new Response(nextResponse.body, { status: nextResponse.status });
+  }) as unknown as typeof fetch;
+});
+
+afterEach(() => {
+  globalThis.fetch = origFetch;
+});
+
+// ─── Constructor ─────────────────────────────────────────────────────────────
+
+describe("SlackAdapter constructor", () => {
+  it("rejects empty allowedUserIds", () => {
+    expect(() => new SlackAdapter(makeConfig({ allowedUserIds: [] }))).toThrow(
+      /at least one allowedUserId/,
+    );
+  });
+
+  it("rejects missing botToken", () => {
+    expect(() => new SlackAdapter(makeConfig({ botToken: "" }))).toThrow(/requires botToken/);
+  });
+
+  it("rejects missing channelId", () => {
+    expect(() => new SlackAdapter(makeConfig({ channelId: "" }))).toThrow(/requires channelId/);
+  });
+
+  it("accepts valid config", () => {
+    expect(() => new SlackAdapter(makeConfig())).not.toThrow();
+  });
+});
+
+// ─── renderProposal ──────────────────────────────────────────────────────────
+
+describe("SlackAdapter.renderProposal", () => {
+  it("posts to /chat.postMessage with Bearer auth header", async () => {
+    const adapter = new SlackAdapter(makeConfig());
+    await adapter.renderProposal(makeProposal());
+    expect(capturedCalls).toHaveLength(1);
+    const call = capturedCalls[0]!;
+    expect(call.url).toBe("https://slack.test/api/chat.postMessage");
+    const headers = (call.init?.headers ?? {}) as Record<string, string>;
+    expect(headers.Authorization).toBe("Bearer xoxb-test-token");
+    expect(headers["Content-Type"]).toBe("application/json; charset=utf-8");
+  });
+
+  it("never embeds botToken in the URL", async () => {
+    const adapter = new SlackAdapter(makeConfig());
+    await adapter.renderProposal(makeProposal());
+    expect(capturedCalls[0]!.url).not.toContain("xoxb-test-token");
+  });
+
+  it("builds an Apply button per alternative + Refuse/Edit + correct channel + text fallback", async () => {
+    const adapter = new SlackAdapter(makeConfig());
+    await adapter.renderProposal(makeProposal());
+    const body = JSON.parse(capturedCalls[0]!.init?.body as string);
+    expect(body.channel).toBe("C0123456");
+    expect(body.text).toContain("Proposal #42");
+    expect(body.blocks).toHaveLength(2);
+    expect(body.blocks[0].type).toBe("section");
+    expect(body.blocks[1].type).toBe("actions");
+    const elements = body.blocks[1].elements;
+    // 2 alternatives + Refuse + Edit = 4 buttons
+    expect(elements).toHaveLength(4);
+    expect(elements[0].value).toBe("apply:42:a");
+    expect(elements[1].value).toBe("apply:42:b");
+    expect(elements[2].value).toBe("refuse:42");
+    expect(elements[3].value).toBe("edit:42");
+  });
+
+  it("uses primary style on Apply and danger on Refuse", async () => {
+    const adapter = new SlackAdapter(makeConfig());
+    await adapter.renderProposal(makeProposal());
+    const body = JSON.parse(capturedCalls[0]!.init?.body as string);
+    const elements = body.blocks[1].elements;
+    expect(elements[0].style).toBe("primary");
+    expect(elements[1].style).toBe("primary");
+    expect(elements[2].style).toBe("danger");
+    expect(elements[3].style).toBeUndefined();
+  });
+
+  it("truncates button text exceeding Slack's 75-char limit", async () => {
+    const adapter = new SlackAdapter(makeConfig());
+    const longLabel = "x".repeat(200);
+    await adapter.renderProposal(
+      makeProposal({
+        alternatives: [{ id: "a", label: longLabel, diff_or_content: "", tradeoff: "" }],
+      }),
+    );
+    const body = JSON.parse(capturedCalls[0]!.init?.body as string);
+    const text: string = body.blocks[1].elements[0].text.text;
+    expect(text.length).toBeLessThanOrEqual(75);
+  });
+
+  it("throws on HTTP failure", async () => {
+    nextResponse = { ok: false, status: 401, body: "invalid_auth" };
+    const adapter = new SlackAdapter(makeConfig());
+    await expect(adapter.renderProposal(makeProposal())).rejects.toThrow(
+      /Slack chat\.postMessage failed: 401/,
+    );
+  });
+
+  it("throws on Slack API error returned with HTTP 200", async () => {
+    nextResponse = { ok: true, status: 200, body: '{"ok":false,"error":"channel_not_found"}' };
+    const adapter = new SlackAdapter(makeConfig());
+    await expect(adapter.renderProposal(makeProposal())).rejects.toThrow(/channel_not_found/);
+  });
+
+  it("does not leak the botToken in error messages", async () => {
+    nextResponse = { ok: false, status: 500, body: "some error" };
+    const adapter = new SlackAdapter(makeConfig({ botToken: "xoxb-secret-token-do-not-leak" }));
+    let err: Error | null = null;
+    try {
+      await adapter.renderProposal(makeProposal());
+    } catch (e) {
+      err = e as Error;
+    }
+    expect(err).not.toBeNull();
+    expect(err!.message).not.toContain("xoxb-secret-token-do-not-leak");
+  });
+});
+
+// ─── handleCallback ──────────────────────────────────────────────────────────
+
+describe("SlackAdapter.handleCallback", () => {
+  it("rejects users not in allowedUserIds", async () => {
+    const adapter = new SlackAdapter(makeConfig());
+    await expect(adapter.handleCallback("apply:1:a", "U_EVE")).rejects.toThrow(
+      /not in allowedUserIds/,
+    );
+  });
+
+  it("accepts users in allowedUserIds and fires callback", async () => {
+    const seen: { proposalId: number; alternativeId?: string; action: string }[] = [];
+    const adapter = new SlackAdapter(
+      makeConfig({
+        callbackHandler: async (p) => {
+          seen.push(p);
+        },
+      }),
+    );
+    await adapter.handleCallback("apply:42:a", "U_ALICE");
+    expect(seen).toEqual([{ proposalId: 42, alternativeId: "a", action: "apply" }]);
+  });
+
+  it("rejects malformed action value", async () => {
+    const adapter = new SlackAdapter(makeConfig());
+    await expect(adapter.handleCallback("malformed", "U_ALICE")).rejects.toThrow(
+      /Slack callback malformed/,
+    );
+  });
+
+  it("rejects unknown action verb", async () => {
+    const adapter = new SlackAdapter(makeConfig());
+    await expect(adapter.handleCallback("destroy:1", "U_ALICE")).rejects.toThrow(/unknown action/);
+  });
+
+  it("rejects non-numeric proposalId", async () => {
+    const adapter = new SlackAdapter(makeConfig());
+    await expect(adapter.handleCallback("apply:abc:x", "U_ALICE")).rejects.toThrow(
+      /invalid proposalId/,
+    );
+  });
+
+  it("rejects proposalId < 1", async () => {
+    const adapter = new SlackAdapter(makeConfig());
+    await expect(adapter.handleCallback("apply:0:x", "U_ALICE")).rejects.toThrow(
+      /invalid proposalId/,
+    );
+  });
+
+  it("calls verifyProposalFn before firing callback when provided", async () => {
+    let verified: number | null = null;
+    let callbackFired = false;
+    const adapter = new SlackAdapter(
+      makeConfig({
+        verifyProposalFn: async (id) => {
+          verified = id;
+          return true;
+        },
+        callbackHandler: async () => {
+          callbackFired = true;
+        },
+      }),
+    );
+    await adapter.handleCallback("apply:42:a", "U_ALICE");
+    expect(verified).toBe(42);
+    expect(callbackFired).toBe(true);
+  });
+
+  it("blocks the callback when verifyProposalFn returns false", async () => {
+    let callbackFired = false;
+    const adapter = new SlackAdapter(
+      makeConfig({
+        verifyProposalFn: async () => false,
+        callbackHandler: async () => {
+          callbackFired = true;
+        },
+      }),
+    );
+    await expect(adapter.handleCallback("apply:42:a", "U_ALICE")).rejects.toThrow(
+      /verifyProposalFn rejected/,
+    );
+    expect(callbackFired).toBe(false);
+  });
+
+  it("parses refuse without alternativeId", async () => {
+    const seen: { proposalId: number; alternativeId?: string; action: string }[] = [];
+    const adapter = new SlackAdapter(
+      makeConfig({
+        callbackHandler: async (p) => {
+          seen.push(p);
+        },
+      }),
+    );
+    await adapter.handleCallback("refuse:42", "U_ALICE");
+    expect(seen[0]).toEqual({ proposalId: 42, alternativeId: undefined, action: "refuse" });
+  });
+});
+
+// ─── formatProposalText ──────────────────────────────────────────────────────
+
+describe("SlackAdapter.formatProposalText", () => {
+  it("includes proposal id, subject/kind, target path, alternatives", () => {
+    const adapter = new SlackAdapter(makeConfig());
+    const txt = adapter.formatProposalText(makeProposal());
+    expect(txt).toContain("Proposal #42");
+    expect(txt).toContain("skills/create");
+    expect(txt).toContain("/home/user/.claude/skills/foo.md");
+    expect(txt).toContain("Tight option");
+    expect(txt).toContain("Verbose option");
+  });
+
+  it("substitutes 'no tradeoff' when tradeoff is empty", () => {
+    const adapter = new SlackAdapter(makeConfig());
+    const txt = adapter.formatProposalText(
+      makeProposal({
+        alternatives: [{ id: "a", label: "Plain", diff_or_content: "", tradeoff: "" }],
+      }),
+    );
+    expect(txt).toContain("no tradeoff");
+  });
+});

--- a/src/skills-tuner/adapters/slack.ts
+++ b/src/skills-tuner/adapters/slack.ts
@@ -1,0 +1,177 @@
+import { Adapter } from "../core/interfaces.js";
+import type { Proposal } from "../core/types.js";
+import type { CallbackHandler } from "./base.js";
+
+export interface SlackAdapterConfig {
+  /** Slack xoxb-… bot token. Sent only via Authorization header; never embedded in URLs. */
+  botToken: string;
+  /** Channel ID (e.g. C0123456) where proposals are rendered. */
+  channelId: string;
+  /** Override Slack Web API base URL (test/mocking only). */
+  baseUrl?: string;
+  /** Fires when a user clicks a proposal action button. */
+  callbackHandler?: CallbackHandler;
+  /** Slack user IDs (e.g. U12345678) allowed to act on proposals. Empty list is rejected. */
+  allowedUserIds: string[];
+  /** Optional guard: verify the proposal still exists before acting. */
+  verifyProposalFn?: (proposalId: number) => Promise<boolean>;
+}
+
+// Slack Block Kit limits we enforce defensively
+const MAX_BUTTON_TEXT = 75; // chars
+const MAX_ACTION_VALUE = 2000; // chars
+const MAX_ACTION_ID = 255; // chars
+
+export class SlackAdapter extends Adapter {
+  constructor(private cfg: SlackAdapterConfig) {
+    super();
+    if (!cfg.allowedUserIds || cfg.allowedUserIds.length === 0) {
+      throw new Error("SlackAdapter requires at least one allowedUserId");
+    }
+    if (!cfg.botToken) {
+      throw new Error("SlackAdapter requires botToken");
+    }
+    if (!cfg.channelId) {
+      throw new Error("SlackAdapter requires channelId");
+    }
+  }
+
+  async renderProposal(proposal: Proposal): Promise<void> {
+    const baseUrl = this.cfg.baseUrl ?? "https://slack.com/api";
+    const headerText = this.formatProposalText(proposal);
+
+    // Block Kit actions block — one Apply per alternative + Refuse + Edit.
+    // Slack allows up to 25 buttons per `actions` block; alternatives are
+    // capped at 3 by AlternativeSchema so the whole row always fits.
+    const elements = [
+      ...proposal.alternatives.map((alt) => ({
+        type: "button",
+        text: {
+          type: "plain_text",
+          text: truncate("Apply " + alt.id + ": " + alt.label, MAX_BUTTON_TEXT),
+        },
+        value: truncate("apply:" + proposal.id + ":" + alt.id, MAX_ACTION_VALUE),
+        action_id: truncate("tuner_apply_" + proposal.id + "_" + alt.id, MAX_ACTION_ID),
+        style: "primary",
+      })),
+      {
+        type: "button",
+        text: { type: "plain_text", text: "Refuse" },
+        value: truncate("refuse:" + proposal.id, MAX_ACTION_VALUE),
+        action_id: truncate("tuner_refuse_" + proposal.id, MAX_ACTION_ID),
+        style: "danger",
+      },
+      {
+        type: "button",
+        text: { type: "plain_text", text: "Edit" },
+        value: truncate("edit:" + proposal.id, MAX_ACTION_VALUE),
+        action_id: truncate("tuner_edit_" + proposal.id, MAX_ACTION_ID),
+      },
+    ];
+
+    const res = await fetch(baseUrl + "/chat.postMessage", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        Authorization: "Bearer " + this.cfg.botToken,
+      },
+      body: JSON.stringify({
+        channel: this.cfg.channelId,
+        // text is a fallback for notifications + accessibility; Slack requires
+        // a non-empty text field even when blocks carry the visible content.
+        text: "Proposal #" + proposal.id + " (" + proposal.subject + ")",
+        blocks: [
+          { type: "section", text: { type: "mrkdwn", text: headerText } },
+          { type: "actions", elements },
+        ],
+      }),
+    });
+    if (!res.ok) {
+      throw new Error("Slack chat.postMessage failed: " + res.status + " " + (await res.text()));
+    }
+    // Slack returns HTTP 200 with `{ok: false, error: "..."}` on API errors,
+    // so we must inspect the parsed body too — but never echo the bot token.
+    const json = (await res.json().catch(() => ({}) as Record<string, unknown>)) as {
+      ok?: boolean;
+      error?: string;
+    };
+    if (json.ok === false) {
+      throw new Error("Slack chat.postMessage error: " + (json.error ?? "unknown"));
+    }
+  }
+
+  async renderApplyConfirmation(proposal: Proposal, alternativeId: string): Promise<void> {
+    const baseUrl = this.cfg.baseUrl ?? "https://slack.com/api";
+    await fetch(baseUrl + "/chat.postMessage", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json; charset=utf-8",
+        Authorization: "Bearer " + this.cfg.botToken,
+      },
+      body: JSON.stringify({
+        channel: this.cfg.channelId,
+        text:
+          "Applied alt " +
+          alternativeId +
+          " on proposal #" +
+          proposal.id +
+          " (" +
+          proposal.subject +
+          ")",
+      }),
+    });
+  }
+
+  async handleCallback(actionValue: string, fromUserId: string): Promise<void> {
+    if (!this.cfg.allowedUserIds.includes(fromUserId)) {
+      throw new Error("User " + fromUserId + " not in allowedUserIds");
+    }
+    const parts = actionValue.split(":");
+    if (parts.length < 2) {
+      throw new Error(`Slack callback malformed: '${actionValue}' (expected action:id[:alt])`);
+    }
+    const action = parts[0] as "apply" | "refuse" | "edit";
+    if (!["apply", "refuse", "edit"].includes(action)) {
+      throw new Error(`Slack callback unknown action: '${action}'`);
+    }
+    const proposalId = Number.parseInt(parts[1]!, 10);
+    if (!Number.isFinite(proposalId) || proposalId < 1) {
+      throw new Error(`Slack callback invalid proposalId: '${parts[1]}' in '${actionValue}'`);
+    }
+    const alternativeId = parts[2];
+    if (this.cfg.verifyProposalFn) {
+      const valid = await this.cfg.verifyProposalFn(proposalId);
+      if (!valid) {
+        throw new Error(
+          "verifyProposalFn rejected proposal " + proposalId + " for user " + fromUserId,
+        );
+      }
+    }
+    if (this.cfg.callbackHandler) {
+      await this.cfg.callbackHandler({ proposalId, alternativeId, action });
+    }
+  }
+
+  formatProposalText(proposal: Proposal): string {
+    const altLines = proposal.alternatives
+      .map((a) => "*" + a.id + ".* " + a.label + "\n  _" + (a.tradeoff || "no tradeoff") + "_")
+      .join("\n\n");
+    return (
+      "*Proposal #" +
+      proposal.id +
+      "* — " +
+      proposal.subject +
+      "/" +
+      proposal.kind +
+      "\n\n" +
+      "Target: `" +
+      proposal.target_path +
+      "`\n\n" +
+      altLines
+    );
+  }
+}
+
+function truncate(s: string, max: number): string {
+  return s.length <= max ? s : s.slice(0, max);
+}


### PR DESCRIPTION
## Summary

Completes the Discord-then-Slack adapter parity for the skills-tuner. Adds `SlackAdapter` alongside `TelegramAdapter` (in main) and `DiscordAdapter` (#114). Lets the tuner ship proposal approval requests to a Slack channel with Block Kit interactive buttons for Apply / Refuse / Edit.

## What's in

- **`src/skills-tuner/adapters/slack.ts`** (177 LOC) — Mirror of the Discord adapter with Slack-specific adaptations:
  - Slack Block Kit: `section` block for the proposal text + `actions` block with buttons (Primary style for Apply, Danger for Refuse, default for Edit)
  - `value` field on each button carries the same callback schema used by Telegram/Discord: `apply:<proposalId>:<altId>` / `refuse:<proposalId>` / `edit:<proposalId>`
  - `action_id` is also populated (`tuner_<action>_<id>[_<alt>]`) since Slack requires it for action routing
  - Allow-list of Slack user IDs (`U…` strings)
  - Bot token sent only via `Authorization: Bearer xoxb-…` — never embedded in URL
  - **Two-layer error handling**: HTTP-level failures throw immediately; HTTP 200 with `{ok:false,error:"…"}` (Slack's pattern) also throws with the error code
  - Defensive truncation to Block Kit limits (75 char button text, 2000 char value, 255 char action_id)
  - Required `text` field on the API payload as Slack's notification/accessibility fallback

- **`src/__tests__/skills-tuner/slack-adapter.test.ts`** (292 LOC, 23 cases / 45 assertions) — Covers constructor validation, `renderProposal` payload + Block Kit shape + auth header + no-token-leak + HTTP failure + Slack `ok:false` detection + button styles + label truncation, `handleCallback` allow-list / malformed value / unknown action / invalid proposalId / `verifyProposalFn` paths, and `formatProposalText`.

- Bumps plugin + marketplace to **2.2.45**.

## Boundary

**Outbound-only adapter.** The caller is responsible for wiring Slack `block_actions` events into `adapter.handleCallback(actionValue, fromUserId)`. The inbound channel can be the Slack Events API (HTTP webhook with signature verification — `X-Slack-Signature` + `X-Slack-Request-Timestamp`) or Socket Mode. Same boundary as Telegram/Discord adapters.

## Pre-push validation

| Check | Result |
|---|---|
| `bun run lint` (biome check) | 0 errors (930 pre-existing warnings, unchanged from main) |
| `bun build src/index.ts --target bun` smoke | Bundled 329 modules in 66ms |
| New unit tests | **23 pass / 0 fail / 45 expect() calls** |
| Full test suite regression | Same failure set as pure main (65 pre-existing failures, no new failures introduced) |
| `/security-review` | No findings ≥7 confidence. Token-handling matches Discord adapter (header-only, no URL embedding). |

Captured on Ubuntu 24.04 x86_64 with `bun 1.3.11`.

## Notes

- This completes the Discord + Slack parity you asked for. Three adapters now share the same `Adapter` contract: Telegram, Discord (#114), and Slack (this PR).
- The `Proposal.signature` field is not verified inside any adapter — same gap across all three. If you want signature validation, it'd go in a shared place (e.g., the engine before calling `adapter.renderProposal`) rather than per-adapter.