### PR TITLE
fix(bus): wire plus-bus channel correctly so spawned claudes connect to bus

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.61",
+      "version": "2.2.62",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.60",
+      "version": "2.2.61",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.61",
+  "version": "2.2.62",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.60",
+  "version": "2.2.61",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/build-claude-args.test.ts
+++ b/src/bus/__tests__/build-claude-args.test.ts
@@ -9,7 +9,7 @@
  * no channel. Every previous test bypassed this by setting
  * `argsOverride: []` on the SessionManager seam.
  */
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
@@ -106,6 +106,27 @@ describe("writeBusMcpConfig", () => {
       mcpServers: Record<string, unknown>;
     };
     expect(Object.keys(cfg.mcpServers)).toEqual(["plus-bus"]);
+  });
+
+  it("creates the synthesised config with 0600 perms (no leak of operator secrets)", () => {
+    // Codex P2 on PR #131: operator `mcp_config` entries may carry
+    // credentials in `env`/`headers`; the synth copy lives in /tmp and
+    // must not be world-readable. Mirrors PR #72 item 2 for the PTY
+    // mcp-config writer.
+    const userCfgPath = join(tmp, "user-mcp.json");
+    writeFileSync(
+      userCfgPath,
+      JSON.stringify({
+        mcpServers: {
+          secret: { command: "bun", env: { GITHUB_TOKEN: "ghp_secret" } },
+        },
+      }),
+    );
+    const agent = makeAgent({ id: "perms-test", mcp_config: userCfgPath });
+    const path = writeBusMcpConfig(agent, { warn: () => {} });
+    // Lowest 9 bits = file permission bits; mask off type bits.
+    const mode = statSync(path).mode & 0o777;
+    expect(mode).toBe(0o600);
   });
 
   it("falls back to bus-only when operator mcp_config is malformed JSON", () => {

--- a/src/bus/__tests__/build-claude-args.test.ts
+++ b/src/bus/__tests__/build-claude-args.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for `buildClaudeArgs` + `writeBusMcpConfig`.
+ *
+ * These cover the wire-up that Sprint 1 missed: the actual CLI args the
+ * Bus runtime passes to `claude`. Sprint 0.6's working probe used a
+ * bare channel name + an `--mcp-config` JSON whose `mcpServers` key
+ * matched the channel name; the original `plugin:plus-bus@local` arg
+ * shipped in PR #110 never matched that contract and silently loaded
+ * no channel. Every previous test bypassed this by setting
+ * `argsOverride: []` on the SessionManager seam.
+ */
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { PLUS_BUS_CHANNEL, buildClaudeArgs, writeBusMcpConfig } from "../session-manager";
+import type { AgentConfig } from "../types";
+
+function makeAgent(over: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    id: over.id ?? "test-agent",
+    cwd: over.cwd ?? process.cwd(),
+    session_id: over.session_id ?? "00000000-0000-0000-0000-000000000000",
+    permission_mode: over.permission_mode,
+    system_prompt_file: over.system_prompt_file,
+    mcp_config: over.mcp_config,
+    supervision: over.supervision ?? "pty-stdin",
+  };
+}
+
+let tmp: string;
+beforeEach(() => {
+  tmp = mkdtempSync(join(tmpdir(), "claudeclaw-bus-args-test-"));
+});
+afterEach(() => {
+  rmSync(tmp, { recursive: true, force: true });
+});
+
+describe("PLUS_BUS_CHANNEL", () => {
+  it("is the bare channel name expected by --dangerously-load-development-channels", () => {
+    // The flag value MUST match an `mcpServers` key. Anything other than
+    // a bare identifier (e.g. `plugin:plus-bus@local`) silently loads no
+    // channel. Spike 0.6 reference: docs/spikes/0.6-stream-json-channels-probe.md.
+    expect(PLUS_BUS_CHANNEL).toBe("plus-bus");
+  });
+});
+
+describe("writeBusMcpConfig", () => {
+  it("writes a JSON config whose mcpServers contains a plus-bus stdio entry", () => {
+    const agent = makeAgent({ id: "alpha" });
+    const path = writeBusMcpConfig(agent, { warn: () => {} });
+    const cfg = JSON.parse(readFileSync(path, "utf8")) as {
+      mcpServers: Record<string, { command: string; args: string[] }>;
+    };
+    expect(cfg.mcpServers[PLUS_BUS_CHANNEL]).toBeDefined();
+    const entry = cfg.mcpServers[PLUS_BUS_CHANNEL]!;
+    // Spawned via current bun (process.execPath); points at mcp-server.ts.
+    expect(entry.command).toBe(process.execPath);
+    expect(entry.args[0]).toBe("run");
+    expect(entry.args[1]).toMatch(/\/bus\/mcp-server\.ts$/);
+  });
+
+  it("merges operator-supplied mcpServers preserving non-conflicting entries", () => {
+    const userCfgPath = join(tmp, "user-mcp.json");
+    writeFileSync(
+      userCfgPath,
+      JSON.stringify({
+        mcpServers: {
+          playwright: { command: "bun", args: ["run", "/some/playwright.ts"] },
+          everything: { command: "node", args: ["/some/everything.js"] },
+        },
+      }),
+    );
+    const agent = makeAgent({ id: "beta", mcp_config: userCfgPath });
+    const path = writeBusMcpConfig(agent, { warn: () => {} });
+    const cfg = JSON.parse(readFileSync(path, "utf8")) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(Object.keys(cfg.mcpServers).sort()).toEqual(["everything", "playwright", "plus-bus"]);
+  });
+
+  it("overwrites an operator-supplied plus-bus entry and warns", () => {
+    const userCfgPath = join(tmp, "user-mcp.json");
+    writeFileSync(
+      userCfgPath,
+      JSON.stringify({
+        mcpServers: {
+          "plus-bus": { command: "evil", args: ["bad"] },
+        },
+      }),
+    );
+    const agent = makeAgent({ id: "gamma", mcp_config: userCfgPath });
+    const warnings: string[] = [];
+    const path = writeBusMcpConfig(agent, { warn: (m: string) => warnings.push(m) });
+    const cfg = JSON.parse(readFileSync(path, "utf8")) as {
+      mcpServers: Record<string, { command: string }>;
+    };
+    expect(cfg.mcpServers["plus-bus"]?.command).toBe(process.execPath);
+    expect(warnings.some((w) => w.includes("reserved name"))).toBe(true);
+  });
+
+  it("falls back to bus-only when operator mcp_config is unreadable", () => {
+    const agent = makeAgent({ id: "delta", mcp_config: join(tmp, "does-not-exist.json") });
+    const path = writeBusMcpConfig(agent, { warn: () => {} });
+    const cfg = JSON.parse(readFileSync(path, "utf8")) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(Object.keys(cfg.mcpServers)).toEqual(["plus-bus"]);
+  });
+
+  it("falls back to bus-only when operator mcp_config is malformed JSON", () => {
+    const userCfgPath = join(tmp, "bad-mcp.json");
+    writeFileSync(userCfgPath, "{not json");
+    const agent = makeAgent({ id: "epsilon", mcp_config: userCfgPath });
+    const warnings: string[] = [];
+    const path = writeBusMcpConfig(agent, { warn: (m: string) => warnings.push(m) });
+    const cfg = JSON.parse(readFileSync(path, "utf8")) as {
+      mcpServers: Record<string, unknown>;
+    };
+    expect(Object.keys(cfg.mcpServers)).toEqual(["plus-bus"]);
+    expect(warnings.some((w) => w.includes("failed to read operator mcp_config"))).toBe(true);
+  });
+});
+
+describe("buildClaudeArgs", () => {
+  it("includes --mcp-config + bare-name channel arg for pty-stdin agents", () => {
+    const agent = makeAgent({ id: "mu" });
+    const args = buildClaudeArgs(agent, "pty-stdin");
+    const mcpIdx = args.indexOf("--mcp-config");
+    const chanIdx = args.indexOf("--dangerously-load-development-channels");
+    expect(mcpIdx).toBeGreaterThanOrEqual(0);
+    expect(chanIdx).toBeGreaterThanOrEqual(0);
+    expect(args[chanIdx + 1]).toBe(PLUS_BUS_CHANNEL);
+    // The mcp-config path must exist on disk; claude reads it on startup.
+    expect(existsSync(args[mcpIdx + 1]!)).toBe(true);
+  });
+
+  it("prepends -p stream-json flags for process-stream-json mode", () => {
+    const agent = makeAgent({ id: "nu" });
+    const args = buildClaudeArgs(agent, "process-stream-json");
+    expect(args[0]).toBe("-p");
+    expect(args).toContain("--input-format=stream-json");
+    expect(args).toContain("--output-format=stream-json");
+    expect(args).toContain("--mcp-config");
+    expect(args).toContain(PLUS_BUS_CHANNEL);
+  });
+
+  it("passes through permission_mode and session_id", () => {
+    const agent = makeAgent({
+      id: "xi",
+      permission_mode: "acceptEdits",
+      session_id: "deadbeef-1234-1234-1234-000000000000",
+    });
+    const args = buildClaudeArgs(agent, "pty-stdin");
+    const pmIdx = args.indexOf("--permission-mode");
+    const sidIdx = args.indexOf("--session-id");
+    expect(args[pmIdx + 1]).toBe("acceptEdits");
+    expect(args[sidIdx + 1]).toBe("deadbeef-1234-1234-1234-000000000000");
+  });
+});

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -28,7 +28,7 @@
  */
 
 import { spawn as nodeSpawnChildProcess } from "node:child_process";
-import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { chmodSync, existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -207,7 +207,19 @@ export function writeBusMcpConfig(
   }
   mcpServers[PLUS_BUS_CHANNEL] = busEntry;
   const path = join(tmpdir(), `claudeclaw-bus-mcp-${process.pid}-${agent.id}.json`);
-  writeFileSync(path, JSON.stringify({ mcpServers }, null, 2));
+  // 0600 — operator mcp_config entries may carry credentials in `env` or
+  // `headers`; the synthesised copy must not be world-readable in /tmp.
+  // Belt-and-braces (same pattern as src/runner/pty-mcp-config-writer.ts:172):
+  // `writeFileSync({mode})` only takes effect on CREATE and a permissive
+  // umask can still widen bits — an explicit chmodSync after the write
+  // forces 0600 regardless of platform / umask / prior file state.
+  writeFileSync(path, JSON.stringify({ mcpServers }, null, 2), { mode: 0o600 });
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // Best-effort. Some test/FUSE filesystems lack permission semantics;
+    // the writeFileSync mode already applied where supported.
+  }
   return path;
 }
 

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -28,9 +28,10 @@
  */
 
 import { spawn as nodeSpawnChildProcess } from "node:child_process";
