### PR TITLE
feat(wizard): ask about headless permissions at first setup

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.74",
+      "version": "2.2.75",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.75",
+      "version": "2.2.76",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.75",
+  "version": "2.2.76",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.74",
+  "version": "2.2.75",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/commands/start.md
+++ b/commands/start.md
@@ -38,6 +38,7 @@ Start the heartbeat daemon for this project. Follow these steps exactly:
    - **Telegram configured** = `telegram.token` is non-empty
    - **Discord configured** = `discord.token` is non-empty
    - **Security configured** = `security.level` exists and is not `"moderate"` (the default), OR `security.allowedTools`/`security.disallowedTools` are non-empty
+   - **Permissions configured** = `.claude/claudeclaw/permission-mode.json` exists (legacy claude -p runner reads from here), OR every entry in `settings.agents` has an explicit `permission_mode` (bus runtime reads per-agent)
 
 4. **Interactive setup — smart mode** (BEFORE launching the daemon):
 
@@ -66,6 +67,9 @@ Start the heartbeat daemon for this project. Follow these steps exactly:
      - "Locked" (description: "Read-only — can only search and read files, no edits, bash, or web")
      - "Strict" (description: "Can edit files but no bash or web access")
      - "Unrestricted" (description: "Full access with no directory restriction — dangerous"))
+   - **If permissions are NOT configured**: "Headless agents — should Claude run tool calls without asking for permission per call?" (header: "Permissions", options:
+     - "Yes — headless (Recommended)" (description: "Tools execute without prompts. Security is enforced via the security level + project-directory scoping. This matches the legacy `claude -p` daemon behaviour.")
+     - "No — confirm each Bash/Write call" (description: "Permission requests appear on the originating channel (Discord button, Telegram inline keyboard, Slack block) and the turn blocks until you click Allow/Deny."))
 
    Then, based on their answers:
 
@@ -108,6 +112,10 @@ Start the heartbeat daemon for this project. Follow these steps exactly:
    - **If security is "Strict" or "Locked"**: Use AskUserQuestion to ask:
      - "Allow any specific tools on top of the security level? (e.g. Bash(git:*) to allow only git commands)" (header: "Allow tools", options: "None — use level defaults (Recommended)", "Bash(git:*) — git only", "Bash(git:*) Bash(npm:*) — git + npm")
      - If they pick an option with tools or type custom ones, set `security.allowedTools` to the list.
+
+   - **Permission mode mapping** — apply the headless answer to settings:
+     - "Yes — headless (Recommended)" → DO NOTHING. The bus resolver default (`bypassPermissions`) and the legacy `permission-mode.json` absence both already deliver headless behaviour. No explicit write is needed.
+     - "No — confirm each Bash/Write call" → write `.claude/claudeclaw/permission-mode.json` with `{"mode": "plan"}` (the legacy `claude -p` runner reads this). AND, for each existing entry in `settings.agents` (if any), set the agent's `permission_mode` to `"plan"` so the bus runtime picks it up per-agent. If `settings.agents` is empty, only the legacy file needs writing — bus agents added later will need a manual `permission_mode` field (this is intentional; bus agents are explicit per-agent configs).
 
    Update `.claude/claudeclaw/settings.json` with their answers.
 
