### PR TITLE
fix(bus): auto-rotate session id on claude "already in use" collision

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.64",
+      "version": "2.2.65",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.64",
+  "version": "2.2.65",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/session-manager.test.ts
+++ b/src/bus/__tests__/session-manager.test.ts
@@ -480,4 +480,34 @@ describe("session-id collision rotation", () => {
     expect(persisted).toHaveLength(0);
     expect(agent.session_id).toBe(STALE);
   });
+
+  it("releases the registry slot when the proc exits during the detection window for a non-collision reason (Codex P1 on #135)", async () => {
+    // Regression for the race Codex flagged: process exits within the
+    // detection window for a NON-collision reason (auth fail, missing
+    // config, claude crash). If `proc.onExit` cleanup wasn't attached
+    // BEFORE the await, the dead entry stays in `this.agents` and the
+    // next spawn for the same agent throws "already spawned".
+    const STALE = "33333333-3333-3333-3333-333333333bad";
+    const mgr = new SessionManager({
+      commandOverride: "/bin/sh",
+      // Exit fast with no marker — simulates a non-collision crash
+      // inside the detection window.
+      argsOverride: ["-c", "echo non-collision crash; exit 1"],
+      busSocketPath: "/tmp/test-bus-rotate.sock",
+      sessionCollisionDetectMs: 300,
+      logger: { warn: () => {}, info: () => {}, error: () => {} },
+    });
+    const agent = mkAgent({ id: "rot-race", session_id: STALE });
+    // First spawn returns the (now-exited) proc — the manager should
+    // have cleaned up its registry slot via onExit, so a second call
+    // is allowed.
+    const proc1 = await mgr.spawnAgent(agent, "cron");
+    expect(proc1).toBeDefined();
+    // Tiny yield so any pending onExit microtasks settle.
+    await new Promise((r) => setTimeout(r, 50));
+    // If the registry slot wasn't released, the second spawn throws.
+    const proc2 = await mgr.spawnAgent(agent, "cron");
+    expect(proc2).toBeDefined();
+    await new Promise((r) => setTimeout(r, 50));
+  });
 });

--- a/src/bus/__tests__/session-manager.test.ts
+++ b/src/bus/__tests__/session-manager.test.ts
@@ -381,3 +381,103 @@ describe("bus socket path validation", () => {
     await expect(mgr.spawnAgent(agent, "cron")).rejects.toThrow(/96-byte cap/);
   });
 });
