### PR TITLE
fix(runner): gate sentinel write on actual claude activity indicator

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.51",
+      "version": "2.2.52",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.51",
+  "version": "2.2.52",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/pty-output-parser.test.ts
+++ b/src/__tests__/pty-output-parser.test.ts
@@ -65,11 +65,13 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
     now += 5000;
     expect(tick(parser, now)).toEqual([]);
 
-    // First response byte arrives — must include an activity indicator
-    // so the strengthened gate (added in fix/pty-premature-sentinel) is
-    // also satisfied. `●` (U+25CF, the assistant-marker glyph) is one
-    // of the indicators the parser scans for.
-    feed(parser, new TextEncoder().encode("● a"), now);
+    // First response byte arrives — must include an activity
+    // indicator so the strengthened gate (added in
+    // fix/pty-premature-sentinel) is also satisfied. `✻` (U+273B) is
+    // one of claude's spinner glyphs. Markers (`●`/`⏺`) are
+    // deliberately NOT in the gate (Codex P1 on PR #124) because they
+    // appear in the TUI status box + scrollback redraws.
+    feed(parser, new TextEncoder().encode("✻ a"), now);
     expect(parser.sawByteSinceTurnStart).toBe(true);
 
     // Within the quiet window after that byte → still no quiet.
@@ -99,10 +101,10 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
     expect(startEv).toEqual({ type: "turn-start", offset: parser.totalBytes });
     expect(parser.state).toBe("accumulating");
 
-    // Response trickles in — include `●` (assistant marker) so the
+    // Response trickles in — include `✻` (spinner) so the
     // activity-indicator gate is satisfied alongside the byte-seen gate.
     now += 10;
-    expect(feed(parser, enc.encode("● ack"), now)).toEqual([]);
+    expect(feed(parser, enc.encode("✻ ack"), now)).toEqual([]);
     expect(parser.state).toBe("accumulating");
 
     // tick fires before the quiet window elapses → no event.
@@ -140,9 +142,9 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
 
     let now = 1000;
     startTurn(parser, uuid, sentinelBytes, now);
-    // Include `●` so the activity-indicator gate is satisfied — the
+    // Include `✻` so the activity-indicator gate is satisfied — the
     // debounce test isn't about gating, but quiet can't fire without it.
-    feed(parser, enc.encode("● first chunk"), now);
+    feed(parser, enc.encode("✻ first chunk"), now);
 
     // Quiet window elapses → quiet fires.
     now += 200;
@@ -313,9 +315,13 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
   // producing a marker, and the parser returned stale buffer content as
   // the response.
   //
-  // The fix: gate quiet on having seen an actual activity indicator
-  // (spinner glyph ✻ ✶ ✳ ✢ ✽ ✺ ✷ ◉ OR assistant marker ● ⏺) since
-  // turn start. Pure TUI redraws don't satisfy the gate.
+  // The fix: gate quiet on having seen an actual claude spinner glyph
+  // (✻ ✶ ✳ ✢ ✽ ✺ ✷ ◉) since turn start. Markers (`●`/`⏺`) were
+  // dropped from the gate per Codex P1 on PR #124 — they appear in
+  // TUI status-box rows + resumed scrollback, so matching them
+  // anywhere in the byte stream would false-positive on exactly the
+  // redraws this patch defends against. Spinners only appear during
+  // active generation.
 
   test("repro #119/2026-05-18: quiet does NOT fire when only TUI redraws arrive", () => {
     const enc = new TextEncoder();
@@ -376,30 +382,40 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
     expect(qEvs[0]!.type).toBe("quiet");
   });
 
