### PR TITLE
feat(bus): Sprint 5.2c — BusScheduler heartbeat + cron integration

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.54",
+      "version": "2.2.55",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.54",
+  "version": "2.2.55",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/runtime-mount.test.ts
+++ b/src/bus/__tests__/runtime-mount.test.ts
@@ -545,6 +545,86 @@ describe("mountBusRuntime — attachAdapters", () => {
     expect(stopOrder).toEqual(["telegram", "discord"]);
   });
 
+  it("attachScheduler is torn down on handle.stop (Sprint 5.2c)", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    let schedulerStopped = false;
+    const fakeScheduler = {
+      stop: async () => {
+        schedulerStopped = true;
+      },
+    };
+    const handle = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      logger: SILENT_LOGGER,
+    });
+    handle.attachScheduler(fakeScheduler);
+    await handle.stop();
+    expect(schedulerStopped).toBe(true);
+  });
+
+  it("attachScheduler(null) when no scheduler is attached is safe", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    const handle = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      logger: SILENT_LOGGER,
+    });
+    handle.attachScheduler(null);
+    await handle.stop();
+  });
+
+  it("replacing the scheduler stops the previous one to avoid timer leaks", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    let firstStopped = false;
+    let secondStopped = false;
+    const first = {
+      stop: async () => {
+        firstStopped = true;
+      },
+    };
+    const second = {
+      stop: async () => {
+        secondStopped = true;
+      },
+    };
+    const handle = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      logger: SILENT_LOGGER,
+    });
+    handle.attachScheduler(first);
+    handle.attachScheduler(second);
+    // First scheduler's stop is scheduled on microtask queue.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(firstStopped).toBe(true);
+    await handle.stop();
+    expect(secondStopped).toBe(true);
+  });
+
+  it("attachScheduler after stop() schedules teardown so the scheduler doesn't leak", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    let stopped = false;
+    const fakeScheduler = {
+      stop: async () => {
+        stopped = true;
+      },
+    };
+    const handle = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      logger: SILENT_LOGGER,
+    });
+    await handle.stop();
+    handle.attachScheduler(fakeScheduler);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(stopped).toBe(true);
+  });
+
   it("attachAdapters after stop() schedules teardown so adapters don't leak", async () => {
     const bus = createFakeBus();
     const sm = new FakeSessionManager();

--- a/src/bus/__tests__/scheduler-wiring.test.ts
+++ b/src/bus/__tests__/scheduler-wiring.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Tests for `src/bus/scheduler-wiring.ts` (Sprint 5.2c).
+ *
+ * Strategy: stub `createBusScheduler` indirectly by spying on the
+ * returned handle. The wiring is a thin glue layer between settings +
+ * jobs and the `BusScheduler` interface, so we drive it with a fake
+ * BusCore and assert on the schedule calls.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { wireBusScheduler } from "../scheduler-wiring";
+import type { BusCore } from "../core";
+import type { HeartbeatConfig } from "../../config";
+import type { Job } from "../../jobs";
+
+const SILENT_LOGGER = {
+  warn: () => {},
+  info: () => {},
+  error: () => {},
+};
+
+/** Minimal BusCore stub — the wiring only constructs a scheduler against it. */
+function stubBus(): BusCore {
+  return {
+    async sendPrompt() {
+      return { promise_id: "fake" };
+    },
+    subscribe() {
+      return {
+        id: "fake",
+        close() {},
+        get overflowCount() {
+          return 0;
+        },
+        get depth() {
+          return 0;
+        },
+      };
+    },
+    async invokeSlashCommand() {},
+    setSlashCommandHandler() {},
+    ingestReply() {},
+    ingestSessionEvent() {},
+    ingestPermissionDecision() {},
+    ingestAskAnswer() {},
+    state() {
+      return { subscriberCount: 0, connectedAgents: [], totalOverflows: 0 };
+    },
+    async start() {},
+    async stop() {},
+  } as unknown as BusCore;
+}
+
+function baseHeartbeat(over: Partial<HeartbeatConfig> = {}): HeartbeatConfig {
+  return {
+    enabled: false,
+    interval: 15,
+    prompt: "",
+    excludeWindows: [],
+    forwardToTelegram: false,
+    forwardToDiscord: false,
+    ...over,
+  };
+}
+
+function job(over: Partial<Job> = {}): Job {
+  return {
+    name: over.name ?? "test-job",
+    schedule: over.schedule ?? "*/5 * * * *",
+    prompt: over.prompt ?? "do the thing",
+    recurring: over.recurring ?? true,
+    notify: over.notify ?? false,
+    ...over,
+  };
+}
+
+describe("wireBusScheduler — heartbeat", () => {
+  it("schedules a heartbeat when enabled and a defaultAgentId is provided", async () => {
+    const handle = await wireBusScheduler({
+      bus: stubBus(),
+      defaultAgentId: "triage",
+      heartbeat: baseHeartbeat({ enabled: true, interval: 15, prompt: "tick" }),
+      jobs: [],
+      logger: SILENT_LOGGER,
+    });
+    expect(handle.scheduled.map((s) => s.label)).toEqual(["heartbeat"]);
+    await handle.stop();
+  });
+
+  it("skips the heartbeat when enabled but no defaultAgentId", async () => {
+    const handle = await wireBusScheduler({
+      bus: stubBus(),
+      defaultAgentId: null,
+      heartbeat: baseHeartbeat({ enabled: true }),
+      jobs: [],
+      logger: SILENT_LOGGER,
+    });
+    expect(handle.scheduled).toHaveLength(0);
+    await handle.stop();
+  });
+
+  it("skips the heartbeat when not enabled", async () => {
+    const handle = await wireBusScheduler({
+      bus: stubBus(),
+      defaultAgentId: "triage",
+      heartbeat: baseHeartbeat({ enabled: false }),
+      jobs: [],
+      logger: SILENT_LOGGER,
+    });
+    expect(handle.scheduled).toHaveLength(0);
+    await handle.stop();
+  });
+
+  it("warns but still schedules when excludeWindows are set (current limitation)", async () => {
+    const warnings: string[] = [];
+    const handle = await wireBusScheduler({
+      bus: stubBus(),
+      defaultAgentId: "triage",
+      heartbeat: baseHeartbeat({
+        enabled: true,
+        excludeWindows: [{ start: "22:00", end: "07:00" }],
+      }),
+      jobs: [],
+      logger: { ...SILENT_LOGGER, warn: (m: string) => warnings.push(m) },
+    });
+    expect(handle.scheduled).toHaveLength(1);
+    expect(warnings.some((w) => w.includes("excludeWindows"))).toBe(true);
+    await handle.stop();
+  });
+});
+
+describe("wireBusScheduler — cron jobs", () => {
+  it("schedules every enabled job against the resolved agent", async () => {
+    const handle = await wireBusScheduler({
+      bus: stubBus(),
+      defaultAgentId: "triage",
+      heartbeat: baseHeartbeat(),
+      jobs: [job({ name: "a", schedule: "0 9 * * *" }), job({ name: "b", schedule: "0 21 * * *" })],
+      logger: SILENT_LOGGER,
+    });
+    expect(handle.scheduled.map((s) => s.label)).toEqual(["cron:a", "cron:b"]);
+    await handle.stop();
+  });
+
+  it("respects job.enabled === false", async () => {
+    const handle = await wireBusScheduler({
+      bus: stubBus(),
+      defaultAgentId: "triage",
+      heartbeat: baseHeartbeat(),
+      jobs: [
+        job({ name: "active", schedule: "*/10 * * * *", enabled: true }),
+        job({ name: "off", schedule: "*/10 * * * *", enabled: false }),
+      ],
+      logger: SILENT_LOGGER,
+    });
+    expect(handle.scheduled.map((s) => s.label)).toEqual(["cron:active"]);
+    await handle.stop();
+  });
+
+  it("agent override: job.agent wins over defaultAgentId", async () => {
+    const handle = await wireBusScheduler({
+      bus: stubBus(),
+      defaultAgentId: "triage",
+      heartbeat: baseHeartbeat(),
+      jobs: [job({ name: "research-only", schedule: "*/30 * * * *", agent: "research" })],
+      logger: SILENT_LOGGER,
+    });
+    expect(handle.scheduled.map((s) => s.label)).toEqual(["cron:research-only"]);
+    await handle.stop();
+  });
+
+  it("skips jobs with no explicit agent when defaultAgentId is null", async () => {
+    const warnings: string[] = [];
+    const handle = await wireBusScheduler({
+      bus: stubBus(),
+      defaultAgentId: null,
+      heartbeat: baseHeartbeat(),
+      jobs: [
+        job({ name: "no-agent", schedule: "*/5 * * * *" }),
+        job({ name: "explicit-agent", schedule: "*/5 * * * *", agent: "ops" }),
+      ],
+      logger: { ...SILENT_LOGGER, warn: (m: string) => warnings.push(m) },
+    });
+    expect(handle.scheduled.map((s) => s.label)).toEqual(["cron:explicit-agent"]);
+    expect(warnings.some((w) => w.includes("no-agent"))).toBe(true);
+    await handle.stop();
+  });
+
+  it("logs but does not crash on an invalid cron expression", async () => {
+    const warnings: string[] = [];
+    const handle = await wireBusScheduler({
+      bus: stubBus(),
+      defaultAgentId: "triage",
+      heartbeat: baseHeartbeat(),
+      jobs: [
+        job({ name: "ok", schedule: "*/5 * * * *" }),
+        job({ name: "bad", schedule: "totally not a cron expression" }),
+      ],
+      logger: { ...SILENT_LOGGER, warn: (m: string) => warnings.push(m) },
+    });
+    expect(handle.scheduled.map((s) => s.label)).toEqual(["cron:ok"]);
+    expect(warnings.some((w) => w.includes('"bad"'))).toBe(true);
+    await handle.stop();
+  });
+});
+
+describe("wireBusScheduler — stop()", () => {
+  it("cancels every trigger and stops the scheduler", async () => {
+    const handle = await wireBusScheduler({
+      bus: stubBus(),
+      defaultAgentId: "triage",
+      heartbeat: baseHeartbeat({ enabled: true }),
+      jobs: [job({ name: "a", schedule: "0 9 * * *" })],
+      logger: SILENT_LOGGER,
+    });
+    expect(handle.scheduled).toHaveLength(2); // heartbeat + 1 job
+    await handle.stop();
+    // After stop, scheduler is torn down — calling stop again is a no-op
+    // (idempotent).
+    await handle.stop();
+  });
+});

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -69,9 +69,30 @@ export interface BusRuntimeHandle {
    */
   attachAdapters(adapters: readonly MountedAdapter[]): void;
   /**
-   * Tear down adapters + agents + bus in reverse-construction order.
-   * Idempotent; call as many times as you want.
+   * Register a BusScheduler handle with the stop lifecycle. Sprint
+   * 5.2c (PR #125). The scheduler is constructed AFTER mount returns
+   * (so it can dispatch through the live bus) and registered here so
+   * `handle.stop()` cancels every trigger + stops the scheduler
+   * before tearing down agents + bus. Only one scheduler can be
+   * attached; subsequent calls overwrite the previous one (and stop
+   * the previous one first so timers don't leak).
    */
+  attachScheduler(scheduler: AttachedScheduler | null): void;
+  /**
+   * Tear down adapters + scheduler + agents + bus in reverse-
+   * construction order. Idempotent; call as many times as you want.
+   */
+  stop(): Promise<void>;
+}
+
+/**
+ * Minimal shape `attachScheduler` expects — the concrete
+ * `BusSchedulerHandle` from `scheduler-wiring.ts` satisfies it. Kept
+ * minimal here so `runtime-mount` doesn't pull a transitive
+ * dependency on the scheduler module (which would cycle if the
+ * scheduler ever needs the mount).
+ */
+export interface AttachedScheduler {
   stop(): Promise<void>;
 }
 
@@ -216,6 +237,11 @@ export async function mountBusRuntime(
     // `attachAdapters`. Backwards-compatible: `opts.adapters` still
     // accepted for callers that wired before mount.
     const adapters: MountedAdapter[] = opts.adapters ? [...opts.adapters] : [];
+    // Sprint 5.2c (PR #125): the daemon attaches a `BusScheduler`
+    // handle after mount so heartbeat + cron triggers are torn down
+    // alongside adapters + agents + bus. Only one scheduler can be
+    // attached at a time.
+    let attachedScheduler: AttachedScheduler | null = null;
     const spawnedLabel = spawned.length === 0 ? "no agents" : `agents=[${spawned.join(", ")}]`;
     const adaptersLabel =
       adapters.length === 0
@@ -251,12 +277,43 @@ export async function mountBusRuntime(
         }
         for (const a of more) adapters.push(a);
       },
+      attachScheduler(scheduler) {
+        if (stopped) {
+          // Same defence as attachAdapters: tear down immediately on
+          // microtask so the late scheduler doesn't leak its timers.
+          if (scheduler) {
+            Promise.resolve()
+              .then(() => scheduler.stop())
+              .catch((err) => logger.error("[bus-runtime] post-stop attachScheduler", err));
+          }
+          return;
+        }
+        // Replacing an existing scheduler stops the previous one
+        // first so its timers don't leak.
+        if (attachedScheduler && attachedScheduler !== scheduler) {
+          const prev = attachedScheduler;
+          Promise.resolve()
+            .then(() => prev.stop())
+            .catch((err) => logger.error("[bus-runtime] previous scheduler.stop()", err));
+        }
+        attachedScheduler = scheduler;
+      },
       async stop() {
         if (stopped) return;
         stopped = true;
         // Adapters first: stop inbound traffic so nothing new hits the
         // bus while we're tearing down agents. Sprint 5.2b.
         await stopBusAdapters(adapters, logger);
+        // Scheduler next: cancel every recurring trigger so heartbeats
+        // / crons don't fire mid-teardown. Sprint 5.2c.
+        if (attachedScheduler) {
+          try {
+            await attachedScheduler.stop();
+          } catch (err) {
+            logger.error("[bus-runtime] scheduler.stop() failed", err);
+          }
+          attachedScheduler = null;
+        }
         // Detach the slash handler so any closure in `wireSlashCommands`
         // can't reach a torn-down SessionManager.
         try {

--- a/src/bus/scheduler-wiring.ts
+++ b/src/bus/scheduler-wiring.ts
@@ -1,0 +1,176 @@
+/**
+ * Bus runtime scheduler wiring (Sprint 5.2c).
+ *
+ * Spec: `docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md` §5.6 + §10
+ * Sprint 5.2.
+ *
+ * Responsibility: given a parsed `Settings` + the list of cron jobs +
+ * a default agent_id, construct a `BusScheduler` and register every
+ * heartbeat / cron trigger against it. Returns a teardown handle the
+ * daemon's `BusRuntimeHandle` can adopt via `attachScheduler`.
+ *
+ * Mapping from legacy config:
+ *   - `settings.heartbeat.enabled === true` → one `scheduleHeartbeat`
+ *     call against the default agent_id. The legacy heartbeat ran a
+ *     single global session so "first agent" matches that behaviour.
+ *   - Each `Job` from `loadJobs()` → one `scheduleCron` call. Jobs with
+ *     `enabled: false` are skipped (legacy parity).
+ *     - `job.agent` overrides the default agent_id when set; otherwise
+ *       the default applies.
+ *     - The job's `prompt` is forwarded verbatim — model / timeout
+ *       overrides aren't honoured under the Bus runtime yet (Sprint
+ *       5.2c+ follow-up).
+ *
+ * Not handled (deliberately):
+ *   - `settings.heartbeat.excludeWindows` — the BusScheduler doesn't
+ *     model exclusion windows. The legacy `isHeartbeatExcludedNow`
+ *     check lives in `start.ts`'s tick(); we'd need to add a
+ *     scheduler-side filter for the Bus path. Tracked for Sprint
+ *     5.2c+ follow-up; for now operators using exclusion windows stay
+ *     on `runtime: pty`.
+ *   - Hot-reload on settings change. The schedule survives until
+ *     daemon restart.
+ */
+
+import type { BusCore } from "./core";
+import { createBusScheduler, type BusScheduler, type ScheduledTrigger } from "./scheduler";
+import type { HeartbeatConfig } from "../config";
+import type { Job } from "../jobs";
+
+export interface ScheduledItem {
+  /** Stable label for logging — e.g. `"heartbeat"` or `"cron:auto-commit"`. */
+  label: string;
+  trigger: ScheduledTrigger;
+}
+
+export interface BusSchedulerHandle {
+  scheduler: BusScheduler;
+  scheduled: readonly ScheduledItem[];
+  /** Cancel every trigger + stop the scheduler. Idempotent. */
+  stop(): Promise<void>;
+}
+
+export interface WireBusSchedulerOptions {
+  bus: BusCore;
+  /**
+   * The agent_id that catches heartbeats and any job without an explicit
+   * `agent` field. Caller should pass the first spawned agent (matches
+   * the legacy single-global-agent shape).
+   *
+   * If `null`, heartbeats are skipped entirely and only jobs WITH an
+   * explicit `agent` field are scheduled.
+   */
+  defaultAgentId: string | null;
+  heartbeat: HeartbeatConfig;
+  jobs: readonly Job[];
+  /** Mirrors `BusSchedulerOptions.timezoneOffsetMinutes`. */
+  timezoneOffsetMinutes?: number;
+  /** Logger — defaults to `console`. */
+  logger?: Pick<Console, "warn" | "info" | "error">;
+}
+
+/**
+ * Construct a `BusScheduler`, register heartbeat + cron triggers, and
+ * return a teardown handle.
+ *
+ * Failure semantics: per-trigger registration errors (e.g. invalid cron
+ * expression) are logged via `logger.warn` and the offending trigger is
+ * skipped. The scheduler itself stays alive and the rest of the
+ * triggers proceed — matches the operator-friendly "fall back
+ * gracefully" pattern.
+ */
+export async function wireBusScheduler(opts: WireBusSchedulerOptions): Promise<BusSchedulerHandle> {
+  const logger = opts.logger ?? console;
+  const scheduler = createBusScheduler({
+    bus: opts.bus,
+    timezoneOffsetMinutes: opts.timezoneOffsetMinutes ?? 0,
+  });
+  await scheduler.start();
+
+  const scheduled: ScheduledItem[] = [];
+
+  // Heartbeat: one trigger per daemon when enabled.
+  if (opts.heartbeat.enabled && opts.defaultAgentId) {
+    if (opts.heartbeat.excludeWindows.length > 0) {
+      // Documented limitation — operators relying on this stay on
+      // `runtime: pty` until the scheduler grows exclusion-window
+      // support.
+      logger.warn(
+        "[bus-scheduler] settings.heartbeat.excludeWindows is set but the Bus scheduler doesn't honour it yet. The heartbeat will fire every interval regardless of windowing.",
+      );
+    }
+    try {
+      const trigger = scheduler.scheduleHeartbeat({
+        agent_id: opts.defaultAgentId,
+        interval_minutes: opts.heartbeat.interval,
+        prompt: opts.heartbeat.prompt,
+      });
+      scheduled.push({ label: "heartbeat", trigger });
+      logger.info(
+        `[bus-scheduler] heartbeat scheduled every ${opts.heartbeat.interval}m for agent="${opts.defaultAgentId}"`,
+      );
+    } catch (err) {
+      logger.warn(
+        `[bus-scheduler] heartbeat schedule failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  } else if (opts.heartbeat.enabled && !opts.defaultAgentId) {
+    logger.warn(
+      "[bus-scheduler] settings.heartbeat.enabled is true but no agent is configured under settings.agents — heartbeat skipped",
+    );
+  }
+
+  // Cron jobs.
+  for (const job of opts.jobs) {
+    if (job.enabled === false) continue;
+    const agentId = job.agent ?? opts.defaultAgentId;
+    if (!agentId) {
+      logger.warn(
+        `[bus-scheduler] job "${job.name}" has no explicit agent and no defaultAgentId; skipping`,
+      );
+      continue;
+    }
+    try {
+      const trigger = scheduler.scheduleCron({
+        agent_id: agentId,
+        cronExpr: job.schedule,
+        prompt: job.prompt,
+        metadata: { job_name: job.name },
+      });
+      scheduled.push({ label: `cron:${job.name}`, trigger });
+      logger.info(
+        `[bus-scheduler] cron job "${job.name}" scheduled "${job.schedule}" for agent="${agentId}"`,
+      );
+    } catch (err) {
+      logger.warn(
+        `[bus-scheduler] cron job "${job.name}" failed to schedule: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  let stopped = false;
+  return {
+    scheduler,
+    get scheduled() {
+      return scheduled.slice();
+    },
+    async stop() {
+      if (stopped) return;
+      stopped = true;
+      // Cancel individual triggers first so the scheduler.stop() loop
+      // doesn't race with our snapshot.
+      for (const item of scheduled) {
+        try {
+          item.trigger.cancel();
+        } catch (err) {
+          logger.error(`[bus-scheduler] trigger.cancel(${item.label}) failed`, err);
+        }
+      }
+      try {
+        await scheduler.stop();
+      } catch (err) {
+        logger.error("[bus-scheduler] scheduler.stop() failed", err);
+      }
+    },
+  };
+}

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -520,10 +520,24 @@ export async function start(args: string[] = []) {
           console.warn(`[${ts()}] Bus adapter "${name}" failed to mount: ${msg}`);
         }
         handle.attachAdapters(adapters);
+
+        // Sprint 5.2c: wire BusScheduler with heartbeat + jobs against
+        // the first spawned agent (matches legacy single-global-agent
+        // shape). The handle's stop() lifecycle owns scheduler
+        // teardown alongside adapters.
+        const { wireBusScheduler } = await import("../bus/scheduler-wiring");
+        const schedulerHandle = await wireBusScheduler({
+          bus,
+          defaultAgentId: handle.spawnedAgentIds[0] ?? null,
+          heartbeat: settings.heartbeat,
+          jobs,
+          timezoneOffsetMinutes: settings.timezoneOffsetMinutes,
+        });
+        handle.attachScheduler(schedulerHandle);
       } catch (wireErr) {
-        // Adapter wiring threw — stop the handle (which already owns
-        // the bus + agents) before re-throwing to the outer catch so
-        // the daemon falls back to legacy with everything torn down.
+        // Adapter / scheduler wiring threw — stop the handle (which
+        // already owns the bus + agents + whatever was attached
+        // before this throw) before re-throwing to the outer catch.
         try {
           await handle.stop();
         } catch (stopErr) {
@@ -1121,7 +1135,11 @@ export async function start(args: string[] = []) {
   // Install plugins without blocking daemon startup.
   startPreflightInBackground(process.cwd());
 
-  if (currentSettings.heartbeat.enabled) scheduleHeartbeat();
+  // Sprint 5.2c: when the Bus runtime is mounted, the legacy heartbeat
+  // tick is skipped — `wireBusScheduler` already registered the
+  // heartbeat against the Bus scheduler so firing it again here would
+  // double-trigger.
+  if (currentSettings.heartbeat.enabled && !skipLegacyAdapters) scheduleHeartbeat();
 
   // --- Hot-reload loop (every 30s) ---
   setInterval(async () => {


### PR DESCRIPTION
## Summary

Third of three Sprint 5.2 sub-PRs. Stacks on 5.2b (#123, merged). Wires
`BusScheduler` into the daemon so heartbeat + cron jobs fire under
`runtime: \"bus\"` instead of sitting dormant.

## Scope

### Shipped here
- `src/bus/scheduler-wiring.ts` — \`wireBusScheduler(bus, heartbeat,
  jobs, defaultAgentId)\` maps legacy `settings.heartbeat` + `loadJobs()`
  output into `BusScheduler` calls. Per-trigger failures (invalid cron
  expression, missing agent, etc.) log a warning and skip the offending
  trigger; the scheduler stays alive for the rest.
- `BusRuntimeHandle.attachScheduler(handle | null)` — mirrors
  `attachAdapters` from #123. Replacing the attachment stops the
  previous scheduler to avoid timer leaks.
- `src/commands/start.ts` — after `attachAdapters`, calls
  `wireBusScheduler` with the loaded jobs + first spawned agent as
  default. Catch path stops `handle` (which now owns the scheduler too)
  before falling back to legacy.
- Legacy `scheduleHeartbeat()` invocation gated on `!skipLegacyAdapters`
  so heartbeats don't double-fire under Bus.

Stop ordering inside `handle.stop()`:
  adapters → scheduler → slash detach → agents → bus

### Deferred to follow-ups
- `settings.heartbeat.excludeWindows` honouring — logged as a warning
  for now (operators relying on this stay on `runtime: \"pty\"`).
- Bus-adapter / Bus-scheduler hot-reload on settings change.
- Job-level model / timeout overrides under the Bus runtime.
- Upstream Slack feature port (tracking issue #121).

## Tests

+14 across two new + one extended file. All pass.

- `scheduler-wiring.test.ts` (+10, NEW): heartbeat gating (enabled +
  defaultAgentId, null-agent, disabled, excludeWindows warning); cron
  scheduling (every-enabled, enabled-false skip, per-job agent
  override, no-agent skip, invalid-cron survives); stop idempotent.
- `runtime-mount.test.ts` (+4): attachScheduler torn down on stop,
  null-attach safe, replacing scheduler stops previous, late attach
  schedules teardown.

Full repo suite: 1669 pass / 6 skip / 29 fail / 1 error. All
failures match the pre-existing baseline.

## Test plan

- [ ] `runtime: \"pty\"` (default) → no behaviour change.
- [ ] `runtime: \"bus\"` + `heartbeat.enabled: true` + one agent →
      heartbeat fires every `interval` minutes against that agent;
      legacy heartbeat does NOT fire.
- [ ] `runtime: \"bus\"` + cron job → job fires per schedule.
- [ ] `runtime: \"bus\"` + `excludeWindows` set → warning logged at
      boot but heartbeat still fires.
- [ ] SIGTERM cleanly cancels every trigger before bus IPC closes.

## Spec

\`docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md\` §5.6 / §10 Sprint 5.2.

## Sprint 5.2 status

| Sub-PR | What | Status |
|---|---|---|
| 5.2a | agents config + auto-spawn | merged (#122) |
| 5.2b | adapter wiring + routing + legacy gate-off | merged (#123) |
| 5.2c | BusScheduler heartbeat + cron | **this PR** |

After 5.2c merges, the Bus runtime is feature-complete for the
operator-visible surfaces under `runtime: \"bus\"`. Sprint 5.3 is the
Hetzner staging soak; Sprint 5.4 flips the default.