@@ -237,9 +245,11 @@ Defaults: `WEB_HOST=127.0.0.1`, `WEB_PORT=4632` unless changed via settings or `
 - `security.level` — one of: `locked`, `strict`, `moderate`, `unrestricted`
 - `security.allowedTools` — extra tools to allow on top of the level (e.g. `["Bash(git:*)"]`)
 - `security.disallowedTools` — tools to block on top of the level
+- `agents[N].permission_mode` (bus runtime) — one of: `"default"`, `"plan"`, `"acceptEdits"`, `"bypassPermissions"`. Default is `"bypassPermissions"` (headless — no Allow/Deny prompts per tool call). Per-agent override; falls back to the resolver default if unset.
+- `.claude/claudeclaw/permission-mode.json` (legacy `claude -p` runtime) — `{"mode": "..."}` file. Absent ≡ `"bypassPermissions"` (headless). Written by the wizard only when the user explicitly opts out of headless.
 
 ### Security Levels
-All levels run without permission prompts (headless). Security is enforced via tool restrictions and project-directory scoping.
+The security level controls which tools are available; the headless behaviour is controlled separately via `permission_mode`. By default (`permission_mode: "bypassPermissions"`, set by the wizard or assumed when unset) all levels run without permission prompts, with security enforced via tool restrictions and project-directory scoping. Operators can opt into per-call confirmations by setting `permission_mode: "plan"` — useful for review-bot or compliance-bounded setups.
 
 | Level | Tools available | Directory scoped |
 |-------|----------------|-----------------|

--- a/commands/start.md
+++ b/commands/start.md
@@ -38,7 +38,7 @@ Start the heartbeat daemon for this project. Follow these steps exactly:
    - **Telegram configured** = `telegram.token` is non-empty
    - **Discord configured** = `discord.token` is non-empty
    - **Security configured** = `security.level` exists and is not `"moderate"` (the default), OR `security.allowedTools`/`security.disallowedTools` are non-empty
-   - **Permissions configured** = `.claude/claudeclaw/permission-mode.json` exists (legacy claude -p runner reads from here), OR every entry in `settings.agents` has an explicit `permission_mode` (bus runtime reads per-agent)
+   - **Permissions configured** = `.claude/claudeclaw/permission-mode.json` exists. (This is the marker the wizard writes when the operator opts out of headless. Per-agent `permission_mode` overrides in `settings.agents` are independent operator-driven overrides — they do NOT count as "wizard configured" because they can be set without the wizard ever running, and the empty-agents first-setup state would otherwise be vacuously "configured" and the question would be skipped.)
 
 4. **Interactive setup — smart mode** (BEFORE launching the daemon):
 
@@ -245,7 +245,7 @@ Defaults: `WEB_HOST=127.0.0.1`, `WEB_PORT=4632` unless changed via settings or `
 - `security.level` — one of: `locked`, `strict`, `moderate`, `unrestricted`
 - `security.allowedTools` — extra tools to allow on top of the level (e.g. `["Bash(git:*)"]`)
 - `security.disallowedTools` — tools to block on top of the level
-- `agents[N].permission_mode` (bus runtime) — one of: `"default"`, `"plan"`, `"acceptEdits"`, `"bypassPermissions"`. Default is `"bypassPermissions"` (headless — no Allow/Deny prompts per tool call). Per-agent override; falls back to the resolver default if unset.
+- `agents[N].permission_mode` (bus runtime) — one of: `"default"`, `"plan"`, `"bypassPermissions"` (the trio currently accepted by `src/config.ts` `VALID_PERMISSION_MODES`). Default is `"bypassPermissions"` (headless — no Allow/Deny prompts per tool call). Per-agent override; falls back to the resolver default if unset. Claude Code itself accepts more values (`acceptEdits` / `dontAsk` / `auto`) — see follow-up for expanding the validator to match.
 - `.claude/claudeclaw/permission-mode.json` (legacy `claude -p` runtime) — `{"mode": "..."}` file. Absent ≡ `"bypassPermissions"` (headless). Written by the wizard only when the user explicitly opts out of headless.
 
 ### Security Levels


### PR DESCRIPTION
## Summary

Task #174 follow-up to PR #143. The `/claudeclaw:start` wizard already asks for a security level (which tools are allowed) but never asked whether tool calls should run headless. PR #143 fixed the bus default to `bypassPermissions` (matching the documented headless contract); this PR makes that an explicit operator choice at first setup with the same default.

## Wizard addition

A new question is added after the security-level prompt:

> **Headless agents — should Claude run tool calls without asking for permission per call?**
> - **Yes — headless (Recommended)** — tools execute without prompts; security enforced via security level + project-directory scoping (legacy `claude -p` behaviour)
> - **No — confirm each Bash/Write call** — permission requests appear on the originating channel; turn blocks until Allow/Deny

## Storage

- **Yes (Recommended)** → no-op. Resolver default of `bypassPermissions` and the legacy `permission-mode.json` absence both already deliver headless behaviour.
- **No** → writes `.claude/claudeclaw/permission-mode.json` with `{"mode": "plan"}` (legacy `claude -p` reads this), AND for each `settings.agents[N]` (if any) sets `permission_mode: "plan"` (bus runtime reads per-agent).

## Docs cleanup

The "Security Levels" section of `commands/start.md` previously stated unconditionally that all levels run headless. Updated to clarify that `permission_mode` controls headlessness independently of the security level.

## Test plan

- [x] Docs-only diff (`commands/start.md` + version bump to 2.2.75)
- [x] `bun run lint` clean
- [x] `bun test src/bus` 215 pass / 1 skip / 0 fail (sanity — no code paths touched)
- [ ] Codex auto-review on the new sha
- [x] Bootstrap exception: docs-only PR opened with `ALLOW_PR_PUBLISH=1` per the documented SDC override path; no code paths affected so the per-marker gates would just exercise the suite on an unchanged codebase.