### PR TITLE
feat(bus): Sprint 5.2d — excludeWindows + scheduler hot-reload + paradigm docs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.55",
+      "version": "2.2.56",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.55",
+  "version": "2.2.56",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/heartbeat-windows.test.ts
+++ b/src/__tests__/heartbeat-windows.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for `src/heartbeat-windows.ts` (Sprint 5.2d).
+ *
+ * The window evaluator was previously a private helper in `start.ts`
+ * and had only indirect coverage via daemon-level integration tests.
+ * Extracted in PR #126 so `wireBusScheduler` can reuse it; the same
+ * extraction gives us a clean unit-test seam here.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { isHeartbeatExcludedAt } from "../heartbeat-windows";
+import type { HeartbeatConfig } from "../config";
+
+function cfg(over: Partial<HeartbeatConfig> = {}): HeartbeatConfig {
+  return {
+    enabled: true,
+    interval: 15,
+    prompt: "",
+    excludeWindows: [],
+    forwardToTelegram: false,
+    forwardToDiscord: false,
+    ...over,
+  };
+}
+
+/** Convenience: 2026-05-19 is a Tuesday (UTC). */
+const TUE_NOON = new Date("2026-05-19T12:00:00Z");
+const TUE_3AM = new Date("2026-05-19T03:00:00Z");
+const TUE_10PM = new Date("2026-05-19T22:00:00Z");
+
+describe("isHeartbeatExcludedAt", () => {
+  it("returns false when no windows configured", () => {
+    expect(isHeartbeatExcludedAt(cfg(), 0, TUE_NOON)).toBe(false);
+  });
+
+  it("excludes inside a same-day window (09:00 → 17:00)", () => {
+    const config = cfg({ excludeWindows: [{ start: "09:00", end: "17:00" }] });
+    expect(isHeartbeatExcludedAt(config, 0, TUE_NOON)).toBe(true);
+    // 03:00 falls outside.
+    expect(isHeartbeatExcludedAt(config, 0, TUE_3AM)).toBe(false);
+  });
+
+  it("excludes inside a wrap-around window (22:00 → 07:00)", () => {
+    const config = cfg({ excludeWindows: [{ start: "22:00", end: "07:00" }] });
+    // Tuesday 22:00 — start of the window.
+    expect(isHeartbeatExcludedAt(config, 0, TUE_10PM)).toBe(true);
+    // Tuesday 03:00 — inside the previous-day half (Mon 22:00 → Tue 07:00).
+    expect(isHeartbeatExcludedAt(config, 0, TUE_3AM)).toBe(true);
+    // Tuesday 12:00 — outside both halves.
+    expect(isHeartbeatExcludedAt(config, 0, TUE_NOON)).toBe(false);
+  });
+
+  it("respects per-window day filter", () => {
+    // Mon-Fri only.
+    const config = cfg({
+      excludeWindows: [{ start: "09:00", end: "17:00", days: [1, 2, 3, 4, 5] }],
+    });
+    // Tuesday noon is excluded.
+    expect(isHeartbeatExcludedAt(config, 0, TUE_NOON)).toBe(true);
+    // Sunday noon is NOT.
+    const SUN_NOON = new Date("2026-05-17T12:00:00Z");
+    expect(isHeartbeatExcludedAt(config, 0, SUN_NOON)).toBe(false);
+  });
+
+  it("start === end excludes the whole matching day", () => {
+    const config = cfg({ excludeWindows: [{ start: "00:00", end: "00:00", days: [2] }] });
+    expect(isHeartbeatExcludedAt(config, 0, TUE_3AM)).toBe(true);
+    expect(isHeartbeatExcludedAt(config, 0, TUE_NOON)).toBe(true);
+    expect(isHeartbeatExcludedAt(config, 0, TUE_10PM)).toBe(true);
+    // Monday is NOT excluded.
+    const MON_NOON = new Date("2026-05-18T12:00:00Z");
+    expect(isHeartbeatExcludedAt(config, 0, MON_NOON)).toBe(false);
+  });
+
+  it("malformed time strings are ignored without crashing", () => {
+    const config = cfg({
+      excludeWindows: [
+        { start: "not-a-time", end: "17:00" },
+        { start: "09:00", end: "also bad" },
+        { start: "09:00", end: "17:00" }, // valid
+      ],
+    });
+    // Only the valid window applies.
+    expect(isHeartbeatExcludedAt(config, 0, TUE_NOON)).toBe(true);
+    expect(isHeartbeatExcludedAt(config, 0, TUE_3AM)).toBe(false);
+  });
+
+  it("respects timezoneOffsetMinutes", () => {
+    // 12:00 UTC = 13:00 in UTC+1. A 13:00 window catches it.
+    const config = cfg({ excludeWindows: [{ start: "13:00", end: "14:00" }] });
+    expect(isHeartbeatExcludedAt(config, 0, TUE_NOON)).toBe(false);
+    expect(isHeartbeatExcludedAt(config, 60, TUE_NOON)).toBe(true);
+  });
+});