-import { realpathSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { cleanSpawnEnv, withCleanProcessEnv } from "../runner";
 import {
   type AgentProcess,
@@ -144,20 +145,88 @@ function buildChildEnv(agent: AgentConfig, busSocketPath: string): Record<string
 }
 
 /**
- * Build the args list passed to the spawned `claude`. Mirrors §5.3 sample.
+ * Channel name used for the Bus MCP stdio plugin loaded into every
+ * spawned `claude`. The `--dangerously-load-development-channels` value
+ * MUST match an `mcpServers` key in the `--mcp-config` JSON — that
+ * mapping is what tells `claude` which stdio command to start as the
+ * channel-bearing MCP server. Spike 0.6's working probe used a bare
+ * channel name (`probe-channel`); the legacy `plugin:plus-bus@local`
+ * string didn't resolve to anything and silently loaded no channel,
+ * which is why every Sprint 1 e2e test passed (those inject a fake
+ * IPC transport directly) while real `claude` never connected to the
+ * Bus IPC server.
  */
-function buildClaudeArgs(agent: AgentConfig, mode: SupervisionMode): string[] {
+export const PLUS_BUS_CHANNEL = "plus-bus";
+
+/** Absolute path to the Bus MCP server entrypoint we tell `claude` to spawn. */
+function resolveBusMcpServerPath(): string {
+  // `session-manager.ts` lives in `src/bus/`; so does `mcp-server.ts`.
+  // Resolved via `import.meta.url` so it works both for `bun run` against
+  // the TS source (production) and for any future bundled deployment.
+  const here = fileURLToPath(import.meta.url);
+  return join(dirname(here), "mcp-server.ts");
+}
+
+/**
+ * Synthesise the `--mcp-config` JSON `claude` will read at startup. The
+ * config always contains a `plus-bus` entry whose `command`/`args` point
+ * at our Bus MCP server. If the operator supplied their own
+ * `agent.mcp_config` we merge their `mcpServers` map into ours so user
+ * MCPs continue to load alongside Bus IPC. The `plus-bus` key is
+ * reserved — operator entries with the same name are overwritten with a
+ * warning (the bus channel won't function under any other name).
+ *
+ * The synthesised file lives under `os.tmpdir()` and is keyed by pid +
+ * agent id so concurrent daemons / restarts don't clobber each other.
+ */
+export function writeBusMcpConfig(
+  agent: AgentConfig,
+  logger: Pick<Console, "warn"> = console,
+): string {
+  const busEntry = {
+    command: process.execPath, // current bun
+    args: ["run", resolveBusMcpServerPath()],
+  };
+  let mcpServers: Record<string, unknown> = {};
+  if (agent.mcp_config && existsSync(agent.mcp_config)) {
+    try {
+      const parsed = JSON.parse(readFileSync(agent.mcp_config, "utf8")) as {
+        mcpServers?: Record<string, unknown>;
+      };
+      mcpServers = { ...(parsed.mcpServers ?? {}) };
+    } catch (err) {
+      logger.warn(
+        `[bus-session] failed to read operator mcp_config at ${agent.mcp_config}; falling back to bus-only: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+  }
+  if (mcpServers[PLUS_BUS_CHANNEL]) {
+    logger.warn(
+      `[bus-session] operator mcp_config defines a "${PLUS_BUS_CHANNEL}" server — overwriting (reserved name)`,
+    );
+  }
+  mcpServers[PLUS_BUS_CHANNEL] = busEntry;
+  const path = join(tmpdir(), `claudeclaw-bus-mcp-${process.pid}-${agent.id}.json`);
+  writeFileSync(path, JSON.stringify({ mcpServers }, null, 2));
+  return path;
+}
+
+/**
+ * Build the args list passed to the spawned `claude`. Mirrors §5.3 sample.
+ *
+ * Side effect: writes a per-agent `--mcp-config` file to `os.tmpdir()`.
+ * Called once per spawn from `SessionManager.spawnAgent`.
+ */
+export function buildClaudeArgs(agent: AgentConfig, mode: SupervisionMode): string[] {
   const args: string[] = [];
   if (mode === "process-stream-json") {
     args.push("-p", "--input-format=stream-json", "--output-format=stream-json", "--verbose");
   }
-  args.push("--dangerously-load-development-channels", "plugin:plus-bus@local");
+  args.push("--mcp-config", writeBusMcpConfig(agent));
+  args.push("--dangerously-load-development-channels", PLUS_BUS_CHANNEL);
   args.push("--permission-mode", agent.permission_mode ?? "plan");
   if (agent.system_prompt_file) {
     args.push("--append-system-prompt", agent.system_prompt_file);
-  }
-  if (agent.mcp_config) {
-    args.push("--mcp-config", agent.mcp_config);
   }
   args.push("--session-id", agent.session_id);
   return args;


### PR DESCRIPTION
## Summary

Production cutover to `runtime: "bus"` on Hetzner crashed after PR #130 with `No MCP connection for agent_id=default`. Root cause: the Sprint 1 spawn args never actually wired the `plus-bus` channel into claude.

- The flag value `plugin:plus-bus@local` shipped in PR #110 isn't a real claude syntax. `--dangerously-load-development-channels` takes a *bare channel name* that must match an `mcpServers` key in `--mcp-config`.
- No `--mcp-config` containing a `plus-bus` entry was being generated, so even if the name had matched there was nothing to launch.

Every Bus test passed because the SessionManager seam (`argsOverride: []` or fake IPC transport) bypassed both the arg shape and the spawn. The only working probe in the planning history (`docs/spikes/0.6-stream-json-channels-probe.md`) used the correct pattern that Sprint 1 implementation didn't follow.

## Changes

- `src/bus/session-manager.ts`
  - `PLUS_BUS_CHANNEL = "plus-bus"` — bare name claude expects.
  - `writeBusMcpConfig(agent)` — synthesises a per-agent `--mcp-config` JSON under `os.tmpdir()` with a `plus-bus` stdio entry pointing at `src/bus/mcp-server.ts` via the current `bun` binary. Operator-supplied `agent.mcp_config` is merged in; the reserved `plus-bus` key wins on conflict with a warning.
  - `buildClaudeArgs` exported for testing; always emits `--mcp-config <synth path>` + the corrected channel arg.
- `src/bus/__tests__/build-claude-args.test.ts` — new suite covering the arg shape, mcp-config synthesis, operator-config merge, and unreadable/malformed fallback paths.

## Why no shared helper extraction yet

This PR is the smallest viable fix — it does not refactor `mcp-server.ts` to declare itself as a proper claude-installable plugin manifest. That's a larger Sprint 4 deliverable. For now we use the `--mcp-config`-pointing-at-stdio-command pattern that Spike 0.6 validated against a live claude.

## Test plan

- [x] `bun test src/bus/__tests__/build-claude-args.test.ts` — 9 pass / 0 fail
- [x] `bun test src/bus src/adapters` — 337 pass / 0 fail / 1 skip
- [x] `bun run lint` — 0 errors, 940 warnings (baseline 938 + 2 stylistic `!` warnings in tests matching existing 389-instance pattern)
- [x] `bun run bump:plugin-version` + `bun run bump:marketplace-version` → 2.2.61
- [ ] Hetzner cutover retry after merge — expect `[discord-gateway] READY` followed by an actual bus IPC handshake from the spawned default agent, not the `No MCP connection` error