### PR TITLE
feat(bus): wire plus-bus channel via --plugin-dir, finish staging

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.63",
+      "version": "2.2.64",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.62",
+      "version": "2.2.63",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.62",
+  "version": "2.2.63",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.63",
+  "version": "2.2.64",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,8 @@
 {
   "mcpServers": {
     "plus-bus": {
-      "command": "bun",
-      "args": ["run", "${CLAUDE_PLUGIN_ROOT}/src/bus/mcp-server.ts"]
+      "command": "${CLAUDE_PLUGIN_ROOT}/scripts/start-bus-mcp",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/src/bus/mcp-server.ts"]
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "plus-bus": {
+      "command": "bun",
+      "args": ["run", "${CLAUDE_PLUGIN_ROOT}/src/bus/mcp-server.ts"]
+    }
+  }
+}

--- a/scripts/start-bus-mcp
+++ b/scripts/start-bus-mcp
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Bus MCP server launcher — keeps `.mcp.json` portable.
+#
+# claude's plugin .mcp.json substitutes ${CLAUDE_PLUGIN_ROOT} and
+# ${CLAUDE_PLUGIN_DATA} but NOT arbitrary env vars, so we can't bake a
+# bun-path indirection straight into the JSON. This script does it
+# instead: prefer the daemon-supplied absolute bun path (which the
+# daemon sets in the spawned claude's env) and fall back to PATH lookup
+# for marketplace installs that aren't running under the daemon.
+#
+# Codex P2 on PR #133 — without this indirection, restricted-PATH
+# deployments where the daemon was launched via an absolute bun path
+# would fail to start plus-bus because claude inherits the systemd /
+# launcher PATH which may not include the bun directory.
+set -euo pipefail
+BUN="${CCAW_BUS_BUN_PATH:-bun}"
+exec "$BUN" run "$@"

--- a/src/adapters/discord/__tests__/discord-inbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-inbound.test.ts
@@ -300,6 +300,30 @@ describe("DiscordAdapter — attachments", () => {
   });
 });
 
