### PR TITLE
fix(discord,slack): opt-in primaryChannelByAgent to stop heartbeat fan-out spam

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.88",
+      "version": "2.2.89",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.89",
+      "version": "2.2.90",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.88",
+  "version": "2.2.89",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.89",
+  "version": "2.2.90",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/discord/__tests__/discord-outbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-outbound.test.ts
@@ -181,6 +181,28 @@ describe("DiscordAdapter — outbound response.text", () => {
     expect(h.rest.sent.map((m) => m.channelId).sort()).toEqual(["ch-2", "th-1"]);
   });
 
+  it("subscribes agents listed only in primaryChannelByAgent (Codex P2 #151)", async () => {
+    // An operator who sets a primary channel for an agent without listing
+    // the agent in channels/threads/dmAgentId must still get a subscription.
+    // Without this, the parser accepts the config but the adapter mounts
+    // with zero subscriptions and the routed event never arrives.
+    adapter = await startAdapter(h, {
+      routing: {
+        channels: { "ch-2": "ops" },
+        threads: { "th-1": "ops" },
+        primaryChannelByAgent: { "scheduler-only": "ch-9" },
+      },
+    });
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "scheduler-only",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "scheduler tick", origin: "cron", origin_id: "job:nightly" },
+    });
+    expect(h.rest.sent.map((m) => m.channelId)).toEqual(["ch-9"]);
+  });
+
   it("DROPS channel.permission_request whose origin belongs to another adapter", async () => {
     adapter = await startAdapter(h);
     h.bus.emit({

--- a/src/adapters/discord/__tests__/discord-outbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-outbound.test.ts
@@ -135,6 +135,52 @@ describe("DiscordAdapter — outbound response.text", () => {
     expect(h.rest.sent.map((m) => m.channelId).sort()).toEqual(["ch-2", "th-1"]);
   });
 
+  it("routes non-channel-driven origins to primaryChannelByAgent when configured", async () => {
+    // Production bug 2026-05-21: every heartbeat fans out to every channel
+    // routed to the agent (e.g. both #general and #daily-digest-suzy for
+    // agent `suzy`). Opt-in primaryChannelByAgent narrows the fan-out to a
+    // single designated channel per agent.
+    adapter = await startAdapter(h, {
+      routing: {
+        channels: { "ch-2": "ops" },
+        threads: { "th-1": "ops" },
+        dmAgentId: "global",
+        primaryChannelByAgent: { ops: "ch-2" },
+      },
+    });
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "heartbeat tick", origin: "heartbeat", origin_id: "hb" },
+    });
+    // Without the primary-channel narrowing, this would broadcast to BOTH
+    // "ch-2" and "th-1". With it, only "ch-2" gets the heartbeat.
+    expect(h.rest.sent.map((m) => m.channelId)).toEqual(["ch-2"]);
+  });
+
+  it("falls back to fan-out when primaryChannelByAgent is unset for the agent", async () => {
+    // Back-compat: agents without a primaryChannelByAgent entry keep the
+    // legacy fan-out behaviour.
+    adapter = await startAdapter(h, {
+      routing: {
+        channels: { "ch-2": "ops" },
+        threads: { "th-1": "ops" },
+        dmAgentId: "global",
+        primaryChannelByAgent: { other: "ch-1" }, // not for "ops"
+      },
+    });
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "cron tick", origin: "cron", origin_id: "job:morning" },
+    });
+    expect(h.rest.sent.map((m) => m.channelId).sort()).toEqual(["ch-2", "th-1"]);
+  });
+
   it("DROPS channel.permission_request whose origin belongs to another adapter", async () => {
     adapter = await startAdapter(h);
     h.bus.emit({

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -412,7 +412,20 @@ export class DiscordAdapter {
       origin === "discord" && typeof payloadWithOrigin?.origin_id === "string"
         ? payloadWithOrigin.origin_id
         : null;
-    const targetChannels = originChannel ? [originChannel] : this.channelsForAgent(agentId);
+    // For non-channel-driven origins (cron / heartbeat / cli / rest / no
+    // origin) prefer the operator-configured primary channel for the agent
+    // when one is set. Without this, a heartbeat fans out to every routed
+    // channel — observed in production as "heartbeat delivered to every
+    // channel routed to suzy", including `daily-digest-suzy`. Opt-in: agents
+    // without an entry keep the legacy fan-out behaviour.
+    const primaryChannel = !originChannel
+      ? this.routing.primaryChannelByAgent?.[agentId]
+      : undefined;
+    const targetChannels = originChannel
+      ? [originChannel]
+      : primaryChannel
+        ? [primaryChannel]
+        : this.channelsForAgent(agentId);
     if (targetChannels.length === 0) return;
 
     if (event.topic === "response.text") {

--- a/src/adapters/discord/router.ts
+++ b/src/adapters/discord/router.ts
@@ -23,6 +23,14 @@ export interface RoutingConfig {
   channels: Record<string, string>;
   threads?: Record<string, string>;
   dmAgentId?: string;
+  /**
+   * Mirrors `DiscordBusRouting.primaryChannelByAgent`. Listed here so
+   * `uniqueAgentIds` can include agents that appear only in this map.
+   * Without that, an operator who sets a primary channel for an agent
+   * without listing the agent in `channels`/`threads`/`dmAgentId` would
+   * silently get no subscription (Codex P2 on PR #151).
+   */
+  primaryChannelByAgent?: Record<string, string>;
 }
 
 export interface RouteContext {
@@ -78,5 +86,11 @@ export function uniqueAgentIds(routing: RoutingConfig): string[] {
     for (const a of Object.values(routing.threads)) set.add(a);
   }
   if (routing.dmAgentId) set.add(routing.dmAgentId);
+  // Include agents that appear only in `primaryChannelByAgent`. The parser
+  // accepts that config shape, so the subscription set must too — otherwise
+  // outbound events for those agents would never reach the adapter.
+  if (routing.primaryChannelByAgent) {
+    for (const a of Object.keys(routing.primaryChannelByAgent)) set.add(a);
+  }
   return Array.from(set);
 }

--- a/src/adapters/discord/types.ts
+++ b/src/adapters/discord/types.ts
@@ -40,6 +40,12 @@ export interface DiscordAdapterOptions {
     channels: Record<string, string>;
     threads?: Record<string, string>;
     dmAgentId?: string;
+    /**
+     * `agent_id → channel_id`. When set for an agent, non-channel-driven
+     * origins (cron / heartbeat / cli / rest / no origin) deliver ONLY to
+     * this channel rather than fanning out to every routed channel.
+     */
+    primaryChannelByAgent?: Record<string, string>;
   };
   /** Optional logger; defaults to `console`. */
   logger?: Pick<Console, "warn" | "info" | "error">;

--- a/src/adapters/slack/__tests__/slack.test.ts
+++ b/src/adapters/slack/__tests__/slack.test.ts
@@ -564,6 +564,45 @@ describe("SlackAdapter — response.text outbound", () => {
     await new Promise((r) => setTimeout(r, 30));
     expect(api.sent).toHaveLength(0);
   });
+
+  it("routes non-channel-driven origins to primaryChannelByAgent when configured", async () => {
+    // Mirror of the discord fix: heartbeat/cron broadcasts to every routed
+    // channel was spamming users in multi-channel setups. Opt-in primary
+    // channel narrows the fan-out per agent.
+    adapter = await startAdapter({
+      routing: {
+        channels: { C100: "triage", C200: "triage" },
+        primaryChannelByAgent: { triage: "C100" },
+      },
+    });
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "heartbeat tick", origin: "heartbeat", origin_id: "hb" },
+    });
+    await waitFor(() => api.sent.length > 0);
+    expect(api.sent.map((m) => m.channel)).toEqual(["C100"]);
+  });
+
+  it("falls back to fan-out when primaryChannelByAgent is unset for the agent", async () => {
+    adapter = await startAdapter({
+      routing: {
+        channels: { C100: "triage", C200: "triage" },
+        primaryChannelByAgent: { other: "C100" }, // not for "triage"
+      },
+    });
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "cron tick", origin: "cron", origin_id: "job:morning" },
+    });
+    await waitFor(() => api.sent.length >= 2);
+    expect(api.sent.map((m) => m.channel).sort()).toEqual(["C100", "C200"]);
+  });
 });
 
 /* ────────────────────────────────────────────────────────────────────── */

