### PR TITLE
feat(bus): Sprint 5.2a — agents config + auto-spawn

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.50",
+      "version": "2.2.51",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.50",
+  "version": "2.2.51",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/runtime-config.test.ts
+++ b/src/__tests__/runtime-config.test.ts
@@ -79,3 +79,96 @@ describe("parseSettings — runtime field (Sprint 5.1)", () => {
     expect(getSettings().runtime).toBe("bus");
   });
 });
+
+describe("parseSettings — agents field (Sprint 5.2a)", () => {
+  it("defaults to empty array when the field is absent", async () => {
+    await writeRawSettings({});
+    await reloadSettings();
+    expect(getSettings().agents).toEqual([]);
+  });
+
+  it("accepts a minimal entry (id only)", async () => {
+    await writeRawSettings({ agents: [{ id: "triage" }] });
+    await reloadSettings();
+    expect(getSettings().agents).toEqual([{ id: "triage" }]);
+  });
+
+  it("preserves all optional fields when set", async () => {
+    await writeRawSettings({
+      agents: [
+        {
+          id: "research",
+          cwd: "/srv/research",
+          permission_mode: "bypassPermissions",
+          supervision: "pty-stdin",
+          system_prompt_file: "/etc/cc/research.md",
+          memory_file: "/etc/cc/research-memory.md",
+          mcp_config: "/etc/cc/research-mcp.json",
+        },
+      ],
+    });
+    await reloadSettings();
+    expect(getSettings().agents[0]).toMatchObject({
+      id: "research",
+      cwd: "/srv/research",
+      permission_mode: "bypassPermissions",
+      supervision: "pty-stdin",
+      system_prompt_file: "/etc/cc/research.md",
+      memory_file: "/etc/cc/research-memory.md",
+      mcp_config: "/etc/cc/research-mcp.json",
+    });
+  });
+
+  it("drops entries missing or with invalid id", async () => {
+    await writeRawSettings({
+      agents: [
+        { id: "ok-1" },
+        { id: "" },
+        { cwd: "/no/id" },
+        { id: "Has-Caps-And-Periods.bad" },
+        { id: "ok_2" },
+      ],
+    });
+    await reloadSettings();
+    expect(getSettings().agents.map((a) => a.id)).toEqual(["ok-1", "ok_2"]);
+  });
+
+  it("dedupes by id keeping the first occurrence", async () => {
+    await writeRawSettings({
+      agents: [
+        { id: "triage", cwd: "/first" },
+        { id: "triage", cwd: "/second" },
+      ],
+    });
+    await reloadSettings();
+    expect(getSettings().agents).toEqual([{ id: "triage", cwd: "/first" }]);
+  });
+
+  it("drops invalid permission_mode and supervision but keeps the rest", async () => {
+    await writeRawSettings({
+      agents: [
+        {
+          id: "triage",
+          permission_mode: "all-the-powers",
+          supervision: "windows-fancy",
+          cwd: "/srv",
+        },
+      ],
+    });
+    await reloadSettings();
+    expect(getSettings().agents[0]).toEqual({ id: "triage", cwd: "/srv" });
+  });
+
+  it("falls back to empty array when the field is not an array", async () => {
+    await writeRawSettings({ agents: "triage" });
+    await reloadSettings();
+    expect(getSettings().agents).toEqual([]);
+  });
+
+  it("enforces 36-char id cap (sun_path budget)", async () => {
+    const tooLong = "a".repeat(37);
+    await writeRawSettings({ agents: [{ id: tooLong }, { id: "a".repeat(36) }] });
+    await reloadSettings();
+    expect(getSettings().agents.map((a) => a.id)).toEqual(["a".repeat(36)]);
+  });
+});