+describe("DiscordAdapter — typing indicator", () => {
+  it("fires a typing indicator on every accepted prompt", async () => {
+    adapter = await startAdapter(h);
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({ channel_id: "ch-1", guild_id: "g-1", content: "hi" }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(1);
+    expect(h.rest.typings).toContain("ch-1");
+  });
+
+  it("does NOT send typing when the prompt is rejected (rate-limited)", async () => {
+    adapter = await startAdapter(h, { rateLimitCheck: () => false });
+    h.gateway.push({
+      type: "MESSAGE_CREATE",
+      message: makeMessage({ channel_id: "ch-1", guild_id: "g-1", content: "hi" }),
+    });
+    await flushMicrotasks();
+    expect(h.bus.prompts).toHaveLength(0);
+    expect(h.rest.typings).toHaveLength(0);
+  });
+});
+
 describe("DiscordAdapter — rate limit", () => {
   it("drops messages above the limit", async () => {
     let calls = 0;

--- a/src/adapters/discord/__tests__/discord-outbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-outbound.test.ts
@@ -59,6 +59,34 @@ describe("DiscordAdapter — outbound response.text", () => {
     });
     expect(h.rest.sent).toHaveLength(0);
   });
+
+  it("routes response.text ONLY to the originating channel when origin is preserved", async () => {
+    // BusCore now stamps the originating prompt's `origin` + `origin_id`
+    // onto outbound `response.text` events so adapters can reply to the
+    // same surface (DM / specific channel) instead of fanning out.
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "scoped reply", origin: "discord", origin_id: "dm-42" },
+    });
+    expect(h.rest.sent.map((m) => m.channelId)).toEqual(["dm-42"]);
+    expect(h.rest.sent[0]?.text).toBe("scoped reply");
+  });
+
+  it("falls back to channelsForAgent when no origin in payload", async () => {
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "broadcast" },
+    });
+    expect(h.rest.sent.map((m) => m.channelId).sort()).toEqual(["ch-2", "th-1"]);
+  });
 });
 
 describe("DiscordAdapter — permission flow", () => {

--- a/src/adapters/discord/__tests__/fixtures.ts
+++ b/src/adapters/discord/__tests__/fixtures.ts
@@ -158,6 +158,7 @@ export interface SentInteractionAck {
 export class FakeDiscordRestApi implements DiscordRestApiLike {
   public readonly sent: SentMessage[] = [];
   public readonly acks: SentInteractionAck[] = [];
+  public readonly typings: string[] = [];
 
   async sendMessage(channelId: string, text: string, components?: unknown[]): Promise<void> {
     this.sent.push({ channelId, text, components });
@@ -169,6 +170,10 @@ export class FakeDiscordRestApi implements DiscordRestApiLike {
     body: { content: string; flags?: number },
   ): Promise<void> {
     this.acks.push({ interactionId, body });
+  }
+
+  async sendTyping(channelId: string): Promise<void> {
+    this.typings.push(channelId);
   }
 }
 

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -294,7 +294,16 @@ export class DiscordAdapter {
       });
     } catch (err) {
       this.logger.error("[discord-adapter] sendPrompt failed", err);
+      return;
     }
+    // Visible "Bot is typing..." indicator so users get immediate
+    // feedback that the prompt was received. Fire-and-forget — Discord
+    // auto-clears after ~10 seconds; if the agent reply takes longer
+    // the indicator just lapses and reappears on the next typing call.
+    // Failures are logged but don't block prompt processing.
+    void this.restApi.sendTyping(channelId).catch((err) => {
+      this.logger.warn("[discord-adapter] sendTyping failed", err);
+    });
   }
 
   /**
@@ -364,12 +373,18 @@ export class DiscordAdapter {
   /* ──────────────────────────── outbound (bus → discord) ──────────── */
 
   private handleBusEvent(agentId: string, event: BusEvent): void {
-    // The originating channel rides on the prompt event's payload, but
-    // the bus doesn't carry it through to subsequent events for this
-    // session. For now post to every routed channel for the agent.
-    // Single-channel routing per response is a Sprint 4 polish item
-    // (see TODO at the end of this file).
-    const targetChannels = this.channelsForAgent(agentId);
+    // Determine the destination channel set. If the event payload
+    // carries an `origin: "discord"` + `origin_id` pair (populated by
+    // BusCore from the originating prompt), the reply goes ONLY to that
+    // channel — handles DMs and avoids fan-out spam. Otherwise we fall
+    // back to every routed channel for the agent (cron jobs, scheduler-
+    // initiated replies that have no inbound prompt).
+    const payloadWithOrigin = event.payload as { origin?: string; origin_id?: string } | undefined;
+    const originChannel =
+      payloadWithOrigin?.origin === "discord" && typeof payloadWithOrigin?.origin_id === "string"
+        ? payloadWithOrigin.origin_id
+        : null;
+    const targetChannels = originChannel ? [originChannel] : this.channelsForAgent(agentId);
     if (targetChannels.length === 0) return;
 
     if (event.topic === "response.text") {

--- a/src/adapters/discord/rest-api.ts
+++ b/src/adapters/discord/rest-api.ts
@@ -44,6 +44,12 @@ export class DiscordRestApi implements DiscordRestApiLike {
     }
   }
 
+  async sendTyping(channelId: string): Promise<void> {
+    // Returns 204; we just need the side effect (~10s typing indicator).
+    // Errors propagate via this.call so the adapter can log them.
+    await this.call("POST", `/channels/${channelId}/typing`);
+  }
+
   async respondToInteraction(
     interactionId: string,
     interactionToken: string,

--- a/src/adapters/discord/types.ts
+++ b/src/adapters/discord/types.ts
@@ -134,6 +134,13 @@ export interface DiscordRestApiLike {
     interactionToken: string,
     body: { content: string; flags?: number },
   ): Promise<void>;
+  /**
+   * Fire-and-forget typing indicator. Discord shows "Bot is typing..."
+   * for ~10 seconds after this call returns. The adapter triggers one on
+   * every accepted inbound prompt so users get visible feedback while
+   * the agent generates a reply.
+   */
+  sendTyping(channelId: string): Promise<void>;
 }
 
 /* ────────────────────────────────────────────────────────────────────── */

--- a/src/bus/__tests__/build-claude-args.test.ts
+++ b/src/bus/__tests__/build-claude-args.test.ts
@@ -1,19 +1,36 @@
 /**
- * Unit tests for `buildClaudeArgs` + `writeBusMcpConfig`.
+ * Unit tests for `buildClaudeArgs`.
  *
- * These cover the wire-up that Sprint 1 missed: the actual CLI args the
- * Bus runtime passes to `claude`. Sprint 0.6's working probe used a
- * bare channel name + an `--mcp-config` JSON whose `mcpServers` key
- * matched the channel name; the original `plugin:plus-bus@local` arg
- * shipped in PR #110 never matched that contract and silently loaded
- * no channel. Every previous test bypassed this by setting
- * `argsOverride: []` on the SessionManager seam.
+ * History — four wire-up attempts before the current one worked
+ * end-to-end against a live `claude` 2.1.89 in PTY-stdin mode:
+ *
+ *   1. `--dangerously-load-development-channels plugin:plus-bus@local`
+ *      (PR #110) — silently loaded no channel.
+ *   2. `--dangerously-load-development-channels server:plus-bus` +
+ *      synth `--mcp-config` (PR #131) — interactive TUI confirmation
+ *      the PTY supervisor can't drive.
+ *   3. `--plugin-dir <root>` alone — channel loaded but notifications
+ *      silently dropped (allowlist gate).
+ *   4. `--plugin-dir` + `--settings channelsEnabled` + `--channels` —
+ *      managed-settings allowlist override is `team`/`enterprise` only.
+ *
+ * Current: `--plugin-dir` + `--dangerously-load-development-channels
+ * plugin:claudeclaw-plus@inline` + `--allowedTools <plus-bus tools>`.
+ * The danger flag's dialog stays dormant when `channelsEnabled` is
+ * unset; we still send a belt-and-braces Enter from the PTY supervisor
+ * shortly after spawn in case the account has the channels feature flag
+ * on.
  */
-import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { PLUS_BUS_CHANNEL, buildClaudeArgs, writeBusMcpConfig } from "../session-manager";
+import {
+  CLAUDECLAW_PLUGIN_NAME,
+  PLUS_BUS_CHANNEL,
+  buildClaudeArgs,
+  resolveClaudeclawPluginRoot,
+} from "../session-manager";
 import type { AgentConfig } from "../types";
 
 function makeAgent(over: Partial<AgentConfig> = {}): AgentConfig {
@@ -37,145 +54,87 @@ afterEach(() => {
 });
 
 describe("PLUS_BUS_CHANNEL", () => {
-  it("is the bare channel name expected by --dangerously-load-development-channels", () => {
-    // The flag value MUST match an `mcpServers` key. Anything other than
-    // a bare identifier (e.g. `plugin:plus-bus@local`) silently loads no
-    // channel. Spike 0.6 reference: docs/spikes/0.6-stream-json-channels-probe.md.
+  it("is 'plus-bus' (matches the mcpServers key in .mcp.json)", () => {
     expect(PLUS_BUS_CHANNEL).toBe("plus-bus");
   });
 });
 
-describe("writeBusMcpConfig", () => {
-  it("writes a JSON config whose mcpServers contains a plus-bus stdio entry", () => {
-    const agent = makeAgent({ id: "alpha" });
-    const path = writeBusMcpConfig(agent, { warn: () => {} });
-    const cfg = JSON.parse(readFileSync(path, "utf8")) as {
-      mcpServers: Record<string, { command: string; args: string[] }>;
-    };
-    expect(cfg.mcpServers[PLUS_BUS_CHANNEL]).toBeDefined();
-    const entry = cfg.mcpServers[PLUS_BUS_CHANNEL]!;
-    // Spawned via current bun (process.execPath); points at mcp-server.ts.
-    expect(entry.command).toBe(process.execPath);
-    expect(entry.args[0]).toBe("run");
-    expect(entry.args[1]).toMatch(/\/bus\/mcp-server\.ts$/);
+describe("CLAUDECLAW_PLUGIN_NAME", () => {
+  it("is 'claudeclaw-plus' (matches .claude-plugin/plugin.json name)", () => {
+    expect(CLAUDECLAW_PLUGIN_NAME).toBe("claudeclaw-plus");
   });
+});
 
-  it("merges operator-supplied mcpServers preserving non-conflicting entries", () => {
-    const userCfgPath = join(tmp, "user-mcp.json");
-    writeFileSync(
-      userCfgPath,
-      JSON.stringify({
-        mcpServers: {
-          playwright: { command: "bun", args: ["run", "/some/playwright.ts"] },
-          everything: { command: "node", args: ["/some/everything.js"] },
-        },
-      }),
-    );
-    const agent = makeAgent({ id: "beta", mcp_config: userCfgPath });
-    const path = writeBusMcpConfig(agent, { warn: () => {} });
-    const cfg = JSON.parse(readFileSync(path, "utf8")) as {
-      mcpServers: Record<string, unknown>;
-    };
-    expect(Object.keys(cfg.mcpServers).sort()).toEqual(["everything", "playwright", "plus-bus"]);
-  });
-
-  it("overwrites an operator-supplied plus-bus entry and warns", () => {
-    const userCfgPath = join(tmp, "user-mcp.json");
-    writeFileSync(
-      userCfgPath,
-      JSON.stringify({
-        mcpServers: {
-          "plus-bus": { command: "evil", args: ["bad"] },
-        },
-      }),
-    );
-    const agent = makeAgent({ id: "gamma", mcp_config: userCfgPath });
-    const warnings: string[] = [];
-    const path = writeBusMcpConfig(agent, { warn: (m: string) => warnings.push(m) });
-    const cfg = JSON.parse(readFileSync(path, "utf8")) as {
-      mcpServers: Record<string, { command: string }>;
-    };
-    expect(cfg.mcpServers["plus-bus"]?.command).toBe(process.execPath);
-    expect(warnings.some((w) => w.includes("reserved name"))).toBe(true);
-  });
-
-  it("falls back to bus-only when operator mcp_config is unreadable", () => {
-    const agent = makeAgent({ id: "delta", mcp_config: join(tmp, "does-not-exist.json") });
-    const path = writeBusMcpConfig(agent, { warn: () => {} });
-    const cfg = JSON.parse(readFileSync(path, "utf8")) as {
-      mcpServers: Record<string, unknown>;
-    };
-    expect(Object.keys(cfg.mcpServers)).toEqual(["plus-bus"]);
-  });
-
-  it("creates the synthesised config with 0600 perms (no leak of operator secrets)", () => {
-    // Codex P2 on PR #131: operator `mcp_config` entries may carry
-    // credentials in `env`/`headers`; the synth copy lives in /tmp and
-    // must not be world-readable. Mirrors PR #72 item 2 for the PTY
-    // mcp-config writer.
-    const userCfgPath = join(tmp, "user-mcp.json");
-    writeFileSync(
-      userCfgPath,
-      JSON.stringify({
-        mcpServers: {
-          secret: { command: "bun", env: { GITHUB_TOKEN: "ghp_secret" } },
-        },
-      }),
-    );
-    const agent = makeAgent({ id: "perms-test", mcp_config: userCfgPath });
-    const path = writeBusMcpConfig(agent, { warn: () => {} });
-    // Lowest 9 bits = file permission bits; mask off type bits.
-    const mode = statSync(path).mode & 0o777;
-    expect(mode).toBe(0o600);
-  });
-
-  it("falls back to bus-only when operator mcp_config is malformed JSON", () => {
-    const userCfgPath = join(tmp, "bad-mcp.json");
-    writeFileSync(userCfgPath, "{not json");
-    const agent = makeAgent({ id: "epsilon", mcp_config: userCfgPath });
-    const warnings: string[] = [];
-    const path = writeBusMcpConfig(agent, { warn: (m: string) => warnings.push(m) });
-    const cfg = JSON.parse(readFileSync(path, "utf8")) as {
-      mcpServers: Record<string, unknown>;
-    };
-    expect(Object.keys(cfg.mcpServers)).toEqual(["plus-bus"]);
-    expect(warnings.some((w) => w.includes("failed to read operator mcp_config"))).toBe(true);
+describe("resolveClaudeclawPluginRoot", () => {
+  it("points at a directory containing .claude-plugin/plugin.json and .mcp.json", () => {
+    const root = resolveClaudeclawPluginRoot();
+    expect(existsSync(join(root, ".claude-plugin", "plugin.json"))).toBe(true);
+    expect(existsSync(join(root, ".mcp.json"))).toBe(true);
   });
 });
 
 describe("buildClaudeArgs", () => {
-  it("includes --mcp-config + bare-name channel arg for pty-stdin agents", () => {
-    const agent = makeAgent({ id: "mu" });
-    const args = buildClaudeArgs(agent, "pty-stdin");
-    const mcpIdx = args.indexOf("--mcp-config");
+  it("passes --plugin-dir at the plugin root", () => {
+    const args = buildClaudeArgs(makeAgent({ id: "mu" }), "pty-stdin");
+    const pluginIdx = args.indexOf("--plugin-dir");
+    expect(pluginIdx).toBeGreaterThanOrEqual(0);
+    expect(args[pluginIdx + 1]).toBe(resolveClaudeclawPluginRoot());
+  });
+
+  it("passes --dangerously-load-development-channels with the tagged channel name", () => {
+    const args = buildClaudeArgs(makeAgent({ id: "nu" }), "pty-stdin");
     const chanIdx = args.indexOf("--dangerously-load-development-channels");
-    expect(mcpIdx).toBeGreaterThanOrEqual(0);
     expect(chanIdx).toBeGreaterThanOrEqual(0);
-    expect(args[chanIdx + 1]).toBe(PLUS_BUS_CHANNEL);
-    // The mcp-config path must exist on disk; claude reads it on startup.
-    expect(existsSync(args[mcpIdx + 1]!)).toBe(true);
+    // Tagged form: `plugin:<plugin-name>@<marketplace>`. Marketplace tag
+    // is whatever claude assigns to `--plugin-dir`-loaded plugins.
+    expect(args[chanIdx + 1]).toMatch(new RegExp(`^plugin:${CLAUDECLAW_PLUGIN_NAME}@[a-z-]+$`));
+  });
+
+  it("auto-allowlists the plus-bus channel's own MCP tools via --allowedTools", () => {
+    const args = buildClaudeArgs(makeAgent({ id: "xi" }), "pty-stdin");
+    const allowIdx = args.indexOf("--allowedTools");
+    expect(allowIdx).toBeGreaterThanOrEqual(0);
+    const allowed = args[allowIdx + 1] ?? "";
+    expect(allowed).toContain("mcp__plugin_claudeclaw-plus_plus-bus__reply");
+    expect(allowed).toContain("mcp__plugin_claudeclaw-plus_plus-bus__ask");
+    expect(allowed).toContain("mcp__plugin_claudeclaw-plus_plus-bus__cancel");
+    expect(allowed).toContain("mcp__plugin_claudeclaw-plus_plus-bus__request_human");
   });
 
   it("prepends -p stream-json flags for process-stream-json mode", () => {
-    const agent = makeAgent({ id: "nu" });
-    const args = buildClaudeArgs(agent, "process-stream-json");
+    const args = buildClaudeArgs(makeAgent({ id: "omicron" }), "process-stream-json");
     expect(args[0]).toBe("-p");
     expect(args).toContain("--input-format=stream-json");
     expect(args).toContain("--output-format=stream-json");
-    expect(args).toContain("--mcp-config");
-    expect(args).toContain(PLUS_BUS_CHANNEL);
+    expect(args).toContain("--plugin-dir");
+  });
+
+  it("passes through operator-supplied --mcp-config alongside the plugin dir", () => {
+    const userCfgPath = join(tmp, "user-mcp.json");
+    writeFileSync(userCfgPath, JSON.stringify({ mcpServers: {} }));
+    const agent = makeAgent({ id: "rho", mcp_config: userCfgPath });
+    const args = buildClaudeArgs(agent, "pty-stdin");
+    expect(args).toContain("--plugin-dir");
+    const mcpIdx = args.indexOf("--mcp-config");
+    expect(mcpIdx).toBeGreaterThanOrEqual(0);
+    expect(args[mcpIdx + 1]).toBe(userCfgPath);
+  });
+
+  it("omits --mcp-config entirely when no operator config is set", () => {
+    const args = buildClaudeArgs(makeAgent({ id: "sigma" }), "pty-stdin");
+    expect(args).not.toContain("--mcp-config");
   });
 
   it("passes through permission_mode and session_id", () => {
     const agent = makeAgent({
-      id: "xi",
-      permission_mode: "acceptEdits",
+      id: "tau",
+      permission_mode: "default",
       session_id: "deadbeef-1234-1234-1234-000000000000",
     });
     const args = buildClaudeArgs(agent, "pty-stdin");
     const pmIdx = args.indexOf("--permission-mode");
     const sidIdx = args.indexOf("--session-id");
-    expect(args[pmIdx + 1]).toBe("acceptEdits");
+    expect(args[pmIdx + 1]).toBe("default");
     expect(args[sidIdx + 1]).toBe("deadbeef-1234-1234-1234-000000000000");
   });
 });

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -221,6 +221,81 @@ describe("BusCore pub/sub", () => {
       /slashCommandHandler/,
     );
   });
+
+  /* ── origin propagation: see PR #133 + Codex P1 follow-up ──────────── */
+
+  it("ingestReply stamps the originating origin/origin_id from the most recent prompt", async () => {
+    bus = createBusCore({ eventLogAppend: createMockEventLog().append });
+    const received: BusEvent[] = [];
+    bus.subscribe({ agent_id: "alpha", topics: ["response.text"] }, (e) => received.push(e));
+
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "discord",
+      origin_id: "dm-channel-42",
+      user_id: "u1",
+      text: "hi",
+    });
+    bus.ingestReply({ agent_id: "alpha", text: "hi back", intent: "progress" });
+
+    const replies = received.filter((e) => e.topic === "response.text");
+    expect(replies).toHaveLength(1);
+    const payload = replies[0]?.payload as { origin?: string; origin_id?: string };
+    expect(payload.origin).toBe("discord");
+    expect(payload.origin_id).toBe("dm-channel-42");
+  });
+
+  it("clears the cached origin after a 'final' reply so scheduler/cron events don't inherit it (Codex P1 on #133)", async () => {
+    bus = createBusCore({ eventLogAppend: createMockEventLog().append });
+    const received: BusEvent[] = [];
+    bus.subscribe({ agent_id: "alpha", topics: ["response.text"] }, (e) => received.push(e));
+
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "discord",
+      origin_id: "dm-1",
+      user_id: "u1",
+      text: "first",
+    });
+    bus.ingestReply({ agent_id: "alpha", text: "first reply", intent: "final" });
+    // Simulate an unprompted reply that follows — e.g. a scheduler tick
+    // or a tool-status event with no fresh sendPrompt before it.
+    bus.ingestReply({ agent_id: "alpha", text: "unprompted update", intent: "progress" });
+
+    const replies = received.filter((e) => e.topic === "response.text");
+    expect(replies).toHaveLength(2);
+    const finalReply = replies[0]?.payload as { origin_id?: string };
+    const orphanReply = replies[1]?.payload as { origin_id?: string };
+    // The final reply still carries the prompt's origin (used by the
+    // adapter to route the response back to the DM). The follow-up
+    // unprompted reply must NOT inherit it.
+    expect(finalReply.origin_id).toBe("dm-1");
+    expect(orphanReply.origin_id).toBeUndefined();
+  });
+
+  it("keeps the origin across progress + tool_status events until the final reply", async () => {
+    bus = createBusCore({ eventLogAppend: createMockEventLog().append });
+    const received: BusEvent[] = [];
+    bus.subscribe({ agent_id: "alpha", topics: ["response.text", "response.tool_use"] }, (e) =>
+      received.push(e),
+    );
+
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "discord",
+      origin_id: "ch-77",
+      user_id: "u1",
+      text: "do a thing",
+    });
+    bus.ingestReply({ agent_id: "alpha", text: "running", intent: "progress" });
+    bus.ingestReply({ agent_id: "alpha", text: "using tool X", intent: "tool_status" });
+    bus.ingestReply({ agent_id: "alpha", text: "done", intent: "final" });
+
+    expect(received).toHaveLength(3);
+    for (const e of received) {
+      expect((e.payload as { origin_id?: string }).origin_id).toBe("ch-77");
+    }
+  });
 });
 
 /* ───────────────────────────────────────────────────────────────────── */

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -321,6 +321,17 @@ export class BusCoreImpl implements BusCore {
       },
     };
     this.publish(event);
+    // Codex P1 on PR #133: clear the cached origin once the agent has
+    // signalled the turn is done (`intent: "final"`). Without this,
+    // any unprompted reply that follows — scheduler ticks, background
+    // tool_status events, cron-fired jobs without their own sendPrompt
+    // — would inherit the previous prompt's origin and misroute to
+    // whichever DM/channel last asked the agent something. Progress
+    // and tool_status intents keep the origin so mid-stream updates
+    // stay scoped to the originating surface.
+    if (req.intent === "final") {
+      this.lastPromptOrigin.delete(req.agent_id);
+    }
   }
 
   ingestSessionEvent(e: BusEvent): void {

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -143,6 +143,16 @@ export class BusCoreImpl implements BusCore {
   private readonly eventLogAppend: EventLogAppendFn;
   private slashCommandHandler: SlashCommandHandler | null;
   private readonly onError: (err: unknown, ctx?: Record<string, unknown>) => void;
+  /**
+   * Tracks the origin (surface + channel id) of the most recent prompt
+   * per agent. Adapters use this on outbound `response.text` events to
+   * route the reply back to the originating channel/DM rather than
+   * fanning out to every channel the agent owns. Last-write-wins —
+   * acceptable because Discord/Telegram bots wait for a reply before
+   * sending another prompt; interleaved prompts on the same agent
+   * fall back to broadcast behaviour at the adapter level.
+   */
+  private readonly lastPromptOrigin = new Map<string, { origin: BusOrigin; origin_id: string }>();
 
   constructor(opts: BusCoreOptions = {}) {
     this.socketPath = opts.socketPath ?? null;
@@ -213,6 +223,12 @@ export class BusCoreImpl implements BusCore {
       },
     };
     this.publish(promptEvent);
+    // Remember the origin so `ingestReply` can attach it to the
+    // outbound `response.text` event for surface-aware routing.
+    this.lastPromptOrigin.set(req.agent_id, {
+      origin: req.origin,
+      origin_id: req.origin_id,
+    });
 
     const ipcMsg: IpcPrompt = {
       type: "prompt",
@@ -282,12 +298,27 @@ export class BusCoreImpl implements BusCore {
   ingestReply(req: IngestReplyRequest): void {
     const topic: BusEventTopic =
       req.intent === "tool_status" ? "response.tool_use" : "response.text";
-    const event: BusEvent<{ text: string; intent: string }> = {
+    // Attach the originating surface so adapters can route the reply
+    // back to the same DM / channel rather than fanning out. The lookup
+    // is best-effort — if no prompt has been seen yet (e.g. a scheduler-
+    // initiated reply), the field stays undefined and the adapter falls
+    // back to its configured channel set.
+    const origin = this.lastPromptOrigin.get(req.agent_id);
+    const event: BusEvent<{
+      text: string;
+      intent: string;
+      origin?: BusOrigin;
+      origin_id?: string;
+    }> = {
       ts: Date.now(),
       agent_id: req.agent_id,
       session_id: "",
       topic,
-      payload: { text: req.text, intent: req.intent },
+      payload: {
+        text: req.text,
+        intent: req.intent,
+        ...(origin ? { origin: origin.origin, origin_id: origin.origin_id } : {}),
+      },
     };
     this.publish(event);
   }

--- a/src/bus/mcp-server.ts
+++ b/src/bus/mcp-server.ts
@@ -561,6 +561,19 @@ export async function startBusMcpServer(
 }
 
 if (import.meta.main) {
+  // When this server is auto-loaded by `claude --plugin-dir <root>` from
+  // the ClaudeClaw+ plugin's `.mcp.json`, it gets invoked in TWO
+  // contexts:
+  //
+  //   1. Daemon-spawned agent (Bus runtime active): `CCAW_BUS_SOCK` and
+  //      `CCAW_AGENT_ID` are set by SessionManager — boot the server.
+  //   2. Operator's own interactive claude with the plugin installed
+  //      but no daemon running: env vars absent — silently exit. Without
+  //      this guard, every claude session would log a noisy "Bus MCP:
+  //      fatal startup error" from a server they didn't ask for.
+  if (!process.env.CCAW_BUS_SOCK || !process.env.CCAW_AGENT_ID) {
+    process.exit(0);
+  }
   startBusMcpServer().catch((err: unknown) => {
     process.stderr.write(`Bus MCP: fatal startup error: ${String(err)}\n`);
     process.exit(1);

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -120,6 +120,13 @@ function buildChildEnv(agent: AgentConfig, busSocketPath: string): Record<string
   const env = cleanSpawnEnv();
   env.CCAW_AGENT_ID = agent.id;
   env.CCAW_BUS_SOCK = busSocketPath;
+  // Pin the bun runtime path to the daemon's own bun rather than
+  // whatever `which bun` resolves to in the spawned claude's PATH.
+  // Used by `scripts/start-bus-mcp` to launch the plus-bus MCP server.
+  // Codex P2 on PR #133 — without this, restricted-PATH deployments
+  // (e.g. daemons launched via absolute bun path with a stripped PATH)
+  // would fail to start plus-bus.
+  env.CCAW_BUS_BUN_PATH = process.execPath;
   // TCP fallback wiring is a stub in Sprint 1 — values flow through if the
   // daemon set them but we do not synthesise them here.
   //

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -28,8 +28,8 @@
  */
 
 import { spawn as nodeSpawnChildProcess } from "node:child_process";
-import { chmodSync, existsSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
-import { homedir, tmpdir } from "node:os";
+import { realpathSync } from "node:fs";
+import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanSpawnEnv, withCleanProcessEnv } from "../runner";
@@ -145,97 +145,104 @@ function buildChildEnv(agent: AgentConfig, busSocketPath: string): Record<string
 }
 
 /**
- * Channel name used for the Bus MCP stdio plugin loaded into every
- * spawned `claude`. The `--dangerously-load-development-channels` value
- * MUST match an `mcpServers` key in the `--mcp-config` JSON — that
- * mapping is what tells `claude` which stdio command to start as the
- * channel-bearing MCP server. Spike 0.6's working probe used a bare
- * channel name (`probe-channel`); the legacy `plugin:plus-bus@local`
- * string didn't resolve to anything and silently loaded no channel,
- * which is why every Sprint 1 e2e test passed (those inject a fake
- * IPC transport directly) while real `claude` never connected to the
- * Bus IPC server.
+ * Channel name the Bus MCP server registers under inside the spawned
+ * `claude`. Matches the `mcpServers` key in the plugin's `.mcp.json`.
  */
 export const PLUS_BUS_CHANNEL = "plus-bus";
 
-/** Absolute path to the Bus MCP server entrypoint we tell `claude` to spawn. */
-function resolveBusMcpServerPath(): string {
-  // `session-manager.ts` lives in `src/bus/`; so does `mcp-server.ts`.
-  // Resolved via `import.meta.url` so it works both for `bun run` against
-  // the TS source (production) and for any future bundled deployment.
-  const here = fileURLToPath(import.meta.url);
-  return join(dirname(here), "mcp-server.ts");
-}
-
 /**
- * Synthesise the `--mcp-config` JSON `claude` will read at startup. The
- * config always contains a `plus-bus` entry whose `command`/`args` point
- * at our Bus MCP server. If the operator supplied their own
- * `agent.mcp_config` we merge their `mcpServers` map into ours so user
- * MCPs continue to load alongside Bus IPC. The `plus-bus` key is
- * reserved — operator entries with the same name are overwritten with a
- * warning (the bus channel won't function under any other name).
- *
- * The synthesised file lives under `os.tmpdir()` and is keyed by pid +
- * agent id so concurrent daemons / restarts don't clobber each other.
+ * Plugin name as declared in the ClaudeClaw+ plugin's `plugin.json`.
+ * Used to construct the tagged channel name claude requires
+ * (`plugin:<name>@<marketplace>`).
  */
-export function writeBusMcpConfig(
-  agent: AgentConfig,
-  logger: Pick<Console, "warn"> = console,
-): string {
-  const busEntry = {
-    command: process.execPath, // current bun
-    args: ["run", resolveBusMcpServerPath()],
-  };
-  let mcpServers: Record<string, unknown> = {};
-  if (agent.mcp_config && existsSync(agent.mcp_config)) {
-    try {
-      const parsed = JSON.parse(readFileSync(agent.mcp_config, "utf8")) as {
-        mcpServers?: Record<string, unknown>;
-      };
-      mcpServers = { ...(parsed.mcpServers ?? {}) };
-    } catch (err) {
-      logger.warn(
-        `[bus-session] failed to read operator mcp_config at ${agent.mcp_config}; falling back to bus-only: ${err instanceof Error ? err.message : err}`,
-      );
-    }
-  }
-  if (mcpServers[PLUS_BUS_CHANNEL]) {
-    logger.warn(
-      `[bus-session] operator mcp_config defines a "${PLUS_BUS_CHANNEL}" server — overwriting (reserved name)`,
-    );
-  }
-  mcpServers[PLUS_BUS_CHANNEL] = busEntry;
-  const path = join(tmpdir(), `claudeclaw-bus-mcp-${process.pid}-${agent.id}.json`);
-  // 0600 — operator mcp_config entries may carry credentials in `env` or
-  // `headers`; the synthesised copy must not be world-readable in /tmp.
-  // Belt-and-braces (same pattern as src/runner/pty-mcp-config-writer.ts:172):
-  // `writeFileSync({mode})` only takes effect on CREATE and a permissive
-  // umask can still widen bits — an explicit chmodSync after the write
-  // forces 0600 regardless of platform / umask / prior file state.
-  writeFileSync(path, JSON.stringify({ mcpServers }, null, 2), { mode: 0o600 });
-  try {
-    chmodSync(path, 0o600);
-  } catch {
-    // Best-effort. Some test/FUSE filesystems lack permission semantics;
-    // the writeFileSync mode already applied where supported.
-  }
-  return path;
+export const CLAUDECLAW_PLUGIN_NAME = "claudeclaw-plus";
+
+/**
+ * "Marketplace" tag claude assigns to plugins loaded via `--plugin-dir`.
+ * Observed in the `init` event's `plugins[].source` field
+ * (`"claudeclaw-plus@inline"`). We use it to construct the tagged
+ * channel name passed to `--dangerously-load-development-channels`.
+ */
+const PLUGIN_MARKETPLACE_TAG = "inline";
+
+/**
+ * MCP tools exposed by the plus-bus channel. Auto-allowed at spawn time
+ * via `--allowedTools` so claude doesn't prompt the user before sending
+ * an outbound message through the bus — these tools are safe by design
+ * (they only call back through the IPC channel, no filesystem / network
+ * effects outside the daemon).
+ */
+const PLUS_BUS_TOOL_NAMES = [
+  "mcp__plugin_claudeclaw-plus_plus-bus__reply",
+  "mcp__plugin_claudeclaw-plus_plus-bus__ask",
+  "mcp__plugin_claudeclaw-plus_plus-bus__cancel",
+  "mcp__plugin_claudeclaw-plus_plus-bus__request_human",
+];
+
+/**
+ * Resolve the absolute path to the ClaudeClaw+ plugin root — the
+ * directory containing `.claude-plugin/plugin.json` and `.mcp.json`.
+ * Computed from `session-manager.ts`'s own location: this file lives
+ * at `<root>/src/bus/session-manager.ts` so two `dirname` hops give us
+ * the plugin root. Works regardless of install path (`/opt/claudeclaw`
+ * in production, the repo checkout in dev/tests).
+ */
+export function resolveClaudeclawPluginRoot(): string {
+  const here = fileURLToPath(import.meta.url);
+  return dirname(dirname(dirname(here)));
 }
 
 /**
- * Build the args list passed to the spawned `claude`. Mirrors §5.3 sample.
+ * Build the args list passed to the spawned `claude`.
  *
- * Side effect: writes a per-agent `--mcp-config` file to `os.tmpdir()`.
- * Called once per spawn from `SessionManager.spawnAgent`.
+ * Background — four wire-up attempts before this one worked end-to-end:
+ *
+ *   1. `--dangerously-load-development-channels plugin:plus-bus@local`
+ *      (PR #110) — silently loaded no channel.
+ *   2. `--dangerously-load-development-channels server:plus-bus` + a
+ *      synth `--mcp-config` (PR #131) — claude 2.1.89 shows an
+ *      interactive TUI confirmation prompt the PTY can't dismiss.
+ *   3. `--plugin-dir <root>` alone — plugin loads, MCP server
+ *      connects, but `notifications/claude/channel` pushes are
+ *      silently dropped because the channel-notification subsystem
+ *      is opt-in and the plus-bus channel isn't on Anthropic's
+ *      default approved-plugins allowlist.
+ *   4. `--plugin-dir` + `--settings` with `channelsEnabled` +
+ *      `allowedChannelPlugins` — the managed-settings path is only
+ *      honoured for `team`/`enterprise` subscription tiers; Pro users
+ *      fall back to the baked allowlist.
+ *
+ * Working approach (this PR):
+ *
+ *   - `--plugin-dir <root>` declares the ClaudeClaw+ plugin (loads
+ *     `.mcp.json` which registers the `plus-bus` stdio MCP server).
+ *   - `--dangerously-load-development-channels plugin:claudeclaw-plus@inline`
+ *     marks the bus channel as `dev:true`, which bypasses the approved-
+ *     plugins allowlist. The TUI confirmation dialog only fires when
+ *     `channelsEnabled` AND an OAuth token are both present — since we
+ *     never set `channelsEnabled`, claude silently flags the channel
+ *     dev-trusted with no prompt. The PTY supervisor still sends a
+ *     belt-and-braces Enter keypress shortly after spawn to dismiss the
+ *     dialog if it ever does appear (e.g. account-level harbor flag on).
+ *   - `--allowedTools` auto-approves the bus channel's own tools so
+ *     claude doesn't prompt-via-bus on every outbound reply.
+ *
+ * Operator-supplied `agent.mcp_config` is passed through unchanged.
  */
 export function buildClaudeArgs(agent: AgentConfig, mode: SupervisionMode): string[] {
   const args: string[] = [];
   if (mode === "process-stream-json") {
     args.push("-p", "--input-format=stream-json", "--output-format=stream-json", "--verbose");
   }
-  args.push("--mcp-config", writeBusMcpConfig(agent));
-  args.push("--dangerously-load-development-channels", PLUS_BUS_CHANNEL);
+  args.push("--plugin-dir", resolveClaudeclawPluginRoot());
+  args.push("--allowedTools", PLUS_BUS_TOOL_NAMES.join(","));
+  args.push(
+    "--dangerously-load-development-channels",
+    `plugin:${CLAUDECLAW_PLUGIN_NAME}@${PLUGIN_MARKETPLACE_TAG}`,
+  );
+  if (agent.mcp_config) {
+    args.push("--mcp-config", agent.mcp_config);
+  }
   args.push("--permission-mode", agent.permission_mode ?? "plan");
   if (agent.system_prompt_file) {
     args.push("--append-system-prompt", agent.system_prompt_file);
@@ -351,6 +358,29 @@ export class SessionManager {
         env,
       }),
     );
+    // Belt-and-braces: dismiss the WARNING: Loading development channels
+    // TUI dialog claude shows when `--dangerously-load-development-channels`
+    // is set AND the `tengu_harbor` feature flag is on for the account.
+    // Default selection is "I am using this for local development" so a
+    // single Enter accepts it. We send at 1.5s + 4s — the first covers
+    // a fast boot, the second is a no-op if the dialog has already been
+    // dismissed and a safety net for slow boots. With our current
+    // settings (no `channelsEnabled`) the dialog usually doesn't render
+    // at all; the writes are cheap insurance.
+    setTimeout(() => {
+      try {
+        pty.write("\r");
+      } catch {
+        /* pty may have exited already — non-fatal */
+      }
+    }, 1500);
+    setTimeout(() => {
+      try {
+        pty.write("\r");
+      } catch {
+        /* pty may have exited already — non-fatal */
+      }
+    }, 4000);
     return new PtyAgentProcess(agent.id, pty);
   }
 


### PR DESCRIPTION
End-to-end Bus runtime works against live claude 2.1.89 in pty-stdin supervision: Discord DM in → agent reply → DM reply, with typing indicator and no permission spam.

## Wire-up history

Four attempts failed before this one worked end-to-end:

| # | Approach | Failure |
|---|---|---|
| 1 (#110) | \`--dangerously-load-development-channels plugin:plus-bus@local\` | Silently loaded no channel. |
| 2 (#131) | \`--dangerously-load-development-channels server:plus-bus\` + synth \`--mcp-config\` | Claude 2.1.89 shows an interactive TUI confirmation prompt the PTY supervisor can't drive. |
| 3 | \`--plugin-dir <root>\` alone | Plugin + MCP loads, but \`notifications/claude/channel\` pushes are silently dropped (plus-bus not on Anthropic's baked allowlist). |
| 4 | \`--plugin-dir\` + \`--settings channelsEnabled\` + \`--channels\` | \`allowedChannelPlugins\` in managed settings is \`team\`/\`enterprise\` only; Pro accounts fall back to the baked allowlist. |

## Working combination

- **\`.mcp.json\` at the plugin root** declares the \`plus-bus\` stdio MCP server, loaded automatically by \`--plugin-dir <root>\`. Uses \`${CLAUDE_PLUGIN_ROOT}\` substitution so the wire-up is portable.
- **\`--dangerously-load-development-channels plugin:claudeclaw-plus@inline\`** marks the bus channel as \`dev:true\`, bypassing the allowlist gate. The TUI confirmation dialog only fires when \`channelsEnabled\` AND an OAuth token are both present; since we never set \`channelsEnabled\`, claude silently flags the channel dev-trusted with no prompt. PTY supervisor sends a belt-and-braces Enter at 1.5s + 4s after spawn in case the account's \`tengu_harbor\` flag is on.
- **\`--allowedTools\`** auto-approves the plus-bus channel's own MCP tools so claude doesn't gate every outbound reply with a permission ask.

## Other wins in this PR

- **Origin-scoped reply routing.** \`BusCore\` records the originating \`origin\` + \`origin_id\` per prompt and stamps them on outbound \`response.text\` events. \`DiscordAdapter.handleBusEvent\` uses that to route the agent's reply back to the originating channel/DM only, instead of fanning out to every channel configured for the agent. Fixes the DM round-trip — without this, DM-originated prompts got processed but replies went to guild channels.
- **Typing indicator.** \`DiscordRestApi.sendTyping()\` triggers Discord's typing indicator on every accepted inbound prompt so users see immediate feedback while the agent generates.
- **MCP server self-gate.** \`mcp-server.ts\` exits silently when \`CCAW_BUS_SOCK\`/\`CCAW_AGENT_ID\` env vars are absent — needed because the plugin's \`.mcp.json\` now auto-loads in every claude session with the plugin installed; we don't want startup noise in non-daemon sessions.

## Test plan

- [x] \`bun test src/bus src/adapters\` — 343 pass / 0 fail / 1 skip
- [x] \`bun run lint\` — 938 warnings (baseline), 0 errors
- [x] \`bun run bump:plugin-version\` + \`bun run bump:marketplace-version\` → 2.2.63
- [x] **Hetzner end-to-end**: DM Claw → agent reply in DM with typing indicator; post in #general → agent reply in #general; no permission spam; no fanout to wrong channels
- [ ] Watch for issues during overnight soak

## Operational notes

- Settings change required on cutover: \`agents[0].permission_mode\` from \`"plan"\` to \`"default"\` so MCP tools auto-approve. The \`--allowedTools\` flag handles the plus-bus channel tools specifically; setting \`permission_mode: "plan"\` would still gate everything else.
- Stale \`agents/<id>/session.json\` from previous bus attempts can cause \`"Session ID already in use"\` on the next boot. Quick fix: \`rm agents/<id>/session.json\` and restart. Auto-rotation on this error is a follow-up.