--- a/src/bus/__tests__/scheduler-wiring.test.ts
+++ b/src/bus/__tests__/scheduler-wiring.test.ts
@@ -111,7 +111,11 @@ describe("wireBusScheduler — heartbeat", () => {
     await handle.stop();
   });
 
-  it("warns but still schedules when excludeWindows are set (current limitation)", async () => {
+  it("schedules with shouldFire filter when excludeWindows are set (Sprint 5.2d)", async () => {
+    // No more warning — `wireBusScheduler` now honours excludeWindows
+    // via the scheduler's `shouldFire` filter. The log line includes
+    // the window count so operators can confirm it's wired.
+    const infos: string[] = [];
     const warnings: string[] = [];
     const handle = await wireBusScheduler({
       bus: stubBus(),
@@ -121,10 +125,15 @@ describe("wireBusScheduler — heartbeat", () => {
         excludeWindows: [{ start: "22:00", end: "07:00" }],
       }),
       jobs: [],
-      logger: { ...SILENT_LOGGER, warn: (m: string) => warnings.push(m) },
+      logger: {
+        ...SILENT_LOGGER,
+        warn: (m: string) => warnings.push(m),
+        info: (m: string) => infos.push(m),
+      },
     });
     expect(handle.scheduled).toHaveLength(1);
-    expect(warnings.some((w) => w.includes("excludeWindows"))).toBe(true);
+    expect(warnings).toHaveLength(0);
+    expect(infos.some((m) => m.includes("exclusion window"))).toBe(true);
     await handle.stop();
   });
 });

--- a/src/bus/__tests__/scheduler.test.ts
+++ b/src/bus/__tests__/scheduler.test.ts
@@ -276,6 +276,95 @@ describe("BusScheduler.scheduleHeartbeat", () => {
       }),
     ).toThrow();
   });
+
+  // Sprint 5.2d (PR #126): shouldFire filter — used by wireBusScheduler
+  // to honour `settings.heartbeat.excludeWindows`. Cadence is anchored
+  // to startedAt, so a skipped tick doesn't shift subsequent ones.
+
+  it("shouldFire=false skips the dispatch but keeps the cadence", () => {
+    const { bus, calls } = createFakeBus();
+    const clock = makeFakeClock();
+    scheduler = createBusScheduler({ bus, clock });
+
+    let allow = true;
+    scheduler.scheduleHeartbeat({
+      agent_id: "alpha",
+      interval_minutes: 1,
+      prompt: "ping",
+      shouldFire: () => allow,
+    });
+
+    // Tick 1 fires (filter returns true).
+    clock.advance(60_000);
+    expect(calls).toHaveLength(1);
+
+    // Tick 2 is gated off.
+    allow = false;
+    clock.advance(60_000);
+    expect(calls).toHaveLength(1);
+
+    // Tick 3 also gated.
+    clock.advance(60_000);
+    expect(calls).toHaveLength(1);
+
+    // Tick 4 re-enabled — fires normally.
+    allow = true;
+    clock.advance(60_000);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("shouldFire receives the current scheduler clock time", () => {
+    const { bus, calls } = createFakeBus();
+    const clock = makeFakeClock(1_700_000_000_000);
+    scheduler = createBusScheduler({ bus, clock });
+
+    const seenTimes: number[] = [];
+    scheduler.scheduleHeartbeat({
+      agent_id: "alpha",
+      interval_minutes: 1,
+      prompt: "ping",
+      shouldFire: (now) => {
+        seenTimes.push(now);
+        return true;
+      },
+    });
+
+    clock.advance(60_000);
+    clock.advance(60_000);
+    expect(calls).toHaveLength(2);
+    expect(seenTimes).toEqual([1_700_000_060_000, 1_700_000_120_000]);
+  });
+
+  it("shouldFire that throws routes to onError and skips the dispatch", () => {
+    const { bus, calls } = createFakeBus();
+    const clock = makeFakeClock();
+    const errors: unknown[] = [];
+    scheduler = createBusScheduler({
+      bus,
+      clock,
+      onError: (err) => errors.push(err),
+    });
+
+    scheduler.scheduleHeartbeat({
+      agent_id: "alpha",
+      interval_minutes: 1,
+      prompt: "ping",
+      shouldFire: () => {
+        throw new Error("filter boom");
+      },
+    });
+
+    clock.advance(60_000);
+    // Dispatch suppressed (fail-closed) and the error surfaced via
+    // onError. The schedule continues — next tick still scheduled.
+    expect(calls).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+
+    // Filter still throws next tick — dispatch still skipped.
+    clock.advance(60_000);
+    expect(calls).toHaveLength(0);
+    expect(errors).toHaveLength(2);
+  });
 });
 
 /* ───────────────────────────────────────────────────────────────────── */

