### PR TITLE
docs(sdc): document the 9-stage Software Development Cycle

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.71",
+      "version": "2.2.72",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.72",
+      "version": "2.2.74",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.73",
+      "version": "2.2.71",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.71",
+  "version": "2.2.72",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.72",
+  "version": "2.2.74",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.73",
+  "version": "2.2.71",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,3 +84,67 @@ bun run bump:marketplace-version
 ```
 
 Both `plugin-version-guard` and `marketplace-version-guard` are required CI checks. They fail if `.claude-plugin/plugin.json` or `.claude-plugin/marketplace.json` still carry the same version as the merge base. Run the bumps, commit alongside your code changes, and push before creating the PR.
+
+---
+
+## Software Development Cycle (SDC)
+
+This project follows a **9-stage Claude-Code-managed SDC**. The Claude Code agent loop is the orchestrator; specialised sub-agents do the focused work, parallelised where independent and sequential where dependent. Worktrees isolate parallel work streams.
+
+The SDC is **ClaudeClaw+ specific** — it is not proposed for upstream `moazbuilds/claudeclaw`.
+
+**The hook + mark-script implementation lives in the operator's home (`~/.claude/`), NOT in the repo.** Repo stays free of local Claude Code config; hooks stay active across every worktree and branch independent of what's checked out. The previous in-repo location was branch-coupled and trivially bypassable.
+
+### The 9 stages
+
+| # | Stage | Owner | Enforcement |
+|---|---|---|---|
+| 1 | **Architect** | `architect` / `feature-dev:code-architect` sub-agents | Intent-based |
+| 2 | **Plan** | `Plan` agent / plan mode | Intent-based |
+| 3 | **Human review** | Terrence | Conversational gate (no hook) |
+| 4 | **Implementation** | Claude Code + focused sub-agents (parallel where independent) | Intent-based |
+| 5 | **Write tests** | `tdd-guide` / implementer | **Hook-enforced** (`tests-written` marker) |
+| 6 | **Run tests / QA** | `~/.claude/scripts/sdc/mark-tests-passing.sh` (runs `bun test` + `bun run lint`) | **Hook-enforced** (`tests-passing` marker) |
+| 7 | **Security review** | `security-reviewer` agent (or equivalent) | **Hook-enforced** (`security-reviewed` marker) |
+| 8 | **5-agent code review** | `/code-review:code-review` skill + human sign-off | **Hook-enforced** (`pr-review` marker) |
+| 9 | **PR** | `gh pr create` once all four markers are in place | Allowed by the gate hook |
+
+### Parallel and sequential sub-agents
+
+- **Parallel where independent.** Stage 1 architect explorations, stage 4 implementation of unrelated modules, stage 6 running unrelated test suites — fan out into multiple Agent calls in a single message.
+- **Sequential where dependent.** Stage 2 plan depends on stage 1 output; stage 4 implementation depends on stage 3 human sign-off; stages 5–7 sequence after a clean stage 4.
+- **Worktrees as appropriate.** Each independent parallel work stream should occupy its own `.claude/worktrees/<branch>` so subagents don't collide on the working tree.
+- Use `feature-dev:code-explorer` for read-only reconnaissance, `feature-dev:code-architect` for design synthesis, `codex:codex-rescue` for second-opinion / hand-off after two failed fix attempts on the same issue.
+
+### Hook-enforced gates (stages 5–8)
+
+Each enforced gate is keyed by `<branch>` + first 12 chars of `HEAD` sha. A fresh commit invalidates every marker — re-run the relevant gates. Markers live under `.claude/state/` (gitignored) per project.
+
+| Gate | Marker | How to mark |
+|---|---|---|
+| `tests-written` | `.claude/state/tests-written-<branch>-<sha-12>.json` | `~/.claude/scripts/sdc/mark-tests-written.sh "<note>"` |
+| `tests-passing` | `.claude/state/tests-passing-<branch>-<sha-12>.json` | `~/.claude/scripts/sdc/mark-tests-passing.sh` (verifying — runs `bun test` + `bun run lint`, marks only on green) |
+| `security-reviewed` | `.claude/state/security-reviewed-<branch>-<sha-12>.json` | `~/.claude/scripts/sdc/mark-security-reviewed.sh "<reviewer + summary>"` |
+| `pr-review` | `.claude/state/pr-review-<branch>-<sha-12>.json` | `~/.claude/scripts/sdc/mark-pr-reviewed.sh "<note>"` |
+
+The gate hook lives at `~/.claude/hooks/sdc-gate-claudeclaw-plus.sh` (wired in `~/.claude/settings.json` as `PreToolUse` on `Bash`). It scopes itself to `ClaudeClaw-Plus` repos by checking `git remote` — other projects' `gh pr create` is unaffected. If any of the four markers is missing for the current branch + sha, the PR creation is blocked with a checklist of what's missing.
+
+### Override
+
+For emergencies, docs-only PRs, or follow-up commits already covered by an earlier review on the same branch:
+
+```bash
+ALLOW_PR_PUBLISH=1 gh pr create ...
+```
+
+Inline `ALLOW_PR_PUBLISH=1` prefix on the command works too.
+
+### Why these four are hook-enforced and the other five aren't
+
+Stages 1–4 are intent-based by nature — architecture, planning, human review, and implementation can't be deterministically verified by a script. Stages 5–8 are verifiable (tests exist; tests pass; security review ran; code review ran) and have a strong "zero-exception" property. So they're hooks, not docstrings.
+
+### Posting gate (separate)
+
+Two posting gates layer together:
+- `~/.claude/hooks/sdc-gate-claudeclaw-plus.sh` (this project) — gates *creating* the PR
+- `~/.claude/hooks/block-pr-write.sh` (global) — gates *commenting on* or *reviewing* a PR. See `~/.claude/rules/pr-review.md` for why: "Posting unreviewed AI-generated comments under Terrence's maintainer identity to other contributors' PRs is a trust and reputation risk."


### PR DESCRIPTION
## Summary

Adds a "Software Development Cycle (SDC)" section to `CLAUDE.md` documenting the 9-stage Claude-Code-managed flow this project follows:

```
1. Architect  → 2. Plan  → 3. Human review  → 4. Implementation
→ 5. Write tests*  → 6. Run tests/QA*  → 7. Security review*
→ 8. 5-agent code review*  → 9. PR

