### PR TITLE
feat(mcp-multiplexer): response cache for idempotent tools (#69)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.83",
+      "version": "2.2.84",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.82",
+      "version": "2.2.83",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.83",
+  "version": "2.2.84",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.82",
+  "version": "2.2.83",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -187,6 +187,14 @@ const DEFAULT_SETTINGS: Settings = {
     // path. Default OFF for MVP — operators opt in via settings once
     // the schema is stable.
     metricsEnabled: false,
+    // Issue #69: response caching for idempotent tools. Default OFF;
+    // operators enumerate cacheable (server, tool) pairs explicitly.
+    cache: {
+      enabled: false,
+      ttlMs: 5_000,
+      maxEntries: 1_000,
+      cacheable: {},
+    },
   },
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
   session: { autoRotate: false, maxMessages: 50, maxAgeHours: 24, summaryPath: "" },
@@ -426,6 +434,26 @@ export interface McpConfig {
    * (operator-only — bootstrap-token-authenticated).
    */
   metricsEnabled: boolean;
+  /**
+   * Response caching for idempotent multiplexer tools (issue #69).
+   * Opt-in per `(server, tool)` pair — no tool is cacheable by
+   * default. Cache lives in-process, bounded by `maxEntries`, with a
+   * short `ttlMs` expiry. A non-cacheable call against a server with
+   * cacheable tools triggers defensive invalidation of every cached
+   * entry for that server. Cache stats are exposed in the
+   * multiplexer's `health()` snapshot.
+   */
+  cache: {
+    /** Master switch. Default false. */
+    enabled: boolean;
+    /** TTL in milliseconds. Default 5000. */
+    ttlMs: number;
+    /** Max entries across all cache keys. Default 1000. */
+    maxEntries: number;
+    /** Per-server allowlist of cacheable tool names.
+     *  Example: `{ "retrieval-mcp": ["get_record", "list_records"] }`. */
+    cacheable: Record<string, string[]>;
+  };
 }
 
 export interface PtyConfig {
@@ -1247,6 +1275,29 @@ function parseMcpConfig(raw: any, webEnabled: unknown): McpConfig {
   // Issue #68: cost-tracking metrics. Default off — operator opts in.
   const metricsEnabled = raw?.metricsEnabled === true;
 
+  // Issue #69: response caching. Default off; operator must enumerate
+  // cacheable (server, tool) pairs explicitly.
+  const rawCache = raw?.cache;
+  const cacheEnabled = rawCache?.enabled === true;
+  const rawCacheTtl = rawCache?.ttlMs;
+  const cacheTtlMs =
+    typeof rawCacheTtl === "number" && Number.isFinite(rawCacheTtl) && rawCacheTtl > 0
+      ? Math.max(100, Math.floor(rawCacheTtl))
+      : 5_000;
+  const rawCacheMax = rawCache?.maxEntries;
+  const cacheMaxEntries =
+    typeof rawCacheMax === "number" && Number.isFinite(rawCacheMax) && rawCacheMax > 0
+      ? Math.max(1, Math.floor(rawCacheMax))
+      : 1_000;
+  const cacheableRaw =
+    rawCache?.cacheable && typeof rawCache.cacheable === "object" ? rawCache.cacheable : {};
+  const cacheable: Record<string, string[]> = {};
+  for (const [serverName, tools] of Object.entries(cacheableRaw)) {
+    if (!Array.isArray(tools)) continue;
+    const filtered = tools.filter((t): t is string => typeof t === "string" && t.length > 0);
+    if (filtered.length > 0) cacheable[serverName] = filtered;
+  }
+
   return {
     shared: filteredShared,
     perPtyOnly,
@@ -1260,6 +1311,12 @@ function parseMcpConfig(raw: any, webEnabled: unknown): McpConfig {
       windowMs: rateWindowMs,
     },
     metricsEnabled,
+    cache: {
+      enabled: cacheEnabled,
+      ttlMs: cacheTtlMs,
+      maxEntries: cacheMaxEntries,
+      cacheable,
+    },
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -194,6 +194,7 @@ const DEFAULT_SETTINGS: Settings = {
       ttlMs: 5_000,
       maxEntries: 1_000,
       cacheable: {},
+      defensiveInvalidation: true,
     },
   },
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
@@ -453,6 +454,12 @@ export interface McpConfig {
     /** Per-server allowlist of cacheable tool names.
      *  Example: `{ "retrieval-mcp": ["get_record", "list_records"] }`. */
     cacheable: Record<string, string[]>;
+    /** Defensive invalidation on every non-cacheable call against a
+     *  server with cacheable tools. Default true. Operators with
+     *  cleanly partitioned tools (mixed-tool servers where the
+     *  non-cacheable tools are read-only) can flip false to avoid
+     *  thrashing the cache. 5-agent review on PR #69 Agent 3 finding. */
+    defensiveInvalidation: boolean;
   };
 }
 
@@ -1316,6 +1323,9 @@ function parseMcpConfig(raw: any, webEnabled: unknown): McpConfig {
       ttlMs: cacheTtlMs,
       maxEntries: cacheMaxEntries,
       cacheable,
+      // Default true per issue #69 acceptance; operator opts out by
+      // setting false (e.g. cleanly-partitioned tools).
+      defensiveInvalidation: rawCache?.defensiveInvalidation !== false,
     },
   };
 }

