### PR TITLE
fix: expand permission_mode parity across parser, runner, and telegram /mode

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.77",
+      "version": "2.2.78",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.76",
+      "version": "2.2.77",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.77",
+  "version": "2.2.78",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.76",
+  "version": "2.2.77",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/commands/start.md
+++ b/commands/start.md
@@ -245,7 +245,7 @@ Defaults: `WEB_HOST=127.0.0.1`, `WEB_PORT=4632` unless changed via settings or `
 - `security.level` — one of: `locked`, `strict`, `moderate`, `unrestricted`
 - `security.allowedTools` — extra tools to allow on top of the level (e.g. `["Bash(git:*)"]`)
 - `security.disallowedTools` — tools to block on top of the level
-- `agents[N].permission_mode` (bus runtime) — one of: `"default"`, `"plan"`, `"bypassPermissions"` (the trio currently accepted by `src/config.ts` `VALID_PERMISSION_MODES`). Default is `"bypassPermissions"` (headless — no Allow/Deny prompts per tool call). Per-agent override; falls back to the resolver default if unset. Claude Code itself accepts more values (`acceptEdits` / `dontAsk` / `auto`) — see follow-up for expanding the validator to match.
+- `agents[N].permission_mode` (bus runtime) — one of: `"default"`, `"plan"`, `"acceptEdits"`, `"bypassPermissions"`, `"dontAsk"`, `"auto"` (full-parity with Claude Code's `--permission-mode` choices). Default is `"bypassPermissions"` (headless — no Allow/Deny prompts per tool call). Per-agent override; falls back to the resolver default if unset.
 - `.claude/claudeclaw/permission-mode.json` (legacy `claude -p` runtime) — `{"mode": "..."}` file. Absent ≡ `"bypassPermissions"` (headless). Written by the wizard only when the user explicitly opts out of headless.
 
 ### Security Levels

--- a/src/__tests__/runtime-config.test.ts
+++ b/src/__tests__/runtime-config.test.ts
@@ -159,6 +159,20 @@ describe("parseSettings — agents field (Sprint 5.2a)", () => {
     expect(getSettings().agents[0]).toEqual({ id: "triage", cwd: "/srv" });
   });
 
+  it("accepts every Claude Code --permission-mode choice (Codex P2 on PR #145)", async () => {
+    // Earlier the parser only accepted default/plan/bypassPermissions,
+    // so users following commands/start.md's documented choices got
+    // their permission_mode silently dropped if they picked acceptEdits,
+    // dontAsk, or auto. Full-parity with the CLI flag now.
+    const modes = ["default", "plan", "acceptEdits", "bypassPermissions", "dontAsk", "auto"];
+    await writeRawSettings({
+      agents: modes.map((m, i) => ({ id: `agent-${i}`, permission_mode: m })),
+    });
+    await reloadSettings();
+    const parsed = getSettings().agents.map((a) => a.permission_mode);
+    expect(parsed).toEqual(modes);
+  });
+
   it("falls back to empty array when the field is not an array", async () => {
     await writeRawSettings({ agents: "triage" });
     await reloadSettings();

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -335,7 +335,7 @@ export function buildClaudeArgs(agent: AgentConfig, mode: SupervisionMode): stri
   //
   // Operators who want approvals back can set `permission_mode` per
   // agent in `settings.json` to one of the other valid values:
-  //   "default" | "plan" | "acceptEdits" | "bypassPermissions"
+  //   "default" | "plan" | "acceptEdits" | "bypassPermissions" | "dontAsk" | "auto"
   args.push("--permission-mode", agent.permission_mode ?? "bypassPermissions");
   if (agent.system_prompt_file) {
     args.push("--append-system-prompt", agent.system_prompt_file);

--- a/src/bus/types.ts
+++ b/src/bus/types.ts
@@ -156,7 +156,7 @@ export interface AgentConfig {
   /** UUID passed to `claude --session-id`. Stable across restarts. */
   session_id: string;
   /** Default permission mode for spawned claude. */
-  permission_mode?: "plan" | "bypassPermissions" | "default";
+  permission_mode?: "default" | "plan" | "acceptEdits" | "bypassPermissions" | "dontAsk" | "auto";
   /** Optional path to system prompt addendum. */
   system_prompt_file?: string;
   /** Optional path to per-agent MEMORY.md. */

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1446,15 +1446,31 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
 
   if (command === "/mode") {
     const arg = text.trim().slice("/mode".length).trim().toLowerCase();
+    // User-facing aliases → canonical PermissionMode. Keep the short
+    // labels stable for muscle memory; back them with the canonical
+    // mode names. The full set of canonical values is documented at
+    // `src/runner.ts` PermissionMode (full-parity with Claude Code's
+    // `--permission-mode` flag).
     const modeMap: Record<string, PermissionMode> = {
+      default: "default",
       plan: "plan",
       edit: "acceptEdits",
+      acceptedits: "acceptEdits",
       unrestricted: "bypassPermissions",
+      bypass: "bypassPermissions",
+      dontask: "dontAsk",
+      auto: "auto",
     };
+    // Inverse — used to render the canonical mode in a friendly label.
+    // Exhaustive on PermissionMode so any future expansion of the type
+    // surfaces a compile-time error here.
     const modeLabels: Record<PermissionMode, string> = {
+      default: "default",
       plan: "plan",
       acceptEdits: "edit",
       bypassPermissions: "unrestricted",
+      dontAsk: "dontAsk",
+      auto: "auto",
     };
 
     if (!arg) {
@@ -1469,6 +1485,9 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
           "- /mode plan - read-only planning",
           "- /mode edit - auto-accept file edits",
           "- /mode unrestricted - full permissions, no prompts",
+          "- /mode default - prompt per tool call",
+          "- /mode dontAsk - never prompt (alias of unrestricted, distinct semantics in Claude Code)",
+          "- /mode auto - Claude Code picks",
         ].join("\n"),
         threadId,
       );
@@ -1481,7 +1500,7 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
       await sendMessage(
         config.token,
         chatId,
-        `Unknown mode: \`${safeArg}\`\n\nValid modes: plan, edit, unrestricted`,
+        `Unknown mode: \`${safeArg}\`\n\nValid modes: plan, edit, unrestricted, default, dontAsk, auto`,
         threadId,
       );
       return;