--- a/src/bus/__tests__/agent-resolver.test.ts
+++ b/src/bus/__tests__/agent-resolver.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for `src/bus/agent-resolver.ts` (Sprint 5.2a).
+ *
+ * Run with: `bun test src/bus/__tests__/agent-resolver.test.ts`
+ *
+ * The default `defaultResolveSessionId` path reads/writes
+ * `agents/<id>/session.json` via `src/sessions.ts`. To keep the suite
+ * hermetic we inject `resolveSessionId` for the bulk of tests; a single
+ * end-to-end case exercises the real persistence layer against a temp
+ * project dir.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { BusAgentSettings } from "../../config";
+import { resolveBusAgentConfig, resolveBusAgentConfigs } from "../agent-resolver";
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Pure resolution (with injected resolveSessionId)                        */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe("resolveBusAgentConfig — defaults", () => {
+  it("applies defaults for cwd, permission_mode, session_id", async () => {
+    const out = await resolveBusAgentConfig(
+      { id: "triage" },
+      { defaultCwd: "/tmp/proj", resolveSessionId: async () => "uuid-fixed" },
+    );
+    expect(out).toEqual({
+      id: "triage",
+      cwd: "/tmp/proj",
+      session_id: "uuid-fixed",
+      permission_mode: "plan",
+    });
+  });
+
+  it("preserves explicit cwd over defaultCwd", async () => {
+    const out = await resolveBusAgentConfig(
+      { id: "triage", cwd: "/srv/triage" },
+      { defaultCwd: "/tmp/proj", resolveSessionId: async () => "uuid-fixed" },
+    );
+    expect(out.cwd).toBe("/srv/triage");
+  });
+
+  it("falls back to process.cwd() when neither entry.cwd nor defaultCwd is set", async () => {
+    const out = await resolveBusAgentConfig(
+      { id: "triage" },
+      { resolveSessionId: async () => "uuid-fixed" },
+    );
+    expect(out.cwd).toBe(process.cwd());
+  });
+
+  it("passes through every optional file path field when set", async () => {
+    const entry: BusAgentSettings = {
+      id: "research",
+      system_prompt_file: "/etc/cc/prompt.md",
+      memory_file: "/etc/cc/mem.md",
+      mcp_config: "/etc/cc/mcp.json",
+    };
+    const out = await resolveBusAgentConfig(entry, {
+      resolveSessionId: async () => "uuid-fixed",
+    });
+    expect(out.system_prompt_file).toBe("/etc/cc/prompt.md");
+    expect(out.memory_file).toBe("/etc/cc/mem.md");
+    expect(out.mcp_config).toBe("/etc/cc/mcp.json");
+  });
+
+  it("forwards supervision override", async () => {
+    const out = await resolveBusAgentConfig(
+      { id: "triage", supervision: "pty-stdin" },
+      { resolveSessionId: async () => "uuid-fixed" },
+    );
+    expect(out.supervision).toBe("pty-stdin");
+  });
+
+  it("forwards explicit permission_mode override", async () => {
+    const out = await resolveBusAgentConfig(
+      { id: "triage", permission_mode: "bypassPermissions" },
+      { resolveSessionId: async () => "uuid-fixed" },
+    );
+    expect(out.permission_mode).toBe("bypassPermissions");
+  });
+});
+
+describe("resolveBusAgentConfigs — batch", () => {
+  it("resolves every entry in declaration order", async () => {
+    const seq = ["s1", "s2", "s3"];
+    let i = 0;
+    const entries: BusAgentSettings[] = [{ id: "a" }, { id: "b" }, { id: "c" }];
+    const out = await resolveBusAgentConfigs(entries, {
+      defaultCwd: "/tmp/proj",
+      resolveSessionId: async () => seq[i++],
+    });
+    expect(out.map((r) => r.entry.id)).toEqual(["a", "b", "c"]);
+    expect(out.every((r) => r.config !== null)).toBe(true);
+    expect(out.map((r) => r.config?.session_id)).toEqual(["s1", "s2", "s3"]);
+  });
+
+  it("returns config:null + error for a failed resolution without aborting the rest", async () => {
+    const entries: BusAgentSettings[] = [{ id: "ok-a" }, { id: "broken" }, { id: "ok-b" }];
+    const out = await resolveBusAgentConfigs(entries, {
+      resolveSessionId: async (id) => {
+        if (id === "broken") throw new Error("disk full");
+        return `sess-${id}`;
+      },
+    });
+    expect(out[0]?.config).not.toBeNull();
+    expect(out[1]?.config).toBeNull();
+    expect(out[1]?.error).toBeInstanceOf(Error);
+    expect((out[1]?.error as Error).message).toContain("disk full");
+    expect(out[2]?.config).not.toBeNull();
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Default resolveSessionId — real disk round-trip                         */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe("resolveBusAgentConfig — default resolveSessionId persistence", () => {
+  let tmpProj: string;
+  let savedCwd: string;
+
+  beforeEach(() => {
+    savedCwd = process.cwd();
+    tmpProj = mkdtempSync(join(tmpdir(), "ccaw-agent-resolver-"));
+    process.chdir(tmpProj);
+  });
+
+  afterEach(() => {
+    process.chdir(savedCwd);
+    try {
+      rmSync(tmpProj, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it("generates a UUID on first call and reuses it on the second", async () => {
+    const first = await resolveBusAgentConfig({ id: "triage" });
+    expect(first.session_id).toMatch(/^[0-9a-f-]{36}$/i);
+    const second = await resolveBusAgentConfig({ id: "triage" });
+    expect(second.session_id).toBe(first.session_id);
+  });
+
+  it("different agents get different ids", async () => {
+    const a = await resolveBusAgentConfig({ id: "agent-a" });
+    const b = await resolveBusAgentConfig({ id: "agent-b" });
+    expect(a.session_id).not.toBe(b.session_id);
+  });
+});

--- a/src/bus/__tests__/runtime-mount.test.ts
+++ b/src/bus/__tests__/runtime-mount.test.ts
@@ -205,21 +205,17 @@ describe("mountBusRuntime — happy path (injected fakes)", () => {
     expect(errors.length).toBe(2);
   });
 
-  it("stop() is idempotent — second call is safe even with a real BusCore", async () => {
-    // The previous "doesn't throw" test only proved that a permissive
-    // fake doesn't throw. This one closes the gap by routing through the
-    // real production code path: the handle delegates to whichever bus
-    // it was constructed with, and our fake records both calls.
+  it("stop() is idempotent — second call is a no-op (handle-level dedupe)", async () => {
+    // Sprint 5.2a tightened the idempotency guard: the handle now tracks
+    // a `stopped` flag so a second stop() call returns immediately
+    // without re-stopping agents or the bus. This protects against
+    // double-stop noise in shutdown paths (SIGTERM + SIGINT racing).
     const bus = createFakeBus();
     const sm = new SessionManager();
     const h = await mountBusRuntime({ bus, sessionManager: sm, logger: SILENT_LOGGER });
     await h.stop();
     await h.stop();
-    // Each handle.stop() invocation calls bus.setSlashCommandHandler(null)
-    // and bus.stop() once — two invocations = two of each on the fake.
-    // The real BusCoreImpl is guarded internally; the handle doesn't add
-    // its own once-flag because the guarantee is provided by callees.
-    expect(bus.stopCalls()).toBe(2);
+    expect(bus.stopCalls()).toBe(1);
   });
 });
 
@@ -305,5 +301,190 @@ describe("mountBusRuntime — real UDS path", () => {
     } finally {
       await handle.stop();
     }
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Auto-spawn (Sprint 5.2a)                                                */
+/* ────────────────────────────────────────────────────────────────────── */
+
+import type { AgentConfig, BusOrigin } from "../types";
+import type { AgentProcess } from "../session-agent-process";
+
+interface FakeSessionManagerOptions {
+  /** Index (0-based) at which spawnAgent should throw. */
+  failSpawnAtIndex?: number;
+}
+
+interface FakeAgentRecord {
+  config: AgentConfig;
+  origin: BusOrigin;
+  stopped: boolean;
+}
+
+class FakeSessionManager extends SessionManager {
+  public readonly spawnLog: FakeAgentRecord[] = [];
+  public readonly stopLog: string[] = [];
+  private spawnIndex = 0;
+  constructor(private fakeOpts: FakeSessionManagerOptions = {}) {
+    super();
+  }
+  async spawnAgent(agent: AgentConfig, origin: BusOrigin): Promise<AgentProcess> {
+    const i = this.spawnIndex++;
+    if (this.fakeOpts.failSpawnAtIndex === i) {
+      throw new Error(`fake spawn failure at index ${i}`);
+    }
+    const record: FakeAgentRecord = { config: agent, origin, stopped: false };
+    this.spawnLog.push(record);
+    return {
+      onData: () => () => {},
+      onExit: () => () => {},
+      send_prompt: async () => {},
+      send_slash: async () => {},
+      kill: async () => {},
+    } as unknown as AgentProcess;
+  }
+  async stop(agent_id: string): Promise<void> {
+    this.stopLog.push(agent_id);
+    const rec = this.spawnLog.find((r) => r.config.id === agent_id);
+    if (rec) rec.stopped = true;
+  }
+  getAgent(): undefined {
+    return undefined;
+  }
+}
+
+function cfg(id: string, overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    id,
+    cwd: "/tmp/proj",
+    session_id: `sess-${id}`,
+    permission_mode: "plan",
+    ...overrides,
+  };
+}
+
+describe("mountBusRuntime — auto-spawn happy path", () => {
+  let handle: BusRuntimeHandle | null = null;
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.stop();
+      handle = null;
+    }
+  });
+
+  it("spawns every declared agent in order and reports them on the handle", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    handle = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      agents: [cfg("triage"), cfg("research"), cfg("ops")],
+      logger: SILENT_LOGGER,
+    });
+    expect(sm.spawnLog.map((r) => r.config.id)).toEqual(["triage", "research", "ops"]);
+    expect(handle.spawnedAgentIds).toEqual(["triage", "research", "ops"]);
+  });
+
+  it("defaults spawnOrigin to 'system' (matches the spec heartbeat tag)", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    handle = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      agents: [cfg("triage")],
+      logger: SILENT_LOGGER,
+    });
+    expect(sm.spawnLog[0]?.origin).toBe("system");
+  });
+
+  it("honours spawnOrigin override", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    handle = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      agents: [cfg("discord-agent")],
+      spawnOrigin: "discord",
+      logger: SILENT_LOGGER,
+    });
+    expect(sm.spawnLog[0]?.origin).toBe("discord");
+  });
+
+  it("scaffold mode (no agents) leaves spawnedAgentIds empty", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    handle = await mountBusRuntime({ bus, sessionManager: sm, logger: SILENT_LOGGER });
+    expect(handle.spawnedAgentIds).toEqual([]);
+    expect(sm.spawnLog).toEqual([]);
+  });
+});
+
+describe("mountBusRuntime — auto-spawn rollback", () => {
+  it("stops successfully-spawned agents in reverse order when a later spawn throws", async () => {
+    const bus = createFakeBus();
+    // Fail the THIRD spawn — agents 0 + 1 should be stopped on the way out.
+    const sm = new FakeSessionManager({ failSpawnAtIndex: 2 });
+    await expect(
+      mountBusRuntime({
+        bus,
+        sessionManager: sm,
+        agents: [cfg("a"), cfg("b"), cfg("c"), cfg("d")],
+        logger: SILENT_LOGGER,
+      }),
+    ).rejects.toThrow(/failed to spawn agent="c"/);
+    // Rollback order is reverse-construction.
+    expect(sm.stopLog).toEqual(["b", "a"]);
+    // Bus was started, then torn down via the outer catch.
+    expect(bus.startCalls()).toBe(1);
+    expect(bus.stopCalls()).toBe(1);
+  });
+
+  it("does not call sessionManager.stop when the first spawn fails immediately", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager({ failSpawnAtIndex: 0 });
+    await expect(
+      mountBusRuntime({
+        bus,
+        sessionManager: sm,
+        agents: [cfg("only")],
+        logger: SILENT_LOGGER,
+      }),
+    ).rejects.toThrow(/failed to spawn agent="only"/);
+    expect(sm.stopLog).toEqual([]);
+    // Bus still has to be stopped — it was started before the spawn loop.
+    expect(bus.stopCalls()).toBe(1);
+  });
+});
+
+describe("mountBusRuntime — stop() with agents", () => {
+  it("stops every spawned agent in reverse order before bus.stop", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    const h = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      agents: [cfg("a"), cfg("b"), cfg("c")],
+      logger: SILENT_LOGGER,
+    });
+    await h.stop();
+    expect(sm.stopLog).toEqual(["c", "b", "a"]);
+    expect(bus.stopCalls()).toBe(1);
+  });
+
+  it("stop() is idempotent — second call is a no-op", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    const h = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      agents: [cfg("a")],
+      logger: SILENT_LOGGER,
+    });
+    await h.stop();
+    await h.stop();
+    expect(sm.stopLog).toEqual(["a"]); // stopped exactly once
+    expect(bus.stopCalls()).toBe(1);
   });
 });

