### PR TITLE
fix(bus): wire real Discord gateway + REST so production can flip to bus runtime

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.59",
+      "version": "2.2.60",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.59",
+  "version": "2.2.60",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/discord/__tests__/discord-inbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-inbound.test.ts
@@ -49,19 +49,18 @@ describe("DiscordAdapter — lifecycle", () => {
     expect(h.gateway.stopped).toBe(true);
   });
 
-  it("rejects construction with no gateway", () => {
-    expect(
-      () =>
-        new DiscordAdapter({
-          bus: h.bus,
-          token: "t",
-          allowedUserIds: [],
-          routing: { channels: {} },
-          // The constructor throws if `gateway` is missing — exercise that guard.
-          gateway: undefined,
-          restApi: h.rest,
-        }),
-    ).toThrow();
+  it("auto-constructs gateway + restApi when none injected", () => {
+    // Production callers only pass bus + token + routing; the adapter
+    // builds its own DiscordGateway + DiscordRestApi from the token.
+    // Tests inject fakes (see `startAdapter`) to bypass the network —
+    // this case exercises the bare construction path doesn't throw.
+    const a = new DiscordAdapter({
+      bus: h.bus,
+      token: "fake-token",
+      allowedUserIds: [],
+      routing: { channels: {} },
+    });
+    expect(a).toBeDefined();
   });
 });
 

