### PR TITLE
feat(mcp-multiplexer): cost-tracking metrics on dispatch path (#68)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.80",
+      "version": "2.2.81",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.81",
+      "version": "2.2.82",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.78",
+      "version": "2.2.79",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.79",
+      "version": "2.2.80",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.81",
+  "version": "2.2.82",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.79",
+  "version": "2.2.80",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.80",
+  "version": "2.2.81",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.78",
+  "version": "2.2.79",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -182,6 +182,11 @@ const DEFAULT_SETTINGS: Settings = {
     sessionPersistenceEnabled: true,
     sessionMaxAgeSeconds: 3600,
     sessionPersistencePath: "",
+    rateLimit: { maxRequestsPerWindow: 600, windowMs: 60_000 },
+    // Issue #68: cost-tracking metrics on the multiplexer dispatch
+    // path. Default OFF for MVP — operators opt in via settings once
+    // the schema is stable.
+    metricsEnabled: false,
   },
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
   session: { autoRotate: false, maxMessages: 50, maxAgeHours: 24, summaryPath: "" },
@@ -411,6 +416,16 @@ export interface McpConfig {
     /** Sliding-window length in milliseconds. */
     windowMs: number;
   };
+  /**
+   * Cost-tracking metrics on the multiplexer dispatch path (issue #68).
+   * Per-tuple `(serverName, bucketKey, toolName)` counters + latency
+   * samples (p50/p95/p99). Default `false` for MVP; flip on once the
+   * schema is stable.
+   *
+   * When `true`, metrics are exposed at `/api/multiplexer/metrics`
+   * (operator-only — bootstrap-token-authenticated).
+   */
+  metricsEnabled: boolean;
 }
 
 export interface PtyConfig {
@@ -1229,6 +1244,9 @@ function parseMcpConfig(raw: any, webEnabled: unknown): McpConfig {
     rateWindowMs = Math.max(100, Math.floor(rawRateWin));
   }
 
+  // Issue #68: cost-tracking metrics. Default off — operator opts in.
+  const metricsEnabled = raw?.metricsEnabled === true;
+
   return {
     shared: filteredShared,
     perPtyOnly,
@@ -1241,6 +1259,7 @@ function parseMcpConfig(raw: any, webEnabled: unknown): McpConfig {
       maxRequestsPerWindow: rateMaxRequestsPerWindow,
       windowMs: rateWindowMs,
     },
+    metricsEnabled,
   };
 }
 

--- a/src/plugins/http-gateway.ts
+++ b/src/plugins/http-gateway.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync } from "n
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { getMcpBridge } from "./mcp-bridge.js";
+import { getMetricsRegistry } from "./mcp-multiplexer/metrics.js";
 
 const PluginManifestSchema = z.object({
   name: z.string().regex(/^[a-z][a-z0-9-]*$/, "name must be lowercase kebab-case"),
@@ -80,6 +81,15 @@ export class PluginHttpGateway {
 
     if (path === "/api/plugin/register" && method === "POST") return this.handleRegister(req);
     if (path === "/api/plugin/list" && method === "GET") return this.handleList(req);
+
+    // /api/multiplexer/metrics — operator-only metrics snapshot
+    // (issue #68). Authenticated with the bootstrap token, same
+    // pattern as plugin registration. Returns the current counters +
+    // latency percentiles for every (server, bucket, tool) tuple the
+    // multiplexer has dispatched against since start.
+    if (path === "/api/multiplexer/metrics" && method === "GET") {
+      return this.handleMultiplexerMetrics(req);
+    }
 
     // /api/plugin/:name/tools/:tool/invoke
     const invokeM = path.match(/^\/api\/plugin\/([^/]+)\/tools\/([^/]+)\/invoke$/);
@@ -427,6 +437,29 @@ export class PluginHttpGateway {
       last_health_check: p.lastHealthCheck ?? null,
     }));
     return json({ plugins: list, request_id: requestId });
+  }
+
+  /**
+   * /api/multiplexer/metrics — snapshot of multiplexer dispatch
+   * counters + latency percentiles. Issue #68. Bootstrap-token
+   * authenticated (same auth gate as `/api/plugin/register`).
+   *
+   * When `settings.mcp.metricsEnabled` is `false` (the default), the
+   * registry is disabled and the snapshot returns
+   * `{ enabled: false, tuples: [] }` — the endpoint stays reachable
+   * so operators can probe the flag from any tooling.
+   */
+  private async handleMultiplexerMetrics(req: Request): Promise<Response> {
+    const requestId = this.requestId(req);
+    const authToken = (req.headers.get("authorization") ?? "").replace(/^Bearer\s+/, "");
+    if (!this.verifyBootstrap(authToken)) {
+      return json(
+        this.errorBody("invalid_bootstrap", "Invalid or missing Bearer token", requestId),
+        401,
+      );
+    }
+    const snapshot = getMetricsRegistry().snapshot();
+    return json({ ...snapshot, request_id: requestId });
   }
 
   private async handleHealthCheck(req: Request, name: string): Promise<Response> {

--- a/src/plugins/mcp-multiplexer/__tests__/index.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/index.test.ts
@@ -50,6 +50,8 @@ function makeSettingsView(partial: Partial<MuxSettingsView>): () => MuxSettingsV
     sessionPersistenceEnabled: false,
     sessionMaxAgeSeconds: 3600,
     sessionPersistencePath: "",
+    // Issue #68 — default OFF in tests; opt-in tests set true explicitly.
+    metricsEnabled: false,
     ...partial,
   };
   return () => view;

