### PR TITLE
fix(bus): default agent.permission_mode to bypassPermissions (headless contract)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.71",
+      "version": "2.2.72",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.72",
+      "version": "2.2.73",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.70",
+      "version": "2.2.71",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.71",
+  "version": "2.2.72",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.70",
+  "version": "2.2.71",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.72",
+  "version": "2.2.73",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/agent-resolver.test.ts
+++ b/src/bus/__tests__/agent-resolver.test.ts
@@ -31,7 +31,11 @@ describe("resolveBusAgentConfig — defaults", () => {
       id: "triage",
       cwd: "/tmp/proj",
       session_id: "uuid-fixed",
-      permission_mode: "plan",
+      // Codex P1 on PR #143: resolver default is the load-bearing one
+      // because production startup runs entries through this resolver
+      // BEFORE `buildClaudeArgs` ever sees them. Must match the
+      // documented headless contract in `commands/start.md`.
+      permission_mode: "bypassPermissions",
       supervision: "pty-stdin",
     });
   });

--- a/src/bus/__tests__/build-claude-args.test.ts
+++ b/src/bus/__tests__/build-claude-args.test.ts
@@ -137,4 +137,17 @@ describe("buildClaudeArgs", () => {
     expect(args[pmIdx + 1]).toBe("default");
     expect(args[sidIdx + 1]).toBe("deadbeef-1234-1234-1234-000000000000");
   });
+
+  it("defaults permission_mode to bypassPermissions when unset (headless contract)", () => {
+    // commands/start.md §Security Levels: "All levels run without
+    // permission prompts (headless)". Legacy `claude -p` delivered
+    // this implicitly. The bus runtime must match — defaulting to
+    // "plan" surfaces a permission_request for every Bash/Write tool
+    // call to the originating channel, regressing the documented
+    // contract.
+    const agent = makeAgent({ id: "upsilon-default" });
+    const args = buildClaudeArgs(agent, "pty-stdin");
+    const pmIdx = args.indexOf("--permission-mode");
+    expect(args[pmIdx + 1]).toBe("bypassPermissions");
+  });
 });

--- a/src/bus/agent-resolver.ts
+++ b/src/bus/agent-resolver.ts
@@ -45,7 +45,9 @@ export interface ResolveAgentOptions {
  *
  * Defaults applied:
  *   - `cwd` ← `opts.defaultCwd ?? process.cwd()`
- *   - `permission_mode` ← `"plan"`
+ *   - `permission_mode` ← `"bypassPermissions"` (matches the documented
+ *     headless contract in `commands/start.md` §Security Levels — see
+ *     also the fallback in `buildClaudeArgs`)
  *   - `session_id` ← existing `agents/<id>/session.json` value, else a
  *     fresh UUID persisted on first call.
  *   - `supervision` ← `"pty-stdin"` (Codex P1 fold-in from PR #122).
@@ -68,7 +70,7 @@ export async function resolveBusAgentConfig(
     id: entry.id,
     cwd,
     session_id,
-    permission_mode: entry.permission_mode ?? "plan",
+    permission_mode: entry.permission_mode ?? "bypassPermissions",
     supervision: (entry.supervision as SupervisionMode | undefined) ?? "pty-stdin",
   };
   if (entry.system_prompt_file) config.system_prompt_file = entry.system_prompt_file;

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -325,7 +325,18 @@ export function buildClaudeArgs(agent: AgentConfig, mode: SupervisionMode): stri
   if (agent.mcp_config) {
     args.push("--mcp-config", agent.mcp_config);
   }
-  args.push("--permission-mode", agent.permission_mode ?? "plan");
+  // Default to `bypassPermissions` to match the documented headless
+  // contract in `commands/start.md` §"Security Levels": "All levels run
+  // without permission prompts (headless)". The legacy `claude -p` path
+  // delivered this implicitly; the bus runtime previously defaulted to
+  // "plan", which made every Bash / Write tool call surface a
+  // permission_request to the originating channel — a regression from
+  // the legacy headless contract.
+  //
+  // Operators who want approvals back can set `permission_mode` per
+  // agent in `settings.json` to one of the other valid values:
+  //   "default" | "plan" | "acceptEdits" | "bypassPermissions"
+  args.push("--permission-mode", agent.permission_mode ?? "bypassPermissions");
   if (agent.system_prompt_file) {
     args.push("--append-system-prompt", agent.system_prompt_file);
   }

--- a/src/config.ts
+++ b/src/config.ts
@@ -938,8 +938,9 @@ const AGENT_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,35}$/;
  *
  * Validation:
  *   - `id` required, matches `AGENT_ID_PATTERN`, unique across the list.
- *   - `permission_mode` must be one of the valid trio (else fall back to
- *     `"plan"`).
+ *   - `permission_mode` must be one of the valid trio (else drop and let
+ *     `resolveBusAgentConfig` apply the default of `"bypassPermissions"`,
+ *     matching the documented headless contract).
  *   - `supervision` must be a known mode (else drop the field — internal
  *     `defaultSupervisionFor` picks one).
  *   - `cwd` / `system_prompt_file` / `memory_file` / `mcp_config` must be
@@ -974,9 +975,14 @@ function parseBusAgents(raw: unknown): BusAgentSettings[] {
     if (typeof e.permission_mode === "string") {
       const pm = e.permission_mode.trim() as "plan" | "bypassPermissions" | "default";
       if (VALID_PERMISSION_MODES.has(pm)) parsed.permission_mode = pm;
+      // Codex P1 follow-up on PR #143: the warning previously said
+      // "falling back to plan" but left `parsed.permission_mode`
+      // unset, so the resolver's `?? "bypassPermissions"` default
+      // would silently override — i.e. the warning lied. Now state
+      // the actual fallback the resolver applies.
       else
         console.warn(
-          `[config] settings.agents[${i}].permission_mode="${e.permission_mode}" invalid; falling back to "plan"`,
+          `[config] settings.agents[${i}].permission_mode="${e.permission_mode}" invalid; falling back to "bypassPermissions" (resolver default)`,
         );
     }
     if (typeof e.supervision === "string") {


### PR DESCRIPTION
## Summary

Restores the documented headless behaviour for the bus runtime. `commands/start.md` §Security Levels states:

> "All levels run without permission prompts (headless). Security is enforced via tool restrictions and project-directory scoping."

The legacy `claude -p` path delivered this implicitly. The bus session-manager (`src/bus/session-manager.ts:328`) passed `--permission-mode plan` when `agent.permission_mode` was unset, turning every Bash / Write tool call into a permission_request surfaced to the originating channel.

## Fix

`agent.permission_mode` now defaults to `bypassPermissions` (was `"plan"`). Operators wanting approvals back can set per-agent in `settings.json` to one of: `"default" | "plan" | "acceptEdits" | "bypassPermissions"`.

## Test plan

- [x] New regression in `src/bus/__tests__/build-claude-args.test.ts` asserts the unset-permission_mode default lands as `bypassPermissions`
- [x] `bun test src/bus` — 214 pass / 1 skip / 0 fail
- [x] `bun run lint` clean
- [x] Version bumped to 2.2.71
- [x] Verified live on Hetzner: settings flipped + restarted; user confirmed prompts no longer interrupt tool calls
- [ ] Codex auto-review
- [ ] 5-agent review

## Out of scope (follow-up)

Issue/task: add an explicit wizard prompt for permission mode at first setup so operators choosing the non-headless path do so consciously.

## Symmetry note

PTY path (`src/runner.ts:879-905`) already defaults to `bypassPermissions` via the legacy `permission-mode.json` read. This PR brings bus runtime defaults into parity.