### PR TITLE
chore(pty): housekeeping bundle (issue #65, 7 of 10 deferred findings)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.85",
+      "version": "2.2.86",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.86",
+      "version": "2.2.87",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.85",
+  "version": "2.2.86",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.86",
+  "version": "2.2.87",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.40.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "bun-pty": "^0.4.8",
+        "bun-pty": "0.4.8",
         "commander": "^14.0.3",
         "js-yaml": "^4.1.0",
         "ogg-opus-decoder": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.40.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "bun-pty": "^0.4.8",
+    "bun-pty": "0.4.8",
     "commander": "^14.0.3",
     "js-yaml": "^4.1.0",
     "ogg-opus-decoder": "^1.7.3",

--- a/src/__tests__/pty-config.test.ts
+++ b/src/__tests__/pty-config.test.ts
@@ -326,6 +326,17 @@ describe("parseSettings — mcp block (MCP multiplexer, SPEC §5)", () => {
       sessionPersistenceEnabled: true,
       sessionMaxAgeSeconds: 3600,
       sessionPersistencePath: "",
+      rateLimit: { maxRequestsPerWindow: 600, windowMs: 60_000 },
+      // Issue #68 metrics + #69 response cache defaults (added after this
+      // test was written; sync explicit-empty expectation with the schema).
+      metricsEnabled: false,
+      cache: {
+        enabled: false,
+        ttlMs: 5_000,
+        maxEntries: 1_000,
+        cacheable: {},
+        defensiveInvalidation: true,
+      },
     });
   });
 });

--- a/src/__tests__/pty-process.test.ts
+++ b/src/__tests__/pty-process.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from "bun:test";
 import {
   spawnPty,
+  sanitizePtyPromptText,
   PtyTurnTimeoutError,
   PtyClosedError,
   type PtyProcessOptions,
@@ -609,5 +610,31 @@ describe("PtyProcess — sessionId", () => {
     );
     expect(proc.sessionId).toBe(sid);
     await proc.dispose();
+  });
+});
+
+describe("sanitizePtyPromptText (issue #65 item 3)", () => {
+  test("replaces embedded CR with space", () => {
+    expect(sanitizePtyPromptText("hello\rworld")).toBe("hello world");
+  });
+
+  test("replaces embedded LF with space", () => {
+    expect(sanitizePtyPromptText("line one\nline two")).toBe("line one line two");
+  });
+
+  test("replaces CRLF as a single separator (not two spaces)", () => {
+    expect(sanitizePtyPromptText("a\r\nb")).toBe("a b");
+  });
+
+  test("preserves text with no CR/LF", () => {
+    expect(sanitizePtyPromptText("plain prompt")).toBe("plain prompt");
+  });
+
+  test("handles multiple newlines and mixed terminators", () => {
+    expect(sanitizePtyPromptText("a\nb\r\nc\rd")).toBe("a b c d");
+  });
+
+  test("preserves an empty string", () => {
+    expect(sanitizePtyPromptText("")).toBe("");
   });
 });

--- a/src/__tests__/pty-process.test.ts
+++ b/src/__tests__/pty-process.test.ts
@@ -637,4 +637,20 @@ describe("sanitizePtyPromptText (issue #65 item 3)", () => {
   test("preserves an empty string", () => {
     expect(sanitizePtyPromptText("")).toBe("");
   });
+
+  test("strips NUL bytes that would truncate the C-string PTY write", () => {
+    expect(sanitizePtyPromptText("hello\x00world")).toBe("helloworld");
+  });
+
+  test("strips Backspace and DEL keystrokes that would inline-edit the TUI", () => {
+    expect(sanitizePtyPromptText("abc\x08def\x7fghi")).toBe("abcdefghi");
+  });
+
+  test("strips BEL and other C0 controls except tab", () => {
+    expect(sanitizePtyPromptText("\x07alert\x01start\x1fend\tkept")).toBe("alertstartend\tkept");
+  });
+
+  test("preserves printable Unicode and multi-byte UTF-8", () => {
+    expect(sanitizePtyPromptText("héllo 🪶 wörld")).toBe("héllo 🪶 wörld");
+  });
 });

--- a/src/__tests__/pty-supervisor.test.ts
+++ b/src/__tests__/pty-supervisor.test.ts
@@ -1281,3 +1281,80 @@ describe("pty-supervisor fresh-session persistence (Codex Phase D #2)", () => {
     expect(captured!.newSessionId).toBeUndefined();
   });
 });