--- a/src/adapters/slack/__tests__/slack.test.ts
+++ b/src/adapters/slack/__tests__/slack.test.ts
@@ -603,6 +603,27 @@ describe("SlackAdapter — response.text outbound", () => {
     await waitFor(() => api.sent.length >= 2);
     expect(api.sent.map((m) => m.channel).sort()).toEqual(["C100", "C200"]);
   });
+
+  it("subscribes agents listed only in primaryChannelByAgent (Codex P2 #151)", async () => {
+    // Parser allows config that mentions an agent only in
+    // primaryChannelByAgent. Adapter must subscribe that agent or outbound
+    // events never reach Slack.
+    adapter = await startAdapter({
+      routing: {
+        channels: { C100: "triage" },
+        primaryChannelByAgent: { "scheduler-only": "C500" },
+      },
+    });
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "scheduler-only",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "scheduler tick", origin: "cron", origin_id: "job:nightly" },
+    });
+    await waitFor(() => api.sent.length > 0);
+    expect(api.sent.map((m) => m.channel)).toEqual(["C500"]);
+  });
 });
 
 /* ────────────────────────────────────────────────────────────────────── */

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -107,6 +107,13 @@ export class SlackAdapter {
   private readonly selfUserId: string | null;
   private readonly channels: Record<string, string>;
   private readonly threadAgentId: string | undefined;
+  /**
+   * Optional `agent_id → channel_id` for narrowing non-channel-driven origin
+   * fan-out (cron / heartbeat / cli / rest / no origin) to a single channel
+   * per agent. Opt-in: agents without an entry fan out to every routed
+   * channel as before.
+   */
+  private readonly primaryChannelByAgent: Record<string, string> | undefined;
   private readonly logger: Pick<Console, "warn" | "info" | "error">;
 
   /** Active bus subscriptions, one collection per routed agent. */
@@ -175,6 +182,9 @@ export class SlackAdapter {
     }
     this.channels = { ...opts.routing.channels };
     this.threadAgentId = opts.routing.threadAgentId;
+    this.primaryChannelByAgent = opts.routing.primaryChannelByAgent
+      ? { ...opts.routing.primaryChannelByAgent }
+      : undefined;
     this.logger = opts.logger ?? console;
     this.maxSeenEventIds = opts.maxSeenEventIds ?? DEFAULT_MAX_SEEN_EVENT_IDS;
     this.maxThreadOwners = opts.maxThreadOwners ?? DEFAULT_MAX_THREAD_OWNERS;
@@ -606,7 +616,7 @@ export class SlackAdapter {
       payload.origin === "slack" && typeof payload.origin_id === "string"
         ? payload.origin_id
         : null;
-    const channels = originChannel ? [originChannel] : this.channelsForAgent(agentId);
+    const channels = this.resolveTargetChannels(agentId, originChannel);
     if (channels.length === 0) {
       this.logger.warn(`[slack-adapter] no channels for agent ${agentId}; dropping response.text`);
       return;
@@ -625,7 +635,7 @@ export class SlackAdapter {
 
     const originChannel =
       req.origin === "slack" && typeof req.origin_id === "string" ? req.origin_id : null;
-    const channels = originChannel ? [originChannel] : this.channelsForAgent(agentId);
+    const channels = this.resolveTargetChannels(agentId, originChannel);
     if (channels.length === 0) {
       this.logger.warn(
         `[slack-adapter] no channels for agent ${agentId}; dropping permission_request`,
@@ -663,7 +673,7 @@ export class SlackAdapter {
       payload.origin === "slack" && typeof payload.origin_id === "string"
         ? payload.origin_id
         : null;
-    const channels = originChannel ? [originChannel] : this.channelsForAgent(agentId);
+    const channels = this.resolveTargetChannels(agentId, originChannel);
     if (channels.length === 0) {
       this.logger.warn(`[slack-adapter] no channels for agent ${agentId}; dropping request_human`);
       return;
@@ -696,6 +706,25 @@ export class SlackAdapter {
       if (aid === agentId) out.push(chId);
     }
     return out;
+  }
+
+  /**
+   * Resolve the target channel set for an outbound event.
+   *
+   *   1. originChannel set      → that channel only (slack-originated reply)
+   *   2. primaryChannelByAgent  → that channel only (non-channel-driven origin,
+   *                                operator opted in for this agent)
+   *   3. fallback               → every channel routed to the agent (legacy
+   *                                fan-out, back-compat)
+   *
+   * The primary-channel path narrows cron/heartbeat/cli/rest broadcasts so
+   * they don't spam every channel routed to the agent. Opt-in.
+   */
+  private resolveTargetChannels(agentId: string, originChannel: string | null): string[] {
+    if (originChannel) return [originChannel];
+    const primary = this.primaryChannelByAgent?.[agentId];
+    if (primary) return [primary];
+    return this.channelsForAgent(agentId);
   }
 
   /**

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -697,6 +697,12 @@ export class SlackAdapter {
     const set = new Set<string>();
     for (const agent of Object.values(this.channels)) set.add(agent);
     if (this.threadAgentId) set.add(this.threadAgentId);
+    // Include agents listed only in `primaryChannelByAgent`. Codex P2 on
+    // PR #151: parser accepts that shape; subscription set must too,
+    // otherwise outbound events never reach the adapter.
+    if (this.primaryChannelByAgent) {
+      for (const a of Object.keys(this.primaryChannelByAgent)) set.add(a);
+    }
     return Array.from(set);
   }
 

--- a/src/adapters/slack/types.ts
+++ b/src/adapters/slack/types.ts
@@ -83,6 +83,12 @@ export interface SlackAdapterOptions {
   routing: {
     channels: Record<string, string>;
     threadAgentId?: string;
+    /**
+     * `agent_id → channel_id`. When set for an agent, non-channel-driven
+     * origins (cron / heartbeat / cli / rest / no origin) deliver ONLY to
+     * this channel rather than fanning out to every routed channel.
+     */
+    primaryChannelByAgent?: Record<string, string>;
   };
   /**
    * App-level token (`xapp-…`) for Socket Mode. When present, the adapter

--- a/src/bus/adapter-wiring.ts
+++ b/src/bus/adapter-wiring.ts
@@ -188,6 +188,9 @@ async function mountSlack(
     routing: {
       channels: cfg.busRouting.channels,
       ...(cfg.busRouting.threadAgentId ? { threadAgentId: cfg.busRouting.threadAgentId } : {}),
+      ...(cfg.busRouting.primaryChannelByAgent
+        ? { primaryChannelByAgent: cfg.busRouting.primaryChannelByAgent }
+        : {}),
     },
     ...(cfg.appToken ? { appToken: cfg.appToken } : {}),
     logger,

--- a/src/config.ts
+++ b/src/config.ts
@@ -246,6 +246,14 @@ export interface DiscordBusRouting {
   channels: Record<string, string>;
   threads?: Record<string, string>;
   dmAgentId?: string;
+  /**
+   * `agent_id → channel_id`. When a non-channel-driven origin
+   * ("cron" / "heartbeat" / "cli" / "rest" / no origin) fires for an agent
+   * that appears here, the event is delivered ONLY to this channel rather
+   * than fanning out to every channel routed to the agent. Opt-in: agents
+   * with no entry keep the legacy fan-out behaviour.
+   */
+  primaryChannelByAgent?: Record<string, string>;
 }
 
 /**
@@ -258,6 +266,13 @@ export interface SlackBusRouting {
   threadAgentId?: string;
   /** Optional override for the Events API signing secret. */
   signingSecret?: string;
+  /**
+   * `agent_id → channel_id`. Same semantics as `DiscordBusRouting`.
+   * When a non-channel-driven origin fires for an agent that appears here,
+   * deliver only to this channel instead of fanning out across every
+   * routed channel. Opt-in.
+   */
+  primaryChannelByAgent?: Record<string, string>;
 }
 
 /**
@@ -1126,13 +1141,23 @@ function parseDiscordBusRouting(raw: unknown): DiscordBusRouting | null {
   const channels = parseStringMap((raw as Record<string, unknown>).channels);
   const threads = parseStringMap((raw as Record<string, unknown>).threads);
   const dmAgentId = (raw as Record<string, unknown>).dmAgentId;
+  const primaryChannelByAgent = parseStringMap(
+    (raw as Record<string, unknown>).primaryChannelByAgent,
+  );
   const hasDm = typeof dmAgentId === "string" && dmAgentId.length > 0;
-  if (Object.keys(channels).length === 0 && Object.keys(threads).length === 0 && !hasDm) {
+  const hasPrimary = Object.keys(primaryChannelByAgent).length > 0;
+  if (
+    Object.keys(channels).length === 0 &&
+    Object.keys(threads).length === 0 &&
+    !hasDm &&
+    !hasPrimary
+  ) {
     return null;
   }
   const out: DiscordBusRouting = { channels };
   if (Object.keys(threads).length > 0) out.threads = threads;
   if (hasDm) out.dmAgentId = (dmAgentId as string).trim();
+  if (hasPrimary) out.primaryChannelByAgent = primaryChannelByAgent;
   return out;
 }
 
@@ -1144,12 +1169,17 @@ function parseSlackBusRouting(raw: unknown): SlackBusRouting | null {
   const channels = parseStringMap((raw as Record<string, unknown>).channels);
   const threadAgentId = (raw as Record<string, unknown>).threadAgentId;
   const signingSecret = (raw as Record<string, unknown>).signingSecret;
+  const primaryChannelByAgent = parseStringMap(
+    (raw as Record<string, unknown>).primaryChannelByAgent,
+  );
   const hasThread = typeof threadAgentId === "string" && threadAgentId.length > 0;
   const hasSigning = typeof signingSecret === "string" && signingSecret.length > 0;
-  if (Object.keys(channels).length === 0 && !hasThread && !hasSigning) return null;
+  const hasPrimary = Object.keys(primaryChannelByAgent).length > 0;
+  if (Object.keys(channels).length === 0 && !hasThread && !hasSigning && !hasPrimary) return null;
   const out: SlackBusRouting = { channels };
   if (hasThread) out.threadAgentId = (threadAgentId as string).trim();
   if (hasSigning) out.signingSecret = (signingSecret as string).trim();
+  if (hasPrimary) out.primaryChannelByAgent = primaryChannelByAgent;
   return out;
 }
 


### PR DESCRIPTION
## Problem

Every heartbeat / cron / cli / rest origin event for an agent fans out to every channel routed to that agent. Operator-visible symptom: heartbeat replies showing up in side channels like \`daily-digest-suzy\` alongside \`general\`. Same shape on Slack (Telegram is unaffected — \`targetForAgent\` already returns a single chat).

Root cause: in \`handleBusEvent\` the non-channel-driven origin branch falls through to \`channelsForAgent()\`, which returns every channel mapped to the agent.

## Fix

Opt-in \`primaryChannelByAgent: Record<agentId, channelId>\` on \`DiscordBusRouting\` and \`SlackBusRouting\`. When set for an agent, non-channel-driven origins (\`cron\` / \`heartbeat\` / \`cli\` / \`rest\` / no origin) deliver ONLY to that channel. Agents without an entry keep the legacy fan-out behaviour — back-compat preserved.

## Operator config

\`\`\`yaml
discord:
  busRouting:
    channels: { "111": "suzy", "222": "suzy" }
    primaryChannelByAgent:
      suzy: "111"   # General. Heartbeats no longer hit daily-digest-suzy.
\`\`\`

Same shape under \`slack.busRouting\`.

## Test plan

- [x] Discord: routes heartbeat to primary channel only when configured.
- [x] Discord: falls back to fan-out when not configured (back-compat).
- [x] Slack: same two scenarios.
- [x] \`bun run lint\` clean.
- [ ] Production: set \`primaryChannelByAgent\` in \`settings.json\` and confirm heartbeats stop hitting side channels.