--- a/src/config.ts
+++ b/src/config.ts
@@ -945,7 +945,8 @@ const AGENT_ID_PATTERN = /^[a-z0-9][a-z0-9_-]{0,35}$/;
  *
  * Validation:
  *   - `id` required, matches `AGENT_ID_PATTERN`, unique across the list.
- *   - `permission_mode` must be one of the valid trio (else drop and let
+ *   - `permission_mode` must be one of the six values accepted by
+ *     Claude Code's `--permission-mode` flag (else drop and let
  *     `resolveBusAgentConfig` apply the default of `"bypassPermissions"`,
  *     matching the documented headless contract).
  *   - `supervision` must be a known mode (else drop the field — internal

--- a/src/config.ts
+++ b/src/config.ts
@@ -504,7 +504,7 @@ export interface BusAgentSettings {
   /** Working directory the spawned claude runs in. Defaults to `process.cwd()`. */
   cwd?: string;
   /** Permission mode for the spawned claude. Defaults to `"plan"`. */
-  permission_mode?: "plan" | "bypassPermissions" | "default";
+  permission_mode?: "default" | "plan" | "acceptEdits" | "bypassPermissions" | "dontAsk" | "auto";
   /**
    * Override the supervision picker. Default is mode-dependent (see
    * `defaultSupervisionFor` in `src/bus/types.ts`). Operators rarely
@@ -907,12 +907,19 @@ function parseRuntimeMode(raw: unknown): RuntimeMode {
   return "pty";
 }
 
-/** Allowed values for `BusAgentSettings.permission_mode`. */
-const VALID_PERMISSION_MODES = new Set<"plan" | "bypassPermissions" | "default">([
-  "plan",
-  "bypassPermissions",
-  "default",
-]);
+/**
+ * Allowed values for `BusAgentSettings.permission_mode`.
+ *
+ * Full-parity with the choices Claude Code accepts via `--permission-mode`
+ * (verified against `claude --help` 2026-05-20: `acceptEdits`,
+ * `bypassPermissions`, `default`, `dontAsk`, `plan`, `auto`). Earlier
+ * versions of this parser only accepted the `default | plan |
+ * bypassPermissions` trio, which made `commands/start.md` lie when it
+ * documented `acceptEdits` as valid (Codex P2 on PR #145).
+ */
+const VALID_PERMISSION_MODES = new Set<
+  "default" | "plan" | "acceptEdits" | "bypassPermissions" | "dontAsk" | "auto"
+>(["default", "plan", "acceptEdits", "bypassPermissions", "dontAsk", "auto"]);
 
 /** Allowed values for `BusAgentSettings.supervision`. */
 const VALID_SUPERVISION_MODES = new Set<BusSupervisionMode>([
@@ -973,7 +980,13 @@ function parseBusAgents(raw: unknown): BusAgentSettings[] {
     const parsed: BusAgentSettings = { id };
     if (typeof e.cwd === "string" && e.cwd.trim().length > 0) parsed.cwd = e.cwd.trim();
     if (typeof e.permission_mode === "string") {
-      const pm = e.permission_mode.trim() as "plan" | "bypassPermissions" | "default";
+      const pm = e.permission_mode.trim() as
+        | "default"
+        | "plan"
+        | "acceptEdits"
+        | "bypassPermissions"
+        | "dontAsk"
+        | "auto";
       if (VALID_PERMISSION_MODES.has(pm)) parsed.permission_mode = pm;
       // Codex P1 follow-up on PR #143: the warning previously said
       // "falling back to plan" but left `parsed.permission_mode`

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1238,7 +1238,33 @@ export async function ensureProjectClaudeMd(): Promise<void> {
   }
 }
 
-export type PermissionMode = "plan" | "acceptEdits" | "bypassPermissions";
+/**
+ * Permission modes accepted by Claude Code's `--permission-mode` flag.
+ *
+ * Full-parity with the CLI choices (verified against `claude --help`
+ * 2026-05-20). Kept in sync with `VALID_PERMISSION_MODES` in
+ * `src/config.ts` and the union types in `src/bus/types.ts`. If any
+ * one of these three sites is updated, all three must move together —
+ * otherwise a value documented in one path will be silently rejected
+ * by another (Codex P2 on PR #145; 5-agent review Agent 2 on PR
+ * #expand-valid-permission-modes flagged this exact runner gap).
+ */
+export type PermissionMode =
+  | "default"
+  | "plan"
+  | "acceptEdits"
+  | "bypassPermissions"
+  | "dontAsk"
+  | "auto";
+
+const VALID_PERMISSION_MODES: ReadonlySet<PermissionMode> = new Set<PermissionMode>([
+  "default",
+  "plan",
+  "acceptEdits",
+  "bypassPermissions",
+  "dontAsk",
+  "auto",
+]);
 
 let cachedPermissionMode: PermissionMode | null = null;
 
@@ -1246,9 +1272,9 @@ export function getPermissionMode(): PermissionMode {
   if (cachedPermissionMode) return cachedPermissionMode;
   try {
     const raw = JSON.parse(readFileSync(PERMISSION_MODE_FILE, "utf8")) as { mode?: unknown };
-    if (raw.mode === "plan" || raw.mode === "acceptEdits" || raw.mode === "bypassPermissions") {
-      cachedPermissionMode = raw.mode;
-      return raw.mode;
+    if (typeof raw.mode === "string" && VALID_PERMISSION_MODES.has(raw.mode as PermissionMode)) {
+      cachedPermissionMode = raw.mode as PermissionMode;
+      return cachedPermissionMode;
     }
   } catch {}
   return "bypassPermissions";


### PR DESCRIPTION
## Summary

Codex P2 follow-up on #145. The wizard doc listed `acceptEdits` as a valid `agents[N].permission_mode` value, but the parser at `src/config.ts` only accepted `default | plan | bypassPermissions` — users following the doc would have their value silently dropped. This PR makes the parser full-parity with Claude Code's `--permission-mode` flag (verified vs `claude --help` 2026-05-20).

## Changes

| Site | Before | After |
|---|---|---|
| `src/config.ts` `VALID_PERMISSION_MODES` | 3 values | 6 values (`default`, `plan`, `acceptEdits`, `bypassPermissions`, `dontAsk`, `auto`) |
| `src/config.ts` `BusAgentSettings.permission_mode` union | 3-value | 6-value |
| `src/bus/types.ts` `AgentConfig.permission_mode` union | 3-value | 6-value |
| `src/runner.ts` `PermissionMode` (legacy `claude -p` runtime) | 3-value | 6-value + Set-based JSON parse |
| `src/commands/telegram.ts` `/mode` `modeMap` + `modeLabels` | 3-value | 6-value, with `Record<PermissionMode, string>` exhaustiveness |
| `commands/start.md` docs | 3-value list | 6-value list |

## Why all three sites needed updating

5-agent review on the first commit (`7b8da72`) caught that the parser expansion alone was insufficient: the legacy runner and telegram `/mode` command had their own copies of the 3-value union. Users could set a new mode in `permission-mode.json` and have it silently coerced back to `bypassPermissions`, or run `/mode dontAsk` in Telegram and see `Current mode: **undefined**`. Fixed in `054c512`.

## Test plan

- [x] New regression test in `src/__tests__/runtime-config.test.ts` asserts all 6 values survive `parseSettings`
- [x] `bun test src/__tests__/runtime-config.test.ts` — 23 pass
- [x] `bun test src/bus` — 215 pass / 1 skip
- [x] `bun run lint` clean
- [x] Versions bumped to 2.2.78
- [x] 5-agent review on prior sha; all 4 SDC gate markers dropped on the new sha after addressing Agent 2's finding

## SDC

All four gate markers present for `054c512`. Bootstrap-free merge.