--- a/src/bus/agent-resolver.ts
+++ b/src/bus/agent-resolver.ts
@@ -1,0 +1,119 @@
+/**
+ * Resolve `settings.agents` entries into spawnable `AgentConfig`s
+ * (Sprint 5.2a).
+ *
+ * Spec: `docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md` §5.3 + §10
+ * Sprint 5.2.
+ *
+ * Each `BusAgentSettings` entry from settings.json is operator-facing
+ * (terse, mostly-optional). `AgentConfig` is the SessionManager-facing
+ * shape — every field defaulted/derived. The two live as separate types
+ * by design: settings.json stays stable even as `AgentConfig` grows.
+ *
+ * The big responsibility here is **session_id persistence**. Each agent
+ * gets a UUID that's stable across daemon restarts; without that,
+ * `claude --session-id <uuid>` can't resume the JSONL transcript and
+ * every restart loses conversation context. We reuse the existing
+ * `agents/<id>/session.json` storage layer (`src/sessions.ts`) so the
+ * Bus runtime and legacy PTY runtime share session state — operators
+ * can flip `runtime` between modes without losing history.
+ */
+
+import { randomUUID } from "node:crypto";
+import { join } from "node:path";
+import type { BusAgentSettings } from "../config";
+import { getAgentsDir } from "../config";
+import { createSession, getSession } from "../sessions";
+import type { AgentConfig, SupervisionMode } from "./types";
+
+export interface ResolveAgentOptions {
+  /**
+   * Working directory to use when the agent didn't specify one. Defaults
+   * to `process.cwd()` at call time.
+   */
+  defaultCwd?: string;
+  /**
+   * Test seam: when set, replaces the session_id resolver entirely. Lets
+   * tests bypass the on-disk `agents/<id>/session.json` round-trip and
+   * inject a deterministic UUID.
+   */
+  resolveSessionId?: (agentId: string) => Promise<string>;
+}
+
+/**
+ * Resolve one settings entry into a spawnable `AgentConfig`.
+ *
+ * Defaults applied:
+ *   - `cwd` ← `opts.defaultCwd ?? process.cwd()`
+ *   - `permission_mode` ← `"plan"`
+ *   - `session_id` ← existing `agents/<id>/session.json` value, else
+ *     a fresh UUID persisted on first call.
+ *   - `supervision` ← undefined (SessionManager will pick via
+ *     `defaultSupervisionFor`).
+ */
+export async function resolveBusAgentConfig(
+  entry: BusAgentSettings,
+  opts: ResolveAgentOptions = {},
+): Promise<AgentConfig> {
+  const cwd = entry.cwd ?? opts.defaultCwd ?? process.cwd();
+  const session_id = await (opts.resolveSessionId ?? defaultResolveSessionId)(entry.id);
+
+  const config: AgentConfig = {
+    id: entry.id,
+    cwd,
+    session_id,
+    permission_mode: entry.permission_mode ?? "plan",
+  };
+  if (entry.system_prompt_file) config.system_prompt_file = entry.system_prompt_file;
+  if (entry.memory_file) config.memory_file = entry.memory_file;
+  if (entry.mcp_config) config.mcp_config = entry.mcp_config;
+  if (entry.supervision) config.supervision = entry.supervision as SupervisionMode;
+  return config;
+}
+
+/**
+ * Resolve all agent entries in parallel. Failure of one resolution does
+ * NOT abort the others — failures are surfaced as `null` slots so the
+ * caller can decide whether to spawn the remaining agents or refuse.
+ *
+ * Bus runtime's `mountBusRuntime` treats any null as a fatal error and
+ * rolls back the mount, but tests can pick a different policy.
+ */
+export async function resolveBusAgentConfigs(
+  entries: readonly BusAgentSettings[],
+  opts: ResolveAgentOptions = {},
+): Promise<Array<{ entry: BusAgentSettings; config: AgentConfig | null; error?: unknown }>> {
+  return Promise.all(
+    entries.map(async (entry) => {
+      try {
+        const config = await resolveBusAgentConfig(entry, opts);
+        return { entry, config };
+      } catch (error) {
+        return { entry, config: null, error };
+      }
+    }),
+  );
+}
+
+/**
+ * Read the agent's session.json; create a fresh UUID + persist if absent.
+ *
+ * Note on storage layer reuse: `agents/<id>/session.json` is shared with
+ * the legacy `runtime: "pty"` agent-session store (`src/sessions.ts`).
+ * Operators flipping between runtimes keep their conversation history
+ * across the switch. The directory is also where the daemon writes other
+ * per-agent state (memory snapshots, JSONL pointers), so the Bus
+ * runtime's auto-spawn naturally lands in the right place.
+ */
+async function defaultResolveSessionId(agentId: string): Promise<string> {
+  const existing = await getSession(agentId);
+  if (existing?.sessionId) return existing.sessionId;
+  const fresh = randomUUID();
+  await createSession(fresh, agentId);
+  return fresh;
+}
+
+/** Diagnostic-only: where does this agent's session.json live? */
+export function agentSessionPath(agentId: string): string {
+  return join(getAgentsDir(), agentId, "session.json");
+}

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -1,37 +1,33 @@
 /**
- * Bus runtime daemon mount (Sprint 5.1).
+ * Bus runtime daemon mount.
  *
  * Spec: `docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md` §10 Sprint 5 +
  * §5.3 / §5.4. This is the entrypoint that wires the Sprint 1-4 Bus
  * components into a running daemon when `settings.runtime === "bus"`.
  *
- * Sprint 5.1 scope (intentional — kept minimal for reviewability):
- *   - Construct + start `BusCore` with its UDS / TCP-fallback IPC server.
- *   - Construct `SessionManager` so future spawn calls are addressable.
- *   - Install slash-command relay via `wireSlashCommands` (the seam BusCore
- *     exposed in Sprint 4).
- *   - Return a teardown handle the daemon can call on SIGTERM.
+ * Sprint 5.1 (PR #118) shipped the scaffold:
+ *   - BusCore with UDS / TCP-fallback IPC server.
+ *   - SessionManager (constructed only).
+ *   - Slash-command relay via `wireSlashCommands`.
+ *   - Teardown handle.
  *
- * Deferred to Sprint 5.2 (next PR — needs routing-config schema):
- *   - Adapter wiring (DiscordAdapter / TelegramAdapter / SlackAdapter /
- *     WebUiAdapter). Each needs `{channel_id → agent_id}` routing config
- *     that does not yet exist in `settings.json`. Mounting them today
- *     without that config would either silent-drop traffic or require
- *     synthesising a routing layer ad-hoc.
- *   - Auto-spawn of named agents — same reason. Need an `agents: []`
- *     settings block.
- *   - `BusScheduler` for cron/heartbeat — same reason. The legacy
- *     heartbeat config maps to a single agent today; the Bus model wants
- *     per-agent heartbeats.
+ * Sprint 5.2a (this PR) adds:
+ *   - Auto-spawn of named agents from `settings.agents` (resolved into
+ *     `AgentConfig` via `resolveBusAgentConfigs`).
+ *   - `BusRuntimeHandle.stop()` now stops every spawned agent in addition
+ *     to tearing down BusCore.
+ *   - Rollback of partial mounts: if agent N+1 fails to spawn, agents
+ *     0..N are stopped before the error is re-thrown.
  *
- * Why this split: Sprint 5.1's job is to prove the Bus stack can boot
- * inside the daemon without breaking the v1 (`runtime: "pty"`) path.
- * Adapter routing + auto-spawn are non-trivial config-schema decisions
- * better handled in their own PR with operator review.
+ * Sprint 5.2b will follow with adapter wiring (Discord / Telegram /
+ * Slack / WebUi) using a routing-config schema; Sprint 5.2c adds
+ * `BusScheduler` integration. This file stays small by keeping
+ * routing + scheduling as future responsibilities.
  */
 
 import { homedir } from "node:os";
 import { join } from "node:path";