--- a/src/plugins/mcp-multiplexer/__tests__/metrics.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/metrics.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Unit tests for the multiplexer cost-tracking metrics registry.
+ * Issue #68.
+ */
+import { describe, expect, it, beforeEach } from "bun:test";
+import { MetricsRegistry, __setMetricsRegistryForTest, getMetricsRegistry } from "../metrics";
+
+function freshRegistry(): MetricsRegistry {
+  const r = new MetricsRegistry();
+  __setMetricsRegistryForTest(r);
+  return r;
+}
+
+describe("MetricsRegistry — disabled by default", () => {
+  it("isEnabled() returns false on construction", () => {
+    const r = freshRegistry();
+    expect(r.isEnabled()).toBe(false);
+  });
+
+  it("record() returns a no-op timer when disabled", () => {
+    const r = freshRegistry();
+    const timer = r.record("alpha", "bucket-1", "do-thing");
+    timer.end(true);
+    timer.end(false);
+    const snap = r.snapshot();
+    expect(snap.enabled).toBe(false);
+    expect(snap.tuples).toHaveLength(0);
+  });
+});
+
+describe("MetricsRegistry — enabled", () => {
+  let r: MetricsRegistry;
+  beforeEach(() => {
+    r = freshRegistry();
+    r.setEnabled(true);
+  });
+
+  it("end(true) increments invocations + successes; latency recorded", () => {
+    const timer = r.record("alpha", "b1", "foo");
+    timer.end(true);
+    const snap = r.snapshot();
+    expect(snap.tuples).toHaveLength(1);
+    const t = snap.tuples[0]!;
+    expect(t).toMatchObject({
+      server: "alpha",
+      bucket: "b1",
+      tool: "foo",
+      invocations: 1,
+      successes: 1,
+      errors: 0,
+      sampleCount: 1,
+    });
+    expect(t.p50).not.toBeNull();
+    expect(t.p95).not.toBeNull();
+    expect(t.p99).not.toBeNull();
+    expect(t.meanMs).not.toBeNull();
+  });
+
+  it("end(false) increments errors", () => {
+    const t = r.record("alpha", "b1", "foo");
+    t.end(false);
+    const snap = r.snapshot();
+    expect(snap.tuples[0]).toMatchObject({ invocations: 1, successes: 0, errors: 1 });
+  });
+
+  it("aggregates the SAME tuple across multiple calls", () => {
+    r.record("alpha", "b1", "foo").end(true);
+    r.record("alpha", "b1", "foo").end(true);
+    r.record("alpha", "b1", "foo").end(false);
+    const snap = r.snapshot();
+    expect(snap.tuples).toHaveLength(1);
+    expect(snap.tuples[0]).toMatchObject({ invocations: 3, successes: 2, errors: 1 });
+  });
+
+  it("separates DIFFERENT tuples by server / bucket / tool", () => {
+    r.record("alpha", "b1", "foo").end(true);
+    r.record("alpha", "b1", "bar").end(true);
+    r.record("alpha", "b2", "foo").end(true);
+    r.record("beta", "b1", "foo").end(true);
+    const snap = r.snapshot();
+    expect(snap.tuples).toHaveLength(4);
+  });
+
+  it("computes p50/p95/p99 from samples (nearest-rank, sorted ascending)", () => {
+    // Inject synthetic latencies by reaching past record() — easier
+    // than orchestrating real timing. We use a private path: hit
+    // record() many times with no-op timing then verify percentile
+    // shape on the resulting (~0 ms) samples. For deterministic
+    // percentile math we instead inspect the regression structure
+    // via a fresh registry where we end() at known intervals.
+    for (let i = 0; i < 100; i++) {
+      r.record("alpha", "b1", "perc-test").end(true);
+    }
+    const snap = r.snapshot();
+    const t = snap.tuples.find((x) => x.tool === "perc-test")!;
+    expect(t.sampleCount).toBe(100);
+    expect(t.invocations).toBe(100);
+    // All samples are very small (microseconds); p99 ≥ p95 ≥ p50.
+    expect(t.p99!).toBeGreaterThanOrEqual(t.p95!);
+    expect(t.p95!).toBeGreaterThanOrEqual(t.p50!);
+    expect(t.meanMs!).toBeGreaterThanOrEqual(0);
+  });
+
+  it("caps samples per key at MAX_SAMPLES_PER_KEY (1000)", () => {
+    for (let i = 0; i < 1500; i++) {
+      r.record("alpha", "b1", "burst").end(true);
+    }
+    const snap = r.snapshot();
+    const t = snap.tuples.find((x) => x.tool === "burst")!;
+    // Invocations is the full count; sampleCount is bounded.
+    expect(t.invocations).toBe(1500);
+    expect(t.sampleCount).toBeLessThanOrEqual(1000);
+    expect(t.sampleCount).toBeGreaterThan(990); // bounded but not way under
+  });
+
+  it("snapshot.enabled reflects the registry flag", () => {
+    expect(r.snapshot().enabled).toBe(true);
+    r.setEnabled(false);
+    expect(r.snapshot().enabled).toBe(false);
+  });
+
+  it("reset() clears counters", () => {
+    r.record("alpha", "b1", "foo").end(true);
+    r.reset();
+    expect(r.snapshot().tuples).toHaveLength(0);
+  });
+
+  it("disabling mid-test stops recording but keeps existing tuples", () => {
+    r.record("alpha", "b1", "foo").end(true);
+    r.setEnabled(false);
+    // New record() returns no-op.
+    r.record("alpha", "b1", "foo").end(true);
+    const snap = r.snapshot();
+    // Still 1 invocation — the second record() didn't go through.
+    expect(snap.tuples[0]).toMatchObject({ invocations: 1 });
+    expect(snap.enabled).toBe(false);
+  });
+});
+
+describe("getMetricsRegistry singleton", () => {
+  it("returns the same instance across calls", () => {
+    __setMetricsRegistryForTest(null);
+    const a = getMetricsRegistry();
+    const b = getMetricsRegistry();
+    expect(a).toBe(b);
+  });
+
+  it("respects the test-injected registry", () => {
+    const r = new MetricsRegistry();
+    __setMetricsRegistryForTest(r);
+    expect(getMetricsRegistry()).toBe(r);
+  });
+});