+
+/* ───────────────────────────────────────────────────────────────────── */
+/* Session-id collision rotation                                         */
+/* ───────────────────────────────────────────────────────────────────── */
+
+describe("session-id collision rotation", () => {
+  // Detect: spawn /bin/sh with a small script that mimics claude's
+  // "Session ID X is already in use" error on the FIRST spawn (when the
+  // injected ENV says STALE_ID==agent.session_id), then exits 1.
+  // On subsequent spawns (a fresh UUID from rotation) the script
+  // succeeds and stays alive so the manager hands back a normal handle.
+  //
+  // No real `claude` involvement — we just need to drive the same
+  // (data-chunk + non-zero exit) contract the detector listens for.
+  if (!IS_UNIX) return;
+
+  it("rotates the session id and respawns once when claude rejects it as in-use", async () => {
+    // Counter-driven stand-in: first invocation exits 1 with the
+    // session-collision marker, subsequent invocations sleep so the
+    // manager sees a healthy process past the detection window.
+    const STALE = "00000000-0000-0000-0000-000000000bad";
+    const counterFile = `/tmp/test-bus-rotate-${process.pid}.cnt`;
+    rmSync(counterFile, { force: true });
+    const script = `
+      n=$(cat "${counterFile}" 2>/dev/null || echo 0)
+      n=$((n+1))
+      echo "$n" > "${counterFile}"
+      if [ "$n" = "1" ]; then
+        echo "Error: Session ID ${STALE} is already in use."
+        exit 1
+      fi
+      sleep 60
+    `;
+    const persisted: Array<{ agentId: string; sessionId: string }> = [];
+    const mgr = new SessionManager({
+      commandOverride: "/bin/sh",
+      argsOverride: ["-c", script],
+      busSocketPath: "/tmp/test-bus-rotate.sock",
+      sessionCollisionDetectMs: 500,
+      persistRotatedSessionId: async (agentId, sessionId) => {
+        persisted.push({ agentId, sessionId });
+      },
+      logger: { warn: () => {}, info: () => {}, error: () => {} },
+    });
+    const agent = mkAgent({ id: "rot-test", session_id: STALE });
+    const proc = await mgr.spawnAgent(agent, "cron");
+    expect(proc).toBeDefined();
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]?.agentId).toBe("rot-test");
+    expect(persisted[0]?.sessionId).not.toBe(STALE);
+    expect(persisted[0]?.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+    expect(agent.session_id).toBe(persisted[0]?.sessionId);
+    await mgr.stop("rot-test");
+    rmSync(counterFile, { force: true });
+  });
+
+  it("gives up after one retry if the collision persists", async () => {
+    // Always-fail-with-marker stand-in.
+    const STALE = "11111111-1111-1111-1111-111111111bad";
+    const mgr = new SessionManager({
+      commandOverride: "/bin/sh",
+      argsOverride: [
+        "-c",
+        // Pattern must match the detector regex
+        // (`Session ID [0-9a-fA-F-]{8,} is already in use`).
+        `echo "Error: Session ID 99999999-9999-9999-9999-999999999bad is already in use."; exit 1`,
+      ],
+      busSocketPath: "/tmp/test-bus-rotate.sock",
+      sessionCollisionDetectMs: 300,
+      persistRotatedSessionId: async () => {},
+      logger: { warn: () => {}, info: () => {}, error: () => {} },
+    });
+    const agent = mkAgent({ id: "rot-loop", session_id: STALE });
+    await expect(mgr.spawnAgent(agent, "cron")).rejects.toThrow(
+      /collision persisted after rotation/,
+    );
+  });
+
+  it("does NOT rotate on non-collision exit-1 (no marker in output)", async () => {
+    // Crash without the marker — manager must NOT rotate, treats it as
+    // a normal spawn that handed back a process which then exited.
+    const persisted: Array<{ agentId: string; sessionId: string }> = [];
+    const STALE = "22222222-2222-2222-2222-222222222bad";
+    const mgr = new SessionManager({
+      commandOverride: "/bin/sh",
+      argsOverride: ["-c", "echo unrelated boot error; exit 1"],
+      busSocketPath: "/tmp/test-bus-rotate.sock",
+      sessionCollisionDetectMs: 300,
+      persistRotatedSessionId: async (agentId, sessionId) => {
+        persisted.push({ agentId, sessionId });
+      },
+      logger: { warn: () => {}, info: () => {}, error: () => {} },
+    });
+    const agent = mkAgent({ id: "rot-other", session_id: STALE });
+    const proc = await mgr.spawnAgent(agent, "cron");
+    expect(proc).toBeDefined();
+    expect(persisted).toHaveLength(0);
+    expect(agent.session_id).toBe(STALE);
+  });
+});

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -400,6 +400,25 @@ export class SessionManager {
       throw new Error(`unsupported supervision mode: ${mode satisfies never}`);
     }
 
+    // Register the proc + attach the cleanup `onExit` BEFORE awaiting
+    // the collision detector. Codex P1 on this PR: if the process exits
+    // during the detection window for a non-collision reason (auth
+    // error, missing config, claude crash) and we register after the
+    // await, our `proc.onExit` handler is pushed onto a handler array
+    // whose owning proc has already exited — `PtyAgentProcess.onExit` /
+    // `ChildAgentProcess.onExit` are push-only and don't replay past
+    // exits. The cleanup never fires, leaving a dead entry in
+    // `this.agents` that breaks the next `already spawned` guard.
+    const record: AgentRecord = { agent, origin, mode, proc };
+    this.agents.set(agent.id, record);
+    // Auto-cleanup: drop registry entry on exit so restart() can reuse the id.
+    proc.onExit(() => {
+      const current = this.agents.get(agent.id);
+      if (current && current.proc === proc) {
+        this.agents.delete(agent.id);
+      }
+    });
+
     // Watch the spawn for a session-id collision before handing the
     // process back to the caller. Returns true iff claude emitted the
     // marker AND exited with code 1 within the detection window; any