+import type { AgentConfig, BusOrigin } from "./types";
 import { BusCoreImpl, type BusCore } from "./core";
 import { SessionManager } from "./session-manager";
 import { wireSlashCommands } from "./wiring";
@@ -39,11 +35,21 @@ import { wireSlashCommands } from "./wiring";
 export interface BusRuntimeHandle {
   /** The mounted BusCore. Adapters / tests subscribe via this. */
   bus: BusCore;
-  /** The mounted SessionManager. Future `spawnAgent` calls go here. */
+  /** The mounted SessionManager. Adapters call `getAgent()` etc. on this. */
   sessionManager: SessionManager;
   /** The resolved UDS path the IPC server bound to. Logged at start. */
   socketPath: string;
-  /** Tear down in reverse-construction order. Idempotent. */
+  /**
+   * The list of agents successfully spawned by `mountBusRuntime`. Empty
+   * when the caller passed no agents (Sprint 5.1 scaffold mode). The
+   * daemon uses this in logs and the order doubles as the stop order
+   * (reverse-iterated for symmetry with construction).
+   */
+  spawnedAgentIds: readonly string[];
+  /**
+   * Tear down agents + bus in reverse-construction order. Idempotent;
+   * call as many times as you want.
+   */
   stop(): Promise<void>;
 }
 