--- a/src/plugins/mcp-multiplexer/__tests__/metrics.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/metrics.test.ts
@@ -125,6 +125,44 @@ describe("MetricsRegistry — enabled", () => {
     expect(r.snapshot().tuples).toHaveLength(0);
   });
 
+  it("end() is idempotent — calling twice does NOT double-count (Agent 2 finding)", () => {
+    const t = r.record("alpha", "b1", "foo");
+    t.end(true);
+    t.end(true); // ignored
+    t.end(false); // ignored
+    const snap = r.snapshot();
+    expect(snap.tuples[0]).toMatchObject({
+      invocations: 1,
+      successes: 1,
+      errors: 0,
+      sampleCount: 1,
+    });
+  });
+
+  it("releasePty() drops only the matching (server, bucket) tuples (Agent 4 finding)", () => {
+    r.record("alpha", "pty-A", "foo").end(true);
+    r.record("alpha", "pty-A", "bar").end(true);
+    r.record("alpha", "pty-B", "foo").end(true);
+    r.record("beta", "pty-A", "foo").end(true);
+    expect(r.snapshot().tuples).toHaveLength(4);
+
+    r.releasePty("alpha", "pty-A");
+    const tuples = r.snapshot().tuples;
+    // alpha::pty-A::foo and alpha::pty-A::bar gone; alpha::pty-B::foo
+    // and beta::pty-A::foo retained.
+    expect(tuples).toHaveLength(2);
+    expect(tuples.map((t) => `${t.server}::${t.bucket}`).sort()).toEqual([
+      "alpha::pty-B",
+      "beta::pty-A",
+    ]);
+  });
+
+  it("releasePty() is a no-op when no matching tuples exist", () => {
+    r.record("alpha", "pty-A", "foo").end(true);
+    r.releasePty("alpha", "pty-Z"); // no match
+    expect(r.snapshot().tuples).toHaveLength(1);
+  });
+
   it("disabling mid-test stops recording but keeps existing tuples", () => {
     r.record("alpha", "b1", "foo").end(true);
     r.setEnabled(false);

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -24,6 +24,7 @@ import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { randomUUID } from "node:crypto";
 import { getMcpBridge } from "../mcp-bridge.js";
+import { getMetricsRegistry } from "./metrics.js";
 import type { McpServerProcess } from "../mcp-proxy/server-process.js";
 import { AUTH_HEADER, PTY_ID_HEADER, PTY_TS_HEADER, verifyBearer } from "./pty-identity.js";
 import type { SessionPersistenceStore } from "./session-persistence.js";
@@ -549,8 +550,15 @@ export class McpHttpHandler {
           isError: true,
         };
       }
+      // Issue #68: cost-tracking metrics. `record()` returns a no-op
+      // timer when metrics are disabled, so this is zero-cost in the
+      // default path. The timer is started even before we know if the
+      // dispatch will succeed; `end(success)` is called in both arms
+      // so an exception path still records its latency + error count.
+      const timer = getMetricsRegistry().record(this.serverName, bucketKey, name);
       try {
         const result = await this.proc.call(name, args ?? {});
+        timer.end(true);
         return {
           content: [
             {
@@ -560,6 +568,7 @@ export class McpHttpHandler {
           ],
         };
       } catch (err) {
+        timer.end(false);
         const message = err instanceof Error ? err.message : String(err);
         return {
           content: [{ type: "text", text: `Error: ${message}` }],

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -563,17 +563,20 @@ export class McpHttpHandler {
       // default path. The timer is started even before we know if the
       // dispatch will succeed; `end(success)` is called in both arms
       // so an exception path still records its latency + error count.
+      //
+      // Codex P2 on this PR: serialize the response FIRST, then
+      // `end(true)`. If `JSON.stringify(result)` throws (circular data,
+      // BigInt), control falls to the catch and `end(false)` records
+      // the error correctly. Calling `end(true)` before serialization
+      // would latch the timer as a success before the failure was
+      // observable — silently dropping the error increment.
       const timer = getMetricsRegistry().record(this.serverName, bucketKey, name);
       try {
         const result = await this.proc.call(name, args ?? {});
+        const text = typeof result === "string" ? result : JSON.stringify(result);
         timer.end(true);
         return {
-          content: [
-            {
-              type: "text",
-              text: typeof result === "string" ? result : JSON.stringify(result),
-            },
-          ],
+          content: [{ type: "text", text }],
         };
       } catch (err) {
         timer.end(false);

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -57,7 +57,10 @@ export interface McpHttpHandlerOpts {
    *  `onsessioninitialized` callback; `releasePty` drops it; bucket
    *  reuse touches `lastUsedAt`. Stateless buckets are never persisted
    *  (no per-PTY identity to bind to). When undefined, the handler is
-   *  byte-identical to PR #71. */
+   *  behaviourally equivalent to PR #71 for the persistence axis —
+   *  observably identical until the post-#71 cost-tracking metrics
+   *  hook (issue #68) was added, which wraps the dispatch path with a
+   *  no-op timer when `mcp.metricsEnabled` is false (the default). */
   persistence?: SessionPersistenceStore;
   /** Optional per-bearer rate limit config (#72 item 1). When omitted or
    *  `maxRequestsPerWindow <= 0`, no limit is enforced. */
@@ -405,6 +408,11 @@ export class McpHttpHandler {
     // still keyed the window by ptyId (we use `STATELESS_BUCKET` for
     // the SDK session, but `_checkRateLimit` keys on the actual ptyId).
     this._rlWindows.delete(ptyId);
+    // Same hygiene for the cost-tracking metrics (issue #68): drop any
+    // tuples scoped to this PTY so stale percentiles from the reaped
+    // session don't bleed into the next bucket. 5-agent review on
+    // PR #cost-metrics flagged this class from PR #91 P2.
+    getMetricsRegistry().releasePty(this.serverName, ptyId);
     if (this.stateless) return; // no per-PTY bucket exists
     // Drop the persisted record FIRST so that even if the bucket's
     // already gone (race with transport_error path) the disk state is

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -34,6 +34,7 @@ import { getMcpBridge } from "../mcp-bridge.js";
 import { McpServerProcess, type McpServerConfig } from "../mcp-proxy/server-process.js";
 import { getSettings } from "../../config.js";
 import { McpHttpHandler } from "./http-handler.js";
+import { getMetricsRegistry } from "./metrics.js";
 import {
   issueIdentity as _issueIdentity,
   revokeIdentity as _revokeIdentity,
@@ -229,6 +230,13 @@ export class McpMultiplexerPlugin {
     if (this.started) return;
 
     const settings = this.settingsView();
+
+    // Issue #68: cost-tracking metrics. Reflect the settings flag onto
+    // the registry on every start() — covers daemon boot AND
+    // operator-driven re-start() after settings reload. Disabling at
+    // runtime stops new recordings; collected data stays until the
+    // process exits.
+    getMetricsRegistry().setEnabled(getSettings().mcp.metricsEnabled === true);
 
     // Refuse to expose MCP servers over a non-loopback gateway.
     if (settings.webHost !== "127.0.0.1" && settings.webHost !== "localhost") {

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -100,6 +100,11 @@ export interface MuxSettingsView {
    *  start time" — multiplexer resolves to
    *  `~/.config/claudeclaw/mcp-sessions/`. */
   sessionPersistencePath: string;
+  /** Issue #68: cost-tracking metrics on dispatch path. Default false
+   *  (opt-in). When true, `MetricsRegistry` records per-tuple counters
+   *  + latency samples and the `/api/multiplexer/metrics` endpoint
+   *  returns aggregated data. */
+  metricsEnabled: boolean;
 }
 
 function _readSettings(): MuxSettingsView {
@@ -129,6 +134,7 @@ function _readSettings(): MuxSettingsView {
   const rawPath = mcpObj.sessionPersistencePath;
   const sessionPersistencePath =
     typeof rawPath === "string" && rawPath.length > 0 && rawPath.startsWith("/") ? rawPath : "";
+  const metricsEnabled = mcpObj.metricsEnabled === true;
   return {
     webEnabled: s.web?.enabled === true,
     webHost: s.web?.host ?? "127.0.0.1",
@@ -139,6 +145,7 @@ function _readSettings(): MuxSettingsView {
     sessionPersistenceEnabled,
     sessionMaxAgeSeconds,
     sessionPersistencePath,
+    metricsEnabled,
   };
 }
 
@@ -235,8 +242,9 @@ export class McpMultiplexerPlugin {
     // the registry on every start() — covers daemon boot AND
     // operator-driven re-start() after settings reload. Disabling at
     // runtime stops new recordings; collected data stays until the
-    // process exits.
-    getMetricsRegistry().setEnabled(getSettings().mcp.metricsEnabled === true);
+    // process exits. Use the injected settingsView so tests can drive
+    // the flag without standing up real settings.
+    getMetricsRegistry().setEnabled(settings.metricsEnabled);
 
     // Refuse to expose MCP servers over a non-loopback gateway.
     if (settings.webHost !== "127.0.0.1" && settings.webHost !== "localhost") {

--- a/src/plugins/mcp-multiplexer/metrics.ts
+++ b/src/plugins/mcp-multiplexer/metrics.ts
@@ -105,8 +105,17 @@ export class MetricsRegistry {
     if (!this.enabled) return NOOP_TIMER;
     const key = `${serverName}::${bucketKey}::${toolName}`;
     const startedAt = performance.now();
+    // Idempotency guard (5-agent review Agent 2 finding): if a refactor
+    // or test ever double-calls `end()` on the same timer (e.g. a
+    // `finally` added alongside the existing try/catch arms), each call
+    // would otherwise increment the counters again — silently corrupting
+    // invocations/successes/errors. Latch-once on first invocation,
+    // ignore subsequent calls.
+    let done = false;
     return {
       end: (success: boolean) => {
+        if (done) return;
+        done = true;
         const latency = performance.now() - startedAt;
         let rec = this.records.get(key);
         if (!rec) {
@@ -125,6 +134,23 @@ export class MetricsRegistry {
         }
       },
     };
+  }
+
+  /**
+   * Drop every tuple whose `bucketKey` matches the given PTY id. Called
+   * by the handler's `releasePty` on identity revocation so stale
+   * percentiles from a reaped PTY don't bleed into the next bucket
+   * issued under the same id.
+   *
+   * 5-agent review Agent 4 finding (class concern from PR #91 P2): the
+   * handler clears `_rlWindows` on `releasePty`; the metrics registry
+   * needs the same hygiene.
+   */
+  releasePty(serverName: string, bucketKey: string): void {
+    const prefix = `${serverName}::${bucketKey}::`;
+    for (const key of this.records.keys()) {
+      if (key.startsWith(prefix)) this.records.delete(key);
+    }
   }
 
   /** Aggregate snapshot for the `/api/multiplexer/metrics` endpoint. */

--- a/src/plugins/mcp-multiplexer/metrics.ts
+++ b/src/plugins/mcp-multiplexer/metrics.ts
@@ -1,0 +1,175 @@
+/**
+ * Cost-tracking metrics for the MCP multiplexer dispatch path.
+ *
+ * Issue #68 follow-up to #64. Every `tools/call` going through the
+ * multiplexer's per-server bucket already passes through one place
+ * (`CallToolRequestSchema` handler in `http-handler.ts`). Wrap that
+ * dispatch with `record()` / `end()` and we get per-tuple counters +
+ * latency samples for free, with no metrics-pipeline dependency.
+ *
+ * Granularity (per acceptance criteria on issue #68):
+ *   - Tuple key: `(serverName, bucketKey, toolName)` — bucketKey is the
+ *     ptyId-equivalent in the multiplexer (one bucket per spawning PTY).
+ *   - Counters: invocations, successes, errors.
+ *   - Latencies: ring buffer of recent samples (~1000 per tuple) for
+ *     p50 / p95 / p99 computation at snapshot time.
+ *
+ * Disabled by default. Operators opt in via `settings.mcp.metricsEnabled`
+ * once they've validated the schema. When disabled, `record()` returns
+ * a no-op timer and `snapshot()` returns an empty record — zero cost.
+ *
+ * No persistence: metrics are in-memory and reset on daemon restart.
+ * That's intentional for the MVP — operators who want durability
+ * subscribe via the `health()` enrichment hook (see future work).
+ */
+
+/** Most recent N samples kept per tuple. Bounded to keep memory
+ *  predictable on a long-running daemon. ~1000 doubles ≈ 8 KB per
+ *  tuple; 100 tuples → ~800 KB worst case. */
+const MAX_SAMPLES_PER_KEY = 1000;
+
+interface MetricsRecord {
+  invocations: number;
+  successes: number;
+  errors: number;
+  /** Ring buffer of latency samples (ms). Oldest evicted at cap. */
+  latencies: number[];
+}
+
+export interface ToolMetricsSnapshot {
+  server: string;
+  bucket: string;
+  tool: string;
+  invocations: number;
+  successes: number;
+  errors: number;
+  /** Number of samples retained; ≤ MAX_SAMPLES_PER_KEY. */
+  sampleCount: number;
+  /** Latency in ms. `null` when no samples yet. */
+  p50: number | null;
+  p95: number | null;
+  p99: number | null;
+  /** Mean latency in ms across the retained sample set. */
+  meanMs: number | null;
+}
+
+export interface MetricsRegistrySnapshot {
+  enabled: boolean;
+  takenAt: string;
+  tuples: ToolMetricsSnapshot[];
+}
+
+export interface MetricsTimer {
+  /** Mark the dispatch finished. `success: false` increments the
+   *  error counter; latency is recorded either way. No-op if metrics
+   *  are disabled. */
+  end(success: boolean): void;
+}
+
+const NOOP_TIMER: MetricsTimer = { end: () => undefined };
+
+/**
+ * Compute a percentile from a numeric sample array.
+ *
+ * Uses the nearest-rank method (deterministic, no interpolation —
+ * matches what operators typically expect from p50/p95/p99 dashboards).
+ * Returns `null` for empty input so the snapshot caller can render a
+ * "no data yet" cell instead of zero (misleading).
+ */
+function percentile(samples: readonly number[], p: number): number | null {
+  if (samples.length === 0) return null;
+  const sorted = [...samples].sort((a, b) => a - b);
+  const rank = Math.ceil((p / 100) * sorted.length);
+  return sorted[Math.max(0, Math.min(sorted.length - 1, rank - 1))] ?? null;
+}
+
+export class MetricsRegistry {
+  private enabled = false;
+  private readonly records = new Map<string, MetricsRecord>();
+
+  setEnabled(enabled: boolean): void {
+    this.enabled = enabled;
+  }
+
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+
+  /**
+   * Start timing a dispatch. Returns a timer to be `end()`-ed once the
+   * call resolves or throws. The timer is captured at registry level so
+   * an interleaved disable mid-call still completes cleanly — disabling
+   * stops NEW recordings but doesn't poison in-flight ones.
+   */
+  record(serverName: string, bucketKey: string, toolName: string): MetricsTimer {
+    if (!this.enabled) return NOOP_TIMER;
+    const key = `${serverName}::${bucketKey}::${toolName}`;
+    const startedAt = performance.now();
+    return {
+      end: (success: boolean) => {
+        const latency = performance.now() - startedAt;
+        let rec = this.records.get(key);
+        if (!rec) {
+          rec = { invocations: 0, successes: 0, errors: 0, latencies: [] };
+          this.records.set(key, rec);
+        }
+        rec.invocations += 1;
+        if (success) rec.successes += 1;
+        else rec.errors += 1;
+        rec.latencies.push(latency);
+        if (rec.latencies.length > MAX_SAMPLES_PER_KEY) {
+          // Evict oldest. Splice is O(N) but N is bounded by
+          // MAX_SAMPLES_PER_KEY; this fires at most once per call, so
+          // the overhead is one shift per dispatch in steady state.
+          rec.latencies.splice(0, rec.latencies.length - MAX_SAMPLES_PER_KEY);
+        }
+      },
+    };
+  }
+
+  /** Aggregate snapshot for the `/api/multiplexer/metrics` endpoint. */
+  snapshot(): MetricsRegistrySnapshot {
+    const tuples: ToolMetricsSnapshot[] = [];
+    for (const [key, rec] of this.records.entries()) {
+      const [server = "", bucket = "", tool = ""] = key.split("::");
+      const sum = rec.latencies.reduce((s, x) => s + x, 0);
+      const mean = rec.latencies.length > 0 ? sum / rec.latencies.length : null;
+      tuples.push({
+        server,
+        bucket,
+        tool,
+        invocations: rec.invocations,
+        successes: rec.successes,
+        errors: rec.errors,
+        sampleCount: rec.latencies.length,
+        p50: percentile(rec.latencies, 50),
+        p95: percentile(rec.latencies, 95),
+        p99: percentile(rec.latencies, 99),
+        meanMs: mean,
+      });
+    }
+    return {
+      enabled: this.enabled,
+      takenAt: new Date().toISOString(),
+      tuples,
+    };
+  }
+
+  /** Reset all counters and samples. Used by tests; not exposed to
+   *  the operator API. */
+  reset(): void {
+    this.records.clear();
+  }
+}
+
+let registry: MetricsRegistry | null = null;
+
+export function getMetricsRegistry(): MetricsRegistry {
+  if (!registry) registry = new MetricsRegistry();
+  return registry;
+}
+
+/** Test seam — swap in a fresh registry for isolation. */
+export function __setMetricsRegistryForTest(r: MetricsRegistry | null): void {
+  registry = r;
+}


### PR DESCRIPTION
Closes #68.

## Summary

Per-tuple `(serverName, bucketKey, toolName)` counters + latency samples (p50/p95/p99) on the multiplexer `tools/call` dispatch path. Implements all three acceptance criteria from the issue:

- Hook installed at the single `CallToolRequestSchema` dispatch in `src/plugins/mcp-multiplexer/http-handler.ts`.
- Settings flag `mcp.metricsEnabled` (default `false`) — operator opts in once the schema is stable.
- Unit test covers counter increment + latency record path (+ a few more — see below).

## What lands

| File | Purpose |
|---|---|
| `src/plugins/mcp-multiplexer/metrics.ts` (new) | `MetricsRegistry` class + singleton. Per-tuple counters + bounded ring buffer (1000 samples/tuple) + nearest-rank percentile snapshot |
| `src/plugins/mcp-multiplexer/http-handler.ts` | Timer wraps the existing `proc.call()` in both success + error arms. Idempotent — double `end()` is a no-op |
| `src/plugins/mcp-multiplexer/http-handler.ts` (releasePty) | Drops registry tuples scoped to the released PTY (same hygiene path as `_rlWindows.delete`) |
| `src/plugins/http-gateway.ts` | New `GET /api/multiplexer/metrics` endpoint, bootstrap-token-authenticated |
| `src/plugins/mcp-multiplexer/index.ts` | Settings flag propagates via the existing `settingsView` injection seam (testable) |
| `src/config.ts` | `mcp.metricsEnabled: boolean` field + parser entry; pre-existing `rateLimit` typing hole in `DEFAULT_SETTINGS` also filled in |
| `src/plugins/mcp-multiplexer/__tests__/metrics.test.ts` (new) | 15 tests: enabled/disabled, end() idempotency, aggregation per tuple, percentile shape, sample-cap eviction, releasePty selective drop, singleton |

## 5-agent review

| # | Verdict |
|---|---|
| Agent 1 (CLAUDE.md compliance) | Clean |
| Agent 2 (shallow bugs) | Medium: end()-called-once guard — **fixed** in `9d8227c` |
| Agent 3 (git history) | No regressions |
| Agent 4 (prior PR comments) | Class concern from PR #91 P2 (releasePty hygiene) — **fixed** in `9d8227c` |
| Agent 5 (in-file comments) | Stale "byte-identical to PR #71" — **fixed** in `9d8227c` |

All 4 SDC gate markers dropped for HEAD `9d8227c`.

## Test plan

- [x] `bun test src/plugins/` — 121 pass / 0 fail
- [x] `bun run lint` clean
- [x] Version bumped to 2.2.81
- [x] All 5-agent review findings addressed in a fixup commit
- [ ] Codex auto-review on the GitHub side