@@ -426,25 +445,29 @@ export class SessionManager {
         ((agentId: string, sessionId: string) => createSession(sessionId, agentId));
       await persist(agent.id, fresh);
       agent.session_id = fresh;
+      // The proc that emitted the collision marker has exited; clear
+      // its registry slot so the recursive respawn doesn't trip the
+      // `already spawned` guard (the `onExit` cleanup above may not
+      // have fired yet if the exit raced the detector's resolve).
+      const current = this.agents.get(agent.id);
+      if (current && current.proc === proc) {
+        this.agents.delete(agent.id);
+      }
       return this.spawnAgentInternal(agent, origin, retry + 1);
     }
     if (collision) {
       // Retried once and still colliding — surface a real error so the
-      // operator notices instead of silently looping.
+      // operator notices instead of silently looping. Same registry-
+      // slot cleanup as the rotation path.
+      const current = this.agents.get(agent.id);
+      if (current && current.proc === proc) {
+        this.agents.delete(agent.id);
+      }
       throw new Error(
         `agent ${agent.id}: session-id collision persisted after rotation (id=${agent.session_id}) — manual intervention required`,
       );
     }
 
-    const record: AgentRecord = { agent, origin, mode, proc };
-    this.agents.set(agent.id, record);
-    // Auto-cleanup: drop registry entry on exit so restart() can reuse the id.
-    proc.onExit(() => {
-      const current = this.agents.get(agent.id);
-      if (current && current.proc === proc) {
-        this.agents.delete(agent.id);
-      }
-    });
     return proc;
   }
 

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -28,11 +28,13 @@
  */
 
 import { spawn as nodeSpawnChildProcess } from "node:child_process";
+import { randomUUID } from "node:crypto";
 import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanSpawnEnv, withCleanProcessEnv } from "../runner";