@@ -54,6 +60,24 @@ export interface MountBusRuntimeOptions {
    * to the path `SessionManager` will tell spawned agents to dial.
    */
   socketPath?: string;
+  /**
+   * Agents to auto-spawn at mount time. Each entry is the spawnable
+   * `AgentConfig` shape (post-resolution). Empty / absent = mount the
+   * stack with no agents (Sprint 5.1 scaffold mode).
+   *
+   * Origin tag: each agent is associated with a `BusOrigin` for the
+   * spawn call's supervision-mode default. `"system"` is the most
+   * generic — operators can override the supervision mode per-agent if
+   * they need to.
+   */
+  agents?: readonly AgentConfig[];
+  /**
+   * Default `BusOrigin` for the `spawnAgent` call when an agent's
+   * `supervision` field isn't set. Defaults to `"system"` which biases
+   * toward `pty-stdin` (see `defaultSupervisionFor` in
+   * `src/bus/types.ts`).
+   */
+  spawnOrigin?: BusOrigin;
   /**
    * Test seam: inject a pre-built `BusCore` (lets the smoke test exercise
    * the mount path without binding a real UDS).
@@ -101,12 +125,15 @@ export async function mountBusRuntime(
 ): Promise<BusRuntimeHandle> {
   const logger = opts.logger ?? console;
   const socketPath = resolveDaemonSocketPath(opts.socketPath);
+  const origin: BusOrigin = opts.spawnOrigin ?? "system";
 
   const bus: BusCore = opts.bus ?? new BusCoreImpl({ socketPath });
   const sessionManager: SessionManager =
     opts.sessionManager ?? new SessionManager({ busSocketPath: socketPath });
 
   let busStarted = false;
+  const spawned: string[] = [];
+
   try {
     await bus.start();
     busStarted = true;
@@ -116,13 +143,48 @@ export async function mountBusRuntime(
     // through the SessionManager's per-agent process handle.
     wireSlashCommands(bus, sessionManager);
 
-    logger.info(`[bus-runtime] mounted; socket=${socketPath}`);
+    // Auto-spawn declared agents. Sequential rather than parallel so
+    // log output stays readable + spawn failures surface against a
+    // known agent id rather than an unrelated parallel reject.
+    for (const agent of opts.agents ?? []) {
+      try {
+        await sessionManager.spawnAgent(agent, origin);
+        spawned.push(agent.id);
+        logger.info(`[bus-runtime] spawned agent=${agent.id}`);
+      } catch (err) {
+        // Stop any already-spawned agents in reverse order before
+        // bubbling. The outer catch handles bus teardown.
+        for (let i = spawned.length - 1; i >= 0; i--) {
+          try {
+            await sessionManager.stop(spawned[i]);
+          } catch (stopErr) {
+            logger.error(`[bus-runtime] rollback: failed to stop agent=${spawned[i]}`, stopErr);
+          }
+        }
+        spawned.length = 0;
+        throw new Error(
+          `[bus-runtime] failed to spawn agent="${agent.id}": ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
+      }
+    }
 
+    const spawnedLabel = spawned.length === 0 ? "no agents" : `agents=[${spawned.join(", ")}]`;
+    logger.info(`[bus-runtime] mounted; socket=${socketPath}; ${spawnedLabel}`);
+
+    let stopped = false;
     return {
       bus,
       sessionManager,
       socketPath,
+      get spawnedAgentIds() {
+        // Snapshot via getter so the handle reflects the current state
+        // even after stop() empties the list.
+        return [...spawned];
+      },
       async stop() {
+        if (stopped) return;
+        stopped = true;
         // Detach the slash handler first so any in-flight adapter event
         // can't reach a torn-down SessionManager.
         try {
@@ -130,26 +192,41 @@ export async function mountBusRuntime(
         } catch (err) {
           logger.error("[bus-runtime] setSlashCommandHandler(null) failed", err);
         }
+        // Stop every spawned agent BEFORE the bus IPC server closes so
+        // claude children get a clean `/quit` rather than an aborted
+        // socket. Reverse order mirrors construction.
+        for (let i = spawned.length - 1; i >= 0; i--) {
+          const id = spawned[i];
+          try {
+            await sessionManager.stop(id);
+          } catch (err) {
+            logger.error(`[bus-runtime] sessionManager.stop(${id}) failed`, err);
+          }
+        }
+        spawned.length = 0;
         try {
           await bus.stop();
         } catch (err) {
           logger.error("[bus-runtime] bus.stop() failed", err);
         }
-        // SessionManager has no global `stop()` — agent cleanup happens
-        // per-agent via `sessionManager.stop(agent_id)`. Sprint 5.2 will
-        // own the daemon-wide stop semantics once auto-spawn lands.
       },
     };
   } catch (err) {
     if (busStarted) {
-      // Mirror the happy-path teardown order documented on `stop()`:
-      // detach the slash handler first so any closure `wireSlashCommands`
-      // installed before throwing can't reach a torn-down SessionManager,
-      // then stop the bus. PR #117 5-agent review (Agent #2 #1).
+      // Mirror the happy-path teardown order: detach handler, stop any
+      // surviving agents (already cleared above on spawn failure, but
+      // belt-and-braces), then stop the bus.
       try {
         bus.setSlashCommandHandler(null);
       } catch {
         /* ignore — surfacing the original error matters more. */
+      }
+      for (let i = spawned.length - 1; i >= 0; i--) {
+        try {
+          await sessionManager.stop(spawned[i]);
+        } catch {
+          /* ignore */
+        }
       }
       try {
         await bus.stop();

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -452,24 +452,45 @@ export async function start(args: string[] = []) {
     setPluginManager(pluginManager);
   }
 
-  // Bus runtime mount (Sprint 5.1) — opt-in via `settings.runtime: "bus"`.
+  // Bus runtime mount (Sprint 5.1 + 5.2a) — opt-in via `settings.runtime: "bus"`.
   //
-  // Scope: this mounts BusCore + SessionManager + slash-relay so the IPC
-  // server is listening and SessionManager is addressable. Adapter wiring
-  // (Discord/Telegram/Slack/WebUi) and auto-spawn are intentionally deferred
-  // to Sprint 5.2 (next PR) where they land alongside the routing-config
-  // schema. Until then the Bus stack runs as a parallel no-op surface and
-  // the legacy command modules below carry all live traffic.
+  // 5.1 scope: mounts BusCore + SessionManager + slash-relay so the IPC
+  // server is listening and SessionManager is addressable.
+  // 5.2a addition: resolves `settings.agents` into spawnable AgentConfigs
+  // and auto-spawns one `claude` per entry. Failure of any spawn rolls
+  // back the others and falls back to legacy surfaces (so the daemon
+  // never half-mounts and orphans claude children).
+  //
+  // Adapter wiring (Discord/Telegram/Slack/WebUi) and `BusScheduler`
+  // integration still land in 5.2b/c. Until then the Bus stack runs
+  // alongside the legacy command modules — they still carry all live
+  // inbound traffic from messaging platforms.
+  let busRuntimeSpawnedAgents: readonly string[] = [];
   if (settings.runtime === "bus") {
     try {
       const { mountBusRuntime } = await import("../bus/runtime-mount");
-      busRuntimeHandle = await mountBusRuntime();
+      const { resolveBusAgentConfigs } = await import("../bus/agent-resolver");
+      const resolved = await resolveBusAgentConfigs(settings.agents, {
+        defaultCwd: process.cwd(),
+      });
+      const failures = resolved.filter((r) => r.config === null);
+      if (failures.length > 0) {
+        const ids = failures.map((f) => f.entry.id).join(", ");
+        throw new Error(`failed to resolve agent config(s): ${ids}`);
+      }
+      const agentConfigs = resolved
+        .map((r) => r.config)
+        .filter((c): c is NonNullable<typeof c> => c !== null);
+      const handle = await mountBusRuntime({ agents: agentConfigs });
+      busRuntimeHandle = handle;
+      busRuntimeSpawnedAgents = handle.spawnedAgentIds;
     } catch (err) {
       console.error(
         `[${ts()}] Bus runtime: mount failed — falling back to legacy command surfaces only`,
         err,
       );
       busRuntimeHandle = null;
+      busRuntimeSpawnedAgents = [];
     }
   }
 
@@ -513,9 +534,17 @@ export async function start(args: string[] = []) {
       `  Claude CLI: ${cliProbe.version} (NOT in PTY parser's known-good list; turn-boundary detection may degrade — check .planning/pty-migration/SPEC.md §2)`,
     );
   }