--- a/src/adapters/discord/__tests__/gateway.test.ts
+++ b/src/adapters/discord/__tests__/gateway.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Unit tests for `DiscordGateway` — the WS handshake + dispatch logic
+ * ported from the legacy listener. Uses a fake WebSocket constructor so
+ * the tests stay offline. Each scenario drives the gateway through the
+ * handshake (HELLO → IDENTIFY → DISPATCH) and asserts the emitted
+ * `GatewayEvent`s match what `DiscordAdapter` expects.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { DiscordGateway } from "../gateway";
+import type { GatewayEvent } from "../types";
+
+interface FakeSocketHandle {
+  url: string;
+  sent: unknown[];
+  closeCalls: Array<{ code?: number; reason?: string }>;
+  readyState: number;
+  onmessage: ((e: { data: string }) => void) | null;
+  onclose: ((e: { code: number; reason: string }) => void) | null;
+  onerror: (() => void) | null;
+}
+
+/**
+ * `webSocketCtor` is typed as `typeof WebSocket`, so the fake has to
+ * satisfy that constructor's call-signature. We don't actually use
+ * the WebSocket prototype, so a minimal stub is enough.
+ */
+function makeFakeWsCtor(): { Ctor: typeof WebSocket; latest: () => FakeSocketHandle } {
+  let latest: FakeSocketHandle | null = null;
+  class FakeWS {
+    url: string;
+    sent: unknown[] = [];
+    closeCalls: Array<{ code?: number; reason?: string }> = [];
+    readyState = 1; // OPEN
+    onmessage: ((e: { data: string }) => void) | null = null;
+    onclose: ((e: { code: number; reason: string }) => void) | null = null;
+    onerror: (() => void) | null = null;
+    constructor(url: string) {
+      this.url = url;
+      latest = this as unknown as FakeSocketHandle;
+    }
+    send(data: string) {
+      this.sent.push(JSON.parse(data));
+    }
+    close(code?: number, reason?: string) {
+      this.closeCalls.push({ code, reason });
+      this.readyState = 3;
+    }
+  }
+  return {
+    Ctor: FakeWS as unknown as typeof WebSocket,
+    latest: () => {
+      if (!latest) throw new Error("fake WS not constructed");
+      return latest;
+    },
+  };
+}
+
+const SILENT = { warn: () => {}, info: () => {}, error: () => {} };
+
+describe("DiscordGateway", () => {
+  let originalRandom: typeof Math.random;
+  beforeEach(() => {
+    // Deterministic jitter to keep timer behaviour predictable.
+    originalRandom = Math.random;
+    Math.random = () => 0.5;
+  });
+  afterEach(() => {
+    Math.random = originalRandom;
+  });
+
+  it("on HELLO it starts heartbeat and sends IDENTIFY when no session", async () => {
+    const fake = makeFakeWsCtor();
+    const gw = new DiscordGateway({ token: "tok", logger: SILENT, webSocketCtor: fake.Ctor });
+    await gw.start();
+    const ws = fake.latest();
+    ws.onmessage?.({
+      data: JSON.stringify({ op: 10, d: { heartbeat_interval: 41250 }, s: null, t: null }),
+    });
+    // IDENTIFY is sent immediately; HEARTBEAT lives behind the jitter timer.
+    const identify = ws.sent.find(
+      (m): m is { op: number; d: { token: string; intents: number } } =>
+        typeof m === "object" && m !== null && (m as { op?: number }).op === 2,
+    );
+    expect(identify).toBeDefined();
+    expect(identify?.d.token).toBe("tok");
+    expect(typeof identify?.d.intents).toBe("number");
+    await gw.stop();
+  });
+
+  it("on HELLO it sends RESUME when session + sequence are present", async () => {
+    const fake = makeFakeWsCtor();
+    const gw = new DiscordGateway({ token: "tok", logger: SILENT, webSocketCtor: fake.Ctor });
+    await gw.start();
+    const ws = fake.latest();
+    // READY first to populate sessionId.
+    ws.onmessage?.({
+      data: JSON.stringify({
+        op: 0,
+        s: 1,
+        t: "READY",
+        d: {
+          session_id: "sess-1",
+          resume_gateway_url: "wss://resume",
+          user: { id: "u", username: "bot" },
+        },
+      }),
+    });
+    // Now HELLO should resume, not identify.
+    ws.onmessage?.({
+      data: JSON.stringify({ op: 10, d: { heartbeat_interval: 41250 }, s: null, t: null }),
+    });
+    const resume = ws.sent.find(
+      (m): m is { op: number; d: { session_id: string } } =>
+        typeof m === "object" && m !== null && (m as { op?: number }).op === 6,
+    );
+    expect(resume).toBeDefined();
+    expect(resume?.d.session_id).toBe("sess-1");
+    const identify = ws.sent.find(
+      (m) => typeof m === "object" && m !== null && (m as { op?: number }).op === 2,
+    );
+    expect(identify).toBeUndefined();
+    await gw.stop();
+  });
+
+  it("forwards MESSAGE_CREATE dispatches to subscribers", async () => {
+    const fake = makeFakeWsCtor();
+    const gw = new DiscordGateway({ token: "tok", logger: SILENT, webSocketCtor: fake.Ctor });
+    const events: GatewayEvent[] = [];
+    gw.onEvent((e) => events.push(e));
+    await gw.start();
+    const ws = fake.latest();
+    ws.onmessage?.({
+      data: JSON.stringify({
+        op: 0,
+        s: 2,
+        t: "MESSAGE_CREATE",
+        d: {
+          id: "m1",
+          channel_id: "c1",
+          author: { id: "u1", username: "terry" },
+          content: "hi",
+          attachments: [],
+        },
+      }),
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe("MESSAGE_CREATE");
+    if (events[0]?.type === "MESSAGE_CREATE") {
+      expect(events[0].message.id).toBe("m1");
+      expect(events[0].message.content).toBe("hi");
+    }
+    await gw.stop();
+  });
+
+  it("forwards INTERACTION_CREATE dispatches to subscribers", async () => {
+    const fake = makeFakeWsCtor();
+    const gw = new DiscordGateway({ token: "tok", logger: SILENT, webSocketCtor: fake.Ctor });
+    const events: GatewayEvent[] = [];
+    gw.onEvent((e) => events.push(e));
+    await gw.start();
+    const ws = fake.latest();
+    ws.onmessage?.({
+      data: JSON.stringify({
+        op: 0,
+        s: 3,
+        t: "INTERACTION_CREATE",
+        d: {
+          id: "int-1",
+          type: 3,
+          data: { custom_id: "ccaw_perm_allow_abc" },
+          channel_id: "c1",
+          user: { id: "u1", username: "terry" },
+          token: "tok",
+        },
+      }),
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]?.type).toBe("INTERACTION_CREATE");
+  });
+
+  it("HEARTBEAT_ACK marks heartbeat as acked (no reconnect-close)", async () => {
+    const fake = makeFakeWsCtor();
+    const gw = new DiscordGateway({ token: "tok", logger: SILENT, webSocketCtor: fake.Ctor });
+    await gw.start();
+    const ws = fake.latest();
+    ws.onmessage?.({
+      data: JSON.stringify({ op: 10, d: { heartbeat_interval: 41250 }, s: null, t: null }),
+    });
+    ws.onmessage?.({ data: JSON.stringify({ op: 11, d: null, s: null, t: null }) });
+    // No close should have been issued from missed-ack path.
+    expect(ws.closeCalls.find((c) => c.reason === "Heartbeat timeout")).toBeUndefined();
+    await gw.stop();
+  });
+
+  it("op=RECONNECT closes the ws (so onclose can reschedule)", async () => {
+    const fake = makeFakeWsCtor();
+    const gw = new DiscordGateway({ token: "tok", logger: SILENT, webSocketCtor: fake.Ctor });
+    await gw.start();
+    const ws = fake.latest();
+    ws.onmessage?.({ data: JSON.stringify({ op: 7, d: null, s: null, t: null }) });
+    expect(ws.closeCalls.some((c) => c.reason === "Reconnect requested")).toBe(true);
+    await gw.stop();
+  });
+
+  it("stop() closes the ws and clears subscribers", async () => {
+    const fake = makeFakeWsCtor();
+    const gw = new DiscordGateway({ token: "tok", logger: SILENT, webSocketCtor: fake.Ctor });
+    let count = 0;
+    gw.onEvent(() => {
+      count++;
+    });
+    await gw.start();
+    await gw.stop();
+    const ws = fake.latest();
+    expect(ws.closeCalls.length).toBeGreaterThan(0);
+    // After stop, dispatch handlers are cleared — even if a late
+    // onmessage arrived, no subscriber would receive it.
+    expect(count).toBe(0);
+  });
+
+  it("throws when no WebSocket implementation is available", () => {
+    // Force-clear globalThis.WebSocket if present; pass no override.
+    const original = (globalThis as { WebSocket?: typeof WebSocket }).WebSocket;
+    (globalThis as { WebSocket?: typeof WebSocket }).WebSocket = undefined;
+    try {
+      expect(() => new DiscordGateway({ token: "tok", logger: SILENT })).toThrow(
+        /no WebSocket implementation/,
+      );
+    } finally {
+      (globalThis as { WebSocket?: typeof WebSocket }).WebSocket = original;
+    }
+  });
+});

--- a/src/adapters/discord/__tests__/rest-api.test.ts
+++ b/src/adapters/discord/__tests__/rest-api.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for `DiscordRestApi` — the small subset of Discord REST
+ * the Bus adapter needs (chunked message POST + interaction callback).
+ * Uses an injected `fetchImpl` so the suite stays offline.
+ */
+import { describe, expect, it } from "bun:test";
+import { DiscordRestApi } from "../rest-api";
+
+interface CapturedCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | undefined;
+}
+
+function makeFakeFetch(): {
+  fetchImpl: typeof fetch;
+  calls: CapturedCall[];
+  setResponse: (resp: Response) => void;
+} {
+  const calls: CapturedCall[] = [];
+  // Real Discord POSTs return a JSON message body; the fake mirrors that
+  // so `res.json()` in the impl doesn't choke. Override per test for 4xx/5xx.
+  let nextResponse: Response = new Response("{}", {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+  const fetchImpl = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({
+      url: String(url),
+      method: init?.method ?? "GET",
+      headers: (init?.headers as Record<string, string>) ?? {},
+      body: typeof init?.body === "string" ? init.body : undefined,
+    });
+    return nextResponse.clone();
+  }) as unknown as typeof fetch;
+  return {
+    fetchImpl,
+    calls,
+    setResponse: (r) => {
+      nextResponse = r;
+    },
+  };
+}
+
+const SILENT = { warn: () => {}, info: () => {}, error: () => {} };
+
+describe("DiscordRestApi", () => {
+  it("sendMessage POSTs a single chunk for short text", async () => {
+    const fake = makeFakeFetch();
+    const api = new DiscordRestApi({ token: "tok", logger: SILENT, fetchImpl: fake.fetchImpl });
+    await api.sendMessage("c1", "hello world");
+    expect(fake.calls).toHaveLength(1);
+    expect(fake.calls[0]?.url).toBe("https://discord.com/api/v10/channels/c1/messages");
+    expect(fake.calls[0]?.method).toBe("POST");
+    expect(fake.calls[0]?.headers.Authorization).toBe("Bot tok");
+    expect(JSON.parse(fake.calls[0]?.body ?? "{}").content).toBe("hello world");
+  });
+
+  it("sendMessage chunks at 2000 chars and attaches components only to the last chunk", async () => {
+    const fake = makeFakeFetch();
+    const api = new DiscordRestApi({ token: "tok", logger: SILENT, fetchImpl: fake.fetchImpl });
+    const text = "a".repeat(2500);
+    await api.sendMessage("c1", text, [{ x: 1 }]);
+    expect(fake.calls).toHaveLength(2);
+    const body0 = JSON.parse(fake.calls[0]?.body ?? "{}");
+    const body1 = JSON.parse(fake.calls[1]?.body ?? "{}");
+    expect(body0.content.length).toBe(2000);
+    expect(body0.components).toBeUndefined();
+    expect(body1.content.length).toBe(500);
+    expect(body1.components).toEqual([{ x: 1 }]);
+  });
+
+  it("sendMessage strips [react:…] tags before chunking", async () => {
+    const fake = makeFakeFetch();
+    const api = new DiscordRestApi({ token: "tok", logger: SILENT, fetchImpl: fake.fetchImpl });
+    await api.sendMessage("c1", "hi [react:👍] there");
+    expect(fake.calls).toHaveLength(1);
+    expect(JSON.parse(fake.calls[0]?.body ?? "{}").content).toBe("hi  there");
+  });
+
+  it("sendMessage skips empty content entirely", async () => {
+    const fake = makeFakeFetch();
+    const api = new DiscordRestApi({ token: "tok", logger: SILENT, fetchImpl: fake.fetchImpl });
+    await api.sendMessage("c1", "   ");
+    expect(fake.calls).toHaveLength(0);
+  });
+
+  it("respondToInteraction posts CHANNEL_MESSAGE_WITH_SOURCE payload", async () => {
+    const fake = makeFakeFetch();
+    const api = new DiscordRestApi({ token: "tok", logger: SILENT, fetchImpl: fake.fetchImpl });
+    await api.respondToInteraction("int-1", "int-tok", { content: "Allowed.", flags: 64 });
+    expect(fake.calls).toHaveLength(1);
+    expect(fake.calls[0]?.url).toBe(
+      "https://discord.com/api/v10/interactions/int-1/int-tok/callback",
+    );
+    const body = JSON.parse(fake.calls[0]?.body ?? "{}");
+    expect(body.type).toBe(4);
+    expect(body.data.content).toBe("Allowed.");
+    expect(body.data.flags).toBe(64);
+  });
+
+  it("call() raises on non-OK response", async () => {
+    const fake = makeFakeFetch();
+    fake.setResponse(new Response("nope", { status: 403, statusText: "Forbidden" }));
+    const api = new DiscordRestApi({ token: "tok", logger: SILENT, fetchImpl: fake.fetchImpl });
+    await expect(api.sendMessage("c1", "x")).rejects.toThrow(/403/);
+  });
+});

--- a/src/adapters/discord/gateway.ts
+++ b/src/adapters/discord/gateway.ts
@@ -1,0 +1,362 @@
+/**
+ * Real Discord gateway implementation for the Bus runtime.
+ *
+ * Implements `DiscordGatewayLike` so it can drop into `DiscordAdapter` in
+ * place of the test `FakeDiscordGateway`. Ported from the module-level
+ * gateway loop in `src/commands/discord.ts` (~lines 1582–1908) and
+ * wrapped in a class so each adapter instance owns its own connection,
+ * heartbeat timers, and session state.
+ *
+ * Scope is intentionally small: emit `MESSAGE_CREATE` and
+ * `INTERACTION_CREATE` only. The legacy listener also handles
+ * GUILD_CREATE / THREAD_* for thread-rejoin and slash-command
+ * registration — those belong to a Sprint 4 shared helper, not the
+ * Bus adapter, which receives its routing from settings rather than
+ * discovery.
+ */
+import type {
+  DiscordGatewayLike,
+  DiscordInboundMessage,
+  DiscordInboundInteraction,
+  GatewayEvent,
+} from "./types";
+
+const GATEWAY_URL = "wss://gateway.discord.gg/?v=10&encoding=json";
+
+const Op = {
+  DISPATCH: 0,
+  HEARTBEAT: 1,
+  IDENTIFY: 2,
+  RESUME: 6,
+  RECONNECT: 7,
+  INVALID_SESSION: 9,
+  HELLO: 10,
+  HEARTBEAT_ACK: 11,
+} as const;
+
+// GUILDS | GUILD_MESSAGES | GUILD_MESSAGE_REACTIONS | DIRECT_MESSAGES | MESSAGE_CONTENT
+const DEFAULT_INTENTS = (1 << 0) | (1 << 9) | (1 << 10) | (1 << 12) | (1 << 15);
+
+// Auth / sharding / intent failures Discord says are unrecoverable.
+const FATAL_CLOSE_CODES: ReadonlySet<number> = new Set([4004, 4010, 4011, 4012, 4013, 4014]);
+
+interface GatewayPayload {
+  op: number;
+  // biome-ignore lint/suspicious/noExplicitAny: dispatch payloads vary by event
+  d: any;
+  s: number | null;
+  t: string | null;
+}
+
+export interface DiscordGatewayOptions {
+  token: string;
+  /** Override the gateway intents bitfield. Defaults to the legacy listener's set. */
+  intents?: number;
+  /** Logger. Defaults to `console`. */
+  logger?: Pick<Console, "warn" | "info" | "error">;
+  /**
+   * WebSocket constructor — overridable so tests can inject a fake. Defaults
+   * to the global `WebSocket` (Bun + modern Node both provide it).
+   */
+  webSocketCtor?: typeof WebSocket;
+}
+
+export class DiscordGateway implements DiscordGatewayLike {
+  private readonly token: string;
+  private readonly intents: number;
+  private readonly logger: Pick<Console, "warn" | "info" | "error">;
+  private readonly WS: typeof WebSocket;
+
+  private ws: WebSocket | null = null;
+  private running = false;
+
+  private heartbeatIntervalMs = 0;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private heartbeatJitterTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatAcked = true;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private lastSequence: number | null = null;
+  private sessionId: string | null = null;
+  private resumeGatewayUrl: string | null = null;
+
+  private handlers: Array<(e: GatewayEvent) => void> = [];
+
+  constructor(opts: DiscordGatewayOptions) {
+    if (!opts.token) throw new Error("DiscordGateway: `token` is required");
+    this.token = opts.token;
+    this.intents = opts.intents ?? DEFAULT_INTENTS;
+    this.logger = opts.logger ?? console;
+    const Ctor = opts.webSocketCtor ?? (globalThis as { WebSocket?: typeof WebSocket }).WebSocket;
+    if (!Ctor) {
+      throw new Error(
+        "DiscordGateway: no WebSocket implementation available (pass `webSocketCtor` or run on a runtime with global WebSocket)",
+      );
+    }
+    this.WS = Ctor;
+  }
+
+  /* ─────────────────────────────── DiscordGatewayLike ────────────────── */
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    this.connect(GATEWAY_URL);
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    this.stopHeartbeat();
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+    if (this.ws) {
+      try {
+        this.ws.close(1000, "Gateway stop requested");
+      } catch {
+        /* best-effort */
+      }
+      this.ws = null;
+    }
+    this.resetState();
+    this.handlers = [];
+  }
+
+  onEvent(handler: (e: GatewayEvent) => void): () => void {
+    this.handlers.push(handler);
+    return () => {
+      this.handlers = this.handlers.filter((h) => h !== handler);
+    };
+  }
+
+  /* ─────────────────────────────── internals ─────────────────────────── */
+
+  private emit(event: GatewayEvent): void {
+    for (const h of this.handlers) {
+      try {
+        h(event);
+      } catch (err) {
+        this.logger.error("[discord-gateway] handler threw", err);
+      }
+    }
+  }
+
+  private sendWs(data: unknown): void {
+    if (this.ws?.readyState === 1 /* WebSocket.OPEN */) {
+      this.ws.send(JSON.stringify(data));
+    }
+  }
+
+  private sendHeartbeat(): void {
+    this.sendWs({ op: Op.HEARTBEAT, d: this.lastSequence });
+    this.heartbeatAcked = false;
+  }
+
+  private startHeartbeat(): void {
+    this.stopHeartbeat();
+    // Per Discord spec: jitter the first heartbeat between 0 and the interval.
+    this.heartbeatJitterTimer = setTimeout(() => {
+      this.heartbeatJitterTimer = null;
+      this.sendHeartbeat();
+    }, Math.random() * this.heartbeatIntervalMs);
+    this.heartbeatTimer = setInterval(() => {
+      if (!this.heartbeatAcked) {
+        this.logger.warn("[discord-gateway] heartbeat not acked — reconnecting");
+        try {
+          this.ws?.close(4000, "Heartbeat timeout");
+        } catch {
+          /* close errors are non-fatal */
+        }
+        return;
+      }
+      this.sendHeartbeat();
+    }, this.heartbeatIntervalMs);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer) clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+    if (this.heartbeatJitterTimer) clearTimeout(this.heartbeatJitterTimer);
+    this.heartbeatJitterTimer = null;
+  }
+
+  private resetState(): void {
+    this.heartbeatIntervalMs = 0;
+    this.heartbeatAcked = true;
+    this.lastSequence = null;
+    this.sessionId = null;
+    this.resumeGatewayUrl = null;
+  }
+
+  private sendIdentify(): void {
+    this.sendWs({
+      op: Op.IDENTIFY,
+      d: {
+        token: this.token,
+        intents: this.intents,
+        properties: {
+          os: typeof process !== "undefined" ? process.platform : "unknown",
+          browser: "claudeclaw",
+          device: "claudeclaw",
+        },
+      },
+    });
+  }
+
+  private sendResume(): void {
+    this.sendWs({
+      op: Op.RESUME,
+      d: {
+        token: this.token,
+        session_id: this.sessionId,
+        seq: this.lastSequence,
+      },
+    });
+  }
+
+  private handlePayload(payload: GatewayPayload): void {
+    if (payload.s !== null) this.lastSequence = payload.s;
+
+    switch (payload.op) {
+      case Op.HELLO:
+        this.heartbeatIntervalMs = payload.d?.heartbeat_interval ?? 41_250;
+        this.startHeartbeat();
+        if (this.sessionId && this.lastSequence !== null) {
+          this.sendResume();
+        } else {
+          this.sendIdentify();
+        }
+        return;
+
+      case Op.HEARTBEAT_ACK:
+        this.heartbeatAcked = true;
+        return;
+
+      case Op.HEARTBEAT:
+        this.sendHeartbeat();
+        return;
+
+      case Op.RECONNECT:
+        this.logger.info("[discord-gateway] op=RECONNECT — reconnecting");
+        try {
+          this.ws?.close(4000, "Reconnect requested");
+        } catch {
+          /* best-effort */
+        }
+        return;
+
+      case Op.INVALID_SESSION: {
+        const resumable = Boolean(payload.d);
+        this.logger.info(`[discord-gateway] op=INVALID_SESSION resumable=${resumable}`);
+        if (resumable && this.sessionId) {
+          setTimeout(() => this.sendResume(), 1000 + Math.random() * 4000);
+        } else {
+          this.sessionId = null;
+          this.lastSequence = null;
+          try {
+            this.ws?.close(4000, "Non-resumable INVALID_SESSION");
+          } catch {
+            /* best-effort */
+          }
+        }
+        return;
+      }
+
+      case Op.DISPATCH:
+        this.handleDispatch(payload.t ?? "", payload.d);
+        return;
+    }
+  }
+
+  // biome-ignore lint/suspicious/noExplicitAny: dispatch payload shapes vary per event
+  private handleDispatch(eventName: string, data: any): void {
+    switch (eventName) {
+      case "READY":
+        this.sessionId = data?.session_id ?? null;
+        this.resumeGatewayUrl = data?.resume_gateway_url ?? null;
+        this.logger.info(
+          `[discord-gateway] READY as ${data?.user?.username ?? "?"} (${data?.user?.id ?? "?"})`,
+        );
+        return;
+
+      case "RESUMED":
+        this.logger.info("[discord-gateway] RESUMED");
+        return;
+
+      case "MESSAGE_CREATE":
+        this.emit({ type: "MESSAGE_CREATE", message: data as DiscordInboundMessage });
+        return;
+
+      case "INTERACTION_CREATE":
+        this.emit({
+          type: "INTERACTION_CREATE",
+          interaction: data as DiscordInboundInteraction,
+        });
+        return;
+    }
+  }
+
+  private connect(url: string): void {
+    if (!this.running) return;
+    let ws: WebSocket;
+    try {
+      ws = new this.WS(url);
+    } catch (err) {
+      this.logger.error("[discord-gateway] WebSocket construction failed", err);
+      this.scheduleReconnect(/* fresh */ true);
+      return;
+    }
+    this.ws = ws;
+
+    ws.onmessage = (event: MessageEvent) => {
+      try {
+        const payload = JSON.parse(String(event.data)) as GatewayPayload;
+        this.handlePayload(payload);
+      } catch (err) {
+        this.logger.error("[discord-gateway] failed to parse payload", err);
+      }
+    };
+
+    ws.onclose = (event: CloseEvent) => {
+      this.stopHeartbeat();
+      if (!this.running) return;
+
+      if (FATAL_CLOSE_CODES.has(event.code)) {
+        this.logger.error(
+          `[discord-gateway] fatal close code=${event.code} reason=${event.reason} — not reconnecting`,
+        );
+        this.running = false;
+        return;
+      }
+
+      const canResume = this.sessionId !== null && this.lastSequence !== null;
+      this.scheduleReconnect(!canResume);
+    };
+
+    ws.onerror = () => {
+      // onclose will fire after onerror — reconnection is handled there.
+    };
+  }
+
+  private scheduleReconnect(fresh: boolean): void {
+    if (!this.running) return;
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer);
+    if (fresh) {
+      this.sessionId = null;
+      this.lastSequence = null;
+      this.resumeGatewayUrl = null;
+    }
+    const delay = fresh ? 3000 + Math.random() * 4000 : 1000 + Math.random() * 2000;
+    const nextUrl = fresh ? GATEWAY_URL : this.resumeGatewayUrl || GATEWAY_URL;
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connect(nextUrl);
+    }, delay);
+  }
+}
+
+/** Factory matching the wiring style used elsewhere in `src/bus/`. */
+export function createDiscordGateway(opts: DiscordGatewayOptions): DiscordGateway {
+  return new DiscordGateway(opts);
+}

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -19,20 +19,25 @@
  *   - Attachment detection: `discord.ts:604` `isImageAttachment` + friends.
  *   - Channel/thread/DM identity: `discord.ts:527` `guildTriggerReason`
  *     + `knownThreads` (188). Externalised here as `router.ts`.