+import { createSession } from "../sessions";
 import {
   type AgentProcess,
   ChildAgentProcess,
@@ -79,6 +81,26 @@ export interface SessionManagerOptions {
    * default path (`${XDG_RUNTIME_DIR ?? $HOME/.claudeclaw/run}/bus.sock`).
    */
   busSocketPath?: string;
+  /**
+   * Window in milliseconds to watch for claude's "Session ID X is already
+   * in use" startup error before considering the spawn healthy. On hit
+   * the manager rotates the session id (mints a fresh UUID, persists,
+   * respawns) once. Default 2000ms — claude emits the marker within
+   * ~1s of spawn when the id collides, so 2s gives comfortable headroom
+   * without slowing down happy-path spawns. Tests can set to 0 to skip
+   * the wait entirely.
+   */
+  sessionCollisionDetectMs?: number;
+  /**
+   * Persistence hook invoked after a rotation. Defaults to
+   * `createSession(freshId, agent.id)` from `src/sessions.ts`. Override
+   * in tests to capture rotation without writing to disk.
+   */
+  persistRotatedSessionId?: (agentId: string, sessionId: string) => Promise<void>;
+  /**
+   * Optional logger override. Defaults to `console`.
+   */
+  logger?: Pick<Console, "warn" | "info" | "error">;
 }
 
 /* ───────────────────────────────────────────────────────────────────── */
@@ -200,6 +222,52 @@ export function resolveClaudeclawPluginRoot(): string {
 }
 
 /**
+ * Default window for session-collision detection. Empirically the
+ * marker arrives in the first PTY data chunk (~under 1s) when the
+ * session id is stale; 2000ms is comfortable headroom for slow boots
+ * without delaying happy-path spawns by more than a second.
+ */
+const DEFAULT_COLLISION_DETECT_MS = 2000;
+
+/**
+ * Regex matching claude's "Session ID is already in use" startup error.
+ * Permissive on the uuid shape to survive any future formatting tweaks
+ * (claude has used both classic 36-char dashed UUIDs and variants).
+ */
+const SESSION_COLLISION_PATTERN = /Session ID [0-9a-fA-F-]{8,} is already in use/;
+
+/**
+ * Watch the spawned agent process for the session-id collision marker
+ * during a short window after spawn. Resolves true iff the marker is
+ * seen AND the process exits with a non-zero code within the window —
+ * both are required because claude can echo a similar string in benign
+ * contexts and a stale-id failure always pairs with an immediate
+ * exit. Resolves false for: alive past the window, clean exit, exit
+ * without the marker.
+ */
+function detectSessionIdCollision(proc: AgentProcess, windowMs: number): Promise<boolean> {
+  if (windowMs <= 0) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    let resolved = false;
+    let markerSeen = false;
+    const finish = (value: boolean) => {
+      if (resolved) return;
+      resolved = true;
+      resolve(value);
+    };
+    proc.onData((chunk) => {
+      if (!markerSeen && SESSION_COLLISION_PATTERN.test(chunk)) {
+        markerSeen = true;
+      }
+    });
+    proc.onExit((code) => {
+      finish(markerSeen && code !== 0);
+    });
+    setTimeout(() => finish(false), windowMs);
+  });
+}
+
+/**
  * Build the args list passed to the spawned `claude`.
  *
  * Background — four wire-up attempts before this one worked end-to-end:
@@ -278,6 +346,24 @@ export class SessionManager {
   }
 
   async spawnAgent(agent: AgentConfig, origin: BusOrigin): Promise<AgentProcess> {
+    return this.spawnAgentInternal(agent, origin, /* retry */ 0);
+  }
+
+  /**
+   * Internal spawn that supports a single session-id rotation retry.
+   *
+   * If claude rejects the supplied `--session-id` with "Session ID X is
+   * already in use" (typically because the previous daemon left a JSONL
+   * lock or claude's session registry treats the id as live), we mint a
+   * fresh UUID, persist it to `agents/<id>/session.json`, and respawn
+   * once. Without this the operator has to manually `rm session.json`
+   * and restart the daemon — a recurring papercut documented in PR #133.
+   */
+  private async spawnAgentInternal(
+    agent: AgentConfig,
+    origin: BusOrigin,
+    retry: number,
+  ): Promise<AgentProcess> {
     if (this.agents.has(agent.id)) {
       throw new Error(`agent ${agent.id} is already spawned; call stop() or restart() first`);
     }
@@ -305,6 +391,42 @@ export class SessionManager {
       proc = this.spawnTmux(agent, args, env, realCwd);
     } else {
       throw new Error(`unsupported supervision mode: ${mode satisfies never}`);
+    }
+
+    // Watch the spawn for a session-id collision before handing the
+    // process back to the caller. Returns true iff claude emitted the
+    // marker AND exited with code 1 within the detection window; any
+    // other outcome (alive past the window, clean exit, non-collision
+    // crash) returns false and the proc is returned as-is.
+    // Skip the collision-detect wait when the test seam (`argsOverride`)
+    // is in play — the spawned process is a stand-in (e.g. `/bin/cat`)
+    // that will never emit claude's session-id marker, and adding a 2s
+    // blocking wait to every test spawn doubles suite runtime for no
+    // signal. Explicit `sessionCollisionDetectMs` always wins.
+    const collisionWindow =
+      this.options.sessionCollisionDetectMs ??
+      (this.options.argsOverride !== undefined ? 0 : DEFAULT_COLLISION_DETECT_MS);
+    const collision = await detectSessionIdCollision(proc, collisionWindow);
+    if (collision && retry === 0) {
+      const fresh = randomUUID();
+      (this.options.logger ?? console).warn(
+        `[bus-session] agent=${agent.id} claude rejected session_id=${agent.session_id} as already in use — rotating to ${fresh} and respawning`,
+      );
+      // The public option takes `(agentId, sessionId)` for readability;
+      // the legacy `createSession` storage layer takes them reversed.
+      const persist =
+        this.options.persistRotatedSessionId ??
+        ((agentId: string, sessionId: string) => createSession(sessionId, agentId));
+      await persist(agent.id, fresh);
+      agent.session_id = fresh;
+      return this.spawnAgentInternal(agent, origin, retry + 1);
+    }
+    if (collision) {
+      // Retried once and still colliding — surface a real error so the
+      // operator notices instead of silently looping.
+      throw new Error(
+        `agent ${agent.id}: session-id collision persisted after rotation (id=${agent.session_id}) — manual intervention required`,
+      );
     }
 
     const record: AgentRecord = { agent, origin, mode, proc };

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -256,6 +256,13 @@ function detectSessionIdCollision(proc: AgentProcess, windowMs: number): Promise
       resolve(value);
     };
     proc.onData((chunk) => {
+      // Early-exit once the detector has resolved (timeout fired, exit
+      // observed, or marker matched). `PtyAgentProcess.onData` has a
+      // push-only handler array with no removal API, so this listener
+      // stays attached for the proc's lifetime; the cheap flag check
+      // keeps the regex from running on every PTY chunk after the
+      // detection window closes.
+      if (resolved) return;
       if (!markerSeen && SESSION_COLLISION_PATTERN.test(chunk)) {
         markerSeen = true;
       }


### PR DESCRIPTION
## Summary

Closes the "Session ID X is already in use" footgun documented in #133. When claude rejects the bus runtime's persisted `--session-id`, SessionManager now rotates to a fresh UUID, persists, and respawns once instead of exiting and forcing the operator to `rm session.json` by hand.

## Why

After every daemon restart there's a small race where claude considers the persisted session-id still live (lingering JSONL state, in-flight write locks). The runtime exits code 1 with a clear marker:

```
Error: Session ID a04024bc-... is already in use.
```

Operators were doing the manual rotation + restart. Nibbler is about to hit it during the Telegram soak.

## How

`SessionManager.spawnAgent` now spawns, then watches the proc's `onData` channel for the collision marker during a short window (default 2000ms). If the marker fires AND the proc exits with a non-zero code:

1. Mint a fresh UUID
2. Persist to `agents/<id>/session.json` via the existing `sessions.ts` layer (single source of truth shared with the legacy PTY runtime)
3. Respawn once

A second collision after rotation throws — no silent loop.

### New SessionManager options

| Option | Default | Purpose |
|---|---|---|
| `sessionCollisionDetectMs` | `2000` (`0` when `argsOverride` set) | detection window |
| `persistRotatedSessionId` | wraps `createSession` | storage seam for tests |
| `logger` | `console` | logger seam |

Test seam detail: when `argsOverride` is set (unit tests use stand-in processes like `/bin/cat` that will never emit the marker), the default detection window collapses to 0 to avoid adding 2s per spawn-related test. Explicit `sessionCollisionDetectMs` always wins.

## Verified live on Hetzner

Forced a collision by writing the stale `d11edc7a-7457-4cc9-afd1-e811f19863cc` id (which has a live JSONL) into `agents/default/session.json`, restarted the daemon:

```
[bus-session] agent=default claude rejected session_id=d11edc7a-7457-4cc9-afd1-e811f19863cc as already in use — rotating to 6005b37a-5431-43b1-a2d1-542ad447c832 and respawning
[bus-runtime] spawned agent=default
Runtime: bus (Bus stack mounted, agents=[default], adapters=[discord, webui])
```

`session.json` was overwritten with the fresh id, claude alive with the plus-bus MCP child. End-to-end DM still works after rotation.

## Test plan

- [x] `bun test src/bus/__tests__/session-manager.test.ts` — 21 pass / 0 fail (+3 new rotation cases)
- [x] `bun test src/bus src/adapters` — 348 pass / 0 fail / 1 skip
- [x] `bun run lint` — 0 errors (baseline warnings unchanged)
- [x] `bun run bump:plugin-version` + `bump:marketplace-version` → 2.2.65
- [x] Hetzner end-to-end: forced collision triggered rotation, fresh id persisted, claude healthy

## Test cases added

1. **Rotates and respawns once when claude rejects the id** — counter-driven `/bin/sh` stand-in fails-with-marker on the first spawn then succeeds.
2. **Gives up after one retry if the collision persists** — always-fail stand-in surfaces a clear "manual intervention required" error.
3. **Does NOT rotate on non-collision exit-1** — locks the contract that exit-1 alone isn't sufficient; the marker must appear in stdout/stderr too.