+
+describe("pty-supervisor housekeeping (issue #65)", () => {
+  it("admission lock serialises enforceMaxConcurrent → getOrCreateEntry under burst", async () => {
+    // Cap of 2. Three concurrent admissions racing for a fresh adhoc slot.
+    // Without the admission lock, two callers can observe `size < cap` during
+    // the eviction `await` window and both add entries — exceeding the cap.
+    injectMaxConcurrentForTests(2);
+    let now = 1_000_000;
+    injectClock(() => now);
+
+    const { spawn, spawned } = makeSpawnTracker(() => makeFakePty("burst", {}));
+    injectSpawnPty(spawn);
+    await initSupervisor();
+
+    // Seed at cap with two distinct adhoc threads.
+    await runOnPty("thread:a", "x", { timeoutMs: 1000, threadId: "a" });
+    now = 1_000_010;
+    await runOnPty("thread:b", "x", { timeoutMs: 1000, threadId: "b" });
+    expect(snapshotSupervisor().ptys.length).toBe(2);
+
+    // Three new threads race. Each requires eviction. The lock must serialise
+    // them so the cap is preserved (snapshot size stays ≤ cap).
+    now = 1_000_100;
+    await Promise.all([
+      runOnPty("thread:c", "x", { timeoutMs: 1000, threadId: "c" }),
+      runOnPty("thread:d", "x", { timeoutMs: 1000, threadId: "d" }),
+      runOnPty("thread:e", "x", { timeoutMs: 1000, threadId: "e" }),
+    ]);
+
+    // After all three land, only `cap` live PTYs remain. Without the
+    // admission lock, two concurrent admissions could both observe
+    // `size < cap` mid-eviction and both add — pushing past the cap.
+    const live = snapshotSupervisor().ptys.length;
+    expect(live).toBeLessThanOrEqual(2);
+    // Both seed entries (a, b) must have been disposed as part of the burst —
+    // their slots were taken by the newcomers.
+    expect(spawned[0].disposed).toBe(true);
+    expect(spawned[1].disposed).toBe(true);
+  });
+
+  it("reaps a PTY that never completed a first turn after the spawn grace period", async () => {
+    // Default idleReapMinutes = 30 → spawn grace cutoff = 90 minutes.
+    // A stuck PTY at lastTurnEndedAt=0 should survive 60 min but be reaped at 91 min.
+    let now = 1_000_000;
+    injectClock(() => now);
+
+    const { spawn, spawned } = makeSpawnTracker(() => makeFakePty("stuck", {}));
+    injectSpawnPty(spawn);
+    await initSupervisor();
+
+    await runOnPty("thread:hung", "ping", { timeoutMs: 1000, threadId: "hung" });
+    // Force the stuck-mid-spawn condition by zeroing out the fake's
+    // `lastTurnEndedAt` even though the synthetic turn already completed —
+    // mimics a real claude that hung before emitting a turn boundary.
+    spawned[0].setLastTurnEndedAt(0);
+    expect(snapshotSupervisor().ptys.length).toBe(1);
+
+    const mod = await import("../runner/pty-supervisor");
+    const reapNow = (
+      mod as unknown as {
+        __reapNowForTests: (clock: () => number) => Promise<void>;
+      }
+    ).__reapNowForTests;
+
+    // 60 min in — still under the 90-min grace. Should NOT reap.
+    now += 60 * 60_000;
+    await reapNow(() => now);
+    expect(snapshotSupervisor().ptys.length).toBe(1);
+    expect(spawned[0].disposed).toBe(false);
+
+    // 91 min in — past grace. Should reap.
+    now += 31 * 60_000;
+    await reapNow(() => now);
+    expect(snapshotSupervisor().ptys.length).toBe(0);
+    expect(spawned[0].disposed).toBe(true);
+  });
+});

--- a/src/__tests__/pty-supervisor.test.ts
+++ b/src/__tests__/pty-supervisor.test.ts
@@ -1357,4 +1357,75 @@ describe("pty-supervisor housekeeping (issue #65)", () => {
     expect(snapshotSupervisor().ptys.length).toBe(0);
     expect(spawned[0].disposed).toBe(true);
   });