- *   - Gateway connect/heartbeat/reconnect: `discord.ts:1582–1908`. Tests
- *     inject a `FakeDiscordGateway`; production builds will wire a real
- *     gateway in Sprint 4 (see TODO at the bottom of this file).
+ *   - Gateway connect/heartbeat/reconnect: ported into
+ *     `./gateway.ts` (`DiscordGateway` class). Adapter depends on the
+ *     `DiscordGatewayLike` abstraction so tests can inject
+ *     `FakeDiscordGateway`; production constructs `DiscordGateway`
+ *     from the token automatically when no `gateway` is passed.
+ *   - REST surface: ported into `./rest-api.ts`. Same injection /
+ *     auto-construct pattern as the gateway.
  *
- * Sprint 3 deliberately does NOT copy the gateway WS code into this
- * file — that would double-fork the production gateway logic. Instead
- * the adapter depends on `DiscordGatewayLike` and `DiscordRestApiLike`
- * abstractions (see `./types.ts`). Sprint 4 TODO: extract a shared
- * `src/discord/api.ts` + `src/discord/gateway.ts` from the legacy
- * listener so both code paths share one implementation.
+ * Sprint 4 follow-ups (legacy parity not yet ported into the Bus path):
+ * thread rejoin (GUILD_CREATE), slash-command registration, attachment
+ * download + voice transcription, streaming edit-in-place renderer.
+ * These are independent of the gateway lifecycle and can land
+ * incrementally; the staging guide flags which are required for full
+ * legacy parity vs. acceptable-for-staging.
  */
 
 import type { BusCore, Subscription } from "../../bus/core";
 import type { BusEvent, PermissionRequest } from "../../bus/types";