--- a/src/plugins/mcp-multiplexer/__tests__/cache.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/cache.test.ts
@@ -1,0 +1,194 @@
+/**
+ * Unit tests for the multiplexer response cache. Issue #69.
+ */
+import { describe, expect, it, beforeEach } from "bun:test";
+import { ResponseCache, __setResponseCacheForTest, getResponseCache } from "../cache";
+
+function freshCache(): ResponseCache {
+  const c = new ResponseCache();
+  __setResponseCacheForTest(c);
+  return c;
+}
+
+describe("ResponseCache — disabled by default", () => {
+  it("isCacheable() returns false on construction", () => {
+    const c = freshCache();
+    expect(c.isCacheable("retrieval", "get")).toBe(false);
+  });
+
+  it("get/set are no-ops when disabled", () => {
+    const c = freshCache();
+    c.set("retrieval", "get", { id: 1 }, "value");
+    expect(c.get("retrieval", "get", { id: 1 })).toBeUndefined();
+    const stats = c.stats();
+    expect(stats.enabled).toBe(false);
+    expect(stats.entries).toBe(0);
+  });
+});
+
+describe("ResponseCache — enabled", () => {
+  let c: ResponseCache;
+  beforeEach(() => {
+    c = freshCache();
+    c.configure({
+      enabled: true,
+      ttlMs: 5_000,
+      maxEntries: 100,
+      cacheable: { retrieval: new Set(["get", "list"]) },
+    });
+  });
+
+  it("isCacheable() reflects the allowlist", () => {
+    expect(c.isCacheable("retrieval", "get")).toBe(true);
+    expect(c.isCacheable("retrieval", "list")).toBe(true);
+    expect(c.isCacheable("retrieval", "create")).toBe(false);
+    expect(c.isCacheable("other", "get")).toBe(false);
+  });
+
+  it("set + get round-trip for a cacheable (server, tool, args)", () => {
+    c.set("retrieval", "get", { id: 1 }, { name: "alice" });
+    expect(c.get("retrieval", "get", { id: 1 })).toEqual({ name: "alice" });
+    const s = c.stats();
+    expect(s.hits).toBe(1);
+    expect(s.misses).toBe(0);
+    expect(s.entries).toBe(1);
+  });
+
+  it("different args produce different cache slots", () => {
+    c.set("retrieval", "get", { id: 1 }, "alice");
+    c.set("retrieval", "get", { id: 2 }, "bob");
+    expect(c.get("retrieval", "get", { id: 1 })).toBe("alice");
+    expect(c.get("retrieval", "get", { id: 2 })).toBe("bob");
+    expect(c.stats().entries).toBe(2);
+  });
+
+  it("treats semantically-equal args as equal regardless of key order", () => {
+    c.set("retrieval", "get", { a: 1, b: 2 }, "stored");
+    expect(c.get("retrieval", "get", { b: 2, a: 1 })).toBe("stored");
+  });
+
+  it("treats different arg values as cache misses", () => {
+    c.set("retrieval", "get", { id: 1 }, "x");
+    expect(c.get("retrieval", "get", { id: 2 })).toBeUndefined();
+    expect(c.stats().misses).toBe(1);
+  });
+
+  it("set() is a no-op for non-allowlisted tools (defensive)", () => {
+    c.set("retrieval", "create", { name: "alice" }, "stored");
+    expect(c.stats().entries).toBe(0);
+  });
+
+  it("get() on non-cacheable tool increments `skipped`", () => {
+    c.get("retrieval", "create", {});
+    expect(c.stats().skipped).toBe(1);
+    expect(c.stats().misses).toBe(0);
+  });
+
+  it("expires entries past ttlMs", async () => {
+    c.configure({
+      enabled: true,
+      ttlMs: 10,
+      maxEntries: 100,
+      cacheable: { retrieval: new Set(["get"]) },
+    });
+    c.set("retrieval", "get", { id: 1 }, "v");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(c.get("retrieval", "get", { id: 1 })).toBeUndefined();
+    expect(c.stats().misses).toBe(1);
+  });
+
+  it("LRU evicts oldest entry when maxEntries hit", () => {
+    c.configure({
+      enabled: true,
+      ttlMs: 60_000,
+      maxEntries: 3,
+      cacheable: { retrieval: new Set(["get"]) },
+    });
+    c.set("retrieval", "get", { id: 1 }, "a");
+    c.set("retrieval", "get", { id: 2 }, "b");
+    c.set("retrieval", "get", { id: 3 }, "c");
+    c.set("retrieval", "get", { id: 4 }, "d"); // evicts id=1
+    expect(c.get("retrieval", "get", { id: 1 })).toBeUndefined();
+    expect(c.get("retrieval", "get", { id: 4 })).toBe("d");
+    expect(c.stats().evictions).toBe(1);
+  });
+
+  it("LRU touches an entry on get() — it moves to tail", () => {
+    c.configure({
+      enabled: true,
+      ttlMs: 60_000,
+      maxEntries: 3,
+      cacheable: { retrieval: new Set(["get"]) },
+    });
+    c.set("retrieval", "get", { id: 1 }, "a");
+    c.set("retrieval", "get", { id: 2 }, "b");
+    c.set("retrieval", "get", { id: 3 }, "c");
+    // Touch id=1 so id=2 is now oldest.
+    c.get("retrieval", "get", { id: 1 });
+    c.set("retrieval", "get", { id: 4 }, "d"); // evicts id=2
+    expect(c.get("retrieval", "get", { id: 1 })).toBe("a");
+    expect(c.get("retrieval", "get", { id: 2 })).toBeUndefined();
+  });
+
+  it("invalidateServer() drops only the server's entries", () => {
+    c.configure({
+      enabled: true,
+      ttlMs: 60_000,
+      maxEntries: 100,
+      cacheable: { retrieval: new Set(["get"]), other: new Set(["get"]) },
+    });
+    c.set("retrieval", "get", { id: 1 }, "x");
+    c.set("retrieval", "get", { id: 2 }, "y");
+    c.set("other", "get", { id: 1 }, "z");
+    const dropped = c.invalidateServer("retrieval");
+    expect(dropped).toBe(true);
+    expect(c.get("retrieval", "get", { id: 1 })).toBeUndefined();
+    expect(c.get("retrieval", "get", { id: 2 })).toBeUndefined();
+    expect(c.get("other", "get", { id: 1 })).toBe("z");
+    expect(c.stats().invalidations).toBe(1);
+  });
+
+  it("invalidateServer() returns false when nothing to drop", () => {
+    expect(c.invalidateServer("retrieval")).toBe(false);
+  });
+
+  it("serverHasCacheableTools() reflects the allowlist (with master switch)", () => {
+    expect(c.serverHasCacheableTools("retrieval")).toBe(true);
+    expect(c.serverHasCacheableTools("unknown")).toBe(false);
+    c.configure({ enabled: false });
+    expect(c.serverHasCacheableTools("retrieval")).toBe(false);
+  });
+
+  it("configure() shrinking maxEntries evicts down to fit", () => {
+    c.configure({
+      enabled: true,
+      ttlMs: 60_000,
+      maxEntries: 5,
+      cacheable: { retrieval: new Set(["get"]) },
+    });
+    for (let i = 0; i < 5; i++) c.set("retrieval", "get", { id: i }, `v${i}`);
+    expect(c.stats().entries).toBe(5);
+    c.configure({ maxEntries: 2 });
+    expect(c.stats().entries).toBe(2);
+    expect(c.stats().evictions).toBe(3);
+  });
+
+  it("reset() clears entries + counters", () => {
+    c.set("retrieval", "get", { id: 1 }, "x");
+    c.get("retrieval", "get", { id: 1 });
+    c.reset();
+    const s = c.stats();
+    expect(s.entries).toBe(0);
+    expect(s.hits).toBe(0);
+    expect(s.misses).toBe(0);
+  });
+});
+
+describe("getResponseCache singleton", () => {
+  it("returns the same instance across calls", () => {
+    __setResponseCacheForTest(null);
+    const a = getResponseCache();
+    const b = getResponseCache();
+    expect(a).toBe(b);
+  });
+});