-  console.log(
-    `  Runtime: ${settings.runtime}${settings.runtime === "bus" && busRuntimeHandle ? " (Bus stack mounted)" : settings.runtime === "bus" ? " (Bus mount failed; legacy surfaces only)" : ""}`,
-  );
+  if (settings.runtime === "bus" && busRuntimeHandle) {
+    const agentsLabel =
+      busRuntimeSpawnedAgents.length === 0
+        ? "no agents declared"
+        : `agents=[${busRuntimeSpawnedAgents.join(", ")}]`;
+    console.log(`  Runtime: bus (Bus stack mounted, ${agentsLabel})`);
+  } else if (settings.runtime === "bus") {
+    console.log(`  Runtime: bus (Bus mount failed; legacy surfaces only)`);
+  } else {
+    console.log(`  Runtime: ${settings.runtime}`);
+  }
   console.log(`  Security: ${settings.security.level}`);
   if (settings.security.allowedTools.length > 0)
     console.log(`    + allowed: ${settings.security.allowedTools.join(", ")}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -188,6 +188,9 @@ const DEFAULT_SETTINGS: Settings = {
   // Default `pty` keeps v1 behaviour byte-identical. Sprint 5.4 will flip
   // this to `bus` after staging validation.
   runtime: "pty",
+  // Default no agents. Operators who opt in to `runtime: "bus"` declare
+  // agents explicitly. Spec §5.3 / §10 Sprint 5.2.
+  agents: [],
   plugins: {},
   memorySearch: {},
 };
@@ -422,6 +425,45 @@ export interface PtyConfig {
  */
 export type RuntimeMode = "pty" | "bus";
 
+/**
+ * Operator-facing supervision picker. Mirrors the spec's internal
+ * `SupervisionMode` but kept as a separate config string so settings.json
+ * remains a stable surface even if the internal enum changes.
+ */
+export type BusSupervisionMode = "pty-stdin" | "tmux" | "process" | "process-stream-json";
+
+/**
+ * One Bus runtime agent declared in `settings.agents`. The daemon
+ * auto-spawns one `claude` per entry at startup when `runtime: "bus"`.
+ *
+ * `id` is the only required field — defaults keep settings.json terse
+ * for the common single-agent case.
+ */
+export interface BusAgentSettings {
+  /**
+   * Stable slug. Becomes part of the UDS socket path on macOS (≤36 chars
+   * after the bus.sock prefix) and the `agents/<id>/session.json`
+   * directory. Required.
+   */
+  id: string;
+  /** Working directory the spawned claude runs in. Defaults to `process.cwd()`. */
+  cwd?: string;
+  /** Permission mode for the spawned claude. Defaults to `"plan"`. */
+  permission_mode?: "plan" | "bypassPermissions" | "default";
+  /**
+   * Override the supervision picker. Default is mode-dependent (see
+   * `defaultSupervisionFor` in `src/bus/types.ts`). Operators rarely
+   * need to set this.
+   */
+  supervision?: BusSupervisionMode;
+  /** Path to a system-prompt addendum appended to claude's system prompt. */
+  system_prompt_file?: string;
+  /** Path to a per-agent MEMORY.md surfaced to the spawned claude. */
+  memory_file?: string;
+  /** Path to a per-agent MCP config (extra MCP servers). */
+  mcp_config?: string;
+}
+
 export interface Settings {
   model: string;
   api: string;
@@ -446,6 +488,13 @@ export interface Settings {
    * in `settings.json`.
    */
   runtime: RuntimeMode;
+  /**
+   * Bus runtime agent declarations. Only consulted when `runtime: "bus"`;
+   * `runtime: "pty"` ignores this field entirely. Empty list = the daemon
+   * mounts the Bus stack but spawns no agents (operator wires them via
+   * REST/CLI later). See `BusAgentSettings` for the per-agent shape.
+   */
+  agents: BusAgentSettings[];
   pty: PtyConfig;
   mcp: McpConfig;
   watchdog: WatchdogSettings;
@@ -745,6 +794,7 @@ function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Set
           : 30_000,
     },
     runtime: parseRuntimeMode(raw.runtime),
+    agents: parseBusAgents(raw.agents),
     mcp: parseMcpConfig(raw.mcp, raw.web?.enabled),
     watchdog: parseWatchdogConfig(raw.watchdog),
     plugins: parsePlugins(raw.plugins),
@@ -783,6 +833,100 @@ function parseRuntimeMode(raw: unknown): RuntimeMode {
     `[config] settings.runtime="${raw}" is not a valid mode (expected "pty" | "bus"); falling back to "pty"`,
   );
   return "pty";
+}
+
+/** Allowed values for `BusAgentSettings.permission_mode`. */
+const VALID_PERMISSION_MODES = new Set<"plan" | "bypassPermissions" | "default">([
+  "plan",
+  "bypassPermissions",
+  "default",
+]);
+
+/** Allowed values for `BusAgentSettings.supervision`. */
+const VALID_SUPERVISION_MODES = new Set<BusSupervisionMode>([
+  "pty-stdin",
+  "tmux",
+  "process",
+  "process-stream-json",
+]);
+
+/**
+ * Slug constraint for `BusAgentSettings.id`. Kebab-case alphanumeric +
+ * `-` / `_`. We're stricter than the spec's "any string" because the
+ * value lands in UDS socket paths (sun_path budget) and on-disk dirs
+ * (`agents/<id>/...`). The 36-char cap protects the macOS sun_path budget
+ * (spec §5.4 — final UDS path ≤96B, leaves ~36 chars after the typical
+ * `/Users/<user>/.claudeclaw/run/bus-<id>.sock` prefix).
+ */
+const AGENT_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,35}$/;
+
+/**
+ * Parse `settings.agents`. Operator-facing surface — invalid entries log
+ * a warning and are dropped rather than crashing the daemon. Sprint 5.2.
+ *
+ * Validation:
+ *   - `id` required, matches `AGENT_ID_PATTERN`, unique across the list.
+ *   - `permission_mode` must be one of the valid trio (else fall back to
+ *     `"plan"`).
+ *   - `supervision` must be a known mode (else drop the field — internal
+ *     `defaultSupervisionFor` picks one).
+ *   - `cwd` / `system_prompt_file` / `memory_file` / `mcp_config` must be
+ *     non-empty strings if present (else drop the field).
+ */
+function parseBusAgents(raw: unknown): BusAgentSettings[] {
+  if (!Array.isArray(raw)) return [];
+  const out: BusAgentSettings[] = [];
+  const seen = new Set<string>();
+  for (let i = 0; i < raw.length; i++) {
+    const entry = raw[i];
+    if (!entry || typeof entry !== "object") {
+      console.warn(`[config] settings.agents[${i}] is not an object; skipping`);
+      continue;
+    }
+    const id = (entry as { id?: unknown }).id;
+    if (typeof id !== "string" || !AGENT_ID_PATTERN.test(id)) {
+      console.warn(
+        `[config] settings.agents[${i}].id=${JSON.stringify(id)} is invalid (expect [a-z0-9][a-z0-9_-]{0,35}); skipping`,
+      );
+      continue;
+    }
+    if (seen.has(id)) {
+      console.warn(`[config] settings.agents[${i}] duplicate id "${id}"; skipping`);
+      continue;
+    }
+    seen.add(id);
+
+    const e = entry as Record<string, unknown>;
+    const parsed: BusAgentSettings = { id };
+    if (typeof e.cwd === "string" && e.cwd.trim().length > 0) parsed.cwd = e.cwd.trim();
+    if (typeof e.permission_mode === "string") {
+      const pm = e.permission_mode.trim() as "plan" | "bypassPermissions" | "default";
+      if (VALID_PERMISSION_MODES.has(pm)) parsed.permission_mode = pm;
+      else
+        console.warn(
+          `[config] settings.agents[${i}].permission_mode="${e.permission_mode}" invalid; falling back to "plan"`,
+        );
+    }
+    if (typeof e.supervision === "string") {
+      const sv = e.supervision.trim() as BusSupervisionMode;
+      if (VALID_SUPERVISION_MODES.has(sv)) parsed.supervision = sv;
+      else
+        console.warn(
+          `[config] settings.agents[${i}].supervision="${e.supervision}" invalid; dropping (will use default)`,
+        );
+    }
+    if (typeof e.system_prompt_file === "string" && e.system_prompt_file.trim().length > 0) {
+      parsed.system_prompt_file = e.system_prompt_file.trim();
+    }
+    if (typeof e.memory_file === "string" && e.memory_file.trim().length > 0) {
+      parsed.memory_file = e.memory_file.trim();
+    }
+    if (typeof e.mcp_config === "string" && e.mcp_config.trim().length > 0) {
+      parsed.mcp_config = e.mcp_config.trim();
+    }
+    out.push(parsed);
+  }
+  return out;
 }
 
 /**


### PR DESCRIPTION
## Summary

First of three Sprint 5.2 sub-PRs. Gives the Bus daemon a way to
actually launch claude children based on `settings.agents`. Builds on
Sprint 5.1 (#118).

## Scope

### Shipped here
- `Settings.agents: BusAgentSettings[]` config field with full validation
  (kebab-case ids, 36-char sun_path cap, dedup, typed permission_mode /
  supervision).
- `src/bus/agent-resolver.ts` — settings → spawnable `AgentConfig`,
  with session_id persistence reusing `agents/<id>/session.json` from
  the legacy `runtime: \"pty\"` session store. Operators keep their
  history when flipping between runtimes.
- `src/bus/runtime-mount.ts` — auto-spawn loop with reverse-order
  rollback on partial failure, handle-level idempotent stop(), agents
  torn down BEFORE bus.stop() so claude children get a clean exit.
- `src/commands/start.ts` — passes resolved agents into the mount.
  Startup banner lists which agents spawned; failure falls back to
  legacy surfaces.

### Deferred (Sprint 5.2b / 5.2c)
- Adapter wiring (Discord / Telegram / Slack / WebUi) + routing-config
  schema → 5.2b.
- `BusScheduler` integration for heartbeat / cron jobs → 5.2c.
- Legacy adapter gate-off under `runtime: \"bus\"` → 5.2b.

## Tests

+26 across three files. All pass.

- `runtime-config.test.ts` (+8): defaults, full-fields, invalid id
  rejection, dedup, permission_mode / supervision invalid drops,
  non-array fallback, 36-char cap.
- `agent-resolver.test.ts` (+10, NEW): default application, cwd
  precedence, optional fields, batch resolution with per-entry failure,
  real disk session_id round-trip in temp project dir.
- `runtime-mount.test.ts` (+8): auto-spawn order assertion, spawnOrigin
  default + override, scaffold mode, rollback when later spawn throws,
  no-op rollback when first throws, teardown reverse order, handle-level
  idempotency.

Full repo suite: 1627 pass / 6 skip / 29 fail / 1 error. All failures
match the pre-existing baseline.

## Risk

Spawning real claude children is a Sprint 5.2 step worth treating with
care. This PR:
- Falls back to legacy surfaces on ANY mount failure (resolution or
  spawn). The daemon never half-mounts.
- Rolls back partial spawns in reverse order before propagating.
- Tears down agents BEFORE bus IPC on shutdown so children see
  `/quit` rather than a yanked socket.
- Keeps `runtime: \"pty\"` (default) byte-identical — no change for
  existing operators until they opt in.

## Test plan

- [ ] \`runtime: \"bus\"\` + empty \`agents: []\` → daemon mounts the
      Bus stack with \"no agents declared\" in the banner.
- [ ] \`runtime: \"bus\"\` + one agent → daemon banner lists it; the
      agent is reachable via \`sessionManager.getAgent(id)\`; SIGTERM
      cleanly stops it.
- [ ] \`runtime: \"bus\"\` + two agents where the second has a malformed
      \`mcp_config\` path → spawn fails, first agent rolled back, daemon
      logs failure and falls back to legacy surfaces.
- [ ] Restart with same agent ids → session_id persists, conversation
      history survives.
- [ ] \`runtime: \"pty\"\` (default) → no behaviour change vs main.

## Spec

\`docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md\` §5.3 / §10 Sprint 5.2.

Tracking issue #121 lists the upstream Slack features to port in 5.2b
(allowBots, block/attachment text extraction, replyThreadTs).