+import { createDiscordGateway } from "./gateway";
 import {
   attachmentMeta,
   buildPermissionButtons,
@@ -41,6 +46,7 @@ import {
   parsePermissionCustomId,
   summariseAttachments,
 } from "./helpers";
+import { createDiscordRestApi } from "./rest-api";
 import { resolveAgentId, uniqueAgentIds, type RoutingConfig } from "./router";
 import type {
   DiscordAdapterOptions,
@@ -106,22 +112,11 @@ export class DiscordAdapter {
     this.logger = opts.logger ?? console;
     this.rateLimitCheck = opts.rateLimitCheck ?? makeDefaultRateLimit();
 
-    if (!opts.gateway) {
-      throw new Error(
-        "DiscordAdapter: `gateway` injection is required in Sprint 3. " +
-          "Shared gateway helper extraction is a Sprint 4 deliverable; " +
-          "until then production callers must construct their own gateway. " +
-          "Tests inject a FakeDiscordGateway.",
-      );
-    }
-    if (!opts.restApi) {
-      throw new Error(
-        "DiscordAdapter: `restApi` injection is required in Sprint 3. " +
-          "See SPRINT_3_PLAN.md — shared REST helpers are a Sprint 4 task.",
-      );
-    }
-    this.gateway = opts.gateway;
-    this.restApi = opts.restApi;
+    // Production callers pass `bus + token + routing`; the adapter
+    // constructs its own real gateway + REST client. Tests inject
+    // `FakeDiscordGateway` / `FakeDiscordRestApi` to bypass the network.
+    this.gateway = opts.gateway ?? createDiscordGateway({ token: this.token, logger: this.logger });
+    this.restApi = opts.restApi ?? createDiscordRestApi({ token: this.token, logger: this.logger });
   }
 
   /* ──────────────────────────── lifecycle ─────────────────────────── */
@@ -463,10 +458,6 @@ export { resolveAgentId, uniqueAgentIds } from "./router";
 /* Sprint 4 TODOs                                                         */
 /* ────────────────────────────────────────────────────────────────────── */
 /*
- *  - Extract `discordApi`, `sendMessage`, gateway connect/heartbeat from
- *    `src/commands/discord.ts` into a shared `src/discord/api.ts` +
- *    `src/discord/gateway.ts`. Right now the adapter requires `gateway`
- *    + `restApi` injection — production callers must wire their own.
  *  - Track originating channel per bus event so responses go ONLY to
  *    the channel the prompt came from (today we fan out to every
  *    channel owned by the agent — fine for single-channel-per-agent,

--- a/src/adapters/discord/rest-api.ts
+++ b/src/adapters/discord/rest-api.ts
@@ -1,0 +1,126 @@
+/**
+ * Real Discord REST API implementation for the Bus runtime.
+ *
+ * Implements `DiscordRestApiLike` so it can drop into `DiscordAdapter` in
+ * place of the test `FakeDiscordRestApi`. Mirrors the subset of HTTP
+ * calls in `src/commands/discord.ts` the Bus adapter actually uses:
+ *   - POST `/channels/{id}/messages` (auto-chunked at 2000 chars)
+ *   - POST `/interactions/{id}/{token}/callback` (CHANNEL_MESSAGE_WITH_SOURCE)
+ *
+ * Sprint 4 will replace this with a shared `src/discord/api.ts` used by
+ * both runtimes — see TODO at the bottom of `src/adapters/discord/index.ts`.
+ */
+import type { DiscordRestApiLike } from "./types";
+
+const DISCORD_API = "https://discord.com/api/v10";
+const DISCORD_MAX_MESSAGE_LEN = 2000;
+
+export interface DiscordRestApiOptions {
+  token: string;
+  logger?: Pick<Console, "warn" | "info" | "error">;
+  /** Test seam for `fetch`. Defaults to the global. */
+  fetchImpl?: typeof fetch;
+}
+
+export class DiscordRestApi implements DiscordRestApiLike {
+  private readonly token: string;
+  private readonly logger: Pick<Console, "warn" | "info" | "error">;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: DiscordRestApiOptions) {
+    if (!opts.token) throw new Error("DiscordRestApi: `token` is required");
+    this.token = opts.token;
+    this.logger = opts.logger ?? console;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async sendMessage(channelId: string, text: string, components?: unknown[]): Promise<void> {
+    const chunks = chunkContent(text);
+    if (chunks.length === 0) return;
+    for (let i = 0; i < chunks.length; i++) {
+      const body: Record<string, unknown> = { content: chunks[i] };
+      if (components && i === chunks.length - 1) body.components = components;
+      await this.call("POST", `/channels/${channelId}/messages`, body);
+    }
+  }
+
+  async respondToInteraction(
+    interactionId: string,
+    interactionToken: string,
+    body: { content: string; flags?: number },
+  ): Promise<void> {
+    // Interaction callbacks are NOT bot-token authenticated — they use the
+    // ephemeral interaction token in the URL.
+    const res = await this.fetchImpl(
+      `${DISCORD_API}/interactions/${interactionId}/${interactionToken}/callback`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ type: 4, data: body }),
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(
+        `Discord interaction callback failed: ${res.status} ${res.statusText} ${text}`,
+      );
+    }
+  }
+
+  private async call(
+    method: string,
+    endpoint: string,
+    body?: unknown,
+    attempt = 0,
+  ): Promise<unknown> {
+    const res = await this.fetchImpl(`${DISCORD_API}${endpoint}`, {
+      method,
+      headers: {
+        Authorization: `Bot ${this.token}`,
+        "Content-Type": "application/json",
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+
+    if (res.status === 429) {
+      if (attempt >= 3) {
+        throw new Error(`Discord rate limit exceeded after 3 retries on ${method} ${endpoint}`);
+      }
+      const data = (await res.json().catch(() => ({}))) as { retry_after?: number };
+      const retryMs =
+        typeof data.retry_after === "number" && Number.isFinite(data.retry_after)
+          ? Math.ceil(data.retry_after * 1000)
+          : 5_000;
+      this.logger.warn(
+        `[discord-rest] 429 on ${method} ${endpoint}; retrying in ${retryMs}ms (attempt ${attempt + 1}/3)`,
+      );
+      await sleep(retryMs);
+      return this.call(method, endpoint, body, attempt + 1);
+    }
+
+    if (!res.ok) {
+      const text = await res.text().catch(() => "");
+      throw new Error(`Discord API ${method} ${endpoint}: ${res.status} ${res.statusText} ${text}`);
+    }
+    if (res.status === 204) return undefined;
+    return res.json();
+  }
+}
+
+function chunkContent(text: string): string[] {
+  const normalized = text.replace(/\[react:[^\]\r\n]+\]/gi, "").trim();
+  if (!normalized) return [];
+  const chunks: string[] = [];
+  for (let i = 0; i < normalized.length; i += DISCORD_MAX_MESSAGE_LEN) {
+    chunks.push(normalized.slice(i, i + DISCORD_MAX_MESSAGE_LEN));
+  }
+  return chunks;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function createDiscordRestApi(opts: DiscordRestApiOptions): DiscordRestApi {
+  return new DiscordRestApi(opts);
+}


### PR DESCRIPTION
## Summary

- Port the legacy `src/commands/discord.ts` WS gateway loop (lines 1582–1908) into a class-shaped `DiscordGateway` in `src/adapters/discord/gateway.ts` and the REST subset (sendMessage chunking + interaction callback) into `src/adapters/discord/rest-api.ts`.
- `DiscordAdapter` now auto-constructs both from its token when no `gateway`/`restApi` is injected. Tests keep injecting `FakeDiscordGateway` / `FakeDiscordRestApi` so the suite stays offline.
- Adds focused unit tests for both new modules (HELLO/IDENTIFY/RESUME handshake, MESSAGE_CREATE + INTERACTION_CREATE dispatch, RECONNECT close; REST chunking, `[react:…]` stripping, interaction callback shape, non-OK propagation).

## Why

Last night's Hetzner cutover crashed instantly because the Bus `DiscordAdapter` was constructed with `bus + token + routing` (no `gateway` injection), and the Sprint 3 constructor threw:

> DiscordAdapter: \`gateway\` injection is required in Sprint 3. Shared gateway helper extraction is a Sprint 4 deliverable; until then production callers must construct their own gateway.

That Sprint 4 follow-up never landed. This PR is the smallest viable port: no shared helper extraction across both runtimes (legacy `src/commands/discord.ts` is untouched), just enough to make `runtime: "bus"` mount the Discord adapter without a crash.

## What is NOT in this PR

Legacy GUILD_CREATE / THREAD_* (thread rejoin), slash-command registration, attachment downloads + voice transcription, and streaming edit-in-place rendering are still parity gaps. Those are orthogonal to gateway construction and can land incrementally; the Sprint 5.3 staging guide (#128) already flags them as future work.

## Test plan

- [x] `bun test src/adapters/discord` — 38 pass / 0 fail
- [x] `bun test src/bus src/adapters` — 328 pass / 0 fail / 1 skip
- [x] `bun run lint` — 0 errors (baseline 938 warnings unchanged)
- [x] `bun run bump:plugin-version` + `bun run bump:marketplace-version` → 2.2.60
- [ ] Re-attempt Hetzner cutover to `runtime: "bus"` once merged