### PR TITLE
fix(bus): expand jobs digest to detect enabled+agent changes (Codex P1 on #126)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.56",
+      "version": "2.2.57",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.56",
+  "version": "2.2.57",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/jobs-digest.test.ts
+++ b/src/__tests__/jobs-digest.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Tests for `computeJobsDigest` (extracted from `src/commands/start.ts`
+ * in the Codex P1 fix on PR #126).
+ *
+ * The digest determines whether the daemon's 30s hot-reload loop
+ * triggers a Bus scheduler rebuild. If the digest misses a
+ * scheduler-relevant field, in-memory triggers go stale until restart.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { computeJobsDigest } from "../commands/start";
+import type { Job } from "../jobs";
+
+function job(over: Partial<Job> = {}): Job {
+  return {
+    name: over.name ?? "test",
+    schedule: over.schedule ?? "*/5 * * * *",
+    prompt: over.prompt ?? "do the thing",
+    recurring: over.recurring ?? true,
+    notify: over.notify ?? false,
+    ...over,
+  };
+}
+
+describe("computeJobsDigest", () => {
+  it("returns identical digests for identical lists", () => {
+    const a = [job({ name: "a" }), job({ name: "b" })];
+    const b = [job({ name: "b" }), job({ name: "a" })]; // order shouldn't matter
+    expect(computeJobsDigest(a)).toBe(computeJobsDigest(b));
+  });
+
+  it("differs when schedule changes", () => {
+    const a = computeJobsDigest([job({ name: "x", schedule: "*/5 * * * *" })]);
+    const b = computeJobsDigest([job({ name: "x", schedule: "*/10 * * * *" })]);
+    expect(a).not.toBe(b);
+  });
+
+  it("differs when prompt changes", () => {
+    const a = computeJobsDigest([job({ name: "x", prompt: "ping" })]);
+    const b = computeJobsDigest([job({ name: "x", prompt: "pong" })]);
+    expect(a).not.toBe(b);
+  });
+
+  it("differs when enabled toggles (Codex P1 on PR #126)", () => {
+    const enabled = computeJobsDigest([job({ name: "x", enabled: true })]);
+    const disabled = computeJobsDigest([job({ name: "x", enabled: false })]);
+    expect(enabled).not.toBe(disabled);
+  });
+
+  it("missing enabled treated as true (default semantics)", () => {
+    // `enabled` is optional in the legacy Job shape; absence means
+    // enabled. The digest must treat it the same so a settings file
+    // that promotes a job from "no field" to "enabled: true" doesn't
+    // false-positive a reload.
+    const missing = computeJobsDigest([job({ name: "x" })]);
+    const explicit = computeJobsDigest([job({ name: "x", enabled: true })]);
+    expect(missing).toBe(explicit);
+  });
+
+  it("differs when agent changes (Codex P1 on PR #126)", () => {
+    const a = computeJobsDigest([job({ name: "x", agent: "triage" })]);
+    const b = computeJobsDigest([job({ name: "x", agent: "research" })]);
+    expect(a).not.toBe(b);
+  });
+
+  it("missing agent matches empty-string agent (no false-positive reload)", () => {
+    const missing = computeJobsDigest([job({ name: "x" })]);
+    const empty = computeJobsDigest([job({ name: "x", agent: "" })]);
+    expect(missing).toBe(empty);
+  });
+
+  it("adding a job changes the digest", () => {
+    const a = computeJobsDigest([job({ name: "x" })]);
+    const b = computeJobsDigest([job({ name: "x" }), job({ name: "y" })]);
+    expect(a).not.toBe(b);
+  });
+
+  it("empty list digest is stable", () => {
+    expect(computeJobsDigest([])).toBe(computeJobsDigest([]));
+  });
+});

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -158,6 +158,34 @@ try {
 // `src/heartbeat-windows.ts` so `wireBusScheduler` can reuse it. The
 // legacy heartbeat tick still imports + calls these.
 
+/**
+ * Stable digest of the jobs that affect scheduler behaviour. Two job
+ * lists with identical digests can re-use the existing in-memory
+ * scheduler; different digests trigger the hot-reload path.
+ *
+ * Fields covered:
+ *   - `name` — keying / log labels.
+ *   - `schedule` — cron expression.
+ *   - `prompt` — payload sent at each fire.
+ *   - `enabled` — when toggled to false, the Bus scheduler must drop
+ *     the trigger. Defaults to true when missing.
+ *   - `agent` — when changed, the Bus scheduler must reroute. Defaults
+ *     to "" when missing (matches the daemon's "use first agent"
+ *     fallback).
+ *
+ * Codex P1 on PR #126: pre-fix this only covered schedule + prompt,
+ * so flipping `enabled` or rerouting `agent` left stale triggers
+ * firing until daemon restart.
+ *
+ * Exported for unit testing.
+ */
+export function computeJobsDigest(jobs: readonly Job[]): string {
+  return jobs
+    .map((j) => `${j.name}:${j.schedule}:${j.prompt}:${j.enabled !== false}:${j.agent ?? ""}`)
+    .sort()
+    .join("|");
+}
+
 function nextAllowedHeartbeatAt(
   config: HeartbeatConfig,
   timezoneOffsetMinutes: number,
@@ -1146,15 +1174,15 @@ export async function start(args: string[] = []) {
         currentSettings.web.port = web.port;
       }
 
-      // Detect job changes
-      const jobNames = newJobs
-        .map((j) => `${j.name}:${j.schedule}:${j.prompt}`)
-        .sort()
-        .join("|");
-      const oldJobNames = currentJobs
-        .map((j) => `${j.name}:${j.schedule}:${j.prompt}`)
-        .sort()
-        .join("|");
+      // Detect job changes. Digest covers every field the schedulers
+      // consume: schedule + prompt for both paths, plus `enabled` and
+      // `agent` which the Bus scheduler uses to decide whether the job
+      // fires AND which agent it dispatches to (Codex P1 on PR #126 —
+      // `enabled: false` toggles and `agent` reroutes were silently
+      // ignored, so the in-memory scheduler kept stale triggers until
+      // restart).
+      const jobNames = computeJobsDigest(newJobs);
+      const oldJobNames = computeJobsDigest(currentJobs);
       if (jobNames !== oldJobNames) {
         console.log(`[${ts()}] Jobs reloaded: ${newJobs.length} job(s)`);
         newJobs.forEach((j) => {


### PR DESCRIPTION
## Summary

Codex P1 follow-up on PR #126 (Sprint 5.2d). The 30s hot-reload loop's
job digest only covered `name:schedule:prompt`, so under `runtime: \"bus\"`
two scheduler-relevant fields slipped through:

- `job.enabled: true → false` — disabled jobs kept firing because the
  digest didn't change, so `wireBusScheduler` was never re-invoked.
- `job.agent` reroute — dispatched to the OLD agent until restart.

Both held until daemon restart or another tracked field shifted. The
legacy `runtime: \"pty\"` path was unaffected.

## Fix

Extract `computeJobsDigest` to a pure helper covering
`name:schedule:prompt:enabled:agent`. Sensible defaults so legitimate
omissions don't false-positive a reload:
- missing `enabled` → `true` (matches `loadJobs` default)
- missing `agent` → `\"\"` (matches \"use first spawned agent\" fallback)

## Tests

+9 in `src/__tests__/jobs-digest.test.ts` (NEW): identical lists in
any order → identical digest; differs on schedule/prompt/enabled/agent
change; missing enabled treated as true; missing agent matches empty
string; add/remove jobs detected; empty list stable.

Full repo: 1688 pass / 6 skip / 29 fail / 1 error — baseline.

## Test plan

- [ ] `runtime: \"bus\"` + an existing enabled job → toggle to
      `enabled: false` in the job's frontmatter; within 30s daemon
      logs `Bus scheduler reloaded` and the job stops firing.
- [ ] Same with `agent` reroute — within 30s the dispatch shifts to
      the new agent.

Version bump: 2.2.56 → 2.2.57.