### PR TITLE
feat(slack): port upstream features into Bus adapter (closes #121)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.58",
+      "version": "2.2.59",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.58",
+  "version": "2.2.59",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/slack/__tests__/slack.test.ts
+++ b/src/adapters/slack/__tests__/slack.test.ts
@@ -238,16 +238,27 @@ async function startAdapter(
 }
 
 function msg(over: Partial<SlackMessageEvent> = {}): SlackMessageEvent {
+  // Honour explicit `user: undefined` (used by bot-message tests) — `??`
+  // would otherwise back-fill the default. `in` check distinguishes
+  // "key absent" from "key present with undefined".
+  const user = "user" in over ? over.user : "U42";
   return {
     type: over.type ?? "message",
     channel: over.channel ?? "C100",
-    user: over.user ?? "U42",
+    user,
     ts: over.ts ?? "1700000000.000100",
     text: over.text ?? "hello",
     thread_ts: over.thread_ts,
     bot_id: over.bot_id,
     subtype: over.subtype,
     files: over.files,
+    // Issue #121 fields — forward when set so the new test cases can
+    // exercise allowBots, block / attachment extraction, and per-bot
+    // display-name routing.
+    username: over.username,
+    bot_profile: over.bot_profile,
+    blocks: over.blocks,
+    attachments: over.attachments,
   };
 }
 
@@ -1203,5 +1214,328 @@ describe("createSlackApi — fetch timeout (PR #117 review)", () => {
     } finally {
       globalThis.fetch = realFetch;
     }
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Issue #121 — upstream Slack feature port                                */
+/* ────────────────────────────────────────────────────────────────────── */
+
+import { extractTextFromAttachments, extractTextFromBlocks, sanitiseBotText } from "../index";
+
+describe("Issue #121 — upstream PR #210 allowBots + allowBotIds", () => {
+  it("drops bot messages by default (no allowBots config)", async () => {
+    adapter = await startAdapter();
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: undefined,
+          bot_id: "B-monitor",
+          text: "alert: cpu pegged",
+        }),
+      ),
+    );
+    await new Promise((r) => setTimeout(r, 30));
+    expect(bus.prompts).toHaveLength(0);
+  });
+
+  it("passes through bot messages when channel is in allowBots", async () => {
+    adapter = await startAdapter({ allowBots: ["C100"] });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: undefined,
+          bot_id: "B-monitor",
+          text: "alert: cpu pegged",
+        }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts[0]?.text).toBe("alert: cpu pegged");
+    expect(bus.prompts[0]?.user_id).toBe("B-monitor");
+    expect((bus.prompts[0]?.metadata as Record<string, unknown>).bot_id).toBe("B-monitor");
+  });
+
+  it("bypasses allowedUserIds for bot-allowed traffic", async () => {
+    // Tight allow-list — would normally drop anyone but U42.
+    adapter = await startAdapter({
+      allowedUserIds: ["U42"],
+      allowBots: ["C100"],
+    });
+    socket.push(
+      eventsEnvelope(msg({ channel: "C100", user: undefined, bot_id: "B-monitor", text: "alert" })),
+    );
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts).toHaveLength(1);
+  });
+
+  it("allowBotIds narrows to specific bot ids when set", async () => {
+    adapter = await startAdapter({
+      allowBots: ["C100"],
+      allowBotIds: ["B-trusted"],
+    });
+    // Allowed channel but the wrong bot id — drop.
+    socket.push(
+      eventsEnvelope(
+        msg({ channel: "C100", user: undefined, bot_id: "B-stranger", text: "alert" }),
+      ),
+    );
+    // Allowed channel + correct bot id — pass.
+    socket.push(
+      eventsEnvelope(
+        msg({ channel: "C100", user: undefined, bot_id: "B-trusted", text: "trusted alert" }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts).toHaveLength(1);
+    expect(bus.prompts[0]?.text).toBe("trusted alert");
+  });
+
+  it("prefers bot_profile.name → username → bot_id for user_id label", async () => {
+    adapter = await startAdapter({ allowBots: ["C100"] });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: undefined,
+          bot_id: "B-monitor",
+          bot_profile: { name: "Grafana" },
+          username: "fallback-name",
+          text: "alert",
+        }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts[0]?.user_id).toBe("Grafana");
+  });
+
+  it("accepts bot_message subtype only for allowed bot channels", async () => {
+    adapter = await startAdapter({
+      allowBots: ["C100"],
+      routing: { channels: { C100: "triage", C200: "research" } },
+    });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          subtype: "bot_message",
+          user: undefined,
+          bot_id: "B-bot",
+          text: "alert from bot_message",
+        }),
+      ),
+    );
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C200",
+          subtype: "bot_message",
+          user: undefined,
+          bot_id: "B-bot",
+          text: "should be dropped — channel not in allowBots",
+        }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts).toHaveLength(1);
+    expect(bus.prompts[0]?.text).toBe("alert from bot_message");
+  });
+});
+
+describe("Issue #121 — upstream PR #211 block/attachment extraction", () => {
+  it("extractTextFromBlocks walks text + fields + elements", () => {
+    const result = extractTextFromBlocks([
+      { type: "section", text: { type: "mrkdwn", text: "title" } },
+      {
+        type: "section",
+        fields: [
+          { type: "mrkdwn", text: "Status: red" },
+          { type: "mrkdwn", text: "Host: web-01" },
+        ],
+      },
+      {
+        type: "actions",
+        elements: [{ type: "button", text: { type: "plain_text", text: "Ack" } }],
+      },
+    ]);
+    expect(result).toContain("title");
+    expect(result).toContain("Status: red");
+    expect(result).toContain("Host: web-01");
+    expect(result).toContain("Ack");
+  });
+
+  it("extractTextFromAttachments joins pretext + title + text + fields", () => {
+    const result = extractTextFromAttachments([
+      {
+        pretext: "ALERT",
+        title: "CPU > 90%",
+        text: "web-01 has been over 90% for 5 minutes",
+        fields: [
+          { title: "Severity", value: "P1" },
+          { title: "Host", value: "web-01" },
+        ],
+      },
+    ]);
+    expect(result).toContain("ALERT");
+    expect(result).toContain("CPU > 90%");
+    expect(result).toContain("web-01");
+    expect(result).toContain("Severity:");
+    expect(result).toContain("P1");
+  });
+
+  it("falls back to blocks when event.text is empty", async () => {
+    adapter = await startAdapter({ allowBots: ["C100"] });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: undefined,
+          bot_id: "B-monitor",
+          text: "",
+          blocks: [{ type: "section", text: { type: "mrkdwn", text: "from blocks" } }],
+        }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts[0]?.text).toBe("from blocks");
+  });
+
+  it("falls back to attachments when blocks AND text are empty", async () => {
+    adapter = await startAdapter({ allowBots: ["C100"] });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: undefined,
+          bot_id: "B-monitor",
+          text: "",
+          attachments: [{ text: "from attachments" }],
+        }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts[0]?.text).toBe("from attachments");
+  });
+
+  it("text wins over blocks/attachments when all three present", async () => {
+    adapter = await startAdapter({ allowBots: ["C100"] });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: undefined,
+          bot_id: "B-monitor",
+          text: "primary text",
+          blocks: [{ type: "section", text: { type: "mrkdwn", text: "block text" } }],
+          attachments: [{ text: "attachment text" }],
+        }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts[0]?.text).toBe("primary text");
+  });
+});
+
+describe("Issue #121 — upstream PR #214 replyThreadTs routing for bots", () => {
+  it("non-thread bot message records owner under event.ts as the synthetic thread", async () => {
+    adapter = await startAdapter({ allowBots: ["C100"] });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: undefined,
+          bot_id: "B-monitor",
+          ts: "1700000000.123",
+          text: "alert",
+        }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length > 0);
+    // @ts-expect-error — inspect private state for the assertion.
+    expect(adapter.threadOwners.get("C100:1700000000.123")).toBe("triage");
+  });
+
+  it("subsequent reply in the bot's synthetic thread routes to the same agent", async () => {
+    adapter = await startAdapter({
+      allowBots: ["C100"],
+      routing: { channels: { C100: "triage", C200: "research" } },
+    });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: undefined,
+          bot_id: "B-monitor",
+          ts: "T100.alert",
+          text: "alert",
+        }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length === 1);
+
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: "U42",
+          ts: "T100.reply",
+          thread_ts: "T100.alert",
+          text: "looking into it",
+        }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length === 2);
+    expect(bus.prompts[1]?.agent_id).toBe("triage");
+  });
+});
+
+describe("sanitiseBotText", () => {
+  it("strips [react:emoji] directives", () => {
+    expect(sanitiseBotText("hello [react:🔥] world")).toBe("hello  world");
+  });
+
+  it("replaces [[slack_buttons:...]] with a placeholder", () => {
+    expect(sanitiseBotText("alert [[slack_buttons:ack,deny]]")).toContain("[buttons removed]");
+  });
+
+  it("trims trailing whitespace after removals", () => {
+    expect(sanitiseBotText("alert [react:🔥]  ")).toBe("alert");
+  });
+
+  it("leaves plain text untouched", () => {
+    expect(sanitiseBotText("CPU at 95%")).toBe("CPU at 95%");
+  });
+
+  it("sanitises bot-allowed prompts end-to-end", async () => {
+    adapter = await startAdapter({ allowBots: ["C100"] });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: undefined,
+          bot_id: "B-monitor",
+          text: "alert [react:🔥]",
+        }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts[0]?.text).toBe("alert");
+  });
+
+  it("does NOT sanitise human messages (preserves operator intent)", async () => {
+    adapter = await startAdapter({ allowBots: ["C100"] });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: "U42",
+          text: "what's the latest [react:🔥]",
+        }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts[0]?.text).toContain("[react:🔥]");
   });
 });