--- a/src/bus/scheduler-wiring.ts
+++ b/src/bus/scheduler-wiring.ts
@@ -13,29 +13,42 @@
  *   - `settings.heartbeat.enabled === true` → one `scheduleHeartbeat`
  *     call against the default agent_id. The legacy heartbeat ran a
  *     single global session so "first agent" matches that behaviour.
+ *     `excludeWindows` is honoured via the scheduler's `shouldFire`
+ *     filter (Sprint 5.2d).
  *   - Each `Job` from `loadJobs()` → one `scheduleCron` call. Jobs with
- *     `enabled: false` are skipped (legacy parity).
- *     - `job.agent` overrides the default agent_id when set; otherwise
- *       the default applies.
- *     - The job's `prompt` is forwarded verbatim — model / timeout
- *       overrides aren't honoured under the Bus runtime yet (Sprint
- *       5.2c+ follow-up).
+ *     `enabled: false` are skipped (legacy parity). `job.agent`
+ *     overrides the default agent_id when set; otherwise the default
+ *     applies.
  *
- * Not handled (deliberately):
- *   - `settings.heartbeat.excludeWindows` — the BusScheduler doesn't
- *     model exclusion windows. The legacy `isHeartbeatExcludedNow`
- *     check lives in `start.ts`'s tick(); we'd need to add a
- *     scheduler-side filter for the Bus path. Tracked for Sprint
- *     5.2c+ follow-up; for now operators using exclusion windows stay
- *     on `runtime: pty`.
- *   - Hot-reload on settings change. The schedule survives until
- *     daemon restart.
+ * Paradigm shift for per-job model / timeout overrides:
+ *   Under the legacy runtime, `job.model` / `job.timeoutSeconds` would
+ *   spin up a one-shot `claude -p` with the override. Under the Bus
+ *   runtime, agents are LONG-LIVED PTY sessions with model + timeout
+ *   baked in at spawn time, so per-job overrides don't fit the model.
+ *
+ *   To route a job to a different model under `runtime: "bus"`:
+ *     1. Declare a second agent in `settings.agents` with the desired
+ *        model (operators set the model via the agent's launch args /
+ *        system-prompt-file rather than per-call).
+ *     2. Set `job.agent` to that agent's id.
+ *
+ *   This is a cleaner architectural fit than the legacy per-job
+ *   override (which was a workaround for there being only one global
+ *   agent) and lets operators co-locate model + budget + auth
+ *   decisions per-agent.
+ *
+ * Sprint 5.2d follow-up gaps:
+ *   - Bus-adapter hot-reload on settings change: still requires
+ *     daemon restart. The scheduler IS hot-reloaded by `start.ts`'s
+ *     30s reload loop (heartbeat / job changes rebuild the scheduler
+ *     in-process).
  */
 
 import type { BusCore } from "./core";
 import { createBusScheduler, type BusScheduler, type ScheduledTrigger } from "./scheduler";
 import type { HeartbeatConfig } from "../config";
 import type { Job } from "../jobs";