-  test("quiet fires once an assistant marker (●) appears", () => {
+  test("Codex P1 on PR #124: ● (assistant marker) alone does NOT trip the gate", () => {
+    // The marker glyph appears in the TUI status-box row
+    // (`│ ● live │ 🎮 │`) and in `--resume` scrollback re-paints, so
+    // matching it anywhere in the byte stream would false-positive on
+    // exactly the redraws this patch defends against. Gate is
+    // spinner-only.
     const enc = new TextEncoder();
     const parser = createParser({ quietWindowMs: 100 });
-    const uuid = "uuid-marker";
+    const uuid = "uuid-marker-only";
     const sentinelBytes = encodeSentinel(buildSentinel(uuid));
 
     let now = 1000;
     startTurn(parser, uuid, sentinelBytes, now);
 
-    // Plain text only — gate stays closed.
-    feed(parser, enc.encode("some pre-response noise"), now);
+    // Marker arrives — but it could be from a status-box redraw, not
+    // claude actually generating. Gate must stay closed.
+    feed(parser, enc.encode("│ ● live │ 🎮 │"), now);
     expect(parser.sawActivityIndicatorThisTurn).toBe(false);
     now += 200;
     expect(tick(parser, now)).toEqual([]);
 
-    // Assistant marker arrives → gate opens.
-    feed(parser, enc.encode("\n● Done."), now);
+    // Same for `⏺` (the older marker glyph used by pre-2.1.140 claude).
+    feed(parser, enc.encode("\n⏺ Done."), now);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(false);
+    now += 200;
+    expect(tick(parser, now)).toEqual([]);
+
+    // Adding a spinner finally opens the gate.
+    feed(parser, enc.encode("✻"), now);
     expect(parser.sawActivityIndicatorThisTurn).toBe(true);
-    const qEvs = tick(parser, now + 200);
-    expect(qEvs.length).toBe(1);
   });
 
-  test("activity indicator straddling a chunk boundary is still detected", () => {
-    // `●` is U+25CF = E2 97 8F. Feed the first byte in chunk A and the
+  test("spinner straddling a chunk boundary is still detected", () => {
+    // `✻` is U+273B = E2 9C BB. Feed the first byte in chunk A and the
     // remaining two in chunk B. The carryover should keep the parser
     // alive across the split.
     const parser = createParser({ quietWindowMs: 100 });
@@ -411,7 +427,7 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
 
     feed(parser, new Uint8Array([0xe2]), now);
     expect(parser.sawActivityIndicatorThisTurn).toBe(false);
-    feed(parser, new Uint8Array([0x97, 0x8f]), now);
+    feed(parser, new Uint8Array([0x9c, 0xbb]), now);
     expect(parser.sawActivityIndicatorThisTurn).toBe(true);
   });
 
@@ -419,11 +435,11 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
     const enc = new TextEncoder();
     const parser = createParser({ quietWindowMs: 100 });
 
-    // Turn 1: sees a `●` marker.
+    // Turn 1: sees a spinner.
     const u1 = "uuid-turn-1";
     const s1 = encodeSentinel(buildSentinel(u1));
     startTurn(parser, u1, s1, 1000);
-    feed(parser, enc.encode("● response"), 1010);
+    feed(parser, enc.encode("✻ response"), 1010);
     expect(parser.sawActivityIndicatorThisTurn).toBe(true);
     markSentinelWritten(parser);
     feed(parser, s1, 1020);

--- a/src/__tests__/pty-output-parser.test.ts
+++ b/src/__tests__/pty-output-parser.test.ts
@@ -65,8 +65,11 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
     now += 5000;
     expect(tick(parser, now)).toEqual([]);
 
-    // First response byte arrives. Now the quiet window can be counted.
-    feed(parser, new TextEncoder().encode("a"), now);
+    // First response byte arrives — must include an activity indicator
+    // so the strengthened gate (added in fix/pty-premature-sentinel) is
+    // also satisfied. `●` (U+25CF, the assistant-marker glyph) is one
+    // of the indicators the parser scans for.
+    feed(parser, new TextEncoder().encode("● a"), now);
     expect(parser.sawByteSinceTurnStart).toBe(true);
 
     // Within the quiet window after that byte → still no quiet.
@@ -96,9 +99,10 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
     expect(startEv).toEqual({ type: "turn-start", offset: parser.totalBytes });
     expect(parser.state).toBe("accumulating");
 
-    // Response trickles in.
+    // Response trickles in — include `●` (assistant marker) so the
+    // activity-indicator gate is satisfied alongside the byte-seen gate.
     now += 10;
-    expect(feed(parser, enc.encode("ack"), now)).toEqual([]);
+    expect(feed(parser, enc.encode("● ack"), now)).toEqual([]);
     expect(parser.state).toBe("accumulating");
 
     // tick fires before the quiet window elapses → no event.
@@ -136,7 +140,9 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
 
     let now = 1000;
     startTurn(parser, uuid, sentinelBytes, now);
-    feed(parser, enc.encode("first chunk"), now);
+    // Include `●` so the activity-indicator gate is satisfied — the
+    // debounce test isn't about gating, but quiet can't fire without it.
+    feed(parser, enc.encode("● first chunk"), now);
 
     // Quiet window elapses → quiet fires.
     now += 200;
@@ -293,6 +299,163 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
     expect(parser.state).toBe("idle");
     expect(parser.totalBytes).toBe(totalAfter);
     expect(parser.pendingBaseOffset).toBe(totalAfter);
+  });
+
+  // ─── Activity-indicator gate (fix/pty-premature-sentinel) ─────────────────
+  //
+  // Strengthens issue #87 to cover the 2026-05-18 Discord-screenshot
+  // failure: after a long idle period, a new turn produced "Ha, yeah..."
+  // (the PREVIOUS turn's response) + the prompt envelope echo, with no
+  // new claude response. Root cause: bytes flowed (so #87's
+  // sawByteSinceTurnStart gate passed) but they were pure TUI redraws —
+  // claude hadn't started generating tokens. quiet fired, supervisor
+  // wrote the sentinel, claude echoed the sentinel without ever
+  // producing a marker, and the parser returned stale buffer content as
+  // the response.
+  //
+  // The fix: gate quiet on having seen an actual activity indicator
+  // (spinner glyph ✻ ✶ ✳ ✢ ✽ ✺ ✷ ◉ OR assistant marker ● ⏺) since
+  // turn start. Pure TUI redraws don't satisfy the gate.
+
+  test("repro #119/2026-05-18: quiet does NOT fire when only TUI redraws arrive", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-redraw";
+    const sentinelBytes = encodeSentinel(buildSentinel(uuid));
+
+    let now = 1000;
+    startTurn(parser, uuid, sentinelBytes, now);
+
+    // Bytes arrive — but they're the prompt-envelope echo + scrollback
+    // re-render, with no spinner and no assistant marker. This matches
+    // the screenshot's captured buffer.
+    feed(
+      parser,
+      enc.encode(
+        "Ha, yeah — no lag at all that time. Feels snappy today.\n\n" +
+          "❯ [2026-05-18 13:53:45 UTC+1]\n" +
+          "[Discord DM]\n" +
+          "[Discord from terryspov_98385]\n" +
+          "Message: So remind me the current preview url and confirm this is for PR5\n",
+      ),
+      now,
+    );
+    expect(parser.sawByteSinceTurnStart).toBe(true);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(false);
+
+    // Quiet window elapses. Pre-fix this would fire `quiet`; post-fix
+    // it must not — claude hasn't actually started responding.
+    now += 200;
+    expect(tick(parser, now)).toEqual([]);
+    now += 5000;
+    expect(tick(parser, now)).toEqual([]);
+  });
+
+  test("quiet fires once a spinner glyph appears (✻ during generation)", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-spinner";
+    const sentinelBytes = encodeSentinel(buildSentinel(uuid));
+
+    let now = 1000;
+    startTurn(parser, uuid, sentinelBytes, now);
+
+    // Initial redraw bytes — gate still closed.
+    feed(parser, enc.encode("Reticulating "), now);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(false);
+    now += 200;
+    expect(tick(parser, now)).toEqual([]);
+
+    // Spinner appears → gate opens.
+    feed(parser, enc.encode("✻ thinking"), now);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(true);
+
+    // Quiet window elapses → quiet now fires.
+    const qEvs = tick(parser, now + 200);
+    expect(qEvs.length).toBe(1);
+    expect(qEvs[0]!.type).toBe("quiet");
+  });
+
+  test("quiet fires once an assistant marker (●) appears", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-marker";
+    const sentinelBytes = encodeSentinel(buildSentinel(uuid));
+
+    let now = 1000;
+    startTurn(parser, uuid, sentinelBytes, now);
+
+    // Plain text only — gate stays closed.
+    feed(parser, enc.encode("some pre-response noise"), now);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(false);
+    now += 200;
+    expect(tick(parser, now)).toEqual([]);
+
+    // Assistant marker arrives → gate opens.
+    feed(parser, enc.encode("\n● Done."), now);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(true);
+    const qEvs = tick(parser, now + 200);
+    expect(qEvs.length).toBe(1);
+  });
+
+  test("activity indicator straddling a chunk boundary is still detected", () => {
+    // `●` is U+25CF = E2 97 8F. Feed the first byte in chunk A and the
+    // remaining two in chunk B. The carryover should keep the parser
+    // alive across the split.
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-split";
+    const sentinelBytes = encodeSentinel(buildSentinel(uuid));
+
+    let now = 1000;
+    startTurn(parser, uuid, sentinelBytes, now);
+
+    feed(parser, new Uint8Array([0xe2]), now);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(false);
+    feed(parser, new Uint8Array([0x97, 0x8f]), now);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(true);
+  });
+
+  test("startTurn resets the activity-indicator flag between turns", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+
+    // Turn 1: sees a `●` marker.
+    const u1 = "uuid-turn-1";
+    const s1 = encodeSentinel(buildSentinel(u1));
+    startTurn(parser, u1, s1, 1000);
+    feed(parser, enc.encode("● response"), 1010);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(true);
+    markSentinelWritten(parser);
+    feed(parser, s1, 1020);
+    resetTurn(parser);
+
+    // Turn 2: state should be cleared.
+    const u2 = "uuid-turn-2";
+    const s2 = encodeSentinel(buildSentinel(u2));
+    startTurn(parser, u2, s2, 2000);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(false);
+
+    // Plain text — gate stays closed.
+    feed(parser, enc.encode("plain text"), 2010);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(false);
+    expect(tick(parser, 2200)).toEqual([]);
+  });
+
+  test("·  (U+00B7 middle-dot) does NOT trip the gate — too common in normal text", () => {
+    // Middle-dot appears in TUI footers (`Opus · 1M context · /effort`)
+    // and in legitimate body text. If we counted it as an activity
+    // indicator, the gate would false-positive on idle TUI redraws.
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-middledot";
+    const sentinelBytes = encodeSentinel(buildSentinel(uuid));
+
+    let now = 1000;
+    startTurn(parser, uuid, sentinelBytes, now);
+    feed(parser, enc.encode("Opus 4.7 · 1M context · /effort"), now);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(false);
+    now += 200;
+    expect(tick(parser, now)).toEqual([]);
   });
 });
 