(* hook-enforced via markers under .claude/state/<gate>-<branch>-<sha>.json)
```

## Implementation lives outside the repo

The hook script and mark scripts live in the operator's home (`~/.claude/`), **NOT in the repo** — local Claude Code config does not belong in tracked code. This means the hook stays active across every worktree, branch, and `git reset`, and the repo stays free of operator-specific tooling.

Repo footprint (this PR):
- `CLAUDE.md` — new section documenting the SDC, the four hook-enforced gates, parallel/sequential sub-agent guidance, worktree usage, and the `ALLOW_PR_PUBLISH=1` override.

Operator-side install (already done, not in this PR):
- `~/.claude/hooks/sdc-gate-claudeclaw-plus.sh` — PreToolUse Bash hook
- `~/.claude/scripts/sdc/mark-{tests-written,tests-passing,security-reviewed,pr-reviewed}.sh`
- `~/.claude/settings.json` wiring (`PreToolUse` Bash matcher)

The hook scopes itself by `git remote` URL — only fires for `ClaudeClaw-Plus` / `moazbuilds-claudeclaw` repos. Other projects' `gh pr create` is unaffected.

## Bootstrap exception

This is the PR that creates the SDC itself, so the four gates it documents can't run on it (chicken-and-egg). Opened with `ALLOW_PR_PUBLISH=1` per the documented override path. Future PRs in this repo will pass through all four gates normally.

## Test plan

- [x] Hook tested locally: pass-through path, out-of-scope path, block path (exit 2 with checklist), inline `ALLOW_PR_PUBLISH=1` override
- [x] Markers + state dir verified to be project-scoped via `git rev-parse --show-toplevel` (fixed post-#143 — worktrees nested under main workspace previously misrouted to parent)
- [x] Docs-only diff — no functional changes, no tests added
- [x] Version bumped to 2.2.72