### PR TITLE
feat(webui): full dashboard parity under bus runtime

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.65",
+      "version": "2.2.66",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.65",
+  "version": "2.2.66",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/webui-bridge.test.ts
+++ b/src/bus/__tests__/webui-bridge.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for `streamBusPrompt` — the bridge the legacy webui uses to
+ * route its trigger paths (`/api/jobs/fire`, `/api/inject`, `/api/chat`)
+ * through the bus's per-agent claude session instead of spawning a
+ * sidecar PTY that would race the bus.
+ *
+ * Strategy: build a real `BusCoreImpl` against an in-memory mock event
+ * log + no IPC server (just the in-process pub/sub surface). Drive the
+ * reply path by calling `bus.ingestReply` directly — that's how the
+ * plus-bus MCP server normally publishes claude's responses.
+ */
+import { describe, expect, it } from "bun:test";
+import { createBusCore, type BusCore } from "../core";
+import type { EventEntryInput, EventRecord } from "../../event-log";
+import { streamBusPrompt } from "../webui-bridge";
+
+function mockEventLog() {
+  let seq = 0;
+  return async (entry: EventEntryInput): Promise<EventRecord> => {
+    seq += 1;
+    const now = new Date().toISOString();
+    return {
+      id: `mock-${seq}`,
+      seq,
+      type: entry.type,
+      source: entry.source,
+      timestamp: now,
+      createdAt: now,
+      updatedAt: now,
+      status: "done",
+      channelId: entry.channelId,
+      threadId: entry.threadId,
+      payload: entry.payload,
+      dedupeKey: entry.dedupeKey,
+      retryCount: 0,
+      nextRetryAt: null,
+      correlationId: entry.correlationId ?? null,
+      causationId: entry.causationId ?? null,
+      replayedFromEventId: entry.replayedFromEventId ?? null,
+      lastError: null,
+    };
+  };
+}
+
+function makeBus(): BusCore {
+  return createBusCore({ eventLogAppend: mockEventLog() });
+}
+
+describe("streamBusPrompt", () => {
+  it("resolves with the final reply text when claude emits a single 'final' event", async () => {
+    const bus = makeBus();
+    const pending = streamBusPrompt(bus, "alpha", "hi", { timeoutMs: 2000 });
+    // Give bus.sendPrompt a microtask to run + register the subscriber
+    // before we ingest the reply.
+    await Promise.resolve();
+    await Promise.resolve();
+    bus.ingestReply({ agent_id: "alpha", text: "hello back", intent: "final" });
+    const result = await pending;
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe("hello back");
+    expect(result.exitCode).toBe(0);
+  });
+
+  it("accumulates progress + final events into the returned output", async () => {
+    const bus = makeBus();
+    const pending = streamBusPrompt(bus, "alpha", "hi", { timeoutMs: 2000 });
+    await Promise.resolve();
+    await Promise.resolve();
+    bus.ingestReply({ agent_id: "alpha", text: "chunk-1 ", intent: "progress" });
+    bus.ingestReply({ agent_id: "alpha", text: "chunk-2 ", intent: "progress" });
+    bus.ingestReply({ agent_id: "alpha", text: "done", intent: "final" });
+    const result = await pending;
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe("chunk-1 chunk-2 done");
+  });
+
+  it("invokes onChunk for every response.text event", async () => {
+    const bus = makeBus();
+    const chunks: string[] = [];
+    const pending = streamBusPrompt(bus, "alpha", "hi", {
+      timeoutMs: 2000,
+      onChunk: (t) => chunks.push(t),
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    bus.ingestReply({ agent_id: "alpha", text: "one", intent: "progress" });
+    bus.ingestReply({ agent_id: "alpha", text: "two", intent: "final" });
+    await pending;
+    expect(chunks).toEqual(["one", "two"]);
+  });
+
+  it("does NOT receive events for other agents", async () => {
+    const bus = makeBus();
+    const pending = streamBusPrompt(bus, "alpha", "hi", { timeoutMs: 500 });
+    await Promise.resolve();
+    await Promise.resolve();
+    bus.ingestReply({ agent_id: "beta", text: "wrong-agent", intent: "final" });
+    const result = await pending;
+    // beta's reply is ignored — alpha's stream times out empty.
+    expect(result.ok).toBe(false);
+    expect(result.output).toBe("");
+    expect(result.error).toMatch(/timed out/);
+  });
+
+  it("times out with whatever was accumulated when no final lands", async () => {
+    const bus = makeBus();
+    const pending = streamBusPrompt(bus, "alpha", "hi", { timeoutMs: 300 });
+    await Promise.resolve();
+    await Promise.resolve();
+    bus.ingestReply({ agent_id: "alpha", text: "partial-", intent: "progress" });
+    const result = await pending;
+    expect(result.ok).toBe(false);
+    expect(result.exitCode).toBe(1);
+    expect(result.output).toBe("partial-");
+    expect(result.error).toMatch(/timed out after 300ms/);
+  });
+
+  it("survives a chunk callback that throws", async () => {
+    const bus = makeBus();
+    const pending = streamBusPrompt(bus, "alpha", "hi", {
+      timeoutMs: 2000,
+      onChunk: () => {
+        throw new Error("chunk handler exploded");
+      },
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    bus.ingestReply({ agent_id: "alpha", text: "hello", intent: "final" });
+    const result = await pending;
+    expect(result.ok).toBe(true);
+    expect(result.output).toBe("hello");
+  });
+
+  it("propagates a custom BusOrigin tag on the outgoing prompt", async () => {
+    // Subscribe to the `prompt` topic so we can read back what
+    // sendPrompt published.
+    const bus = makeBus();
+    const promptEvents: Array<{ origin: string; origin_id: string; text: string }> = [];
+    bus.subscribe({ agent_id: "alpha", topics: ["prompt"] }, (event) => {
+      const payload = event.payload as { origin: string; origin_id: string; text: string };
+      promptEvents.push({
+        origin: payload.origin,
+        origin_id: payload.origin_id,
+        text: payload.text,
+      });
+    });
+    const pending = streamBusPrompt(bus, "alpha", "do a thing", {
+      timeoutMs: 500,
+      origin: "cron",
+      originId: "job:morning-digest",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    bus.ingestReply({ agent_id: "alpha", text: "done", intent: "final" });
+    await pending;
+    expect(promptEvents).toHaveLength(1);
+    expect(promptEvents[0]).toEqual({
+      origin: "cron",
+      origin_id: "job:morning-digest",
+      text: "do a thing",
+    });
+  });
+
+  it("cleans up subscriber + timer on resolution (no leaked listeners)", async () => {
+    const bus = makeBus();
+    expect(bus.state().subscriberCount).toBe(0);
+    const pending = streamBusPrompt(bus, "alpha", "hi", { timeoutMs: 2000 });
+    await Promise.resolve();
+    await Promise.resolve();
+    // One subscriber active during the prompt flow.
+    expect(bus.state().subscriberCount).toBe(1);
+    bus.ingestReply({ agent_id: "alpha", text: "done", intent: "final" });
+    await pending;
+    // Subscriber should be closed after resolution.
+    expect(bus.state().subscriberCount).toBe(0);
+  });
+});

--- a/src/bus/__tests__/webui-bridge.test.ts
+++ b/src/bus/__tests__/webui-bridge.test.ts
@@ -174,4 +174,55 @@ describe("streamBusPrompt", () => {
     // Subscriber should be closed after resolution.
     expect(bus.state().subscriberCount).toBe(0);
   });
+
+  it("serializes concurrent prompts to the same agent (Codex P1 on #136)", async () => {
+    // The bridge subscribes by agent_id only; without serialization a
+    // second prompt's `final` could resolve the first caller. We assert
+    // the second prompt does NOT start (no subscriber registered)
+    // until the first one resolves.
+    const bus = makeBus();
+    const firstPending = streamBusPrompt(bus, "alpha", "first", { timeoutMs: 2000 });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bus.state().subscriberCount).toBe(1);
+
+    const secondPending = streamBusPrompt(bus, "alpha", "second", { timeoutMs: 2000 });
+    // Give the second call a tick to enter the queue.
+    await Promise.resolve();
+    await Promise.resolve();
+    // First is still the only subscriber — second is parked on the
+    // mutex tail.
+    expect(bus.state().subscriberCount).toBe(1);
+
+    // A reply lands. With unfiltered subscription this would resolve
+    // whichever caller subscribed first; we assert it's the FIRST call
+    // (the only one with an active subscriber).
+    bus.ingestReply({ agent_id: "alpha", text: "first-reply", intent: "final" });
+    const firstResult = await firstPending;
+    expect(firstResult.output).toBe("first-reply");
+
+    // Now the second call's subscriber registers.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(bus.state().subscriberCount).toBe(1);
+    bus.ingestReply({ agent_id: "alpha", text: "second-reply", intent: "final" });
+    const secondResult = await secondPending;
+    expect(secondResult.output).toBe("second-reply");
+    expect(bus.state().subscriberCount).toBe(0);
+  });
+
+  it("serialization is per-agent (different agents proceed in parallel)", async () => {
+    const bus = makeBus();
+    const aPending = streamBusPrompt(bus, "alpha", "to-alpha", { timeoutMs: 2000 });
+    const bPending = streamBusPrompt(bus, "beta", "to-beta", { timeoutMs: 2000 });
+    await Promise.resolve();
+    await Promise.resolve();
+    // Both subscribers active simultaneously — separate agents.
+    expect(bus.state().subscriberCount).toBe(2);
+    bus.ingestReply({ agent_id: "beta", text: "beta-reply", intent: "final" });
+    bus.ingestReply({ agent_id: "alpha", text: "alpha-reply", intent: "final" });
+    const [a, b] = await Promise.all([aPending, bPending]);
+    expect(a.output).toBe("alpha-reply");
+    expect(b.output).toBe("beta-reply");
+  });
 });

--- a/src/bus/webui-bridge.ts
+++ b/src/bus/webui-bridge.ts
@@ -1,0 +1,131 @@
+/**
+ * Bridge helpers used by the legacy webui (`src/ui/server.ts`) to drive
+ * the bus runtime's claude session instead of spawning a sidecar PTY.
+ *
+ * Pulled out of `src/commands/start.ts` so it can be unit-tested
+ * without booting the full daemon.
+ *
+ * Routes consuming this:
+ *   - `/api/jobs/fire` — injects a runner into `fireJob` that calls
+ *     `streamBusPrompt` with no `onChunk` and returns the accumulated
+ *     final reply.
+ *   - `/api/inject` — same shape, defaulting the agent to
+ *     `BusWebUiBridge.defaultAgentId`.
+ *   - `/api/chat` — passes `onChunk` so each `response.text` event is
+ *     streamed back to the dashboard SSE as it arrives. Resolves
+ *     when `intent: "final"` lands or the timeout fires.
+ */
+
+import type { BusCore } from "./core";
+import type { BusOrigin } from "./types";
+
+export interface StreamBusPromptOptions {
+  /** BusOrigin tag attached to the outgoing prompt. Defaults to "webui". */
+  origin?: BusOrigin;
+  /** Free-form correlation id stamped on the prompt event. */
+  originId?: string;
+  /** Per-chunk callback. Called on every `response.text` event with non-empty text. */
+  onChunk?: (text: string) => void;
+  /**
+   * Hard ceiling on how long to wait for `intent: "final"`. Defaults to
+   * 5 minutes — claude turns under bus can be long-running. Returns
+   * with `ok: false` and whatever was accumulated when the timeout fires.
+   */
+  timeoutMs?: number;
+}
+
+export interface BusPromptResult {
+  ok: boolean;
+  output: string;
+  exitCode: number;
+  error?: string;
+}
+
+const DEFAULT_PROMPT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Send a prompt through the bus to one agent and resolve with the
+ * accumulated reply.
+ *
+ * Subscribes to `response.text` events for the target agent, streams
+ * any text via `onChunk` (if provided), and resolves with the
+ * accumulated text on `intent: "final"`. Cleans up its subscriber and
+ * timer before resolving so callers don't leak listeners.
+ *
+ * In the common case claude emits ONE event with `intent: "final"`
+ * containing the full reply. The accumulator + chunk callback also
+ * cover any future progress-streaming behaviour without changing the
+ * caller contract.
+ *
+ * Failure paths:
+ *   - `bus.sendPrompt` rejects → resolves `{ok:false, error}` immediately.
+ *   - Timeout fires before `final` lands → resolves with whatever was
+ *     accumulated so far + `exitCode: 1` + error message.
+ */
+export async function streamBusPrompt(
+  bus: BusCore,
+  agentId: string,
+  message: string,
+  opts: StreamBusPromptOptions = {},
+): Promise<BusPromptResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_PROMPT_TIMEOUT_MS;
+  let accumulated = "";
+  return new Promise<BusPromptResult>((resolve) => {
+    let resolved = false;
+    const finish = (r: BusPromptResult) => {
+      if (resolved) return;
+      resolved = true;
+      try {
+        sub.close();
+      } catch {
+        /* idempotent close — fine */
+      }
+      clearTimeout(timer);
+      resolve(r);
+    };
+    const sub = bus.subscribe({ agent_id: agentId, topics: ["response.text"] }, (event) => {
+      const payload = event.payload as { text?: string; intent?: string };
+      if (typeof payload.text === "string" && payload.text.length > 0) {
+        accumulated += payload.text;
+        if (opts.onChunk) {
+          try {
+            opts.onChunk(payload.text);
+          } catch {
+            /* chunk callback errors must not break the prompt flow */
+          }
+        }
+      }
+      if (payload.intent === "final") {
+        finish({
+          ok: true,
+          output: accumulated || (payload.text ?? ""),
+          exitCode: 0,
+        });
+      }
+    });
+    const timer = setTimeout(() => {
+      finish({
+        ok: false,
+        output: accumulated,
+        exitCode: 1,
+        error: `timed out after ${timeoutMs}ms waiting for agent ${agentId} reply`,
+      });
+    }, timeoutMs);
+    bus
+      .sendPrompt({
+        agent_id: agentId,
+        origin: opts.origin ?? "webui",
+        origin_id: opts.originId ?? "webui",
+        user_id: "webui",
+        text: message,
+      })
+      .catch((err) => {
+        finish({
+          ok: false,
+          output: accumulated,
+          exitCode: 1,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      });
+  });
+}

--- a/src/bus/webui-bridge.ts
+++ b/src/bus/webui-bridge.ts
@@ -19,6 +19,25 @@
 import type { BusCore } from "./core";
 import type { BusOrigin } from "./types";
 
+/**
+ * Per-agent mutex tail used to serialize `streamBusPrompt` calls. Codex
+ * P1 on #136: the bus subscriber filter `{agent_id, topics:
+ * ["response.text"]}` doesn't carry a per-prompt correlation id, and
+ * `BusCore.lastPromptOrigin` is last-write-wins, so two prompts in
+ * flight on the same agent can return each other's replies. Serializing
+ * at the bridge guarantees at most one prompt awaits per agent — chat,
+ * fire, and inject from the dashboard now queue rather than racing.
+ *
+ * Tradeoff: a long-running cron job firing through `streamBusPrompt`
+ * would block a follow-up chat. Acceptable: BusScheduler doesn't go
+ * through this bridge (it dispatches via `bus.sendPrompt` directly and
+ * doesn't await), and dashboard interactions are intrinsically
+ * single-user. If we ever route scheduler triggers through this
+ * bridge, swap the mutex for a per-prompt correlation id propagated
+ * from the bus core.
+ */
+const agentMutex = new Map<string, Promise<unknown>>();
+
 export interface StreamBusPromptOptions {
   /** BusOrigin tag attached to the outgoing prompt. Defaults to "webui". */
   origin?: BusOrigin;
@@ -67,6 +86,41 @@ export async function streamBusPrompt(
   agentId: string,
   message: string,
   opts: StreamBusPromptOptions = {},
+): Promise<BusPromptResult> {
+  // Serialize per-agent so the unfiltered `response.text` subscriber
+  // below can't pick up a reply meant for an earlier in-flight prompt.
+  // The mutex tail is a Promise that the previous call resolves when
+  // it finishes; this call awaits it before sending its own prompt.
+  // Callers race each other only on which one enters the queue first,
+  // not on which reply they consume.
+  const prev = agentMutex.get(agentId);
+  let release: () => void = () => undefined;
+  const slot = new Promise<void>((res) => {
+    release = res;
+  });
+  agentMutex.set(agentId, slot);
+  if (prev) {
+    try {
+      await prev;
+    } catch {
+      /* upstream errors don't block our own attempt */
+    }
+  }
+  try {
+    return await runPrompt(bus, agentId, message, opts);
+  } finally {
+    // Only clear the tail slot if no other call has chained onto us;
+    // chained callers will overwrite the map entry themselves.
+    if (agentMutex.get(agentId) === slot) agentMutex.delete(agentId);
+    release();
+  }
+}
+
+function runPrompt(
+  bus: BusCore,
+  agentId: string,
+  message: string,
+  opts: StreamBusPromptOptions,
 ): Promise<BusPromptResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_PROMPT_TIMEOUT_MS;
   let accumulated = "";

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -39,6 +39,7 @@ import {
 import { getDayAndMinuteAtOffset, buildClockPromptPrefix } from "../timezone";
 import { isHeartbeatExcludedAt, isHeartbeatExcludedNow } from "../heartbeat-windows";
 import { startWebUi, type WebServerHandle } from "../web";
+import { streamBusPrompt } from "../bus/webui-bridge";
 import { initializeJobSystem } from "../orchestrator/resumable-jobs";
 import type { Job } from "../jobs";
 import { isWizardTrigger, hasActiveWizard, handleWizardInput } from "./plugin-wizard";
@@ -435,6 +436,11 @@ export async function start(args: string[] = []) {
   // so the hot-reload loop can reach `.bus` to rebuild the scheduler
   // when heartbeat/jobs change. Sprint 5.2d.
   let busRuntimeHandle: import("../bus/runtime-mount").BusRuntimeHandle | null = null;
+  // The live BusCore once `runtime: "bus"` mounts. Hoisted so the
+  // webui can build a bridge that calls `bus.sendPrompt` for its
+  // trigger routes (jobs/fire, inject, chat) instead of spawning a
+  // sidecar PTY claude that would race the bus's own session.
+  let busCoreForWebUi: import("../bus/core").BusCore | null = null;
 
   // Plugin system — initialize before gateway start
   const pluginManager = new PluginManager(process.cwd());
@@ -539,6 +545,7 @@ export async function start(args: string[] = []) {
       busRuntimeHandle = handle;
       busRuntimeSpawnedAgents = handle.spawnedAgentIds;
       busRuntimeAdapterNames = handle.mountedAdapterNames;
+      busCoreForWebUi = bus;
     } catch (err) {
       console.error(
         `[${ts()}] Bus runtime: mount failed — falling back to legacy command surfaces only`,
@@ -550,10 +557,19 @@ export async function start(args: string[] = []) {
     }
   }
   // Legacy adapter gate (Sprint 5.2b): when the Bus mount succeeded, the
-  // legacy initTelegram / initDiscord / initSlack / legacy Web UI startup
-  // below MUST be skipped so each platform's inbound traffic is handled
-  // only by the Bus adapter. The variable is hoisted so the existing
+  // legacy initTelegram / initDiscord / initSlack startup below MUST be
+  // skipped so each platform's inbound traffic is handled only by the
+  // Bus adapter. The variable is hoisted so the existing
   // `await initTelegram(...)` call sites further down can guard on it.
+  //
+  // NOTE: web is NOT skipped any more. The legacy dashboard (sessions,
+  // logs, kanban, settings, job mgmt) is the documented operator UI
+  // and has feature parity for read paths; the trigger paths
+  // (/api/jobs/fire, /api/inject, /api/chat) route through
+  // `bus.sendPrompt` via the BusWebUiBridge so they don't sidestep the
+  // bus's per-agent claude. Sprint 5.2b's old behaviour (skip legacy
+  // web) left operators with a "not_found" page because the bus webui
+  // adapter at `/health` + `/prompt` is not a dashboard replacement.
   const skipLegacyAdapters = busRuntimeHandle !== null;
 
   let mcpProxyStarted: Promise<void> = Promise.resolve();
@@ -926,8 +942,46 @@ export async function start(args: string[] = []) {
               onChunk(await handleWizardInput(wizardCtx, message));
               return;
             }
+            // Bus runtime: route the chat through the bus's default
+            // agent so it lands in the same claude session every other
+            // surface (Discord/Telegram/cron) drives. Pass the chunk
+            // callback so each `response.text` event from the agent
+            // gets streamed back to the dashboard SSE in real time.
+            const bus = busCoreForWebUi;
+            const defaultAgent = busRuntimeSpawnedAgents[0];
+            if (bus && defaultAgent) {
+              await streamBusPrompt(bus, defaultAgent, message, {
+                origin: "webui",
+                originId: "chat",
+                onChunk,
+              });
+              onUnblock();
+              return;
+            }
             await streamUserMessage("chat", message, onChunk, onUnblock, onAgentEvent);
           },
+          bus:
+            busCoreForWebUi && busRuntimeSpawnedAgents[0]
+              ? {
+                  defaultAgentId: busRuntimeSpawnedAgents[0],
+                  sendPromptAndAwait: (agentId, text, sendOpts) =>
+                    streamBusPrompt(
+                      busCoreForWebUi as NonNullable<typeof busCoreForWebUi>,
+                      agentId,
+                      text,
+                      {
+                        // `BusWebUiBridge.sendPromptAndAwait`'s `origin` is
+                        // typed as `string` to keep `src/ui/types.ts`
+                        // independent of the bus types. The bus tagged
+                        // union is narrower; only webui callers reach
+                        // this path so the cast is safe at the seam.
+                        origin: sendOpts?.origin as import("../bus/types").BusOrigin | undefined,
+                        originId: sendOpts?.originId,
+                        timeoutMs: sendOpts?.timeoutMs,
+                      },
+                    ),
+                }
+              : undefined,
         });
       } catch (err) {
         lastError = err;
@@ -938,20 +992,23 @@ export async function start(args: string[] = []) {
     throw lastError;
   }
 
-  if (webEnabled && !skipLegacyAdapters) {
+  if (webEnabled) {
     currentSettings.web.enabled = true;
     web = startWebWithFallback(currentSettings.web.host, webPort);
     currentSettings.web.port = web.port;
     console.log(
-      `[${new Date().toLocaleTimeString()}] Web UI listening on http://${web.host}:${web.port}`,
+      `[${new Date().toLocaleTimeString()}] Web UI listening on http://${web.host}:${web.port}` +
+        (skipLegacyAdapters ? " (bus-aware)" : ""),
     );
-  } else if (webEnabled && skipLegacyAdapters) {
-    // The Bus Web UI adapter (when configured via `settings.web.bus`) is
-    // already mounted by `wireBusAdapters`. We skip the legacy dashboard
-    // to avoid two HTTP listeners trying to claim the same port.
-    console.log(
-      `[${new Date().toLocaleTimeString()}] Web UI: handled by Bus adapter${busRuntimeAdapterNames.includes("webui") ? "" : " (not configured)"}`,
-    );
+    if (skipLegacyAdapters && busRuntimeAdapterNames.includes("webui")) {
+      // Operator has BOTH the legacy dashboard AND the optional bus
+      // webui adapter mounted. They serve different surfaces (dashboard
+      // vs `/health` + `/prompt`) and live on different ports. Worth a
+      // one-line log so the operator isn't surprised by two listeners.
+      console.log(
+        `[${new Date().toLocaleTimeString()}] Web UI: bus adapter also mounted on ${currentSettings.web.bus?.bind ?? "(no bind configured)"}`,
+      );
+    }
   }
 
   // --- Helpers ---

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -950,11 +950,19 @@ export async function start(args: string[] = []) {
             const bus = busCoreForWebUi;
             const defaultAgent = busRuntimeSpawnedAgents[0];
             if (bus && defaultAgent) {
-              await streamBusPrompt(bus, defaultAgent, message, {
+              const result = await streamBusPrompt(bus, defaultAgent, message, {
                 origin: "webui",
                 originId: "chat",
                 onChunk,
               });
+              // Codex P2 on #136: surface timeout / dispatch failure to
+              // the SSE stream so a failed turn doesn't render as a
+              // successful `done` event on the dashboard. The error
+              // chunk is rendered inline; the SSE `done` still follows
+              // via `onUnblock` so the client unblocks the input.
+              if (!result.ok && result.error) {
+                onChunk(`\n[chat error: ${result.error}]\n`);
+              }
               onUnblock();
               return;
             }

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -298,7 +298,30 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
           if (!agent || !label) {
             return json({ ok: false, error: "agent and label are required" });
           }
-          const result = await fireJob(agent, label);
+          // Bus runtime: route the prompt through the live bus so claude
+          // is driven by the existing per-agent session rather than a
+          // sidecar PTY spawn (which would race the bus's own claude).
+          // Inject a runner that maps `runner(name, prompt, agent)` to
+          // `bus.sendPromptAndAwait(agent, prompt)` and keep `fireJob`'s
+          // existing storage-lookup + prompt-resolution logic intact.
+          const fireOpts = opts.bus
+            ? {
+                runner: async (name: string, prompt: string, jobAgent?: string) => {
+                  const target = jobAgent ?? agent;
+                  const out = await (opts.bus as NonNullable<typeof opts.bus>).sendPromptAndAwait(
+                    target,
+                    prompt,
+                    { origin: "webui", originId: `job:${name}` },
+                  );
+                  return {
+                    exitCode: out.exitCode,
+                    stdout: out.output,
+                    stderr: out.ok ? "" : (out.error ?? ""),
+                  };
+                },
+              }
+            : undefined;
+          const result = await fireJob(agent, label, fireOpts);
           return json({
             ok: result.success,
             success: result.success,
@@ -367,8 +390,26 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
           const body = await req.json();
           const message = typeof body.message === "string" ? body.message.trim() : "";
           if (!message) return json({ ok: false, error: "message is required" }, 400);
-          const result = await runUserMessage("inject", message);
-          const text = result.stdout.trim();
+          // Bus runtime: route the inject through the bus's default
+          // agent so it lands in the same claude session the heartbeat
+          // and adapters are driving. Legacy runtime falls back to the
+          // PTY runner — `inject` was its "send a prompt into the
+          // current session" path.
+          let stdout: string;
+          let exitCode: number;
+          if (opts.bus) {
+            const out = await opts.bus.sendPromptAndAwait(opts.bus.defaultAgentId, message, {
+              origin: "webui",
+              originId: "inject",
+            });
+            stdout = out.output;
+            exitCode = out.exitCode;
+          } else {
+            const result = await runUserMessage("inject", message);
+            stdout = result.stdout;
+            exitCode = result.exitCode;
+          }
+          const text = stdout.trim();
           const { telegram } = opts.getSnapshot().settings;
           if (text && telegram.token && telegram.allowedUserIds.length > 0) {
             const chatId = telegram.allowedUserIds[0];
@@ -378,7 +419,7 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
               body: JSON.stringify({ chat_id: chatId, text }),
             }).catch(() => {});
           }
-          return json({ ok: true, result: result.stdout, exitCode: result.exitCode });
+          return json({ ok: true, result: stdout, exitCode });
         } catch (err) {
           return json({ ok: false, error: String(err) }, 500);
         }

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -304,6 +304,14 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
           // Inject a runner that maps `runner(name, prompt, agent)` to
           // `bus.sendPromptAndAwait(agent, prompt)` and keep `fireJob`'s
           // existing storage-lookup + prompt-resolution logic intact.
+          //
+          // Capture bus-mode failures (`ok: false` from the bridge —
+          // timeout, dispatch error) in an out-of-band variable so we
+          // can surface the error on the response. fireJob's `error`
+          // field is only set when the agent/job isn't found; the
+          // runner's failure mode is signalled via exit code + stderr,
+          // which fireJob doesn't propagate up.
+          let busRunnerError: string | undefined;
           const fireOpts = opts.bus
             ? {
                 runner: async (name: string, prompt: string, jobAgent?: string) => {
@@ -313,6 +321,7 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
                     prompt,
                     { origin: "webui", originId: `job:${name}` },
                   );
+                  if (!out.ok && out.error) busRunnerError = out.error;
                   return {
                     exitCode: out.exitCode,
                     stdout: out.output,
@@ -327,7 +336,7 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
             success: result.success,
             exitCode: result.exitCode,
             output: result.output,
-            error: result.error,
+            error: result.error ?? busRunnerError,
             agent,
             label,
           });
@@ -397,6 +406,11 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
           // current session" path.
           let stdout: string;
           let exitCode: number;
+          // Track bus-mode failure so we can surface it on the response
+          // instead of returning `{ok: true}` with empty output —
+          // companion to the chat-error surfacing in start.ts's onChat.
+          let busError: string | undefined;
+          let ok = true;
           if (opts.bus) {
             const out = await opts.bus.sendPromptAndAwait(opts.bus.defaultAgentId, message, {
               origin: "webui",
@@ -404,6 +418,10 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
             });
             stdout = out.output;
             exitCode = out.exitCode;
+            if (!out.ok) {
+              ok = false;
+              busError = out.error;
+            }
           } else {
             const result = await runUserMessage("inject", message);
             stdout = result.stdout;
@@ -419,7 +437,12 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
               body: JSON.stringify({ chat_id: chatId, text }),
             }).catch(() => {});
           }
-          return json({ ok: true, result: stdout, exitCode });
+          return json({
+            ok,
+            result: stdout,
+            exitCode,
+            ...(busError ? { error: busError } : {}),
+          });
         } catch (err) {
           return json({ ok: false, error: String(err) }, 500);
         }

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -34,4 +34,49 @@ export interface StartWebUiOptions {
     onUnblock: () => void,
     onAgentEvent: (ev: import("../runner").AgentStreamEvent) => void,
   ) => Promise<void>;
+  /**
+   * Present when the daemon is running in bus mode. Routes that trigger
+   * claude (`/api/jobs/fire`, `/api/inject`) call `sendPromptAndAwait`
+   * instead of spawning a PTY claude directly; without this option the
+   * routes fall back to the legacy `runUserMessage` / `fireJob` paths.
+   *
+   * The interface is intentionally callback-shaped so `server.ts`
+   * doesn't depend on `BusCore` — `start.ts` owns the bus wiring.
+   *
+   * The chat SSE route (`/api/chat`) continues to use `onChat`;
+   * `start.ts` switches its implementation between bus and PTY when
+   * wiring that callback.
+   */
+  bus?: BusWebUiBridge;
+}
+
+/**
+ * Bridge contract between the legacy webui and the bus runtime. See
+ * `StartWebUiOptions.bus`.
+ */
+export interface BusWebUiBridge {
+  /**
+   * Send a one-shot prompt to an agent and resolve with the final
+   * reply. Used by `/api/jobs/fire` and `/api/inject`. Shape mirrors
+   * the legacy `runUserMessage` result so the response JSON the
+   * dashboard already renders doesn't change.
+   */
+  sendPromptAndAwait: (
+    agentId: string,
+    text: string,
+    opts?: { timeoutMs?: number; origin?: string; originId?: string },
+  ) => Promise<BusWebUiPromptResult>;
+  /**
+   * Default agent id used when the route has no agent in the request
+   * (e.g. `/api/inject`). Resolved from `settings.agents[0].id` at
+   * daemon boot.
+   */
+  defaultAgentId: string;
+}
+
+export interface BusWebUiPromptResult {
+  ok: boolean;
+  output: string;
+  exitCode: number;
+  error?: string;
 }


### PR DESCRIPTION
Restores `claudeclaw.poview.ai` and the legacy operator dashboard under `runtime: "bus"` — properly this time, not the bus webui adapter's `/health` + `/prompt` stub.

## The bug

When the bus runtime mounted, `src/commands/start.ts` set `skipLegacyAdapters = true` and skipped `startWebUi` entirely. The bus webui adapter (`src/adapters/webui/index.ts`) is a minimal surface that does NOT serve the dashboard frontend's `/api/state`, `/api/sessions`, `/api/jobs`, `/api/logs`, kanban, etc. Hitting the dashboard URL returned `{"ok":false,"error":"not_found"}`.

Operators who relied on the dashboard for visibility (sessions, logs, manual job firing) lost it on the bus cutover. This wasn't called out as a tradeoff because nothing in the bus runtime PRs documented that the legacy webui would be retired.

## The fix

Restore the legacy dashboard alongside the bus runtime, with the three trigger paths routed through `bus.sendPrompt`:

| Route | Pre-fix | Post-fix |
|---|---|---|
| `/api/state`, `/api/sessions`, `/api/logs`, `/api/kanban`, `/api/jobs` (list), `/api/agents`, `/api/usage`, `/api/settings`, `/api/technical-info`, `/api/sessions/<id>/messages`, `/api/jobs/quick` (write), `/api/jobs/<n>` (DELETE), `/api/plugin/*`, `/api/csrf-token`, `/api/health` | 404 (legacy webui skipped) | unchanged — these read shared storage that bus already writes through |
| `/api/jobs/fire` | 404 | routes through `bus.sendPrompt` via injected runner; preserves response shape |
| `/api/inject` | 404 | same — uses `bus.defaultAgentId` (first `settings.agents` entry) |
| `/api/chat` (SSE) | 404 | `onChat` closure in `start.ts` branches: PTY → `streamUserMessage`, bus → `streamBusPrompt` with `onChunk` per event |

## How

New `src/bus/webui-bridge.ts` exports `streamBusPrompt(bus, agentId, message, opts)`:

- Subscribes to `response.text` events on the target agent.
- Streams via optional `onChunk` callback for SSE / streaming UX.
- Resolves on `intent: "final"` with accumulated text.
- 5-minute default timeout; resolves with `ok: false` + whatever accumulated on expiry.
- Cleans up subscriber + timer before resolving (no leaked listeners).

`StartWebUiOptions` gains a `bus?: BusWebUiBridge` option (`{sendPromptAndAwait, defaultAgentId}`). `start.ts` builds the bridge from the live `BusCore` after `mountBusRuntime` succeeds. `server.ts` checks `opts.bus` on each trigger route and branches.

The `fireJob` integration uses the existing `opts.runner` injection seam — we don't touch fireJob's storage lookup or prompt resolution, just swap where execution lands.

## Verified live on Hetzner

```
[bus-runtime] mounted; socket=/run/user/1000/bus.sock; agents=[default]; no adapters
  Runtime: bus (Bus stack mounted, agents=[default], adapters=[discord])
  Web UI: http://127.0.0.1:4632
[8:16:28 PM] Web UI listening on http://127.0.0.1:4632 (bus-aware)
```

`claudeclaw.poview.ai` renders the dashboard. Operator confirmed read paths + trigger paths work end-to-end before this PR was opened.

## Operational note

If `web.bus` is configured alongside `web.enabled: true`, port them differently — the legacy dashboard takes `web.port` (default 4632) and the bus webui adapter takes `web.bus.bind`. Most operators won't need both; the bus webui adapter is the optional `/prompt` + `/ws` surface, not the dashboard. The start banner logs both when both are active.

## Test plan

- [x] `bun test src/bus src/adapters` — 357 pass / 0 fail / 1 skip (+8 new in `webui-bridge.test.ts`)
- [x] `bun run lint` — 0 errors, baseline warnings unchanged
- [x] Version bumps: `2.2.65` → `2.2.66`
- [x] Hetzner end-to-end: dashboard renders + trigger paths work via bus