### PR TITLE
chore(bus): #134 follow-ups from #133 5-agent review

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.66",
+      "version": "2.2.67",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.66",
+  "version": "2.2.67",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -473,10 +473,12 @@ export { resolveAgentId, uniqueAgentIds } from "./router";
 /* Sprint 4 TODOs                                                         */
 /* ────────────────────────────────────────────────────────────────────── */
 /*
- *  - Track originating channel per bus event so responses go ONLY to
- *    the channel the prompt came from (today we fan out to every
- *    channel owned by the agent — fine for single-channel-per-agent,
- *    noisy for multi).
+ * Origin-id routing landed in #133: `handleBusEvent` reads
+ * `event.payload.origin_id` and replies on the originating Discord
+ * channel only. `channelsForAgent` remains the fallback for events
+ * with no origin (cron / scheduler ticks), so multi-channel agents
+ * still receive scheduled output everywhere.
+ *
  *  - DM channel resolution: legacy `sendMessageToUser` requires a
  *    `/users/@me/channels` POST to create the DM channel. Surface DM
  *    response routing via `dmAgentId` once that helper is extracted.

--- a/src/bus/mcp-server.ts
+++ b/src/bus/mcp-server.ts
@@ -12,8 +12,13 @@
  *   this plugin ↔ Bus core: length-prefixed JSON (`<uint32-be><bytes>`) over
  *     Unix domain socket (or localhost TCP as fallback).
  *
- * The plugin is registered with:
- *   claude --dangerously-load-development-channels plugin:plus-bus@local
+ * The plugin is registered by the daemon when spawning each agent:
+ *   claude --plugin-dir <claudeclaw-plus repo root> \
+ *          --dangerously-load-development-channels plugin:claudeclaw-plus@inline
+ * `--plugin-dir` points claude at the repo so it discovers the channel
+ * definitions in `.claude-plugin/`, and the `@inline` tag matches the
+ * plugin name registered there. Note the pre-#133 form
+ * `plugin:plus-bus@local` no longer works.
  *
  * Env vars (set by Session Manager when spawning claude):
  *   CCAW_AGENT_ID  — stable slug for the agent; tags every outbound IPC frame
@@ -571,8 +576,24 @@ if (import.meta.main) {
   //      but no daemon running: env vars absent — silently exit. Without
   //      this guard, every claude session would log a noisy "Bus MCP:
   //      fatal startup error" from a server they didn't ask for.
-  if (!process.env.CCAW_BUS_SOCK || !process.env.CCAW_AGENT_ID) {
+  //
+  // Partial-set (exactly one of the two env vars present) is a real
+  // operator error — a half-finished bootstrap or a stale env. Treat it
+  // as a fatal misconfiguration so it surfaces in the operator's claude
+  // log instead of silently no-op'ing.
+  const hasSock = !!process.env.CCAW_BUS_SOCK;
+  const hasAgent = !!process.env.CCAW_AGENT_ID;
+  if (!hasSock && !hasAgent) {
     process.exit(0);
+  }
+  if (hasSock !== hasAgent) {
+    const set = hasSock ? "CCAW_BUS_SOCK" : "CCAW_AGENT_ID";
+    const missing = hasSock ? "CCAW_AGENT_ID" : "CCAW_BUS_SOCK";
+    process.stderr.write(
+      `Bus MCP: ${set} is set but ${missing} is not — refusing to boot. ` +
+        `Both env vars must be set together (daemon path) or both unset (operator path).\n`,
+    );
+    process.exit(2);
   }
   startBusMcpServer().catch((err: unknown) => {
     process.stderr.write(`Bus MCP: fatal startup error: ${String(err)}\n`);


### PR DESCRIPTION
## Summary

Closes #134. Three small cleanups from the 5-agent review of #133 that fell below the 80-confidence inline threshold but were tracked for a soak-period sweep.

- **`src/bus/mcp-server.ts`** — partial-env exit is now a fatal misconfig (logs to stderr, exits 2). Both unset still silently exits (operator-installed-plugin path); both set still boots normally (daemon path); exactly-one-set is now visible.
- **`src/bus/mcp-server.ts`** — refreshed stale `plugin:plus-bus@local` invocation comment to document the current `--plugin-dir` + `plugin:claudeclaw-plus@inline` flow that #133 introduced.
- **`src/adapters/discord/index.ts`** — struck the completed Sprint-4 fan-out TODO; #133 implemented origin-id routing in `handleBusEvent`. Comment now describes the actual current behaviour + the `channelsForAgent` fallback used for origin-less events (cron / scheduler).

No behaviour change in the operator path or the daemon happy path; the only new behaviour is loud-fail on partial-env, which would previously have been a silent operator-error footgun.

## Test plan

- [x] `bun test src/bus src/adapters` — 359 pass / 1 skip / 0 fail
- [x] `bun run lint` — exit 0
- [x] `bun run bump:plugin-version` + `bun run bump:marketplace-version` — 2.2.67
- [ ] Codex auto-review
- [ ] Operator-mandated `/code-review:code-review` 5-agent pass before merge