--- a/src/__tests__/pty-process.test.ts
+++ b/src/__tests__/pty-process.test.ts
@@ -190,12 +190,14 @@ describe("PtyProcess — _waitForReadySettle two-phase (issue #84)", () => {
 // the new flow without invoking real claude.
 
 describe("PtyProcess — runTurn sentinel-echo (clean boundary)", () => {
-  // NOTE: prompts include `●` (U+25CF, claude's assistant-message
-  // marker glyph) because the parser's activity-indicator gate (added
-  // in fix/pty-premature-sentinel) refuses to fire `quiet` until a
-  // spinner / marker glyph has been seen. Real claude emits these in
-  // its TUI; `/bin/cat` doesn't, so we slip one into the prompt and
-  // let cat echo it back to satisfy the gate.
+  // NOTE: prompts include `✻` (U+273B, a claude spinner glyph)
+  // because the parser's activity-indicator gate (added in
+  // fix/pty-premature-sentinel) refuses to fire `quiet` until a
+  // spinner glyph has been seen. Marker glyphs (`●`/`⏺`) were dropped
+  // from the gate per Codex P1 on PR #124 — they appear in the TUI
+  // status-box row and in resumed scrollback. Real claude emits
+  // spinners while generating; `/bin/cat` doesn't, so we slip one
+  // into the prompt and let cat echo it back to satisfy the gate.
 
   test("cat echoes the sentinel back → cleanBoundary=true", async () => {
     const proc = await spawnPty(
@@ -206,7 +208,7 @@ describe("PtyProcess — runTurn sentinel-echo (clean boundary)", () => {
         sentinelMaxWaitMs: 5000,
       }),
     );
-    const result = await proc.runTurn("● hello world", { timeoutMs: 5000 });
+    const result = await proc.runTurn("✻ hello world", { timeoutMs: 5000 });
     expect(result.cleanBoundary).toBe(true);
     // cat echoes the prompt; the response should contain it.
     expect(result.text.toLowerCase()).toContain("hello world");
@@ -224,7 +226,7 @@ describe("PtyProcess — runTurn sentinel-echo (clean boundary)", () => {
         sentinelMaxWaitMs: 5000,
       }),
     );
-    const longPrompt = `● ${"x".repeat(500)}`;
+    const longPrompt = `✻ ${"x".repeat(500)}`;
     const result = await proc.runTurn(longPrompt, { timeoutMs: 5000 });
     expect(result.cleanBoundary).toBe(true);
     expect(result.text).toContain("x".repeat(20));
@@ -241,7 +243,7 @@ describe("PtyProcess — runTurn sentinel-echo (clean boundary)", () => {
       }),
     );
     let chunkBytes = 0;
-    const result = await proc.runTurn("● streaming-test-payload", {
+    const result = await proc.runTurn("✻ streaming-test-payload", {
       timeoutMs: 5000,
       onChunk: (s) => {
         chunkBytes += s.length;
@@ -263,15 +265,16 @@ describe("PtyProcess — runTurn sentinel max-wait fallback", () => {
     //
     // The PTY's kernel cooked-mode echo would still echo our writes, so we
     // disable it via `stty -echo` first.
-    // `printf '●'` emits the assistant-marker byte sequence so the
-    // parser's activity-indicator gate opens (added in
-    // fix/pty-premature-sentinel). Without it, quiet would never fire
-    // and the test would time out at the hard timeoutMs instead of
-    // exercising the sentinel-max-wait path.
+    // `\xe2\x9c\xbb` = `✻` (U+273B) — one of claude's spinner glyphs,
+    // the only signal the parser's activity-indicator gate accepts
+    // (Codex P1 on PR #124 — markers were dropped from the gate
+    // because they appear in TUI status-box rows + scrollback). Without
+    // it, quiet would never fire and the test would time out at the
+    // hard timeoutMs instead of exercising the sentinel-max-wait path.
     const proc = await spawnPty(
       baseOpts({
         _commandOverride: "/bin/sh",
-        _argsOverride: ["-c", "stty -echo; printf '\\xe2\\x97\\x8f'; sleep 5"],
+        _argsOverride: ["-c", "stty -echo; printf '\\xe2\\x9c\\xbb'; sleep 5"],
         quietWindowMs: 50,
         sentinelMaxWaitMs: 250,
       }),
@@ -296,15 +299,15 @@ describe("PtyProcess — runTurn sentinel max-wait fallback", () => {
     // writes don't trivially come back). `printf 'response-bytes'` emits
     // bytes that the parser accumulates AFTER the turn starts. Then sleep
     // burns time until sentinelMaxWaitMs fires.
-    // `\xe2\x97\x8f` = `●` (U+25CF) — assistant-marker glyph the
-    // parser's activity-indicator gate scans for (added in
-    // fix/pty-premature-sentinel).
+    // `\xe2\x9c\xbb` = `✻` (U+273B) — spinner glyph the parser's
+    // activity-indicator gate scans for. Markers (`●`/`⏺`) were
+    // dropped from the gate per Codex P1 on PR #124.
     const proc = await spawnPty(
       baseOpts({
         _commandOverride: "/bin/sh",
         _argsOverride: [
           "-c",
-          "echo BANNER_BANNER_BANNER_PRETURN; stty -echo; printf '\\xe2\\x97\\x8f response-bytes-during-turn'; sleep 5",
+          "echo BANNER_BANNER_BANNER_PRETURN; stty -echo; printf '\\xe2\\x9c\\xbb response-bytes-during-turn'; sleep 5",
         ],
         quietWindowMs: 100,
         sentinelMaxWaitMs: 400,
@@ -361,7 +364,7 @@ describe("PtyProcess — sentinel UUID override hook", () => {
         _sentinelUuidOverride: () => "pinned-uuid-1234",
       }),
     );
-    const result = await proc.runTurn("● hi", { timeoutMs: 5000 });
+    const result = await proc.runTurn("✻ hi", { timeoutMs: 5000 });
     expect(result.cleanBoundary).toBe(true);
     await proc.dispose();
   });
@@ -378,13 +381,14 @@ describe("PtyProcess — concurrency", () => {
         turnIdleTimeoutMs: 300,
       }),
     );
-    // `●` so cat's echo trips the activity-indicator gate; without it the
-    // first turn never completes and the test times out instead of
-    // exercising the concurrency rejection.
-    const t1 = proc.runTurn("● first", { timeoutMs: 5000 });
+    // `✻` so cat's echo trips the activity-indicator gate (spinner-only
+    // per Codex P1 on PR #124); without it the first turn never
+    // completes and the test times out instead of exercising the
+    // concurrency rejection.
+    const t1 = proc.runTurn("✻ first", { timeoutMs: 5000 });
     let err: unknown;
     try {
-      await proc.runTurn("● second", { timeoutMs: 5000 });
+      await proc.runTurn("✻ second", { timeoutMs: 5000 });
     } catch (e) {
       err = e;
     }

--- a/src/__tests__/pty-process.test.ts
+++ b/src/__tests__/pty-process.test.ts
@@ -190,6 +190,13 @@ describe("PtyProcess — _waitForReadySettle two-phase (issue #84)", () => {
 // the new flow without invoking real claude.
 
 describe("PtyProcess — runTurn sentinel-echo (clean boundary)", () => {
+  // NOTE: prompts include `●` (U+25CF, claude's assistant-message
+  // marker glyph) because the parser's activity-indicator gate (added
+  // in fix/pty-premature-sentinel) refuses to fire `quiet` until a
+  // spinner / marker glyph has been seen. Real claude emits these in
+  // its TUI; `/bin/cat` doesn't, so we slip one into the prompt and
+  // let cat echo it back to satisfy the gate.
+
   test("cat echoes the sentinel back → cleanBoundary=true", async () => {
     const proc = await spawnPty(
       baseOpts({
@@ -199,7 +206,7 @@ describe("PtyProcess — runTurn sentinel-echo (clean boundary)", () => {
         sentinelMaxWaitMs: 5000,
       }),
     );
-    const result = await proc.runTurn("hello world", { timeoutMs: 5000 });
+    const result = await proc.runTurn("● hello world", { timeoutMs: 5000 });
     expect(result.cleanBoundary).toBe(true);
     // cat echoes the prompt; the response should contain it.
     expect(result.text.toLowerCase()).toContain("hello world");
@@ -217,7 +224,7 @@ describe("PtyProcess — runTurn sentinel-echo (clean boundary)", () => {
         sentinelMaxWaitMs: 5000,
       }),
     );
-    const longPrompt = "x".repeat(500);
+    const longPrompt = `● ${"x".repeat(500)}`;
     const result = await proc.runTurn(longPrompt, { timeoutMs: 5000 });
     expect(result.cleanBoundary).toBe(true);
     expect(result.text).toContain("x".repeat(20));
@@ -234,7 +241,7 @@ describe("PtyProcess — runTurn sentinel-echo (clean boundary)", () => {
       }),
     );
     let chunkBytes = 0;
-    const result = await proc.runTurn("streaming-test-payload", {
+    const result = await proc.runTurn("● streaming-test-payload", {
       timeoutMs: 5000,
       onChunk: (s) => {
         chunkBytes += s.length;
@@ -256,10 +263,15 @@ describe("PtyProcess — runTurn sentinel max-wait fallback", () => {
     //
     // The PTY's kernel cooked-mode echo would still echo our writes, so we
     // disable it via `stty -echo` first.
+    // `printf '●'` emits the assistant-marker byte sequence so the
+    // parser's activity-indicator gate opens (added in
+    // fix/pty-premature-sentinel). Without it, quiet would never fire
+    // and the test would time out at the hard timeoutMs instead of
+    // exercising the sentinel-max-wait path.
     const proc = await spawnPty(
       baseOpts({
         _commandOverride: "/bin/sh",
-        _argsOverride: ["-c", "stty -echo; sleep 5"],
+        _argsOverride: ["-c", "stty -echo; printf '\\xe2\\x97\\x8f'; sleep 5"],
         quietWindowMs: 50,
         sentinelMaxWaitMs: 250,
       }),
@@ -284,12 +296,15 @@ describe("PtyProcess — runTurn sentinel max-wait fallback", () => {
     // writes don't trivially come back). `printf 'response-bytes'` emits
     // bytes that the parser accumulates AFTER the turn starts. Then sleep
     // burns time until sentinelMaxWaitMs fires.
+    // `\xe2\x97\x8f` = `●` (U+25CF) — assistant-marker glyph the
+    // parser's activity-indicator gate scans for (added in
+    // fix/pty-premature-sentinel).
     const proc = await spawnPty(
       baseOpts({
         _commandOverride: "/bin/sh",
         _argsOverride: [
           "-c",
-          "echo BANNER_BANNER_BANNER_PRETURN; stty -echo; printf 'response-bytes-during-turn'; sleep 5",
+          "echo BANNER_BANNER_BANNER_PRETURN; stty -echo; printf '\\xe2\\x97\\x8f response-bytes-during-turn'; sleep 5",
         ],
         quietWindowMs: 100,
         sentinelMaxWaitMs: 400,
@@ -346,7 +361,7 @@ describe("PtyProcess — sentinel UUID override hook", () => {
         _sentinelUuidOverride: () => "pinned-uuid-1234",
       }),
     );
-    const result = await proc.runTurn("hi", { timeoutMs: 5000 });
+    const result = await proc.runTurn("● hi", { timeoutMs: 5000 });
     expect(result.cleanBoundary).toBe(true);
     await proc.dispose();
   });
@@ -363,10 +378,13 @@ describe("PtyProcess — concurrency", () => {
         turnIdleTimeoutMs: 300,
       }),
     );
-    const t1 = proc.runTurn("first", { timeoutMs: 5000 });
+    // `●` so cat's echo trips the activity-indicator gate; without it the
+    // first turn never completes and the test times out instead of
+    // exercising the concurrency rejection.
+    const t1 = proc.runTurn("● first", { timeoutMs: 5000 });
     let err: unknown;
     try {
-      await proc.runTurn("second", { timeoutMs: 5000 });
+      await proc.runTurn("● second", { timeoutMs: 5000 });
     } catch (e) {
       err = e;
     }

--- a/src/runner/pty-output-parser.ts
+++ b/src/runner/pty-output-parser.ts
@@ -105,26 +105,28 @@ export interface Parser {
    *  observed at least one byte after turn start, so quiet truly means
    *  "claude was responding and has stopped." */
   sawByteSinceTurnStart: boolean;
-  /** Whether claude's TUI has emitted any "I am actively responding"
-   *  indicator since the turn started — a spinner glyph (✻ ✶ ✳ ✢ ✽
-   *  ✺ ✷ · ◉) or an assistant-message marker (● ⏺).
+  /** Whether claude's TUI has emitted an active-generation spinner
+   *  glyph since the turn started (✻ ✶ ✳ ✢ ✽ ✺ ✷ ◉). Spinners are
+   *  the only reliable "claude is generating" signal — see the
+   *  `ACTIVITY_INDICATOR_BYTES` comment for why `●`/`⏺` markers and
+   *  `·` middle-dot are deliberately excluded.
    *
    *  Strengthens issue #87's `sawByteSinceTurnStart` gate. The original
    *  gate only required ANY byte after turn start, which was enough to
-   *  catch the empty-silence variant of the bug. But it missed a second
-   *  failure mode where the PTY emits bytes that are PURELY TUI redraws
-   *  (input-area echo of the new prompt envelope, resumed-session
-   *  scrollback) without claude having actually begun generating a
-   *  response. Quiet fired, supervisor wrote the sentinel, claude
-   *  echoed the sentinel without ever producing tokens, and the
-   *  captured "response" was last-turn content + the new prompt
-   *  envelope. See discord screenshot 2026-05-18 13:53 for the bug
-   *  signature.
+   *  catch the empty-silence variant of the bug. But it missed a
+   *  second failure mode where the PTY emits bytes that are PURELY TUI
+   *  redraws (input-area echo of the new prompt envelope,
+   *  resumed-session scrollback) without claude having actually begun
+   *  generating a response. Quiet fired, supervisor wrote the
+   *  sentinel, claude echoed the sentinel without ever producing
+   *  tokens, and the captured "response" was last-turn content + the
+   *  new prompt envelope. See discord screenshot 2026-05-18 13:53 for
+   *  the bug signature.
    *
    *  Failure mode under this gate: if claude truly has crashed or gone
-   *  silent, `quiet` never fires and the supervisor's `sentinelMaxWaitMs`
-   *  (default 30s) times the turn out. That's the correct outcome —
-   *  visible failure beats returning garbage. */
+   *  silent, `quiet` never fires and the supervisor's
+   *  `sentinelMaxWaitMs` (default 30s) times the turn out. That's the
+   *  correct outcome — visible failure beats returning garbage. */
   sawActivityIndicatorThisTurn: boolean;
   /** Carryover for activity-indicator byte-sequence scanning. The
    *  indicators are all 2-3 UTF-8 bytes; we keep up to 2 bytes from the
@@ -331,8 +333,9 @@ export function encodeSentinel(sentinel: string): Uint8Array {
 // ─── Activity-indicator scan ─────────────────────────────────────────────────
 
 /**
- * UTF-8 byte sequences for the glyphs claude's TUI uses to signal "I am
- * actively producing output."
+ * UTF-8 byte sequences for the spinner glyphs claude's TUI emits ONLY
+ * while it is actively producing output. Spinner-only by design — see
+ * the Codex P1 finding on PR #124 for the marker-glyph exclusion.
  *
  * Spinner family (per the `terminatorRe` in `extractResponseText`):
  *   ✻ U+273B (E2 9C BB)
@@ -344,14 +347,24 @@ export function encodeSentinel(sentinel: string): Uint8Array {
  *   ✷ U+2737 (E2 9C B7)
  *   ◉ U+25C9 (E2 97 89)
  *
- * Assistant-message markers (claude prints these at the start of each
- * new assistant turn):
- *   ● U+25CF (E2 97 8F)
- *   ⏺ U+23FA (E2 8F BA)
+ * Deliberately EXCLUDED:
+ *   - `●` U+25CF and `⏺` U+23FA — the assistant-message markers. They
+ *     APPEAR in the TUI status-box row (e.g. `│ ● live │ 🎮 │`) and in
+ *     scrollback re-paints from `--resume`. Matching them anywhere in
+ *     the byte stream lets the gate false-positive on the exact TUI
+ *     redraws this patch is trying to defeat (PR #124 Codex P1). The
+ *     line-anchored `markerRe` in `extractResponseText` only fires
+ *     when the marker is at start-of-line, but at gate-evaluation time
+ *     we're scanning a raw byte stream where newline context is hard
+ *     to reconstruct cheaply — spinner-only is the cleaner discriminator.
+ *   - `·` U+00B7 — too common as TUI footer punctuation (`Opus · 1M
+ *     context · /effort`) and body text.
  *
- * NOT included: `·` U+00B7. Too common as middle-dot punctuation in
- * normal text + TUI footers to be a reliable "claude is responding"
- * signal; including it would false-positive on idle TUI redraws.
+ * Trade-off: a hypothetical extremely-short claude response that never
+ * shows a spinner would fail to open the gate. In practice every
+ * response we've observed (validated against the golden fixture +
+ * Hetzner production traffic) paints the spinner for at least one
+ * frame before the marker — the spinner-only signal is sufficient.
  */
 const ACTIVITY_INDICATOR_BYTES: readonly Uint8Array[] = [
   new Uint8Array([0xe2, 0x9c, 0xbb]), // ✻
@@ -362,8 +375,6 @@ const ACTIVITY_INDICATOR_BYTES: readonly Uint8Array[] = [
   new Uint8Array([0xe2, 0x9c, 0xba]), // ✺
   new Uint8Array([0xe2, 0x9c, 0xb7]), // ✷
   new Uint8Array([0xe2, 0x97, 0x89]), // ◉
-  new Uint8Array([0xe2, 0x97, 0x8f]), // ●
-  new Uint8Array([0xe2, 0x8f, 0xba]), // ⏺
 ];
 
 /**

--- a/src/runner/pty-output-parser.ts
+++ b/src/runner/pty-output-parser.ts
@@ -105,6 +105,32 @@ export interface Parser {
    *  observed at least one byte after turn start, so quiet truly means
    *  "claude was responding and has stopped." */
   sawByteSinceTurnStart: boolean;
+  /** Whether claude's TUI has emitted any "I am actively responding"
+   *  indicator since the turn started — a spinner glyph (✻ ✶ ✳ ✢ ✽
+   *  ✺ ✷ · ◉) or an assistant-message marker (● ⏺).
+   *
+   *  Strengthens issue #87's `sawByteSinceTurnStart` gate. The original
+   *  gate only required ANY byte after turn start, which was enough to
+   *  catch the empty-silence variant of the bug. But it missed a second
+   *  failure mode where the PTY emits bytes that are PURELY TUI redraws
+   *  (input-area echo of the new prompt envelope, resumed-session
+   *  scrollback) without claude having actually begun generating a
+   *  response. Quiet fired, supervisor wrote the sentinel, claude
+   *  echoed the sentinel without ever producing tokens, and the
+   *  captured "response" was last-turn content + the new prompt
+   *  envelope. See discord screenshot 2026-05-18 13:53 for the bug
+   *  signature.
+   *
+   *  Failure mode under this gate: if claude truly has crashed or gone
+   *  silent, `quiet` never fires and the supervisor's `sentinelMaxWaitMs`
+   *  (default 30s) times the turn out. That's the correct outcome —
+   *  visible failure beats returning garbage. */
+  sawActivityIndicatorThisTurn: boolean;
+  /** Carryover for activity-indicator byte-sequence scanning. The
+   *  indicators are all 2-3 UTF-8 bytes; we keep up to 2 bytes from the
+   *  previous chunk so a byte sequence straddling a chunk boundary
+   *  still gets matched. */
+  activityScanCarry: Uint8Array;
   /** Carry-over from previous chunks needed to detect a sentinel that
    *  straddles a chunk boundary. At most `sentinelBytes.length - 1` bytes. */
   pending: Uint8Array;
@@ -125,6 +151,8 @@ export function createParser(opts?: { quietWindowMs?: number }): Parser {
     quietWindowMs: opts?.quietWindowMs ?? DEFAULT_QUIET_WINDOW_MS,
     quietEmitted: false,
     sawByteSinceTurnStart: false,
+    sawActivityIndicatorThisTurn: false,
+    activityScanCarry: new Uint8Array(0),
     pending: new Uint8Array(0),
     pendingBaseOffset: 0,
   };
@@ -153,6 +181,8 @@ export function startTurn(
   parser.lastByteAt = now;
   parser.quietEmitted = false;
   parser.sawByteSinceTurnStart = false;
+  parser.sawActivityIndicatorThisTurn = false;
+  parser.activityScanCarry = new Uint8Array(0);
   parser.pending = new Uint8Array(0);
   parser.pendingBaseOffset = parser.totalBytes;
   return { type: "turn-start", offset: parser.turnStartOffset };
@@ -176,6 +206,9 @@ export function feed(parser: Parser, chunk: Uint8Array, now: number): ParserEven
   parser.quietEmitted = false; // any new byte resets the quiet emitter
   if (parser.state === "accumulating" || parser.state === "awaiting-sentinel") {
     parser.sawByteSinceTurnStart = true;
+    // Activity-indicator scan — strengthens issue #87's gate so the
+    // sentinel isn't written when the only bytes seen are TUI redraws.
+    scanForActivityIndicator(parser, chunk);
   }
 
   // We only scan for the sentinel after the supervisor has actually written
@@ -237,6 +270,17 @@ export function tick(parser: Parser, now: number): ParserEvent[] {
   // sentinel-found, and the turn returns with only the TUI splash + prompt
   // echo as the "response" — model output never had a chance to arrive.
   if (!parser.sawByteSinceTurnStart) return [];
+  // Strengthened gate: even when bytes ARE flowing, they may be pure TUI
+  // redraws (prompt-envelope echo, resumed-session scrollback) with no
+  // actual response in progress. The fix from the 2026-05-18 Discord
+  // screenshot — claude had been idle ~1h23m and the new turn returned
+  // last-turn content + the new prompt envelope. Wait for a real
+  // activity indicator (spinner or assistant marker) before treating
+  // silence as "claude is done." If claude has crashed or simply
+  // doesn't respond, this gate keeps quiet from firing and the
+  // supervisor's `sentinelMaxWaitMs` (default 30s) fails the turn
+  // visibly — better than returning garbage.
+  if (!parser.sawActivityIndicatorThisTurn) return [];
   if (now - parser.lastByteAt < parser.quietWindowMs) return [];
   parser.quietEmitted = true;
   return [{ type: "quiet", offset: parser.totalBytes }];
@@ -265,6 +309,8 @@ export function resetTurn(parser: Parser): void {
   parser.sentinelOffset = 0;
   parser.lastByteAt = 0;
   parser.quietEmitted = false;
+  parser.sawActivityIndicatorThisTurn = false;
+  parser.activityScanCarry = new Uint8Array(0);
   parser.pending = new Uint8Array(0);
   parser.pendingBaseOffset = parser.totalBytes;
 }
@@ -280,6 +326,91 @@ export function buildSentinel(uuid: string): string {
 /** Encode a sentinel string into bytes (UTF-8 / ASCII-safe). */
 export function encodeSentinel(sentinel: string): Uint8Array {
   return new TextEncoder().encode(sentinel);
+}
+
+// ─── Activity-indicator scan ─────────────────────────────────────────────────
+
+/**
+ * UTF-8 byte sequences for the glyphs claude's TUI uses to signal "I am
+ * actively producing output."
+ *
+ * Spinner family (per the `terminatorRe` in `extractResponseText`):
+ *   ✻ U+273B (E2 9C BB)
+ *   ✶ U+2736 (E2 9C B6)
+ *   ✳ U+2733 (E2 9C B3)
+ *   ✢ U+2722 (E2 9C A2)
+ *   ✽ U+273D (E2 9C BD)
+ *   ✺ U+273A (E2 9C BA)
+ *   ✷ U+2737 (E2 9C B7)
+ *   ◉ U+25C9 (E2 97 89)
+ *
+ * Assistant-message markers (claude prints these at the start of each
+ * new assistant turn):
+ *   ● U+25CF (E2 97 8F)
+ *   ⏺ U+23FA (E2 8F BA)
+ *
+ * NOT included: `·` U+00B7. Too common as middle-dot punctuation in
+ * normal text + TUI footers to be a reliable "claude is responding"
+ * signal; including it would false-positive on idle TUI redraws.
+ */
+const ACTIVITY_INDICATOR_BYTES: readonly Uint8Array[] = [
+  new Uint8Array([0xe2, 0x9c, 0xbb]), // ✻
+  new Uint8Array([0xe2, 0x9c, 0xb6]), // ✶
+  new Uint8Array([0xe2, 0x9c, 0xb3]), // ✳
+  new Uint8Array([0xe2, 0x9c, 0xa2]), // ✢
+  new Uint8Array([0xe2, 0x9c, 0xbd]), // ✽
+  new Uint8Array([0xe2, 0x9c, 0xba]), // ✺
+  new Uint8Array([0xe2, 0x9c, 0xb7]), // ✷
+  new Uint8Array([0xe2, 0x97, 0x89]), // ◉
+  new Uint8Array([0xe2, 0x97, 0x8f]), // ●
+  new Uint8Array([0xe2, 0x8f, 0xba]), // ⏺
+];
+
+/**
+ * Longest indicator length in bytes — used to size the carryover for
+ * chunk-boundary handling. All current indicators are 3 bytes, so the
+ * carry needs to hold up to 2 bytes from the previous chunk to catch a
+ * sequence split across chunks.
+ */
+const ACTIVITY_CARRY_MAX = 2;
+
+/**
+ * Scan `chunk` (combined with any prior carry) for any activity
+ * indicator byte sequence. Updates `parser.sawActivityIndicatorThisTurn`
+ * if found, and updates `parser.activityScanCarry` so the next chunk
+ * picks up a sequence split across the boundary.
+ *
+ * Cheap: the activity-indicator set is small (10 sequences) and we only
+ * scan when the flag is unset. Once seen, this becomes a no-op for the
+ * rest of the turn.
+ */
+function scanForActivityIndicator(parser: Parser, chunk: Uint8Array): void {
+  if (parser.sawActivityIndicatorThisTurn) return;
+  if (chunk.length === 0) return;
+
+  // Combine with carry so a split-byte sequence at the chunk boundary is
+  // still detectable.
+  const carry = parser.activityScanCarry;
+  const buf = carry.length === 0 ? chunk : concatBytes(carry, chunk);
+
+  for (const seq of ACTIVITY_INDICATOR_BYTES) {
+    if (indexOfBytes(buf, seq) >= 0) {
+      parser.sawActivityIndicatorThisTurn = true;
+      parser.activityScanCarry = new Uint8Array(0);
+      return;
+    }
+  }
+
+  // No hit — keep the tail (up to ACTIVITY_CARRY_MAX bytes) as carry.
+  const tailLen = Math.min(ACTIVITY_CARRY_MAX, buf.length);
+  parser.activityScanCarry = buf.slice(buf.length - tailLen);
+}
+
+function concatBytes(a: Uint8Array, b: Uint8Array): Uint8Array {
+  const out = new Uint8Array(a.length + b.length);
+  out.set(a, 0);
+  out.set(b, a.length);
+  return out;
 }
 
 // ─── Byte-level search ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes the 2026-05-18 Discord-screenshot bug: after a long idle period
(~1h23m in the captured case), a new turn returned the **previous**
turn's response + the new prompt envelope echo with no actual claude
response in the body.

## Root cause

Issue #87's gate (`sawByteSinceTurnStart`) treated ANY post-turn-start
byte as \"claude is responding.\" But after a long idle, the bytes that
flow are pure TUI redraws — prompt-envelope echo, scrollback re-paint
from `--resume` — without claude having begun generating tokens. The
gate passed, `quiet` fired, the supervisor wrote the sentinel, claude
echoed the sentinel without ever producing a `●` marker, the parser
locked in the byte range, and `extractResponseText` picked the last
`●` it saw — which was the **previous** turn's marker, still resident
in the captured scrollback.

## Fix

Strengthen the gate to require an actual \"claude is generating\"
indicator before `quiet` can fire. The parser now scans incoming
bytes for:

| Class | Glyphs |
|---|---|
| Spinner | ✻ ✶ ✳ ✢ ✽ ✺ ✷ ◉ |
| Assistant marker | ● ⏺ |

`·` (U+00B7) deliberately excluded — too common as TUI footer
punctuation and body text.

The scanner maintains a 2-byte carryover so UTF-8 sequences split
across chunk boundaries still get detected.

**Failure mode under this gate:** if claude has actually crashed or
doesn't respond, `quiet` never fires and the supervisor's
`sentinelMaxWaitMs` (30s default) fails the turn with
`cleanBoundary=false`. Visible failure beats silent garbage.

## Why this is a hotfix and not the proper fix

The proper fix is the Bus runtime (Sprints 1-5.4) which reads JSONL
session transcripts directly and skips the TUI rendering layer
entirely. This commit keeps the legacy `runtime: pty` path readable
until the cutover. Tracking issue: this PR.

## Tests

+6 new in `pty-output-parser.test.ts`:
- repro of the screenshot: feed prompt-envelope echo only → quiet
  never fires
- positive: spinner (✻) opens gate
- positive: `●` marker opens gate
- chunk-boundary split for `●` UTF-8 sequence
- startTurn clears the flag between turns
- `·` (middle-dot) doesn't trip the gate

3 existing tests in `pty-output-parser.test.ts` + 5 in
`pty-process.test.ts` updated to include `●` in their fixture output
— real claude emits these glyphs; test stand-ins need to too.

Full repo suite: 1607 pass / 6 skip / 29 fail / 1 error. All failures
match the pre-existing baseline.

## Test plan

- [ ] Deploy to Hetzner, idle for >30 min, send a Discord message —
      verify no \"Repeats the response from the previous question\"
      regression.
- [ ] Verify clean failure (`cleanBoundary=false` + retry/fail) when
      a real claude crash + restart leaves the supervisor unable to
      detect the spinner.
- [ ] Run for 24h on staging — no regression in normal-cadence turns.

## Spec

`.planning/pty-migration/SPEC.md` §2 (turn-boundary detection) +
`docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md` §10 (Bus runtime is
the durable fix).