### PR TITLE
fix(bus): drop foreign-origin events + propagate origin onto perm/ask

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.68",
+      "version": "2.2.69",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.67",
+      "version": "2.2.68",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.69",
+      "version": "2.2.70",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.69",
+  "version": "2.2.70",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.68",
+  "version": "2.2.69",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.67",
+  "version": "2.2.68",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/discord/__tests__/discord-outbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-outbound.test.ts
@@ -92,8 +92,9 @@ describe("DiscordAdapter — outbound response.text", () => {
     // Production incident on 2026-05-20: webui-originated replies were
     // mirroring into every Discord channel routed to the agent because
     // the old branch fell back to `channelsForAgent` when origin didn't
-    // match "discord". Foreign-origin events must be dropped silently;
-    // fan-out is reserved for events with NO origin.
+    // match "discord". Foreign CHANNEL-DRIVEN origins must be dropped
+    // silently; fan-out is reserved for events with NO origin OR with
+    // a NON-CHANNEL origin (cron / heartbeat / cli / rest).
     adapter = await startAdapter(h);
     h.bus.emit({
       ts: Date.now(),
@@ -103,6 +104,35 @@ describe("DiscordAdapter — outbound response.text", () => {
       payload: { text: "webui reply", origin: "webui", origin_id: "webui-42" },
     });
     expect(h.rest.sent).toHaveLength(0);
+  });
+
+  it("KEEPS response.text with origin 'cron' — Codex P1 on #138", async () => {
+    // Codex caught this on #138: scheduler emits prompts with explicit
+    // origin: "cron" | "heartbeat". A blunt "drop if origin is set"
+    // rule would silently stop scheduler replies reaching any channel.
+    // Only foreign CHANNEL-DRIVEN origins drop; non-channel origins
+    // fall through to fan-out.
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "cron tick reply", origin: "cron", origin_id: "job:morning" },
+    });
+    expect(h.rest.sent.map((m) => m.channelId).sort()).toEqual(["ch-2", "th-1"]);
+  });
+
+  it("KEEPS response.text with origin 'heartbeat' — Codex P1 on #138", async () => {
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "heartbeat reply", origin: "heartbeat", origin_id: "hb" },
+    });
+    expect(h.rest.sent.map((m) => m.channelId).sort()).toEqual(["ch-2", "th-1"]);
   });
 
   it("DROPS channel.permission_request whose origin belongs to another adapter", async () => {

--- a/src/adapters/discord/__tests__/discord-outbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-outbound.test.ts
@@ -87,6 +87,64 @@ describe("DiscordAdapter — outbound response.text", () => {
     });
     expect(h.rest.sent.map((m) => m.channelId).sort()).toEqual(["ch-2", "th-1"]);
   });