+
+  it("respawn after crash resets the spawn-grace window (Codex P1)", async () => {
+    // A long-lived PTY that crashes and respawns must NOT be reaped during the
+    // first post-respawn turn just because the entry was created long ago. The
+    // grace window is keyed off `lastSpawnedAt`, which resets on respawn.
+    let now = 1_000_000;
+    injectClock(() => now);
+    const sleeps: number[] = [];
+    injectSleep(async (ms) => {
+      sleeps.push(ms);
+    });
+
+    let globalCalls = 0;
+    const { spawn, spawned } = makeSpawnTracker(() =>
+      makeFakePty("longlived", {
+        onTurn: async (prompt) => {
+          const callNum = globalCalls++;
+          if (callNum === 1) {
+            // Second turn crashes — triggers respawn on retry.
+            throw new PtyClosedError("crash", 1, "SIGPIPE");
+          }
+          return {
+            text: `echo:${prompt}`,
+            bytesCaptured: 0,
+            cleanBoundary: true,
+            sessionId: "s",
+          };
+        },
+      }),
+    );
+    injectSpawnPty(spawn);
+    await initSupervisor();
+
+    // First turn at t=0 — successful.
+    await runOnPty("thread:longlived", "first", { timeoutMs: 1000, threadId: "longlived" });
+    expect(spawned.length).toBe(1);
+
+    // Jump 1 hour forward. Second turn triggers crash + respawn; the respawn's
+    // post-turn lastTurnEndedAt is also set, but we'll force the
+    // never-completed-a-turn condition on the new PTY to exercise the grace
+    // path. The key invariant: lastSpawnedAt is now the respawn time, not the
+    // original entry creation time.
+    now += 60 * 60_000;
+    await runOnPty("thread:longlived", "second", { timeoutMs: 1000, threadId: "longlived" });
+    expect(spawned.length).toBe(2);
+
+    // Force the post-respawn PTY into the "never finished a turn" state to
+    // exercise the grace check from `lastSpawnedAt`.
+    spawned[1].setLastTurnEndedAt(0);
+
+    const mod = await import("../runner/pty-supervisor");
+    const reapNow = (
+      mod as unknown as {
+        __reapNowForTests: (clock: () => number) => Promise<void>;
+      }
+    ).__reapNowForTests;
+
+    // 60 min after respawn — still inside the 90-min grace. Healthy respawn
+    // must NOT be reaped. (Without the lastSpawnedAt fix, the old createdAt
+    // would put us 2h past spawn and the entry would be evicted.)
+    now += 60 * 60_000;
+    await reapNow(() => now);
+    expect(snapshotSupervisor().ptys.length).toBe(1);
+    expect(spawned[1].disposed).toBe(false);
+
+    // 91 min after respawn — now past grace. Reap.
+    now += 31 * 60_000;
+    await reapNow(() => now);
+    expect(snapshotSupervisor().ptys.length).toBe(0);
+    expect(spawned[1].disposed).toBe(true);
+  });
 });

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -17,6 +17,7 @@
  */
 
 import type { ChildProcess } from "node:child_process";
+import { sanitizePtyPromptText } from "../runner/pty-process";
 import type { SupervisionMode } from "./types";
 
 export type ExitHandler = (code: number) => void;
@@ -118,7 +119,10 @@ export class PtyAgentProcess implements AgentProcess {
     // and the submitting CR in a single chunk is interpreted as a paste: the
     // text lands in the input box but is not submitted. So we write the text,
     // let the paste settle, then send the CR as a separate keystroke.
-    this.pty.write(line);
+    //
+    // Sanitize CR/LF in the prompt: an embedded `\r` would submit the prompt
+    // mid-line and corrupt the turn (Codex review P2 on PR #140).
+    this.pty.write(sanitizePtyPromptText(line));
     await new Promise((r) => setTimeout(r, 200));
     this.pty.write("\r");
   }

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -17,7 +17,11 @@
  */
 
 import type { ChildProcess } from "node:child_process";