--- a/src/adapters/slack/__tests__/slack.test.ts
+++ b/src/adapters/slack/__tests__/slack.test.ts
@@ -1223,6 +1223,102 @@ describe("createSlackApi — fetch timeout (PR #117 review)", () => {
 
 import { extractTextFromAttachments, extractTextFromBlocks, sanitiseBotText } from "../index";
 
+describe("Issue #121 — Codex P1 on PR #129: self-bot feedback-loop guard", () => {
+  // Without this guard, our own chat.postMessage replies come back
+  // as bot_message events. In an allowBots channel they would be
+  // re-ingested as fresh prompts — feedback loop.
+
+  it("drops events where event.bot_id === selfBotId, even in allowBots channels", async () => {
+    adapter = await startAdapter({
+      allowBots: ["C100"],
+      selfBotId: "B-us",
+    });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: undefined,
+          bot_id: "B-us",
+          text: "I just posted this myself!",
+        }),
+      ),
+    );
+    await new Promise((r) => setTimeout(r, 30));
+    expect(bus.prompts).toHaveLength(0);
+  });
+
+  it("drops events where event.user === selfUserId", async () => {
+    adapter = await startAdapter({
+      allowBots: ["C100"],
+      selfUserId: "U-us",
+    });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: "U-us",
+          text: "we somehow got back our own user-authored msg",
+        }),
+      ),
+    );
+    await new Promise((r) => setTimeout(r, 30));
+    expect(bus.prompts).toHaveLength(0);
+  });
+
+  it("still passes through OTHER bots in allowBots channels", async () => {
+    adapter = await startAdapter({
+      allowBots: ["C100"],
+      selfBotId: "B-us",
+    });
+    socket.push(
+      eventsEnvelope(
+        msg({
+          channel: "C100",
+          user: undefined,
+          bot_id: "B-monitor",
+          text: "alert from another bot",
+        }),
+      ),
+    );
+    await waitFor(() => bus.prompts.length > 0);
+    expect(bus.prompts[0]?.text).toBe("alert from another bot");
+  });
+
+  it("warns at start when allowBots is set but neither selfBotId nor selfUserId is set", async () => {
+    const warnings: string[] = [];
+    const adapt = new SlackAdapter({
+      bus,
+      token: FAKE_BOT_TOKEN,
+      signingSecret: FAKE_SIGNING_SECRET,
+      allowedUserIds: [],
+      allowBots: ["C100"],
+      // selfBotId / selfUserId deliberately omitted
+      routing: { channels: { C100: "triage" } },
+      api,
+      logger: { ...SILENT_LOGGER, warn: (m: string) => warnings.push(m) },
+    });
+    await adapt.start();
+    await adapt.stop();
+    expect(warnings.some((w) => w.includes("feedback loop"))).toBe(true);
+  });
+
+  it("does NOT warn when allowBots is empty (no loop risk)", async () => {
+    const warnings: string[] = [];
+    const adapt = new SlackAdapter({
+      bus,
+      token: FAKE_BOT_TOKEN,
+      signingSecret: FAKE_SIGNING_SECRET,
+      allowedUserIds: [],
+      routing: { channels: { C100: "triage" } },
+      api,
+      logger: { ...SILENT_LOGGER, warn: (m: string) => warnings.push(m) },
+    });
+    await adapt.start();
+    await adapt.stop();
+    expect(warnings.some((w) => w.includes("feedback loop"))).toBe(false);
+  });
+});
+
 describe("Issue #121 — upstream PR #210 allowBots + allowBotIds", () => {
   it("drops bot messages by default (no allowBots config)", async () => {
     adapter = await startAdapter();

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -26,7 +26,9 @@ import {
   type SlackApi,
   type SlackBlock,
   type SlackBlockActionsPayload,
+  type SlackBlockKitMessageBlock,
   type SlackEventsApiEnvelope,
+  type SlackInboundAttachment,
   type SlackMessageEvent,
   type SlackSocketEnvelope,
   type SlackSocketLike,
@@ -68,6 +70,9 @@ export class SlackAdapter {
   private readonly api: SlackApi;
   private readonly socket: SlackSocketLike | null;
   private readonly allowedUserIds: ReadonlySet<string>;
+  /** Issue #121 port of upstream PR #210: per-channel bot pass-through. */
+  private readonly allowBots: ReadonlySet<string>;
+  private readonly allowBotIds: ReadonlySet<string>;
   private readonly channels: Record<string, string>;
   private readonly threadAgentId: string | undefined;
   private readonly logger: Pick<Console, "warn" | "info" | "error">;
@@ -121,6 +126,8 @@ export class SlackAdapter {
     this.api = opts.api ?? createSlackApi(opts.token);
     this.socket = opts.socket ?? null;
     this.allowedUserIds = new Set(opts.allowedUserIds);
+    this.allowBots = new Set(opts.allowBots ?? []);
+    this.allowBotIds = new Set(opts.allowBotIds ?? []);
     this.channels = { ...opts.routing.channels };
     this.threadAgentId = opts.routing.threadAgentId;
     this.logger = opts.logger ?? console;
@@ -323,20 +330,49 @@ export class SlackAdapter {
   /* ──────────────────────────── message handler ─────────────────── */
 
   private async handleMessageEvent(event: SlackMessageEvent): Promise<void> {
-    // Drop bots + non-file_share subtypes (legacy `slack.ts:940-950`). No
-    // allowBots support in Sprint 4 — operators using that pattern stay on
-    // the PTY runtime.
-    if (event.bot_id) return;
-    if (event.subtype && event.subtype !== "file_share") return;
-    if (!event.user) return;
+    // Issue #121 port of upstream PRs #210, #211, #214.
+    //
+    // PR #210: per-channel bot pass-through. Replace the blanket
+    // `event.bot_id → drop` gate with allowBots-aware logic.
+    // PR #211: when `event.text` is empty, fall through to blocks /
+    // attachments before discarding.
+    // PR #214: non-thread bot messages route via
+    // `replyThreadTs = event.thread_ts ?? event.ts` so subsequent
+    // replies in the synthetic thread find the agent owner.
 
-    const userId = event.user;
     const channelId = event.channel;
+    const channelAllowsBots = !!event.bot_id && this.allowBots.has(channelId);
+    const botIdAllowed =
+      this.allowBotIds.size === 0 || (!!event.bot_id && this.allowBotIds.has(event.bot_id));
+    const isBotAllowed = channelAllowsBots && botIdAllowed;
 
-    // Allow-list — empty = allow all (legacy `slack.ts:976` semantics; PR
-    // #113 review caught Discord/Telegram regressing to "empty = deny").
-    // Slack is multi-channel so we silent-skip — no "Unauthorized." DM.
-    if (this.allowedUserIds.size > 0 && !this.allowedUserIds.has(userId)) {
+    // Bot gate. Drop bot traffic unless the channel + bot id both
+    // match the allow-list. Empty-`user` events with no `bot_id`
+    // remain dropped (system events, join/leave, etc).
+    if (event.bot_id) {
+      if (!isBotAllowed) return;
+    } else if (!event.user) {
+      return;
+    }
+
+    // Subtype gate. `file_share` always allowed; `bot_message` allowed
+    // only when this event is an allowed bot.
+    if (
+      event.subtype &&
+      event.subtype !== "file_share" &&
+      !(isBotAllowed && event.subtype === "bot_message")
+    ) {
+      return;
+    }
+
+    // userId fallback chain: human user → bot display name → bot id.
+    // Used for the `sendPrompt.user_id` tag.
+    const userId = event.user ?? event.bot_profile?.name ?? event.username ?? event.bot_id ?? "";
+
+    // Allow-list — empty = allow all (legacy `slack.ts:976` semantics).
+    // Bot-allowed traffic bypasses this gate per upstream PR #210 — bots
+    // don't have a human userId to check.
+    if (!isBotAllowed && this.allowedUserIds.size > 0 && !this.allowedUserIds.has(userId)) {
       return;
     }
 
@@ -345,8 +381,16 @@ export class SlackAdapter {
       this.logger.warn(`[slack-adapter] unrouted channel=${channelId} — skip`);
       return;
     }
+
+    // PR #214 fold-in: for bot messages NOT in a thread, the bot's reply
+    // will create a thread under event.ts. Record owner under
+    // replyThreadTs so subsequent replies in that synthetic thread route
+    // to the same agent.
+    const replyThreadTs = event.thread_ts ?? event.ts;
     if (event.thread_ts) {
       this.recordThreadOwner(`${channelId}:${event.thread_ts}`, agentId);
+    } else if (isBotAllowed) {
+      this.recordThreadOwner(`${channelId}:${replyThreadTs}`, agentId);
     }
 
     // Pending request_human → route reply as ask_answer. Composite key per
@@ -368,8 +412,23 @@ export class SlackAdapter {
       return;
     }
 
+    // PR #211 fold-in: when `text` is empty, recover content from
+    // blocks → attachments before discarding. Bot alerts (Gatus,
+    // Grafana, etc) often post via blocks with empty `text`.
+    let textBody = event.text ?? "";
+    if (textBody.length === 0 && event.blocks && event.blocks.length > 0) {
+      textBody = extractTextFromBlocks(event.blocks);
+    }
+    if (textBody.length === 0 && event.attachments && event.attachments.length > 0) {
+      textBody = extractTextFromAttachments(event.attachments);
+    }
+    // Sanitize bot-sourced text — the prompt-injection surface is real
+    // when arbitrary monitoring tools post into our channels. Matches
+    // upstream PR #210's `sanitizeUserInput` treatment.
+    if (isBotAllowed) textBody = sanitiseBotText(textBody);
+
     const hasFiles = Array.isArray(event.files) && event.files.length > 0;
-    const trimmed = (event.text ?? "").trim();
+    const trimmed = textBody.trim();
     if (!trimmed && !hasFiles) return;
 
     // Sprint 4 forwards file metadata only — download/transcription is a
@@ -377,6 +436,7 @@ export class SlackAdapter {
     const metadata: Record<string, unknown> = {
       ts: event.ts,
       ...(event.thread_ts ? { thread_ts: event.thread_ts } : {}),
+      ...(isBotAllowed ? { bot_id: event.bot_id ?? "", bot_name: userId } : {}),
       ...(hasFiles && event.files
         ? {
             files: event.files.map((f) => ({
@@ -598,6 +658,73 @@ export class SlackAdapter {
       this.logger.error("[slack-adapter] chat.postMessage threw", err);
     }
   }
+}
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Issue #121 — upstream Slack feature helpers                             */
+/* ────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Walk a Block Kit message-block tree and return the human-readable
+ * text concatenated with newlines. Recovers content from bot alerts
+ * that post via `event.blocks` with an empty `event.text` (Gatus,
+ * Grafana, etc). Issue #121 port of upstream PR #211.
+ *
+ * Exported for unit testing.
+ */
+export function extractTextFromBlocks(blocks: readonly SlackBlockKitMessageBlock[]): string {
+  const parts: string[] = [];
+  for (const block of blocks) {
+    if (block.text?.text) parts.push(block.text.text);
+    if (block.fields) {
+      for (const f of block.fields) {
+        if (f.text) parts.push(f.text);
+      }
+    }
+    if (block.elements) {
+      for (const el of block.elements) {
+        if (el.text?.text) parts.push(el.text.text);
+      }
+    }
+  }
+  return parts.filter((p) => p.length > 0).join("\n");
+}
+
+/**
+ * Legacy attachments-shape text recovery. Joined chain:
+ * `pretext` → `title` → `text` → each field as `title:\nvalue`.
+ * Issue #121 port of upstream PR #211.
+ *
+ * Exported for unit testing.
+ */
+export function extractTextFromAttachments(attachments: readonly SlackInboundAttachment[]): string {
+  return attachments
+    .map((a) =>
+      [a.pretext, a.title, a.text, ...(a.fields?.map((f) => `${f.title}:\n${f.value}`) ?? [])]
+        .filter((p): p is string => typeof p === "string" && p.length > 0)
+        .join("\n"),
+    )
+    .filter((p) => p.length > 0)
+    .join("\n");
+}
+
+/**
+ * Strip directive-like markers that could be used by a third-party bot
+ * (or a compromised one) to inject control sequences the Bus adapter
+ * understands. Currently scrubs:
+ *   - `[react:<emoji>]` — Telegram-style reaction directive
+ *   - `[[slack_buttons:...]]` / `[[slack_select:...]]` — legacy Slack
+ *     interactivity hints
+ *
+ * Matches upstream `sanitizeUserInput` in `src/commands/slack.ts`.
+ * Exported for unit testing.
+ */
+export function sanitiseBotText(text: string): string {
+  return text
+    .replace(/\[react:[^\]]*\]/gi, "")
+    .replace(/\[\[slack_buttons:[^\]]*\]\]/gi, "[buttons removed]")
+    .replace(/\[\[slack_select:[^\]]*\]\]/gi, "[select removed]")
+    .trim();
 }
 
 // Re-exports for ergonomic test imports.

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -73,6 +73,13 @@ export class SlackAdapter {
   /** Issue #121 port of upstream PR #210: per-channel bot pass-through. */
   private readonly allowBots: ReadonlySet<string>;
   private readonly allowBotIds: ReadonlySet<string>;
+  /**
+   * Self-id guard — drop events authored by this adapter's own Slack
+   * app to prevent a feedback loop when `allowBots` is enabled
+   * (Issue #121 Codex P1).
+   */
+  private readonly selfBotId: string | null;
+  private readonly selfUserId: string | null;
   private readonly channels: Record<string, string>;
   private readonly threadAgentId: string | undefined;
   private readonly logger: Pick<Console, "warn" | "info" | "error">;
@@ -128,6 +135,19 @@ export class SlackAdapter {
     this.allowedUserIds = new Set(opts.allowedUserIds);
     this.allowBots = new Set(opts.allowBots ?? []);
     this.allowBotIds = new Set(opts.allowBotIds ?? []);
+    this.selfBotId = opts.selfBotId ?? null;
+    this.selfUserId = opts.selfUserId ?? null;
+    // Codex P1 on PR #129: warn loudly when allowBots is on but no
+    // self-id is configured. Without it, our own chat.postMessage
+    // replies feed back as bot_message events and would re-ingest as
+    // fresh prompts. We can't safely refuse to start (operator may
+    // not be using bot pass-through), but the warning makes the
+    // failure mode obvious before it bites in production.
+    if (this.allowBots.size > 0 && !this.selfBotId && !this.selfUserId) {
+      (opts.logger ?? console).warn(
+        "[slack-adapter] allowBots is configured but neither selfBotId nor selfUserId is set — our own chat.postMessage replies will be re-ingested as fresh prompts, creating a feedback loop. Set slack.selfBotId (from auth.test).",
+      );
+    }
     this.channels = { ...opts.routing.channels };
     this.threadAgentId = opts.routing.threadAgentId;
     this.logger = opts.logger ?? console;
@@ -339,6 +359,14 @@ export class SlackAdapter {
     // PR #214: non-thread bot messages route via
     // `replyThreadTs = event.thread_ts ?? event.ts` so subsequent
     // replies in the synthetic thread find the agent owner.
+
+    // Self-bot guard FIRST (Codex P1 on PR #129). Drop any event
+    // authored by this adapter's own Slack app to prevent a feedback
+    // loop where our `chat.postMessage` replies get re-ingested as
+    // fresh prompts. Must run BEFORE the allowBots logic — otherwise
+    // an unprotected allowBots channel would loop forever.
+    if (this.selfBotId && event.bot_id === this.selfBotId) return;
+    if (this.selfUserId && event.user === this.selfUserId) return;
 
     const channelId = event.channel;
     const channelAllowsBots = !!event.bot_id && this.allowBots.has(channelId);

--- a/src/adapters/slack/types.ts
+++ b/src/adapters/slack/types.ts
@@ -45,6 +45,19 @@ export interface SlackAdapterOptions {
    * caught the same regression; we preserve the documented semantics here.
    */
   allowedUserIds: string[];
+  /**
+   * Channel ids where messages from OTHER bots (event.bot_id set) are
+   * passed through to claude instead of being silently dropped. Issue
+   * #121 port of upstream PR #210. Empty list (default) preserves the
+   * original Sprint 4 behaviour — all bot-authored events are dropped.
+   */
+  allowBots?: string[];
+  /**
+   * Optional bot-id allow-list (`B…` ids). When non-empty, both the
+   * channel AND the bot id must match before pass-through. Empty list
+   * (default) accepts any bot in an allowBots channel.
+   */
+  allowBotIds?: string[];
   /** Routing config. Slack has no DMs-as-channels distinction the same way
    * Discord does — DMs are just channels of type `im`. We map by channel
    * id flat. Thread routing inherits the parent channel's agent_id unless
@@ -115,10 +128,52 @@ export interface SlackMessageEvent {
   text: string;
   /** Slack sets this for bot-authored messages. */
   bot_id?: string;
-  /** `message_changed`, `file_share`, etc. */
+  /**
+   * Bot-friendly display name when present (Issue #121 port of upstream
+   * PR #210 review-feedback commit). Falls through username → bot_id
+   * for the prompt's `user_id` tag when no human `user` is set.
+   */
+  username?: string;
+  /** Slack's nested bot profile; we read `bot_profile.name` for display. */
+  bot_profile?: { name?: string };
+  /** `message_changed`, `file_share`, `bot_message`, etc. */
   subtype?: string;
   /** File attachments (images, voice, docs). */
   files?: SlackFile[];
+  /**
+   * Block Kit blocks — Slack's modern rich-content format. Issue #121
+   * port of upstream PR #211: when `text` is empty, we walk these to
+   * recover the human-readable content from monitoring tools (Gatus,
+   * Grafana, etc.) that post via blocks instead of `text`.
+   */
+  blocks?: SlackBlockKitMessageBlock[];
+  /**
+   * Legacy attachments — older bots (PagerDuty, some Datadog flows)
+   * post structured payloads here. Same fallback path as `blocks`.
+   */
+  attachments?: SlackInboundAttachment[];
+}
+
+/**
+ * Subset of Slack's Block Kit shape that holds human-readable text.
+ * Distinct from `SlackBlock` (outbound — for the permission Block Kit
+ * builders) because inbound block payloads use slightly different
+ * field names + recursive `elements`.
+ */
+export interface SlackBlockKitMessageBlock {
+  type: string;
+  text?: { type: string; text: string };
+  fields?: Array<{ type?: string; text: string }>;
+  elements?: Array<{ type: string; text?: { type: string; text: string } }>;
+}
+
+/** Legacy `attachments[]` shape — the chain a bot might fill. */
+export interface SlackInboundAttachment {
+  text?: string;
+  fallback?: string;
+  pretext?: string;
+  title?: string;
+  fields?: Array<{ title: string; value: string }>;
 }
 
 export interface SlackFile {

--- a/src/adapters/slack/types.ts
+++ b/src/adapters/slack/types.ts
@@ -58,6 +58,23 @@ export interface SlackAdapterOptions {
    * (default) accepts any bot in an allowBots channel.
    */
   allowBotIds?: string[];
+  /**
+   * The bot id (`B…`) of THIS adapter's own Slack app. Issue #121
+   * Codex P1 fold-in: when `allowBots` is non-empty, our own
+   * `chat.postMessage` replies come back as `bot_message` events
+   * and — without this guard — would be re-ingested as fresh
+   * prompts, creating a feedback loop. Set this to the value Slack's
+   * `auth.test` returns for `bot_id`. The adapter skips any inbound
+   * event where `event.bot_id === selfBotId` BEFORE any pass-through
+   * check.
+   */
+  selfBotId?: string;
+  /**
+   * The bot user id (`U…`) of THIS adapter's own Slack app. Same
+   * loop-prevention purpose as `selfBotId` — covers events where
+   * Slack only sets `user` (not `bot_id`) for app-authored messages.
+   */
+  selfUserId?: string;
   /** Routing config. Slack has no DMs-as-channels distinction the same way
    * Discord does — DMs are just channels of type `im`. We map by channel
    * id flat. Thread routing inherits the parent channel's agent_id unless


### PR DESCRIPTION
## Summary

Ports the three upstream Slack PRs from moazbuilds/claudeclaw that were
deferred when sync PR #119 was closed in favour of the Sprint 4 Bus
adapter rewrite. Tracking issue #121 captured them; this PR lands all
three in `src/adapters/slack/`.

## Features

### 1. allowBots + allowBotIds (upstream PR #210)
`SlackAdapterOptions` gains `allowBots: string[]` + `allowBotIds:
string[]`. Bot messages in allow-listed channels pass through to claude
instead of being silently dropped — unlocks monitoring-tool integration
(Gatus, Grafana, PagerDuty). Bot traffic bypasses the human
`allowedUserIds` gate; `user_id` label falls through `bot_profile.name
→ username → bot_id`.

### 2. Block/attachment text extraction (upstream PR #211)
When `event.text` is empty, fall through to
`extractTextFromBlocks(event.blocks)` then to
`extractTextFromAttachments(event.attachments)`. Recovers content from
bots that post structured payloads. Both helpers exported for unit
testing.

### 3. replyThreadTs routing (upstream PR #214)
Non-thread bot messages record the thread-owner under
`replyThreadTs = event.thread_ts ?? event.ts` so subsequent human
replies in the bot's synthetic thread route to the same agent. Fixes a
real bug where bot alert → agent X, then a human reply in the thread
routed to the default agent.

### 4. Bot-text sanitisation
Bot-sourced text passes through `sanitiseBotText` (exported) before
reaching `bus.sendPrompt`. Scrubs `[react:<emoji>]`,
`[[slack_buttons:...]]`, `[[slack_select:...]]`. Human messages NOT
sanitised so operators can use directives intentionally.

## Tests

+19 in the existing suite (41 → 60), covering each feature plus
unit-level tests of the extraction + sanitisation helpers. The
`msg()` test helper updated to honour explicit `user: undefined` and
forward the new fields.

Full repo: 1707 pass / 6 skip / 28 fail / 1 error — all failures
match the pre-existing baseline.

## Test plan

- [ ] Configure `slack.allowBots: ['C-alerts']` on staging; send a
      Gatus alert into `C-alerts`; verify claude sees the alert text.
- [ ] Verify a non-alert channel still drops bot messages.
- [ ] Bot alert NOT in a thread → human reply in the resulting thread
      routes to the same agent as the bot's alert.
- [ ] Verify `[react:🔥]` injected by a bot is scrubbed; same directive
      from a human user passes through.

## Notes

- Version bump 2.2.57 → 2.2.58 collides with PR #128 (staging guide,
  still in review). Whichever lands second rebumps on rebase.
- Closes issue #121.

## Spec

`docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md` §5.5.3.