+
+  it("DROPS response.text whose origin belongs to another adapter (post-#137 regression)", async () => {
+    // Production incident on 2026-05-20: webui-originated replies were
+    // mirroring into every Discord channel routed to the agent because
+    // the old branch fell back to `channelsForAgent` when origin didn't
+    // match "discord". Foreign-origin events must be dropped silently;
+    // fan-out is reserved for events with NO origin.
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "webui reply", origin: "webui", origin_id: "webui-42" },
+    });
+    expect(h.rest.sent).toHaveLength(0);
+  });
+
+  it("DROPS channel.permission_request whose origin belongs to another adapter", async () => {
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s",
+      topic: "channel.permission_request",
+      payload: {
+        request_id: "fghij",
+        tool_name: "Bash",
+        description: "run command",
+        input_preview: "echo hi",
+        origin: "webui",
+        origin_id: "webui-42",
+      } as PermissionRequest & { origin: string; origin_id: string },
+    });
+    expect(h.rest.sent).toHaveLength(0);
+  });
+
+  it("routes channel.permission_request ONLY to origin_id channel when origin is discord", async () => {
+    // Bug B fix: BusCore now attaches origin/origin_id from the
+    // triggering prompt onto permission_request events so the button
+    // prompt lands on the channel that asked for the tool call.
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "channel.permission_request",
+      payload: {
+        request_id: "klmno",
+        tool_name: "Write",
+        description: "write a file",
+        input_preview: "{path: ...}",
+        origin: "discord",
+        origin_id: "ch-2",
+      } as PermissionRequest & { origin: string; origin_id: string },
+    });
+    expect(h.rest.sent.map((m) => m.channelId)).toEqual(["ch-2"]);
+  });
 });
 
 describe("DiscordAdapter — permission flow", () => {

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -36,7 +36,12 @@
  */
 
 import type { BusCore, Subscription } from "../../bus/core";
-import type { BusEvent, PermissionRequest } from "../../bus/types";
+import {
+  CHANNEL_DRIVEN_ORIGINS,
+  type BusEvent,
+  type BusOrigin,
+  type PermissionRequest,
+} from "../../bus/types";
 import { createDiscordGateway } from "./gateway";
 import {
   attachmentMeta,
@@ -376,22 +381,33 @@ export class DiscordAdapter {
     // Determine the destination channel set based on the event's origin
     // surface (populated by BusCore from the originating prompt).
     //
-    // Three cases:
-    //   1. origin === "discord"          → route ONLY to origin_id channel
-    //   2. origin missing / undefined    → fan-out via channelsForAgent
-    //                                       (cron, heartbeat, scheduler
-    //                                        events with no inbound prompt)
-    //   3. origin present but ≠ "discord" → DROP — the event belongs to
-    //                                       another adapter (webui /
-    //                                       telegram / slack). The
-    //                                       post-#137 prod incident was
-    //                                       this case silently falling
-    //                                       back to fan-out, mirroring
-    //                                       webui chat into every Discord
-    //                                       channel routed to the agent.
+    // Three classes of origin:
+    //   1. "discord"                    → route ONLY to origin_id channel
+    //   2. Another channel-driven origin ("telegram" / "slack" / "webui")
+    //                                   → DROP — owned by that adapter.
+    //                                     The post-#137 prod incident was
+    //                                     this case silently fanning out,
+    //                                     mirroring webui chat into every
+    //                                     Discord channel routed to the
+    //                                     agent.
+    //   3. No origin OR a non-channel origin ("cron" / "heartbeat" /
+    //      "cli" / "rest")              → fan-out via channelsForAgent.
+    //                                     Codex P1 on #138: scheduler
+    //                                     emits prompts with explicit
+    //                                     origin: "cron" | "heartbeat",
+    //                                     so a blunt "drop if origin is
+    //                                     present" filter would silently
+    //                                     stop scheduler replies reaching
+    //                                     any channel. Only drop foreign
+    //                                     CHANNEL-DRIVEN origins.
     const payloadWithOrigin = event.payload as { origin?: string; origin_id?: string } | undefined;
     const origin = payloadWithOrigin?.origin;
-    if (origin !== undefined && origin !== "discord") return;
+    if (
+      origin !== undefined &&
+      origin !== "discord" &&
+      CHANNEL_DRIVEN_ORIGINS.has(origin as BusOrigin)
+    )
+      return;
     const originChannel =
       origin === "discord" && typeof payloadWithOrigin?.origin_id === "string"
         ? payloadWithOrigin.origin_id

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -373,15 +373,27 @@ export class DiscordAdapter {
   /* ──────────────────────────── outbound (bus → discord) ──────────── */
 
   private handleBusEvent(agentId: string, event: BusEvent): void {
-    // Determine the destination channel set. If the event payload
-    // carries an `origin: "discord"` + `origin_id` pair (populated by
-    // BusCore from the originating prompt), the reply goes ONLY to that
-    // channel — handles DMs and avoids fan-out spam. Otherwise we fall
-    // back to every routed channel for the agent (cron jobs, scheduler-
-    // initiated replies that have no inbound prompt).
+    // Determine the destination channel set based on the event's origin
+    // surface (populated by BusCore from the originating prompt).
+    //
+    // Three cases:
+    //   1. origin === "discord"          → route ONLY to origin_id channel
+    //   2. origin missing / undefined    → fan-out via channelsForAgent
+    //                                       (cron, heartbeat, scheduler
+    //                                        events with no inbound prompt)
+    //   3. origin present but ≠ "discord" → DROP — the event belongs to
+    //                                       another adapter (webui /
+    //                                       telegram / slack). The
+    //                                       post-#137 prod incident was
+    //                                       this case silently falling
+    //                                       back to fan-out, mirroring
+    //                                       webui chat into every Discord
+    //                                       channel routed to the agent.
     const payloadWithOrigin = event.payload as { origin?: string; origin_id?: string } | undefined;
+    const origin = payloadWithOrigin?.origin;
+    if (origin !== undefined && origin !== "discord") return;
     const originChannel =
-      payloadWithOrigin?.origin === "discord" && typeof payloadWithOrigin?.origin_id === "string"
+      origin === "discord" && typeof payloadWithOrigin?.origin_id === "string"
         ? payloadWithOrigin.origin_id
         : null;
     const targetChannels = originChannel ? [originChannel] : this.channelsForAgent(agentId);

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -16,7 +16,12 @@
  */
 
 import type { BusCore, Subscription } from "../../bus/core";
-import type { BusEvent, PermissionRequest } from "../../bus/types";
+import {
+  CHANNEL_DRIVEN_ORIGINS,
+  type BusEvent,
+  type BusOrigin,
+  type PermissionRequest,
+} from "../../bus/types";
 import { createSlackApi } from "./api";
 import { buildPermissionBlocks } from "./blocks";
 import { verifySlackSignature } from "./signature";
@@ -49,17 +54,23 @@ interface PendingHumanAsk {
 }
 
 /**
- * Reject bus events whose origin is owned by a different adapter.
+ * Reject bus events owned by a DIFFERENT channel-driven adapter.
  *
  * Post-#137 prod incident: webui-originated replies (`origin: "webui"`)
  * fanned out across every Slack channel routed to the agent because
- * the slack adapter only knew how to fan out — it had no origin filter.
- * Foreign origins must be dropped; fan-out remains the correct behaviour
- * only for events with NO origin (cron, heartbeat, scheduler).
+ * the slack adapter had no origin filter at all.
+ *
+ * Codex P1 on #138: scheduler emits prompts with explicit
+ * `origin: "cron" | "heartbeat"`. A blunt "drop if origin is set" rule
+ * would silently stop scheduler replies reaching any channel. Only
+ * FOREIGN CHANNEL-DRIVEN origins (discord / telegram / webui) drop;
+ * non-channel origins (cron / heartbeat / cli / rest) fall through to
+ * the normal fan-out path.
  */
 function eventBelongsToSlack(event: BusEvent): boolean {
   const origin = (event.payload as { origin?: string } | undefined)?.origin;
-  return origin === undefined || origin === "slack";
+  if (origin === undefined || origin === "slack") return true;
+  return !CHANNEL_DRIVEN_ORIGINS.has(origin as BusOrigin);
 }
 
 /**

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -49,6 +49,20 @@ interface PendingHumanAsk {
 }
 
 /**
+ * Reject bus events whose origin is owned by a different adapter.
+ *
+ * Post-#137 prod incident: webui-originated replies (`origin: "webui"`)
+ * fanned out across every Slack channel routed to the agent because
+ * the slack adapter only knew how to fan out — it had no origin filter.
+ * Foreign origins must be dropped; fan-out remains the correct behaviour
+ * only for events with NO origin (cron, heartbeat, scheduler).
+ */
+function eventBelongsToSlack(event: BusEvent): boolean {
+  const origin = (event.payload as { origin?: string } | undefined)?.origin;
+  return origin === undefined || origin === "slack";
+}
+
+/**
  * Cap on the `seenEventIds` LRU. Slack retries every ~1s up to 3 times,
  * so a 5k entry cap covers >1h of traffic at 1 event/sec — far beyond
  * the retry window — while bounding memory to ~5k strings (~200kB).
@@ -570,14 +584,18 @@ export class SlackAdapter {
   }
 
   private async handleResponseText(agentId: string, event: BusEvent): Promise<void> {
-    const payload = event.payload as { text?: string };
+    if (!eventBelongsToSlack(event)) return;
+    const payload = event.payload as { text?: string; origin?: string; origin_id?: string };
     const text = typeof payload?.text === "string" ? payload.text : "";
     if (text.length === 0) return;
 
-    // Fan-out to every routed channel — Bus runtime doesn't track
-    // originating channel through events yet (Sprint 4 polish item shared
-    // with Discord/Telegram).
-    const channels = this.channelsForAgent(agentId);
+    // If the event names its origin channel, route there only. Otherwise
+    // fan-out (cron / heartbeat / scheduler with no inbound prompt).
+    const originChannel =
+      payload.origin === "slack" && typeof payload.origin_id === "string"
+        ? payload.origin_id
+        : null;
+    const channels = originChannel ? [originChannel] : this.channelsForAgent(agentId);
     if (channels.length === 0) {
       this.logger.warn(`[slack-adapter] no channels for agent ${agentId}; dropping response.text`);
       return;
@@ -588,10 +606,15 @@ export class SlackAdapter {
   }
 
   private async handlePermissionRequest(agentId: string, event: BusEvent): Promise<void> {
-    const req = event.payload as PermissionRequest | undefined;
+    if (!eventBelongsToSlack(event)) return;
+    const req = event.payload as
+      | (PermissionRequest & { origin?: string; origin_id?: string })
+      | undefined;
     if (!req || typeof req.request_id !== "string") return;
 
-    const channels = this.channelsForAgent(agentId);
+    const originChannel =
+      req.origin === "slack" && typeof req.origin_id === "string" ? req.origin_id : null;
+    const channels = originChannel ? [originChannel] : this.channelsForAgent(agentId);
     if (channels.length === 0) {
       this.logger.warn(
         `[slack-adapter] no channels for agent ${agentId}; dropping permission_request`,
@@ -615,11 +638,21 @@ export class SlackAdapter {
   }
 
   private async handleRequestHuman(agentId: string, event: BusEvent): Promise<void> {
-    const payload = event.payload as { ask_id?: string; question?: string };
+    if (!eventBelongsToSlack(event)) return;
+    const payload = event.payload as {
+      ask_id?: string;
+      question?: string;
+      origin?: string;
+      origin_id?: string;
+    };
     if (typeof payload?.ask_id !== "string" || typeof payload?.question !== "string") {
       return;
     }
-    const channels = this.channelsForAgent(agentId);
+    const originChannel =
+      payload.origin === "slack" && typeof payload.origin_id === "string"
+        ? payload.origin_id
+        : null;
+    const channels = originChannel ? [originChannel] : this.channelsForAgent(agentId);
     if (channels.length === 0) {
       this.logger.warn(`[slack-adapter] no channels for agent ${agentId}; dropping request_human`);
       return;

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -7,7 +7,12 @@
  */
 
 import type { BusCore, Subscription } from "../../bus/core";
-import type { BusEvent, PermissionRequest } from "../../bus/types";
+import {
+  CHANNEL_DRIVEN_ORIGINS,
+  type BusEvent,
+  type BusOrigin,
+  type PermissionRequest,
+} from "../../bus/types";
 import { createTelegramApi } from "./api";
 import { extractReactionDirectives } from "./directives";
 import { buildPromptMetadata } from "./metadata";
@@ -61,17 +66,23 @@ interface PendingHumanAsk {
 }
 
 /**
- * Reject bus events whose origin is owned by a different adapter.
+ * Reject bus events owned by a DIFFERENT channel-driven adapter.
  *
  * Post-#137 prod incident: webui-originated replies (`origin: "webui"`)
  * were leaking into Telegram (and Discord, Slack) because the adapters
  * only checked their own origin tag and otherwise fell back to fan-out.
- * Foreign origins must be dropped — fan-out is reserved for events with
- * NO origin (cron, heartbeat, scheduler-initiated work).
+ *
+ * Codex P1 on #138: scheduler emits prompts with explicit
+ * `origin: "cron" | "heartbeat"`, so a blunt "drop if origin is set"
+ * rule would silently stop scheduler replies reaching any channel.
+ * Only FOREIGN CHANNEL-DRIVEN origins (discord / slack / webui) drop;
+ * non-channel origins (cron / heartbeat / cli / rest) fall through to
+ * the normal fan-out path.
  */
 function eventBelongsToTelegram(event: BusEvent): boolean {
   const origin = (event.payload as { origin?: string } | undefined)?.origin;
-  return origin === undefined || origin === "telegram";
+  if (origin === undefined || origin === "telegram") return true;
+  return !CHANNEL_DRIVEN_ORIGINS.has(origin as BusOrigin);
 }
 
 export class TelegramAdapter {

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -60,6 +60,20 @@ interface PendingHumanAsk {
   agent_id: string;
 }
 
+/**
+ * Reject bus events whose origin is owned by a different adapter.
+ *
+ * Post-#137 prod incident: webui-originated replies (`origin: "webui"`)
+ * were leaking into Telegram (and Discord, Slack) because the adapters
+ * only checked their own origin tag and otherwise fell back to fan-out.
+ * Foreign origins must be dropped — fan-out is reserved for events with
+ * NO origin (cron, heartbeat, scheduler-initiated work).
+ */
+function eventBelongsToTelegram(event: BusEvent): boolean {
+  const origin = (event.payload as { origin?: string } | undefined)?.origin;
+  return origin === undefined || origin === "telegram";
+}
+
 export class TelegramAdapter {
   private readonly bus: BusCore;
   private readonly api: TelegramApi;
@@ -326,6 +340,7 @@ export class TelegramAdapter {
   }
 
   private async handleResponseText(agentId: string, event: BusEvent): Promise<void> {
+    if (!eventBelongsToTelegram(event)) return;
     const payload = event.payload as { text?: string };
     const rawText = typeof payload?.text === "string" ? payload.text : "";
     if (rawText.length === 0) return;
@@ -362,6 +377,7 @@ export class TelegramAdapter {
   }
 
   private async handlePermissionRequest(agentId: string, event: BusEvent): Promise<void> {
+    if (!eventBelongsToTelegram(event)) return;
     const req = event.payload as PermissionRequest | undefined;
     if (!req || typeof req.request_id !== "string") return;
 
@@ -401,6 +417,7 @@ export class TelegramAdapter {
   }
 
   private async handleRequestHuman(agentId: string, event: BusEvent): Promise<void> {
+    if (!eventBelongsToTelegram(event)) return;
     const payload = event.payload as { ask_id?: string; question?: string };
     if (typeof payload?.ask_id !== "string" || typeof payload?.question !== "string") {
       return;

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -612,6 +612,68 @@ describe("BusCore IPC", () => {
     client.close();
   });
 
+  it("permission_request payload carries origin/origin_id from the most recent prompt (post-#137 fix)", async () => {
+    // Post-#137 prod incident: permission requests fanned out across every
+    // adapter because the published event had no origin. BusCore now
+    // attaches the originating surface so adapters can route the prompt
+    // back to the channel that triggered the tool call.
+    const sockPath = join(tempDir, "bus.sock");
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      socketPath: sockPath,
+    });
+    await bus.start();
+
+    const received: BusEvent[] = [];
+    bus.subscribe({ agent_id: "alpha", topics: ["channel.permission_request"] }, (e) =>
+      received.push(e),
+    );
+
+    const client = await connectIpcClient(sockPath);
+    client.send({
+      type: "hello",
+      agent_id: "alpha",
+      capabilities: ["claude/channel", "claude/channel/permission"],
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Establish an origin for the next reply / permission_request.
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "discord",
+      origin_id: "ch-99",
+      user_id: "u1",
+      text: "do a thing",
+    });
+
+    const req: IpcPermissionRequest = {
+      type: "permission_request",
+      agent_id: "alpha",
+      request: {
+        request_id: "pqrst",
+        tool_name: "Write",
+        description: "write a file",
+        input_preview: "{...}",
+      },
+    };
+    client.send(req);
+
+    const start = Date.now();
+    while (received.length === 0 && Date.now() - start < 1000) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    expect(received).toHaveLength(1);
+    const payload = received[0].payload as {
+      request_id: string;
+      origin?: string;
+      origin_id?: string;
+    };
+    expect(payload.request_id).toBe("pqrst");
+    expect(payload.origin).toBe("discord");
+    expect(payload.origin_id).toBe("ch-99");
+    client.close();
+  });
+
   it("request_human from MCP fans out as system.request_human carrying ask_id", async () => {
     // Regression for PR #110 review agent #5: BusEvent dropped ask_id from
     // the IPC payload, leaving subscribers unable to echo the correlation

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -674,6 +674,125 @@ describe("BusCore IPC", () => {
     client.close();
   });
 
+  it("cancel IPC clears lastPromptOrigin so subsequent unprompted replies don't inherit it (5-agent review A1)", async () => {
+    // A1 finding on PR #138's 5-agent review: lastPromptOrigin was only
+    // cleared on `intent: "final"`. If a turn ended via `cancel` (or
+    // errored out) instead, the next scheduler/cron event would inherit
+    // the stale origin and misroute.
+    const sockPath = join(tempDir, "bus.sock");
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      socketPath: sockPath,
+    });
+    await bus.start();
+
+    const received: BusEvent[] = [];
+    bus.subscribe({ agent_id: "alpha", topics: ["response.text"] }, (e) => received.push(e));
+
+    const client = await connectIpcClient(sockPath);
+    client.send({
+      type: "hello",
+      agent_id: "alpha",
+      capabilities: ["claude/channel", "claude/channel/permission"],
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "discord",
+      origin_id: "ch-cancel",
+      user_id: "u1",
+      text: "do a thing",
+    });
+    // Model cancels mid-turn (no `final` reply).
+    client.send({ type: "cancel", agent_id: "alpha", reason: "user cancelled" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    // Now an unprompted reply arrives (scheduler / background event).
+    bus.ingestReply({ agent_id: "alpha", text: "scheduler tick", intent: "progress" });
+    const replies = received.filter((e) => e.topic === "response.text");
+    expect(replies).toHaveLength(1);
+    expect((replies[0].payload as { origin?: string }).origin).toBeUndefined();
+    client.close();
+  });
+
+  it("error IPC clears lastPromptOrigin (5-agent review A1)", async () => {
+    const sockPath = join(tempDir, "bus.sock");
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      socketPath: sockPath,
+      onError: () => undefined, // suppress test-noise — we expect one error
+    });
+    await bus.start();
+
+    const received: BusEvent[] = [];
+    bus.subscribe({ agent_id: "alpha", topics: ["response.text"] }, (e) => received.push(e));
+
+    const client = await connectIpcClient(sockPath);
+    client.send({
+      type: "hello",
+      agent_id: "alpha",
+      capabilities: ["claude/channel", "claude/channel/permission"],
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "discord",
+      origin_id: "ch-error",
+      user_id: "u1",
+      text: "do a thing",
+    });
+    client.send({ type: "error", agent_id: "alpha", code: "TOOL_FAILED", message: "boom" });
+    await new Promise((r) => setTimeout(r, 50));
+
+    bus.ingestReply({ agent_id: "alpha", text: "scheduler tick", intent: "progress" });
+    const replies = received.filter((e) => e.topic === "response.text");
+    expect(replies).toHaveLength(1);
+    expect((replies[0].payload as { origin?: string }).origin).toBeUndefined();
+    client.close();
+  });
+
+  it("socket disconnect clears lastPromptOrigin (5-agent review A1)", async () => {
+    // Subprocess exit / claude crash without a `final` — the agent's IPC
+    // connection closes. Origin must clear so a reconnect's first
+    // unprompted reply doesn't inherit the dead session's routing.
+    const sockPath = join(tempDir, "bus.sock");
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      socketPath: sockPath,
+    });
+    await bus.start();
+
+    const received: BusEvent[] = [];
+    bus.subscribe({ agent_id: "alpha", topics: ["response.text"] }, (e) => received.push(e));
+
+    const client = await connectIpcClient(sockPath);
+    client.send({
+      type: "hello",
+      agent_id: "alpha",
+      capabilities: ["claude/channel", "claude/channel/permission"],
+    });
+    await new Promise((r) => setTimeout(r, 50));
+
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "discord",
+      origin_id: "ch-disco",
+      user_id: "u1",
+      text: "do a thing",
+    });
+
+    // Subprocess goes away.
+    client.close();
+    await new Promise((r) => setTimeout(r, 100));
+
+    bus.ingestReply({ agent_id: "alpha", text: "scheduler tick", intent: "progress" });
+    const replies = received.filter((e) => e.topic === "response.text");
+    expect(replies).toHaveLength(1);
+    expect((replies[0].payload as { origin?: string }).origin).toBeUndefined();
+  });
+
   it("request_human from MCP fans out as system.request_human carrying ask_id", async () => {
     // Regression for PR #110 review agent #5: BusEvent dropped ask_id from
     // the IPC payload, leaving subscribers unable to echo the correlation

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -172,7 +172,16 @@ export class BusCoreImpl implements BusCore {
       },
       onMessage: (agentId, msg) => this.handleIpcMessage(agentId, msg),
       onClose: (agentId) => {
-        if (agentId) this.connectedAgents.delete(agentId);
+        if (agentId) {
+          this.connectedAgents.delete(agentId);
+          // Clear any cached origin for this agent on disconnect — the
+          // claude subprocess is gone, so any in-flight prompt won't
+          // produce a `final` reply to trigger the usual clear path.
+          // Without this, a subsequent scheduler/cron event for this
+          // agent (after a reconnect) would inherit the dead session's
+          // origin and misroute (5-agent review on PR #138, A1 finding).
+          this.lastPromptOrigin.delete(agentId);
+        }
       },
       onError: (err, agentId) => this.onError(err, { ctx: "ipc", agentId }),
     });
@@ -329,6 +338,15 @@ export class BusCoreImpl implements BusCore {
     // whichever DM/channel last asked the agent something. Progress
     // and tool_status intents keep the origin so mid-stream updates
     // stay scoped to the originating surface.
+    //
+    // Other clear sites (5-agent review on PR #138, A1 finding):
+    //   - `cancel` IPC      — turn won't emit `final`
+    //   - `error` IPC       — turn likely won't emit `final`
+    //   - socket disconnect — claude subprocess gone, no `final` coming
+    // These are the only consumers of `lastPromptOrigin`:
+    //   - this `ingestReply` (origin on response.text events)
+    //   - `request_human` IPC handler (origin on system.request_human)
+    //   - `permission_request` IPC handler (origin on channel.permission_request)
     if (req.intent === "final") {
       this.lastPromptOrigin.delete(req.agent_id);
     }
@@ -460,6 +478,11 @@ export class BusCoreImpl implements BusCore {
           topic: "system.cancel",
           payload: { reason: msg.reason },
         });
+        // Cancel signals the turn won't produce a `final` reply. Clear
+        // the cached origin so any subsequent scheduler/cron event for
+        // this agent doesn't inherit it and misroute (5-agent review
+        // on PR #138, A1 finding).
+        this.lastPromptOrigin.delete(agentId);
         break;
       case "request_human": {
         // Forward the correlation id along with the question. Without
@@ -509,6 +532,11 @@ export class BusCoreImpl implements BusCore {
           ctx: "ipc-error",
           agentId,
         });
+        // Error means the turn likely won't produce a `final` reply.
+        // Same lifecycle concern as `cancel` — clear so subsequent
+        // scheduler events for this agent don't inherit the stale
+        // origin (5-agent review on PR #138, A1 finding).
+        this.lastPromptOrigin.delete(agentId);
         break;
       // hello already handled in the IPC layer; outbound types (prompt,
       // permission_response, ask_answer) shouldn't arrive from MCP.

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -461,29 +461,49 @@ export class BusCoreImpl implements BusCore {
           payload: { reason: msg.reason },
         });
         break;
-      case "request_human":
+      case "request_human": {
         // Forward the correlation id along with the question. Without
         // `ask_id` the subscriber (Sprint 3 adapter) can't echo back the
         // matching `IpcAskAnswer` and the originating tool call blocks
         // forever. PR #110 review (agent #5): the wire format carries
         // `ask_id` but this fan-out previously dropped it.
+        //
+        // Origin propagation (post-#137 bug): attach the originating
+        // surface so the adapter that owns it (and only that adapter)
+        // surfaces the question. Without this, the request fanned out
+        // to every channel of every adapter that subscribed.
+        const askOrigin = this.lastPromptOrigin.get(agentId);
         this.publish({
           ts: Date.now(),
           agent_id: agentId,
           session_id: "",
           topic: "system.request_human",
-          payload: { ask_id: msg.ask_id, question: msg.question },
+          payload: {
+            ask_id: msg.ask_id,
+            question: msg.question,
+            ...(askOrigin ? { origin: askOrigin.origin, origin_id: askOrigin.origin_id } : {}),
+          },
         });
         break;
-      case "permission_request":
+      }
+      case "permission_request": {
+        // Same origin-propagation fix as request_human above: the
+        // request_id-bearing payload now also carries the originating
+        // surface so the prompt UI lands only on the channel that
+        // triggered the tool call.
+        const permOrigin = this.lastPromptOrigin.get(agentId);
         this.publish({
           ts: Date.now(),
           agent_id: agentId,
           session_id: "",
           topic: "channel.permission_request",
-          payload: msg.request,
+          payload: {
+            ...msg.request,
+            ...(permOrigin ? { origin: permOrigin.origin, origin_id: permOrigin.origin_id } : {}),
+          },
         });
         break;
+      }
       case "error":
         this.onError(new Error(`MCP error: ${msg.code} ${msg.message}`), {
           ctx: "ipc-error",


### PR DESCRIPTION
## Summary

Two distinct bugs surfaced in Hetzner prod after #137 merged. Both reproduced from the 2026-05-20 incident in the POVIEW.AI Discord workspace.

**Bug A — Adapters fan out on foreign origin.** WebUI-originated replies (`origin: "webui"`) were mirroring into every Discord channel routed to the agent. #133's routing only handled the "this IS my origin" branch — foreign origins fell through to `channelsForAgent` and fanned out. Telegram + Slack had the same class of bug.

**Bug B — `channel.permission_request` / `system.request_human` carried no origin.** BusCore was publishing these without attaching `lastPromptOrigin`, so every subscriber received them and fanned out. The screenshot's "Permission requested: Bash / Post to Suzy's Discord channel" appearing in `#content-reg` is exactly this.

## Fixes

- All three adapters (Discord, Telegram, Slack): drop events whose origin is set to a different surface. Fan-out reserved for origin-absent events (cron, heartbeat, scheduler).
- Slack adapter: also gains origin-id routing (it was always fanning out before — never had #133-style origin filter).
- `src/bus/core.ts`: `channel.permission_request` and `system.request_human` now carry `origin`/`origin_id` from `lastPromptOrigin` the same way `response.text` already did.

## Test plan

- [x] `bun test src/bus src/adapters` — 363 pass / 1 skip / 0 fail
- [x] New regressions:
  - `src/bus/__tests__/core.test.ts` — permission_request carries origin from most recent prompt
  - `src/adapters/discord/__tests__/discord-outbound.test.ts` — drops response.text + permission_request with foreign origin; routes permission_request to origin_id only when origin === "discord"
- [x] `bun run lint` clean
- [x] Version bumped to 2.2.68
- [ ] 5-agent code review
- [ ] Manual verification in prod after Hetzner deploy: webui chat doesn't mirror to discord; permission_request from one channel doesn't appear in another