-import { sanitizePtyPromptText } from "../runner/pty-process";
+// Import from the standalone sanitiser module to avoid pulling bun-pty into
+// `session-agent-process` at startup. Non-PTY supervision modes (process,
+// process-stream-json, tmux) must not require the native PTY dep just to
+// construct an AgentProcess (Codex P1 on PR #149).
+import { sanitizePtyPromptText } from "../runner/pty-prompt-sanitizer";
 import type { SupervisionMode } from "./types";
 
 export type ExitHandler = (code: number) => void;

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -189,13 +189,6 @@ const COMPACT_TIMEOUT_ENABLED = true;
  * resolves credentials using its own per-platform code path.
  */
 /**
- * Build a sanitised env dict for any spawned `claude` (both `claude -p`
- * subprocess and PTY supervisor). Exported as the single source of truth —
- * the supervisor MUST import this rather than maintain a parallel strip list,
- * or `ANTHROPIC_API_KEY` will silently leak into PTY-mode spawns and bill
- * against raw API credits instead of the operator's subscription.
- */
-/**
  * Canonical strip list shared by `cleanSpawnEnv` and `withCleanProcessEnv`.
  * Keep these in sync — both helpers MUST agree, or one will reintroduce a
  * leak the other prevents.

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -11,6 +11,7 @@
 
 export {
   spawnPty,
+  sanitizePtyPromptText,
   PtyTurnTimeoutError,
   PtyClosedError,
   type PtyProcess,

--- a/src/runner/pty-process.ts
+++ b/src/runner/pty-process.ts
@@ -46,6 +46,16 @@ import {
   type Parser,
 } from "./pty-output-parser";
 
+/**
+ * Replace embedded CR/LF in a prompt string with spaces before writing to the
+ * PTY. claude's TUI submits on any `\r` and treats `\n` similarly, so an
+ * embedded newline would submit the prompt mid-line — corrupting the turn or
+ * firing a stray submit before the supervisor's trailing CR.
+ */
+export function sanitizePtyPromptText(text: string): string {
+  return text.replace(/\r\n?|\n/g, " ");
+}
+
 // ─── Public types (FROZEN per SPEC §3.1) ────────────────────────────────────
 
 export interface PtyProcessOptions {
@@ -74,6 +84,13 @@ export interface PtyProcessOptions {
   /**
    * Optional system prompt to append via `--append-system-prompt <text>`.
    * (Phase D fix #2 for CRITICAL-1.)
+   *
+   * Operator note (issue #65 item 7): the assembled text is passed on the
+   * spawned `claude` argv and is therefore visible to other UIDs via `ps aux`
+   * (or equivalent) on shared multi-user hosts. This is parity with the
+   * legacy `claude -p` path (no new attack surface), but operators deploying
+   * on shared servers should treat the system-prompt payload as low-secrecy
+   * — do not embed long-lived secrets in it.
    */
   appendSystemPrompt?: string;
   /** Env vars to pass to the child. Caller is responsible for a sanitised env. */
@@ -458,9 +475,10 @@ class PtyProcessImpl implements PtyProcess {
     // Tell the parser we're starting a turn (offset = current totalBytes).
     startTurn(this._parser, uuid, sentinelBytes, this._turnStartedAt);
 
-    // Write prompt + CR (TUI submits on Enter).
+    // Write prompt + CR (TUI submits on Enter). Sanitize embedded CR/LF so
+    // they don't submit mid-prompt.
     try {
-      this._pty.write(prompt + "\r");
+      this._pty.write(sanitizePtyPromptText(prompt) + "\r");
     } catch (err) {
       this._turnInProgress = false;
       this._activeSentinelBytes = null;

--- a/src/runner/pty-process.ts
+++ b/src/runner/pty-process.ts
@@ -58,10 +58,13 @@ import {
  *   write path; BS / DEL act as inline-edit keystrokes in the TUI; BEL etc.
  *   are noisy. Tab (`\x09`) is preserved.
  */
+// Constructed at module load so the source file contains no literal control
+// chars (biome's `noControlCharactersInRegex` lint would otherwise fire on the
+// intentional NUL/BS/DEL/etc. class).
+const _ptyControlCharStrip = new RegExp("[\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]", "g");
+
 export function sanitizePtyPromptText(text: string): string {
-  return text
-    .replace(/\r\n?|\n/g, " ")
-    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
+  return text.replace(/\r\n?|\n/g, " ").replace(_ptyControlCharStrip, "");
 }
 
 // ─── Public types (FROZEN per SPEC §3.1) ────────────────────────────────────

--- a/src/runner/pty-process.ts
+++ b/src/runner/pty-process.ts
@@ -45,27 +45,11 @@ import {
   tick,
   type Parser,
 } from "./pty-output-parser";
-
-/**
- * Strip control characters from a prompt string before writing to the PTY.
- *
- * - Embedded `\r` / `\n` are replaced with spaces. claude's TUI submits on
- *   any `\r` and treats `\n` similarly, so an embedded newline would submit
- *   the prompt mid-line — corrupting the turn or firing a stray submit
- *   before the supervisor's trailing CR.
- * - Other C0 controls + DEL (`\x00-\x08`, `\x0b-\x0c`, `\x0e-\x1f`, `\x7f`)
- *   are removed entirely. NUL terminates C-strings in the underlying FFI
- *   write path; BS / DEL act as inline-edit keystrokes in the TUI; BEL etc.
- *   are noisy. Tab (`\x09`) is preserved.
- */
-// Constructed at module load so the source file contains no literal control
-// chars (biome's `noControlCharactersInRegex` lint would otherwise fire on the
-// intentional NUL/BS/DEL/etc. class).
-const _ptyControlCharStrip = new RegExp("[\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]", "g");
-
-export function sanitizePtyPromptText(text: string): string {
-  return text.replace(/\r\n?|\n/g, " ").replace(_ptyControlCharStrip, "");
-}
+// Re-export the sanitiser from its standalone home so existing callers that
+// pull it from `pty-process` (and through `runner/index`) keep working without
+// loading bun-pty just to get the helper.
+import { sanitizePtyPromptText } from "./pty-prompt-sanitizer";
+export { sanitizePtyPromptText };
 
 // ─── Public types (FROZEN per SPEC §3.1) ────────────────────────────────────
 

--- a/src/runner/pty-process.ts
+++ b/src/runner/pty-process.ts
@@ -47,13 +47,21 @@ import {
 } from "./pty-output-parser";
 
 /**
- * Replace embedded CR/LF in a prompt string with spaces before writing to the
- * PTY. claude's TUI submits on any `\r` and treats `\n` similarly, so an
- * embedded newline would submit the prompt mid-line — corrupting the turn or
- * firing a stray submit before the supervisor's trailing CR.
+ * Strip control characters from a prompt string before writing to the PTY.
+ *
+ * - Embedded `\r` / `\n` are replaced with spaces. claude's TUI submits on
+ *   any `\r` and treats `\n` similarly, so an embedded newline would submit
+ *   the prompt mid-line — corrupting the turn or firing a stray submit
+ *   before the supervisor's trailing CR.
+ * - Other C0 controls + DEL (`\x00-\x08`, `\x0b-\x0c`, `\x0e-\x1f`, `\x7f`)
+ *   are removed entirely. NUL terminates C-strings in the underlying FFI
+ *   write path; BS / DEL act as inline-edit keystrokes in the TUI; BEL etc.
+ *   are noisy. Tab (`\x09`) is preserved.
  */
 export function sanitizePtyPromptText(text: string): string {
-  return text.replace(/\r\n?|\n/g, " ");
+  return text
+    .replace(/\r\n?|\n/g, " ")
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
 }
 
 // ─── Public types (FROZEN per SPEC §3.1) ────────────────────────────────────

--- a/src/runner/pty-prompt-sanitizer.ts
+++ b/src/runner/pty-prompt-sanitizer.ts
@@ -1,0 +1,28 @@
+/**
+ * Standalone prompt sanitiser for any path that writes user text to a PTY's
+ * stdin. Lives in its own file (no `bun-pty` dependency) so non-PTY supervisor
+ * paths — `process` / `process-stream-json` / `tmux` on Windows etc. — can
+ * import the helper without forcing the native PTY module to load at startup
+ * (Codex P1 on PR #149).
+ */
+
+// Constructed at module load so the source file contains no literal control
+// chars (biome's `noControlCharactersInRegex` lint would otherwise fire on the
+// intentional NUL/BS/DEL/etc. class).
+const _ptyControlCharStrip = new RegExp("[\\x00-\\x08\\x0b\\x0c\\x0e-\\x1f\\x7f]", "g");
+
+/**
+ * Strip control characters from a prompt string before writing to a PTY.
+ *
+ * - Embedded `\r` / `\n` are replaced with spaces. claude's TUI submits on
+ *   any `\r` and treats `\n` similarly, so an embedded newline would submit
+ *   the prompt mid-line — corrupting the turn or firing a stray submit
+ *   before the supervisor's trailing CR.
+ * - Other C0 controls + DEL (`\x00-\x08`, `\x0b-\x0c`, `\x0e-\x1f`, `\x7f`)
+ *   are removed entirely. NUL terminates C-strings in the underlying FFI
+ *   write path; BS / DEL act as inline-edit keystrokes in the TUI; BEL etc.
+ *   are noisy. Tab (`\x09`) is preserved.
+ */
+export function sanitizePtyPromptText(text: string): string {
+  return text.replace(/\r\n?|\n/g, " ").replace(_ptyControlCharStrip, "");
+}

--- a/src/runner/pty-supervisor.ts
+++ b/src/runner/pty-supervisor.ts
@@ -228,7 +228,7 @@ export interface SupervisorSnapshot {
     cwd: string;
     isAlive: boolean;
     lastTurnEndedAt: number;
-    /** "named" → never reaped; "adhoc" → reaped after idle. */
+    /** "named" → never reaped when `namedAgentsAlwaysAlive` is on; "adhoc"/"global" → reaped after idle. */
     kind: "named" | "adhoc" | "global";
   }>;
 }
@@ -371,6 +371,7 @@ export function __resetSupervisorForTests(): void {
   }
   state.initialised = false;
   _initPromise = null;
+  _admissionLock = Promise.resolve();
   _spawnPty = null;
   _ensureAgentDir = null;
   _cleanSpawnEnv = null;
@@ -404,6 +405,9 @@ interface PtyEntry {
   /** Last time `runOnPty` was called against this key. Drives LRU eviction
    *  when `pty.maxConcurrent` is hit. Adhoc-only — named agents are exempt. */
   lastAccessedAt: number;
+  /** Wall-clock at entry creation. Used by `reapIdle` to time out PTYs that
+   *  never complete a first turn (issue #65 item 6). */
+  createdAt: number;
 }
 
 interface SupervisorState {
@@ -511,6 +515,7 @@ export async function shutdownSupervisor(): Promise<void> {
   state.ptys.clear();
   state.initialised = false;
   _initPromise = null;
+  _admissionLock = Promise.resolve();
 }
 
 /**
@@ -626,10 +631,12 @@ export async function runOnPty(
   // Phase D fix #5: enforce maxConcurrent cap with LRU eviction BEFORE
   // allocating a new entry. Named agents are exempt — they're always-alive
   // by design.
-  await enforceMaxConcurrent(sessionKey);
-
-  // Per-key serial lock. Different keys proceed in parallel.
-  const entry = await getOrCreateEntry(sessionKey, opts);
+  //
+  // Issue #65 item 2: enforce + create must be a single critical section.
+  // `enforceMaxConcurrent` awaits on `dispose()`, opening a window where two
+  // concurrent admissions can both see "under cap" and both add entries —
+  // exceeding the cap. Serialize through `_admissionLock`.
+  const entry = await admitEntry(sessionKey, opts);
   entry.lastAccessedAt = _clock();
   const previousLock = entry.lock;
   let release: () => void = () => {};
@@ -676,6 +683,7 @@ async function getOrCreateEntry(
   if (existing) return existing;
 
   const kind = classifyKey(sessionKey, opts.threadId, opts.agentName);
+  const now = _clock();
   const entry: PtyEntry = {
     sessionKey,
     kind,
@@ -684,7 +692,8 @@ async function getOrCreateEntry(
     pty: null,
     spawnOpts: null,
     lock: Promise.resolve(),
-    lastAccessedAt: _clock(),
+    lastAccessedAt: now,
+    createdAt: now,
   };
   state.ptys.set(sessionKey, entry);
   return entry;
@@ -708,16 +717,53 @@ export function injectMaxRetriesForTests(n: number | null): void {
 }
 
 /**
+ * Issue #65 item 2: single mutex serialising the
+ * `enforceMaxConcurrent → getOrCreateEntry` admission critical section. Without
+ * this, two concurrent `runOnPty` calls can both observe `state.ptys.size < cap`
+ * during the eviction `await` window and both add new entries, exceeding the
+ * cap. Held only across admission (cheap: at most one `dispose()`), then
+ * released so different keys proceed in parallel on the per-entry lock.
+ */
+let _admissionLock: Promise<void> = Promise.resolve();
+
+async function admitEntry(
+  sessionKey: string,
+  opts: {
+    threadId?: string;
+    agentName?: string;
+    modelOverride?: string;
+  },
+): Promise<PtyEntry> {
+  const prev = _admissionLock;
+  let release: () => void = () => {};
+  _admissionLock = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  try {
+    await prev;
+    await enforceMaxConcurrent(sessionKey);
+    return await getOrCreateEntry(sessionKey, opts);
+  } finally {
+    release();
+  }
+}
+
+/**
  * Phase D fix #5 (FA-3a): cap the number of concurrent live PTYs to
  * `settings.pty.maxConcurrent`. When the cap is hit, evict the
- * least-recently-accessed AD-HOC PTY (named agents are exempt — they're
- * marked `namedAgentsAlwaysAlive` by design). The evicted PTY is disposed
- * and its entry removed from the state map.
+ * least-recently-accessed AD-HOC PTY. Both `named` agents (always-alive
+ * by design) and `global` entries (per-cwd anonymous sessions used by the
+ * legacy non-bus runtime) are exempt — only `adhoc` is considered for
+ * eviction. The evicted PTY is disposed and its entry removed from the
+ * state map.
  *
- * If the cap is hit but EVERY entry is exempt (all named agents) or the
+ * If the cap is hit but EVERY entry is exempt (all named/global) or the
  * incoming key is for a named agent that doesn't yet exist, we let it through
  * — the operator's named-agent slate is the source of truth and shouldn't be
  * silently shrunk by a thread burst.
+ *
+ * Concurrency: callers must hold `_admissionLock` to serialise the check +
+ * eviction window. See `admitEntry`.
  */
 async function enforceMaxConcurrent(incomingKey: string): Promise<void> {
   let cap: number;
@@ -1265,15 +1311,25 @@ async function persistSessionId(entry: PtyEntry, sessionId: string): Promise<voi
 }
 
 async function reapIdle(opts: SupervisorOptions): Promise<void> {
-  const cutoff = _clock() - opts.idleReapMinutes * 60_000;
+  const now = _clock();
+  const cutoff = now - opts.idleReapMinutes * 60_000;
+  // Issue #65 item 6: PTYs that never complete a first turn used to be skipped
+  // forever, so a claude that crashed during spawn (or any case where
+  // `lastTurnEndedAt` stays 0) would hold a slot under `maxConcurrent`
+  // indefinitely. Give a generous grace period (3× idleReapMinutes) so slow
+  // first-turn cases aren't false-positives, then reap by `createdAt`.
+  const spawnGraceCutoff = now - opts.idleReapMinutes * 60_000 * 3;
   const toReap: PtyEntry[] = [];
   for (const entry of state.ptys.values()) {
     if (!entry.pty) continue;
     // Named agents stay alive forever when the flag is on.
     if (entry.kind === "named" && opts.namedAgentsAlwaysAlive) continue;
     const last = entry.pty.lastTurnEndedAt();
-    // A PTY that has never finished a turn is mid-spawn — leave it alone.
-    if (last === 0) continue;
+    if (last === 0) {
+      // Mid-spawn or stuck: reap only past the grace period.
+      if (entry.createdAt < spawnGraceCutoff) toReap.push(entry);
+      continue;
+    }
     if (last < cutoff) toReap.push(entry);
   }
   for (const entry of toReap) {

--- a/src/runner/pty-supervisor.ts
+++ b/src/runner/pty-supervisor.ts
@@ -405,9 +405,13 @@ interface PtyEntry {
   /** Last time `runOnPty` was called against this key. Drives LRU eviction
    *  when `pty.maxConcurrent` is hit. Adhoc-only — named agents are exempt. */
   lastAccessedAt: number;
-  /** Wall-clock at entry creation. Used by `reapIdle` to time out PTYs that
-   *  never complete a first turn (issue #65 item 6). */
-  createdAt: number;
+  /** Wall-clock at the most recent spawn (or respawn). Used by `reapIdle` to
+   *  time out PTYs that never complete a first turn after a (re)spawn
+   *  (issue #65 item 6). Reset on every respawn so a healthy long-lived PTY
+   *  that crashes and respawns gets a fresh grace window — keying off entry
+   *  creation time would incorrectly evict it (Codex P1 on PR #149).
+   *  Stays 0 until the first successful spawn completes. */
+  lastSpawnedAt: number;
 }
 
 interface SupervisorState {
@@ -693,7 +697,9 @@ async function getOrCreateEntry(
     spawnOpts: null,
     lock: Promise.resolve(),
     lastAccessedAt: now,
-    createdAt: now,
+    // Stamped at every (re)spawn site below. 0 until the first spawn lands —
+    // `reapIdle` treats that as "still admitting, leave alone".
+    lastSpawnedAt: 0,
   };
   state.ptys.set(sessionKey, entry);
   return entry;
@@ -1100,6 +1106,9 @@ async function spawnEntry(
 
   try {
     entry.pty = await spawn(spawnOpts);
+    // Stamp the (re)spawn time so the reaper's spawn-grace window restarts
+    // from now — see PtyEntry.lastSpawnedAt + reapIdle.
+    entry.lastSpawnedAt = _clock();
   } catch (err) {
     // If the spawn itself failed AFTER we synthesized an --mcp-config file,
     // clean up the on-disk artifact so the next attempt doesn't leak it on
@@ -1179,6 +1188,10 @@ async function respawnEntry(entry: PtyEntry): Promise<void> {
   entry.pty = null;
   entry.pty = await spawn(opts);
   entry.spawnOpts = opts;
+  // Reset the spawn-grace window on respawn so a healthy long-lived PTY that
+  // crashes doesn't get immediately reaped before its first post-respawn turn
+  // (Codex P1 on PR #149).
+  entry.lastSpawnedAt = _clock();
 }
 
 async function runTurnWithRetries(
@@ -1317,7 +1330,9 @@ async function reapIdle(opts: SupervisorOptions): Promise<void> {
   // forever, so a claude that crashed during spawn (or any case where
   // `lastTurnEndedAt` stays 0) would hold a slot under `maxConcurrent`
   // indefinitely. Give a generous grace period (3× idleReapMinutes) so slow
-  // first-turn cases aren't false-positives, then reap by `createdAt`.
+  // first-turn cases aren't false-positives, then reap by `lastSpawnedAt`.
+  // Keying off `lastSpawnedAt` (not entry-creation time) lets a long-lived PTY
+  // that crashes and respawns get a fresh grace window — Codex P1 on PR #149.
   const spawnGraceCutoff = now - opts.idleReapMinutes * 60_000 * 3;
   const toReap: PtyEntry[] = [];
   for (const entry of state.ptys.values()) {
@@ -1326,8 +1341,12 @@ async function reapIdle(opts: SupervisorOptions): Promise<void> {
     if (entry.kind === "named" && opts.namedAgentsAlwaysAlive) continue;
     const last = entry.pty.lastTurnEndedAt();
     if (last === 0) {
-      // Mid-spawn or stuck: reap only past the grace period.
-      if (entry.createdAt < spawnGraceCutoff) toReap.push(entry);
+      // Mid-spawn or stuck. If `lastSpawnedAt === 0` we haven't even finished
+      // the first spawn yet — leave it alone. Otherwise reap once we're past
+      // the grace window counted from the most recent (re)spawn.
+      if (entry.lastSpawnedAt !== 0 && entry.lastSpawnedAt < spawnGraceCutoff) {
+        toReap.push(entry);
+      }
       continue;
     }
     if (last < cutoff) toReap.push(entry);


### PR DESCRIPTION
## Summary

Bundles seven of the ten minor PTY-migration findings deferred from PR #62 into a single housekeeping PR. Items 1, 5, 8 from issue #65 are deferred — they need more design work than a tidy-up pass.

Closes part of #65.

### Items in this PR

| # | Finding | Fix |
|---|---|---|
| 2 | TOCTOU in `enforceMaxConcurrent` | New `_admissionLock` mutex serialises the eviction → admission critical section so two concurrent admissions can't both observe `size < cap` during the `dispose()` await window. Held only across admission; per-key turn locking unchanged. |
| 3 | CR sanitisation before PTY stdin | New `sanitizePtyPromptText` helper exported from `pty-process.ts`; applied at both write sites (`PtyProcess.runTurn` and `session-agent-process.ts:send_prompt_stream`). Strips `\r\n` (mid-line submit guard) AND NUL/BS/DEL/BEL/other C0 controls (would corrupt PTY write or inline-edit claude's TUI). Tab is preserved. |
| 4 | `bun-pty` exact-pin | `^0.4.8` → `0.4.8`. Lockfile already resolved exact; narrows supply-chain risk per security audit MINOR. |
| 6 | Reaper gap for permanently-stuck entries | Added `createdAt` to PtyEntry; `reapIdle` now also reaps PTYs with `lastTurnEndedAt === 0` past a 3× `idleReapMinutes` grace cutoff so legitimate slow-first-turn cases aren't false-positives. |
| 7 | `--append-system-prompt` `ps aux` visibility | Documented on `PtyProcessOptions.appendSystemPrompt`. Parity with legacy `claude -p` (no new attack surface); operators on shared multi-user hosts should treat system-prompt payload as low-secrecy. |
| 9 | Duplicate JSDoc on `cleanSpawnEnv` | Removed the redundant shorter block. |
| 10 | `global`-kind LRU exemption doc gap | Updated `enforceMaxConcurrent` JSDoc + `kind` field comment to reflect that both `named` and `global` are exempt from LRU eviction. |

### Items NOT in this PR

- **Item 1** (cwd race on CLAUDE.md/MEMORY.md) — pre-existing under `claude -p`; needs design.
- **Item 5** (`_handleData` closure cleanup) — needs design pass on the settle window.
- **Item 8** (appendSystemPrompt captured at spawn time only) — behavioural change requiring product input.

### Drive-by

- `pty-config.test.ts` "explicit empty mcp object" assertion synced with the new fields landed via PRs #147 (metrics) + #148 (cache). The test was failing on `povai/main` before this PR; not introduced here.

### Pre-PR 5-agent review (Sonnet × 5)

Ran the 5-agent parallel review locally before publishing. One legitimate finding surfaced and was addressed in follow-up commits:

- **Agent 2 (shallow bug scan):** flagged that the first-cut `sanitizePtyPromptText` only stripped CR/LF, leaving NUL/BS/DEL/BEL as live PTY-corruption vectors. **Fixed** in `8597847` (extended sanitiser + tests) and `389fae8` (lint-suppress for intentional control-char regex).
- Other findings were false positives (sync-block "race" that isn't), out-of-scope (`rotation.ts` divergent strip list — pre-existing, follow-up issue), or already covered (`send_prompt_stream` race is Nibbler's open P1 on #141, intentionally not folded in here).

## Test plan

- [x] `bun test src/__tests__/pty-{process,supervisor,supervisor-mcp,integration,config,trust-prompt,output-parser,backward-compat,mcp-config-writer}.test.ts src/bus/__tests__/` — 426 pass, 0 fail.
- [x] `bun run lint` — clean (warnings unchanged from baseline).
- [x] New tests: admission-lock burst (3 concurrent admissions at cap), reaper grace-period (60-min survive, 91-min reap), `sanitizePtyPromptText` unit suite covering NUL/BS/DEL/BEL/multi-byte UTF-8.
- [ ] Soak in production on the bus runtime (PR #138 baseline + this).