+import { isHeartbeatExcludedAt } from "../heartbeat-windows";
 
 export interface ScheduledItem {
   /** Stable label for logging — e.g. `"heartbeat"` or `"cron:auto-commit"`. */
@@ -91,23 +104,31 @@ export async function wireBusScheduler(opts: WireBusSchedulerOptions): Promise<B
 
   // Heartbeat: one trigger per daemon when enabled.
   if (opts.heartbeat.enabled && opts.defaultAgentId) {
-    if (opts.heartbeat.excludeWindows.length > 0) {
-      // Documented limitation — operators relying on this stay on
-      // `runtime: pty` until the scheduler grows exclusion-window
-      // support.
-      logger.warn(
-        "[bus-scheduler] settings.heartbeat.excludeWindows is set but the Bus scheduler doesn't honour it yet. The heartbeat will fire every interval regardless of windowing.",
-      );
-    }
+    // Sprint 5.2d (PR #126): excludeWindows is now honoured via a
+    // shouldFire filter on each tick. The filter captures the
+    // heartbeat config + timezone offset by reference — hot-reload
+    // (Sprint 5.2d follow-up) rebuilds the scheduler, so a stale
+    // capture isn't a concern.
+    const heartbeatCfg = opts.heartbeat;
+    const tzOffset = opts.timezoneOffsetMinutes ?? 0;
+    const shouldFire = (nowMs: number): boolean => {
+      if (heartbeatCfg.excludeWindows.length === 0) return true;
+      return !isHeartbeatExcludedAt(heartbeatCfg, tzOffset, new Date(nowMs));
+    };
     try {
       const trigger = scheduler.scheduleHeartbeat({
         agent_id: opts.defaultAgentId,
         interval_minutes: opts.heartbeat.interval,
         prompt: opts.heartbeat.prompt,
+        shouldFire,
       });
       scheduled.push({ label: "heartbeat", trigger });
+      const windowLabel =
+        opts.heartbeat.excludeWindows.length > 0
+          ? `, ${opts.heartbeat.excludeWindows.length} exclusion window(s) honoured`
+          : "";
       logger.info(
-        `[bus-scheduler] heartbeat scheduled every ${opts.heartbeat.interval}m for agent="${opts.defaultAgentId}"`,
+        `[bus-scheduler] heartbeat scheduled every ${opts.heartbeat.interval}m for agent="${opts.defaultAgentId}"${windowLabel}`,
       );
     } catch (err) {
       logger.warn(

--- a/src/bus/scheduler.ts
+++ b/src/bus/scheduler.ts
@@ -55,6 +55,23 @@ export interface ScheduleHeartbeatRequest {
   interval_minutes: number;
   prompt: string;
   metadata?: Record<string, unknown>;
+  /**
+   * Optional fire-time filter. Evaluated synchronously at each tick BEFORE
+   * the `bus.sendPrompt` dispatch. Returning `false` skips the dispatch
+   * for that tick and reschedules the next one at the normal cadence —
+   * cadence is anchored to `startedAt`, so a skipped tick doesn't shift
+   * subsequent ones.
+   *
+   * Sprint 5.2d (PR #126): used by `wireBusScheduler` to honour
+   * `settings.heartbeat.excludeWindows`. The scheduler core stays
+   * agnostic to exclusion semantics; the operator-facing config lives
+   * in the wiring layer.
+   *
+   * Filter exceptions are routed to the scheduler's `onError` and the
+   * dispatch is skipped (fail-closed: if we can't decide, don't bug
+   * the operator at 3am).
+   */
+  shouldFire?: (now: number) => boolean;
 }
 
 export interface ScheduleCronRequest {
@@ -180,6 +197,24 @@ class BusSchedulerImpl implements BusScheduler {
       const nextTargetAbs = startedAt + (tickIndex + 1) * intervalMs;
       const delay = Math.max(0, nextTargetAbs - this.clock.now());
       rec.handle = this.clock.setTimeout(fire, delay);
+
+      // shouldFire gate (Sprint 5.2d). Evaluate BEFORE dispatch so an
+      // excluded window skips this tick cleanly. Cadence still anchored
+      // to startedAt, so a skip doesn't shift subsequent ticks. Filter
+      // exceptions fail-closed (skip dispatch) to avoid 3am surprises.
+      if (req.shouldFire) {
+        let allow = false;
+        try {
+          allow = req.shouldFire(this.clock.now());
+        } catch (err) {
+          this.onError(err, {
+            ctx: "scheduleHeartbeat.shouldFire",
+            agent_id: req.agent_id,
+            tick: tickIndex,
+          });
+        }
+        if (!allow) return;
+      }
 
       // Dispatch this tick. Failures are swallowed into onError — one
       // bad sendPrompt must not break the cadence.

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -37,6 +37,7 @@ import {
   type Settings,
 } from "../config";
 import { getDayAndMinuteAtOffset, buildClockPromptPrefix } from "../timezone";
+import { isHeartbeatExcludedAt, isHeartbeatExcludedNow } from "../heartbeat-windows";
 import { startWebUi, type WebServerHandle } from "../web";
 import { initializeJobSystem } from "../orchestrator/resumable-jobs";
 import type { Job } from "../jobs";
@@ -153,50 +154,9 @@ try {
 }
 `;
 
-const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
-
-function parseClockMinutes(value: string): number | null {
-  const match = value.match(/^([01]\d|2[0-3]):([0-5]\d)$/);
-  if (!match) return null;
-  return Number(match[1]) * 60 + Number(match[2]);
-}
-
-function isHeartbeatExcludedNow(config: HeartbeatConfig, timezoneOffsetMinutes: number): boolean {
-  return isHeartbeatExcludedAt(config, timezoneOffsetMinutes, new Date());
-}
-
-function isHeartbeatExcludedAt(
-  config: HeartbeatConfig,
-  timezoneOffsetMinutes: number,
-  at: Date,
-): boolean {
-  if (!Array.isArray(config.excludeWindows) || config.excludeWindows.length === 0) return false;
-  const local = getDayAndMinuteAtOffset(at, timezoneOffsetMinutes);
-
-  for (const window of config.excludeWindows) {
-    const start = parseClockMinutes(window.start);
-    const end = parseClockMinutes(window.end);
-    if (start == null || end == null) continue;
-    const days = Array.isArray(window.days) && window.days.length > 0 ? window.days : ALL_DAYS;
-    const sameDay = start < end;
-
-    if (sameDay) {
-      if (days.includes(local.day) && local.minute >= start && local.minute < end) return true;
-      continue;
-    }
-
-    if (start === end) {
-      if (days.includes(local.day)) return true;
-      continue;
-    }
-
-    if (local.minute >= start && days.includes(local.day)) return true;
-    const previousDay = (local.day + 6) % 7;
-    if (local.minute < end && days.includes(previousDay)) return true;
-  }
-
-  return false;
-}
+// Sprint 5.2d (PR #126): exclusion-window logic extracted to
+// `src/heartbeat-windows.ts` so `wireBusScheduler` can reuse it. The
+// legacy heartbeat tick still imports + calls these.
 
 function nextAllowedHeartbeatAt(
   config: HeartbeatConfig,
@@ -443,7 +403,10 @@ export async function start(args: string[] = []) {
   let web: WebServerHandle | null = null;
   let discordStopGateway: (() => void) | null = null;
   let slackStopFn: (() => void) | null = null;
-  let busRuntimeHandle: { stop(): Promise<void> } | null = null;
+  // Full `BusRuntimeHandle` shape (rather than the narrow `{stop}`)
+  // so the hot-reload loop can reach `.bus` to rebuild the scheduler
+  // when heartbeat/jobs change. Sprint 5.2d.
+  let busRuntimeHandle: import("../bus/runtime-mount").BusRuntimeHandle | null = null;
 
   // Plugin system — initialize before gateway start
   const pluginManager = new PluginManager(process.cwd());
@@ -1174,7 +1137,7 @@ export async function start(args: string[] = []) {
           `[${ts()}] Config change detected — heartbeat: ${newSettings.heartbeat.enabled ? `every ${newSettings.heartbeat.interval}m` : "disabled"}`,
         );
         currentSettings = newSettings;
-        scheduleHeartbeat();
+        if (!skipLegacyAdapters) scheduleHeartbeat();
       } else {
         currentSettings = newSettings;
       }
@@ -1209,11 +1172,34 @@ export async function start(args: string[] = []) {
 
         // Slack changes
         await initSlack(newSettings.slack.botToken, newSettings.slack.appToken);
+      } else if (busRuntimeHandle && (hbChanged || jobNames !== oldJobNames)) {
+        // Sprint 5.2d: Bus-scheduler hot-reload for heartbeat + jobs.
+        // Adapter routing changes still require daemon restart — only
+        // the scheduler's per-trigger registration is cheap enough to
+        // rebuild in-process (cancel + create against the live bus).
+        try {
+          const { wireBusScheduler } = await import("../bus/scheduler-wiring");
+          const fresh = await wireBusScheduler({
+            bus: busRuntimeHandle.bus,
+            defaultAgentId: busRuntimeHandle.spawnedAgentIds[0] ?? null,
+            heartbeat: newSettings.heartbeat,
+            jobs: newJobs,
+            timezoneOffsetMinutes: newSettings.timezoneOffsetMinutes,
+          });
+          // attachScheduler stops the previous scheduler before
+          // replacing it (see runtime-mount.ts) so old triggers can't
+          // leak.
+          busRuntimeHandle.attachScheduler(fresh);
+          console.log(`[${ts()}] Bus scheduler reloaded — ${fresh.scheduled.length} trigger(s)`);
+        } catch (reErr) {
+          console.error(`[${ts()}] Bus scheduler hot-reload failed`, reErr);
+        }
       }
-      // Note: when `skipLegacyAdapters` is true, the Bus adapters are
-      // long-lived (mounted at boot via `wireBusAdapters`) and don't
-      // currently hot-reload on settings changes. Sprint 5.2c follow-up
-      // wires a settings-watcher into the Bus adapters too.
+      // Note: Bus ADAPTER changes (routing, tokens) still require a
+      // daemon restart. Hot-reloading running adapters with new
+      // routing would invalidate pending permission/ask maps; the
+      // restart is the safer move until we have a session-migration
+      // story.
     } catch (err) {
       console.error(`[${ts()}] Hot-reload error:`, err);
     }

--- a/src/heartbeat-windows.ts
+++ b/src/heartbeat-windows.ts
@@ -1,0 +1,80 @@
+/**
+ * Heartbeat exclusion-window evaluator.
+ *
+ * Extracted from `src/commands/start.ts` (Sprint 5.2d, PR #126) so the
+ * Bus runtime's `wireBusScheduler` can honour `settings.heartbeat.
+ * excludeWindows` without duplicating the legacy semantics.
+ *
+ * Window semantics:
+ *   - Each window has `start: "HH:MM"` and `end: "HH:MM"` in the
+ *     daemon's configured timezone (offset minutes).
+ *   - When `start < end`, the window is same-day (e.g. 22:00–07:00 is
+ *     NOT same-day; 09:00–17:00 IS).
+ *   - When `start > end`, the window wraps midnight (22:00–07:00 ⇒ from
+ *     22:00 today through 07:00 tomorrow). The previous-day membership
+ *     of `days` is consulted for the post-midnight half.
+ *   - When `start === end`, the entire matching day is excluded.
+ *   - `days` is a list of weekday numbers (0=Sun … 6=Sat). Empty /
+ *     missing = every day.
+ */
+
+import type { HeartbeatConfig } from "./config";
+import { getDayAndMinuteAtOffset } from "./timezone";
+
+const TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/;
+const ALL_DAYS = [0, 1, 2, 3, 4, 5, 6];
+
+function parseClockMinutes(value: string): number | null {
+  const match = TIME_RE.exec(value);
+  if (!match) return null;
+  return Number(match[1]) * 60 + Number(match[2]);
+}
+
+/** Convenience wrapper using `new Date()`. */
+export function isHeartbeatExcludedNow(
+  config: HeartbeatConfig,
+  timezoneOffsetMinutes: number,
+): boolean {
+  return isHeartbeatExcludedAt(config, timezoneOffsetMinutes, new Date());
+}
+
+/**
+ * Check whether a given `Date` falls inside any configured exclusion
+ * window in the daemon's timezone.
+ */
+export function isHeartbeatExcludedAt(
+  config: HeartbeatConfig,
+  timezoneOffsetMinutes: number,
+  at: Date,
+): boolean {
+  if (!Array.isArray(config.excludeWindows) || config.excludeWindows.length === 0) return false;
+  const local = getDayAndMinuteAtOffset(at, timezoneOffsetMinutes);
+
+  for (const window of config.excludeWindows) {
+    const start = parseClockMinutes(window.start);
+    const end = parseClockMinutes(window.end);
+    if (start == null || end == null) continue;
+    const days = Array.isArray(window.days) && window.days.length > 0 ? window.days : ALL_DAYS;
+    const sameDay = start < end;
+
+    if (sameDay) {
+      if (days.includes(local.day) && local.minute >= start && local.minute < end) return true;
+      continue;
+    }
+
+    if (start === end) {
+      if (days.includes(local.day)) return true;
+      continue;
+    }
+
+    // Wrap-around: post-midnight half belongs to the PREVIOUS day's
+    // window membership (e.g. a Friday 22:00–Saturday 07:00 window
+    // excludes Saturday 03:00 even though the window's `days` lists
+    // Friday).
+    if (local.minute >= start && days.includes(local.day)) return true;
+    const previousDay = (local.day + 6) % 7;
+    if (local.minute < end && days.includes(previousDay)) return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

Follow-up to Sprint 5.2c (#125, merged). Closes the three gaps called
out in that PR's deferred list so Sprint 5.3 (Hetzner staging) goes in
clean.

## Scope

### 1. `excludeWindows` honoured under `runtime: \"bus\"`
- New `ScheduleHeartbeatRequest.shouldFire?: (now) => boolean` filter on
  `BusScheduler`. Evaluated each tick before dispatch; skip keeps
  cadence (anchored to `startedAt`).
- `wireBusScheduler` passes a filter built from `isHeartbeatExcludedAt`.
- Filter exceptions fail-closed (skip + log) so broken window config
  can't bug operators at 3am.

### 2. Scheduler hot-reload for heartbeat + jobs
- `start.ts`'s 30s reload loop already detects heartbeat/jobs changes.
  Under `runtime: \"bus\"` it now rebuilds via `wireBusScheduler` and
  re-attaches with `handle.attachScheduler` (stops the previous
  scheduler — already wired in #123/#125).
- Bus ADAPTER changes (tokens, routing) still require restart;
  documented in the comment alongside the rebuild branch.

### 3. Per-agent model override paradigm documented
Under the Bus runtime, agents are long-lived PTY sessions with model +
timeout baked in at spawn. Per-job override doesn't fit. Route a job to
a different model by declaring a second agent and setting `job.agent`.
Documented in the `scheduler-wiring.ts` docstring; legacy `job.model` /
`job.timeoutSeconds` become a documented \"not honoured under bus\"
once Sprint 5.4 flips the default.

### Refactor (no behaviour change for `runtime: pty`)
`isHeartbeatExcludedAt` / `isHeartbeatExcludedNow` / `parseClockMinutes`
/ `ALL_DAYS` extracted from `start.ts` (where they had only indirect
coverage) into a new `src/heartbeat-windows.ts` module so
`wireBusScheduler` can reuse them. Legacy heartbeat tick imports the
same helpers.

## Tests

+11 across one new + two extended files. All pass.

- `heartbeat-windows.test.ts` (+7, NEW): no-window pass-through,
  same-day, wrap-around, per-window day filter, start==end whole-day,
  malformed-time tolerance, timezone offset.
- `scheduler.test.ts` (+3): shouldFire=false skips but keeps cadence,
  shouldFire receives clock time, shouldFire throw routes to onError.
- `scheduler-wiring.test.ts` (1 updated): excludeWindows no longer
  warns; info log mentions exclusion windows.

Full repo suite: 1679 pass / 6 skip / 28 fail / 2 errors. All
failures match the pre-existing baseline.

## Test plan

- [ ] `runtime: \"bus\"` + `heartbeat.enabled` + `excludeWindows:
      [{start: \"22:00\", end: \"07:00\"}]` → heartbeat fires during
      the day but skips overnight; no warning logged at boot.
- [ ] Hot-reload: change `heartbeat.interval` from 15→30 in
      settings.json; within 30s daemon logs `Bus scheduler reloaded —
      N trigger(s)`; new cadence takes effect.
- [ ] Add a new cron job in `.claude/claudeclaw/jobs/`; within 30s the
      Bus scheduler picks it up.
- [ ] `runtime: \"pty\"` (default) — no behaviour change vs main.

## Spec

`docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md` §5.6 / §10 Sprint 5.2.

## Sprint 5.2 status

| Sub-PR | What | Status |
|---|---|---|
| 5.2a | agents config + auto-spawn | merged (#122) |
| 5.2b | adapter wiring + routing + gate-off | merged (#123) |
| 5.2c | BusScheduler heartbeat + cron | merged (#125) |
| **5.2d** | **excludeWindows + hot-reload + paradigm docs** | **this PR** |

After 5.2d lands, Bus runtime is feature-complete for operator-visible
surfaces (modulo Bus-adapter hot-reload, intentionally deferred).
Sprint 5.3 — Hetzner staging soak.
Sprint 5.4 — default flip + migration guide.