--- a/src/plugins/mcp-multiplexer/__tests__/cache.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/cache.test.ts
@@ -159,6 +159,21 @@ describe("ResponseCache — enabled", () => {
     expect(c.serverHasCacheableTools("retrieval")).toBe(false);
   });
 
+  it("shouldInvalidateOnNonCacheableCall() honours the defensiveInvalidation flag", () => {
+    // Default: ON.
+    expect(c.shouldInvalidateOnNonCacheableCall("retrieval")).toBe(true);
+    // Opt-out (5-agent review Agent 3 finding on mixed-tool servers):
+    c.configure({ defensiveInvalidation: false });
+    expect(c.shouldInvalidateOnNonCacheableCall("retrieval")).toBe(false);
+    // Re-enabling restores behaviour.
+    c.configure({ defensiveInvalidation: true });
+    expect(c.shouldInvalidateOnNonCacheableCall("retrieval")).toBe(true);
+  });
+
+  it("shouldInvalidateOnNonCacheableCall() returns false when server has no cacheable tools", () => {
+    expect(c.shouldInvalidateOnNonCacheableCall("unknown-server")).toBe(false);
+  });
+
   it("configure() shrinking maxEntries evicts down to fit", () => {
     c.configure({
       enabled: true,

--- a/src/plugins/mcp-multiplexer/__tests__/index.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/index.test.ts
@@ -53,7 +53,13 @@ function makeSettingsView(partial: Partial<MuxSettingsView>): () => MuxSettingsV
     // Issue #68 — default OFF in tests; opt-in tests set true explicitly.
     metricsEnabled: false,
     // Issue #69 — default OFF in tests; opt-in tests provide cacheable map.
-    cache: { enabled: false, ttlMs: 5_000, maxEntries: 1_000, cacheable: {} },
+    cache: {
+      enabled: false,
+      ttlMs: 5_000,
+      maxEntries: 1_000,
+      cacheable: {},
+      defensiveInvalidation: true,
+    },
     ...partial,
   };
   return () => view;

--- a/src/plugins/mcp-multiplexer/__tests__/index.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/index.test.ts
@@ -52,6 +52,8 @@ function makeSettingsView(partial: Partial<MuxSettingsView>): () => MuxSettingsV
     sessionPersistencePath: "",
     // Issue #68 — default OFF in tests; opt-in tests set true explicitly.
     metricsEnabled: false,
+    // Issue #69 — default OFF in tests; opt-in tests provide cacheable map.
+    cache: { enabled: false, ttlMs: 5_000, maxEntries: 1_000, cacheable: {} },
     ...partial,
   };
   return () => view;

--- a/src/plugins/mcp-multiplexer/cache.ts
+++ b/src/plugins/mcp-multiplexer/cache.ts
@@ -1,0 +1,266 @@
+/**
+ * Response caching for idempotent multiplexer tools (issue #69).
+ *
+ * When several PTYs hit the same retrieval/lookup MCP for the same
+ * record, the multiplexer should be able to serve identical responses
+ * from a short-TTL in-memory cache instead of dispatching to the
+ * upstream child every time. Particularly useful for the
+ * `get_*` / `list_*` shape of tools.
+ *
+ * Design constraints (issue #69 acceptance + Nibbler's review on #64):
+ *   - **Opt-in per (server, tool)** — operator declares cacheable
+ *     tools in `settings.mcp.cache.cacheable`. No tool is cacheable
+ *     by default. Caching the wrong tool would silently corrupt
+ *     behaviour for state-changing calls.
+ *   - **Short TTL** — default 5 s, operator-tunable. The point is
+ *     deduplicating concurrent fan-out, not warming a long-lived
+ *     cache. State drifts in seconds.
+ *   - **Defensive invalidation** — when ANY non-cacheable tool is
+ *     called against a server that has at least one cacheable tool,
+ *     drop every cached entry for that server. Conservative but
+ *     correct: a non-cacheable call signals "this server might have
+ *     mutated state", and we can't tell what it touched.
+ *   - **In-memory only** — cleared on bridge restart. No persistence;
+ *     the whole point is "fresh enough".
+ *   - **Bounded** — LRU cap on total entries to keep memory predictable
+ *     under bursty workloads.
+ *
+ * Cache key shape: `${serverName}::${toolName}::${argsHash}` where
+ * `argsHash` is a deterministic SHA-256 of canonical-JSON-stringified
+ * arguments. Canonical = recursively sorted keys, no trailing whitespace.
+ */
+
+import { createHash } from "node:crypto";
+
+/** Cap on total entries across all (server, tool, args) keys. Older
+ *  entries are evicted on insertion when the cap is hit. */
+const DEFAULT_MAX_ENTRIES = 1000;
+
+/** Default cache TTL in milliseconds. */
+const DEFAULT_TTL_MS = 5_000;
+
+/** Configuration shape consumed by the cache. Sourced from
+ *  `settings.mcp.cache` at startup; see `src/config.ts` for the
+ *  parser. */
+export interface ResponseCacheConfig {
+  /** Master switch. Default false. When false, `get()` always misses
+   *  and `set()` is a no-op. */
+  enabled: boolean;
+  /** TTL in milliseconds. Default 5000. */
+  ttlMs: number;
+  /** Max entries across all cache keys. Default 1000. */
+  maxEntries: number;
+  /** Per-server allowlist of cacheable tool names. A tool is cacheable
+   *  iff it appears in the array for its server. */
+  cacheable: Record<string, ReadonlySet<string>>;
+}
+
+interface CacheEntry {
+  value: unknown;
+  expiresAt: number;
+  /** Insertion order key for LRU eviction. Map iteration order is
+   *  insertion-order in JS, so a fresh `set()` after `delete()` moves
+   *  the entry to the tail naturally. */
+  key: string;
+}
+
+export interface CacheStats {
+  enabled: boolean;
+  ttlMs: number;
+  maxEntries: number;
+  entries: number;
+  hits: number;
+  misses: number;
+  evictions: number;
+  /** Defensive invalidations triggered by non-cacheable calls. */
+  invalidations: number;
+  /** Calls bypassed because the (server, tool) wasn't on the allowlist. */
+  skipped: number;
+}
+
+/**
+ * Canonical JSON: sort keys recursively so semantically-equivalent
+ * argument objects produce the same hash regardless of key order. The
+ * MCP arguments shape is operator-controlled, so we can't rely on the
+ * upstream sending consistent ordering.
+ */
+function canonicalJson(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${canonicalJson(obj[k])}`).join(",")}}`;
+}
+
+function hashArgs(args: unknown): string {
+  return createHash("sha256").update(canonicalJson(args)).digest("hex");
+}
+
+const DEFAULT_CONFIG: ResponseCacheConfig = {
+  enabled: false,
+  ttlMs: DEFAULT_TTL_MS,
+  maxEntries: DEFAULT_MAX_ENTRIES,
+  cacheable: {},
+};
+
+export class ResponseCache {
+  private config: ResponseCacheConfig = { ...DEFAULT_CONFIG };
+  private readonly entries = new Map<string, CacheEntry>();
+  private hits = 0;
+  private misses = 0;
+  private evictions = 0;
+  private invalidations = 0;
+  private skipped = 0;
+
+  configure(opts: Partial<ResponseCacheConfig>): void {
+    this.config = {
+      enabled: opts.enabled ?? this.config.enabled,
+      ttlMs: opts.ttlMs ?? this.config.ttlMs,
+      maxEntries: opts.maxEntries ?? this.config.maxEntries,
+      cacheable: opts.cacheable ?? this.config.cacheable,
+    };
+    // If the cap shrunk, evict from the head until we fit.
+    while (this.entries.size > this.config.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+      this.evictions += 1;
+    }
+  }
+
+  /** Is the (server, tool) pair on the operator's allowlist? Used by
+   *  the dispatch path to decide whether to consult the cache at all. */
+  isCacheable(serverName: string, toolName: string): boolean {
+    if (!this.config.enabled) return false;
+    const allowed = this.config.cacheable[serverName];
+    return allowed !== undefined && allowed.has(toolName);
+  }
+
+  /**
+   * Look up a cached response. Returns the cached value on hit, or
+   * `undefined` on miss or TTL expiry. Records hit/miss counters even
+   * when the cache is disabled — operators want to see "we tried but
+   * the flag was off" in `health()`.
+   *
+   * Caller MUST gate this with `isCacheable()` first; calling `get()`
+   * on a non-cacheable tool is treated as a skip (incremented in the
+   * `skip` counter) and returns `undefined`.
+   */
+  get(serverName: string, toolName: string, args: unknown): unknown | undefined {
+    if (!this.isCacheable(serverName, toolName)) {
+      this.skipped += 1;
+      return undefined;
+    }
+    const key = `${serverName}::${toolName}::${hashArgs(args)}`;
+    const entry = this.entries.get(key);
+    if (!entry) {
+      this.misses += 1;
+      return undefined;
+    }
+    if (entry.expiresAt < Date.now()) {
+      this.entries.delete(key);
+      this.misses += 1;
+      return undefined;
+    }
+    // Re-insert to move to LRU tail.
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    this.hits += 1;
+    return entry.value;
+  }
+
+  /**
+   * Cache a response. No-op when the cache is disabled or the
+   * (server, tool) isn't on the allowlist (defensive — protects
+   * against callers who forgot to gate with `isCacheable()`).
+   */
+  set(serverName: string, toolName: string, args: unknown, value: unknown): void {
+    if (!this.isCacheable(serverName, toolName)) return;
+    const key = `${serverName}::${toolName}::${hashArgs(args)}`;
+    const entry: CacheEntry = {
+      value,
+      expiresAt: Date.now() + this.config.ttlMs,
+      key,
+    };
+    // Existing entry → delete first so the re-insert moves to LRU tail.
+    if (this.entries.has(key)) this.entries.delete(key);
+    this.entries.set(key, entry);
+    // Cap enforcement.
+    while (this.entries.size > this.config.maxEntries) {
+      const oldest = this.entries.keys().next().value;
+      if (oldest === undefined) break;
+      this.entries.delete(oldest);
+      this.evictions += 1;
+    }
+  }
+
+  /**
+   * Drop every cached entry for a server. Called when a non-cacheable
+   * tool is dispatched against a server that has cacheable tools —
+   * the non-cacheable call MIGHT have mutated state we don't track,
+   * so the safe move is to invalidate.
+   *
+   * Returns true if at least one entry was dropped.
+   */
+  invalidateServer(serverName: string): boolean {
+    if (!this.config.enabled) return false;
+    const prefix = `${serverName}::`;
+    let dropped = false;
+    for (const key of this.entries.keys()) {
+      if (key.startsWith(prefix)) {
+        this.entries.delete(key);
+        dropped = true;
+      }
+    }
+    if (dropped) this.invalidations += 1;
+    return dropped;
+  }
+
+  /**
+   * Does the server have any cacheable tools declared? Used by the
+   * dispatch path to decide whether a non-cacheable call should
+   * trigger defensive invalidation — if the server has NO cacheable
+   * tools, there's nothing to invalidate.
+   */
+  serverHasCacheableTools(serverName: string): boolean {
+    if (!this.config.enabled) return false;
+    const allowed = this.config.cacheable[serverName];
+    return allowed !== undefined && allowed.size > 0;
+  }
+
+  stats(): CacheStats {
+    return {
+      enabled: this.config.enabled,
+      ttlMs: this.config.ttlMs,
+      maxEntries: this.config.maxEntries,
+      entries: this.entries.size,
+      hits: this.hits,
+      misses: this.misses,
+      evictions: this.evictions,
+      invalidations: this.invalidations,
+      skipped: this.skipped,
+    };
+  }
+
+  /** Test seam — drop all entries and reset counters. */
+  reset(): void {
+    this.entries.clear();
+    this.hits = 0;
+    this.misses = 0;
+    this.evictions = 0;
+    this.invalidations = 0;
+    this.skipped = 0;
+  }
+}
+
+let cache: ResponseCache | null = null;
+
+export function getResponseCache(): ResponseCache {
+  if (!cache) cache = new ResponseCache();
+  return cache;
+}
+
+/** Test seam — swap in a fresh cache for isolation. */
+export function __setResponseCacheForTest(c: ResponseCache | null): void {
+  cache = c;
+}

--- a/src/plugins/mcp-multiplexer/cache.ts
+++ b/src/plugins/mcp-multiplexer/cache.ts
@@ -53,6 +53,13 @@ export interface ResponseCacheConfig {
   /** Per-server allowlist of cacheable tool names. A tool is cacheable
    *  iff it appears in the array for its server. */
   cacheable: Record<string, ReadonlySet<string>>;
+  /** Defensive invalidation on every non-cacheable call against a
+   *  server with cacheable tools. Default true (matches issue #69
+   *  acceptance). Operators with cleanly partitioned tools — where
+   *  non-cacheable calls are known to be read-only / non-mutating —
+   *  can flip this off to avoid thrashing the cache for mixed-tool
+   *  servers (5-agent review on PR #69 Agent 3 finding). */
+  defensiveInvalidation: boolean;
 }
 
 interface CacheEntry {
@@ -68,6 +75,8 @@ export interface CacheStats {
   enabled: boolean;
   ttlMs: number;
   maxEntries: number;
+  /** Whether defensive invalidation is on (issue #69 default true). */
+  defensiveInvalidation: boolean;
   entries: number;
   hits: number;
   misses: number;
@@ -101,6 +110,7 @@ const DEFAULT_CONFIG: ResponseCacheConfig = {
   ttlMs: DEFAULT_TTL_MS,
   maxEntries: DEFAULT_MAX_ENTRIES,
   cacheable: {},
+  defensiveInvalidation: true,
 };
 
 export class ResponseCache {
@@ -118,6 +128,7 @@ export class ResponseCache {
       ttlMs: opts.ttlMs ?? this.config.ttlMs,
       maxEntries: opts.maxEntries ?? this.config.maxEntries,
       cacheable: opts.cacheable ?? this.config.cacheable,
+      defensiveInvalidation: opts.defensiveInvalidation ?? this.config.defensiveInvalidation,
     };
     // If the cap shrunk, evict from the head until we fit.
     while (this.entries.size > this.config.maxEntries) {
@@ -228,11 +239,28 @@ export class ResponseCache {
     return allowed !== undefined && allowed.size > 0;
   }
 
+  /**
+   * Should a non-cacheable call against this server trigger defensive
+   * invalidation? True iff:
+   *   - cache is enabled, AND
+   *   - the server has cacheable tools declared, AND
+   *   - `defensiveInvalidation` flag is on (the issue #69 default).
+   *
+   * Lets the dispatch path collapse the two checks into one call;
+   * also lets operators with cleanly partitioned tools opt out to
+   * avoid thrashing the cache for mixed-tool servers.
+   */
+  shouldInvalidateOnNonCacheableCall(serverName: string): boolean {
+    if (!this.config.defensiveInvalidation) return false;
+    return this.serverHasCacheableTools(serverName);
+  }
+
   stats(): CacheStats {
     return {
       enabled: this.config.enabled,
       ttlMs: this.config.ttlMs,
       maxEntries: this.config.maxEntries,
+      defensiveInvalidation: this.config.defensiveInvalidation,
       entries: this.entries.size,
       hits: this.hits,
       misses: this.misses,

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -57,11 +57,11 @@ export interface McpHttpHandlerOpts {
    *  (serverName, ptyId, sessionId) tuple on the SDK transport's
    *  `onsessioninitialized` callback; `releasePty` drops it; bucket
    *  reuse touches `lastUsedAt`. Stateless buckets are never persisted
-   *  (no per-PTY identity to bind to). When undefined, the handler is
-   *  behaviourally equivalent to PR #71 for the persistence axis —
-   *  observably identical until the post-#71 cost-tracking metrics
-   *  hook (issue #68) was added, which wraps the dispatch path with a
-   *  no-op timer when `mcp.metricsEnabled` is false (the default). */
+   *  (no per-PTY identity to bind to). When undefined, no on-disk
+   *  session-binding state is written — the dispatch path otherwise
+   *  honours the issue #68 metrics hook and issue #69 cache hook
+   *  (both default-off, opt-in via `settings.mcp.metricsEnabled` /
+   *  `settings.mcp.cache.enabled`). */
   persistence?: SessionPersistenceStore;
   /** Optional per-bearer rate limit config (#72 item 1). When omitted or
    *  `maxRequestsPerWindow <= 0`, no limit is enforced. */
@@ -559,40 +559,45 @@ export class McpHttpHandler {
           isError: true,
         };
       }
-      // Issue #69: response cache for idempotent tools. Check the
-      // cache BEFORE starting the metrics timer — a cache hit avoids
-      // both the dispatch AND the latency-sample noise.
+      // Issue #68 + #69: start the metrics timer FIRST so EVERY
+      // tools/call dispatch records a sample, including cache hits.
+      // 5-agent review on PR #69 Agent 3: PR #147 established the
+      // invariant that every call gets a metric; skipping the timer
+      // on cache hit silently biased p50/p99 downward when both flags
+      // were enabled. The cache hit IS a successful call from the
+      // operator's perspective — recording it surfaces "look how fast
+      // cached requests are" as a useful operational signal.
+      const timer = getMetricsRegistry().record(this.serverName, bucketKey, name);
+
+      // Issue #69: response cache for idempotent tools.
       //
       // Defensive invalidation: if this tool is NOT cacheable but the
       // server HAS cacheable tools, the call might be mutating state
       // those cached entries reflect. Drop the server's cache before
       // dispatching. Conservative but correct: we don't track what
-      // each tool touches.
+      // each tool touches. Operators with cleanly partitioned tools
+      // (mixed-tool servers where non-cacheable calls are still
+      // read-only) can disable this via
+      // `settings.mcp.cache.defensiveInvalidation: false`.
       const cache = getResponseCache();
       const cacheableCall = cache.isCacheable(this.serverName, name);
       if (cacheableCall) {
         const cached = cache.get(this.serverName, name, args ?? {});
         if (cached !== undefined) {
           const text = typeof cached === "string" ? cached : JSON.stringify(cached);
+          timer.end(true);
           return { content: [{ type: "text", text }] };
         }
-      } else if (cache.serverHasCacheableTools(this.serverName)) {
+      } else if (cache.shouldInvalidateOnNonCacheableCall(this.serverName)) {
         cache.invalidateServer(this.serverName);
       }
 
-      // Issue #68: cost-tracking metrics. `record()` returns a no-op
-      // timer when metrics are disabled, so this is zero-cost in the
-      // default path. The timer is started even before we know if the
-      // dispatch will succeed; `end(success)` is called in both arms
-      // so an exception path still records its latency + error count.
-      //
       // Codex P2 on PR #147: serialize the response FIRST, then
       // `end(true)`. If `JSON.stringify(result)` throws (circular data,
       // BigInt), control falls to the catch and `end(false)` records
       // the error correctly. Calling `end(true)` before serialization
       // would latch the timer as a success before the failure was
       // observable — silently dropping the error increment.
-      const timer = getMetricsRegistry().record(this.serverName, bucketKey, name);
       try {
         const result = await this.proc.call(name, args ?? {});
         const text = typeof result === "string" ? result : JSON.stringify(result);

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -25,6 +25,7 @@ import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprot
 import { randomUUID } from "node:crypto";
 import { getMcpBridge } from "../mcp-bridge.js";
 import { getMetricsRegistry } from "./metrics.js";
+import { getResponseCache } from "./cache.js";
 import type { McpServerProcess } from "../mcp-proxy/server-process.js";
 import { AUTH_HEADER, PTY_ID_HEADER, PTY_TS_HEADER, verifyBearer } from "./pty-identity.js";
 import type { SessionPersistenceStore } from "./session-persistence.js";
@@ -558,13 +559,34 @@ export class McpHttpHandler {
           isError: true,
         };
       }
+      // Issue #69: response cache for idempotent tools. Check the
+      // cache BEFORE starting the metrics timer — a cache hit avoids
+      // both the dispatch AND the latency-sample noise.
+      //
+      // Defensive invalidation: if this tool is NOT cacheable but the
+      // server HAS cacheable tools, the call might be mutating state
+      // those cached entries reflect. Drop the server's cache before
+      // dispatching. Conservative but correct: we don't track what
+      // each tool touches.
+      const cache = getResponseCache();
+      const cacheableCall = cache.isCacheable(this.serverName, name);
+      if (cacheableCall) {
+        const cached = cache.get(this.serverName, name, args ?? {});
+        if (cached !== undefined) {
+          const text = typeof cached === "string" ? cached : JSON.stringify(cached);
+          return { content: [{ type: "text", text }] };
+        }
+      } else if (cache.serverHasCacheableTools(this.serverName)) {
+        cache.invalidateServer(this.serverName);
+      }
+
       // Issue #68: cost-tracking metrics. `record()` returns a no-op
       // timer when metrics are disabled, so this is zero-cost in the
       // default path. The timer is started even before we know if the
       // dispatch will succeed; `end(success)` is called in both arms
       // so an exception path still records its latency + error count.
       //
-      // Codex P2 on this PR: serialize the response FIRST, then
+      // Codex P2 on PR #147: serialize the response FIRST, then
       // `end(true)`. If `JSON.stringify(result)` throws (circular data,
       // BigInt), control falls to the catch and `end(false)` records
       // the error correctly. Calling `end(true)` before serialization
@@ -575,6 +597,10 @@ export class McpHttpHandler {
         const result = await this.proc.call(name, args ?? {});
         const text = typeof result === "string" ? result : JSON.stringify(result);
         timer.end(true);
+        // Cache the raw response (not the serialized text) — a later
+        // cache hit re-serializes via the same code path, matching
+        // upstream's call() return shape.
+        if (cacheableCall) cache.set(this.serverName, name, args ?? {}, result);
         return {
           content: [{ type: "text", text }],
         };

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -35,6 +35,7 @@ import { McpServerProcess, type McpServerConfig } from "../mcp-proxy/server-proc
 import { getSettings } from "../../config.js";
 import { McpHttpHandler } from "./http-handler.js";
 import { getMetricsRegistry } from "./metrics.js";
+import { getResponseCache } from "./cache.js";
 import {
   issueIdentity as _issueIdentity,
   revokeIdentity as _revokeIdentity,
@@ -105,6 +106,13 @@ export interface MuxSettingsView {
    *  + latency samples and the `/api/multiplexer/metrics` endpoint
    *  returns aggregated data. */
   metricsEnabled: boolean;
+  /** Issue #69: response cache for idempotent tools. */
+  cache: {
+    enabled: boolean;
+    ttlMs: number;
+    maxEntries: number;
+    cacheable: Record<string, string[]>;
+  };
 }
 
 function _readSettings(): MuxSettingsView {
@@ -135,6 +143,31 @@ function _readSettings(): MuxSettingsView {
   const sessionPersistencePath =
     typeof rawPath === "string" && rawPath.length > 0 && rawPath.startsWith("/") ? rawPath : "";
   const metricsEnabled = mcpObj.metricsEnabled === true;
+  // Issue #69 cache config from settings.mcp.cache; falls back to a
+  // safe disabled default when absent so existing test fixtures keep
+  // working.
+  const cacheRaw =
+    mcpObj.cache && typeof mcpObj.cache === "object"
+      ? (mcpObj.cache as Record<string, unknown>)
+      : {};
+  const cacheEnabled = cacheRaw.enabled === true;
+  const cacheTtlMs =
+    typeof cacheRaw.ttlMs === "number" && cacheRaw.ttlMs > 0 ? Math.floor(cacheRaw.ttlMs) : 5_000;
+  const cacheMaxEntries =
+    typeof cacheRaw.maxEntries === "number" && cacheRaw.maxEntries > 0
+      ? Math.floor(cacheRaw.maxEntries)
+      : 1_000;
+  const cacheableObj =
+    cacheRaw.cacheable && typeof cacheRaw.cacheable === "object"
+      ? (cacheRaw.cacheable as Record<string, unknown>)
+      : {};
+  const cacheable: Record<string, string[]> = {};
+  for (const [server, tools] of Object.entries(cacheableObj)) {
+    if (Array.isArray(tools)) {
+      const filtered = tools.filter((t): t is string => typeof t === "string");
+      if (filtered.length > 0) cacheable[server] = filtered;
+    }
+  }
   return {
     webEnabled: s.web?.enabled === true,
     webHost: s.web?.host ?? "127.0.0.1",
@@ -146,6 +179,12 @@ function _readSettings(): MuxSettingsView {
     sessionMaxAgeSeconds,
     sessionPersistencePath,
     metricsEnabled,
+    cache: {
+      enabled: cacheEnabled,
+      ttlMs: cacheTtlMs,
+      maxEntries: cacheMaxEntries,
+      cacheable,
+    },
   };
 }
 
@@ -245,6 +284,20 @@ export class McpMultiplexerPlugin {
     // process exits. Use the injected settingsView so tests can drive
     // the flag without standing up real settings.
     getMetricsRegistry().setEnabled(settings.metricsEnabled);
+
+    // Issue #69: response cache. Same reflection pattern — translate
+    // the `cacheable: Record<string, string[]>` from settings into the
+    // cache's `Record<string, Set<string>>` lookup shape.
+    const cacheable: Record<string, ReadonlySet<string>> = {};
+    for (const [server, tools] of Object.entries(settings.cache.cacheable)) {
+      cacheable[server] = new Set(tools);
+    }
+    getResponseCache().configure({
+      enabled: settings.cache.enabled,
+      ttlMs: settings.cache.ttlMs,
+      maxEntries: settings.cache.maxEntries,
+      cacheable,
+    });
 
     // Refuse to expose MCP servers over a non-loopback gateway.
     if (settings.webHost !== "127.0.0.1" && settings.webHost !== "localhost") {
@@ -746,6 +799,9 @@ export class McpMultiplexerPlugin {
       shared: this.cachedSharedNames.slice(),
       stateless: this.cachedStatelessNames.slice(),
       servers,
+      // Issue #69 acceptance: cache stats in health() so operators can
+      // validate hit rate before flipping `mcp.cache.enabled` in prod.
+      cache: getResponseCache().stats(),
     };
   }
 

--- a/src/plugins/mcp-multiplexer/index.ts
+++ b/src/plugins/mcp-multiplexer/index.ts
@@ -112,6 +112,9 @@ export interface MuxSettingsView {
     ttlMs: number;
     maxEntries: number;
     cacheable: Record<string, string[]>;
+    /** Default true per issue #69 acceptance; opt-out for mixed-tool
+     *  servers (5-agent review on PR #69 Agent 3 follow-up). */
+    defensiveInvalidation: boolean;
   };
 }
 
@@ -184,6 +187,7 @@ function _readSettings(): MuxSettingsView {
       ttlMs: cacheTtlMs,
       maxEntries: cacheMaxEntries,
       cacheable,
+      defensiveInvalidation: cacheRaw.defensiveInvalidation !== false,
     },
   };
 }
@@ -297,6 +301,7 @@ export class McpMultiplexerPlugin {
       ttlMs: settings.cache.ttlMs,
       maxEntries: settings.cache.maxEntries,
       cacheable,
+      defensiveInvalidation: settings.cache.defensiveInvalidation,
     });
 
     // Refuse to expose MCP servers over a non-loopback gateway.
@@ -520,6 +525,13 @@ export class McpMultiplexerPlugin {
     // forget). Letting GC reclaim the store object is fine; the next
     // `start()` constructs a new one.
     this.persistence = null;
+    // Issue #69 / Agent 4 follow-up on PR #147: flush the response
+    // cache on stop. Same precedent as PR #91 P2 (release per-PTY rate
+    // window) and PR #147 (release per-PTY metrics tuples) — every
+    // bounded process-level state surface gets a teardown hook so a
+    // hot-reload or test that reuses the process doesn't serve stale
+    // entries to the next start().
+    getResponseCache().reset();
     this.cachedSharedNames = [];
     this.cachedStatelessNames = [];
     this.cachedBridgeBaseUrl = "http://127.0.0.1:4632";


### PR DESCRIPTION
Closes #69.

## Summary

Per-tool opt-in response cache on the multiplexer `tools/call` dispatch path. Cacheable tools declared via `settings.mcp.cache.cacheable: Record<server, tool[]>` are served from a short-TTL in-memory cache when `(server, tool, args-hash)` matches.

## Behaviour

- **Cache key**: `${serverName}::${toolName}::sha256(canonicalJson(args))`. Canonical JSON sorts keys recursively → semantically-equal arg objects collide cleanly.
- **Default OFF** (`mcp.cache.enabled: false`). Operators opt in once they've audited which tools are safe to cache.
- **Bounded**: LRU cap (default 1000 entries) + TTL (default 5 s) — tunable via settings.
- **Defensive invalidation**: a non-cacheable call against a server with cacheable tools drops the server's cache. Default ON (matches issue #69 acceptance); operators with cleanly partitioned tools can flip `mcp.cache.defensiveInvalidation: false` to avoid thrashing.
- **Cache stats in `health()`** so operators can verify hit rate before flipping the flag in prod.
- **Metrics still fire on cache hits** — PR #147's "every dispatch records a sample" contract preserved; cache hits show as near-zero-latency successes in the operator dashboard.
- **`getResponseCache().reset()` in stop()** — same teardown discipline as #91 P2 (rate-limit windows) and #147 (metrics tuples).

## 5-agent review

| # | Verdict |
|---|---|
| Agent 1 (CLAUDE.md compliance) | Clean |
| Agent 2 (shallow bugs) | No real bugs |
| Agent 3 (git history) | Medium x2 — cache hit bypassed metrics + invalidation thrashing — **fixed** in e0714dc |
| Agent 4 (prior PR comments) | P3 — `reset()` missing from stop() — **fixed** in e0714dc |
| Agent 5 (in-file comments) | Stale `persistence` JSDoc — **fixed** in e0714dc |

All 4 SDC gate markers dropped for HEAD `e0714dc`.

## Test plan

- [x] `bun test src/plugins/` — 141 pass / 0 fail
- [x] `bun run lint` clean
- [x] 20 unit tests in `cache.test.ts`
- [x] Version bumped to 2.2.84
- [x] All 5-agent findings addressed in a fixup commit
- [ ] Codex auto-review on the GitHub side