### PR TITLE
fix(telegram): bound spinner edits + per-chat flood cooldown

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.88",
+      "version": "2.2.89",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.88",
+  "version": "2.2.89",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/telegram/__tests__/api.test.ts
+++ b/src/adapters/telegram/__tests__/api.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for the per-chat flood cooldown in `createTelegramApi`.
+ *
+ * Background (#141 incident 2026-05-21): the progress spinner edited a message
+ * ~1/s for the duration of a turn; Telegram escalated to a flood-ban with
+ * `retry_after` ~1730s, and every further send 429'd, blocking all replies.
+ * The cooldown records the `retry_after` deadline per chat and short-circuits
+ * subsequent sends WITHOUT hitting the API until it clears.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { createTelegramApi } from "../api";
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+function stub429(retryAfter: number, counter: { n: number }): void {
+  globalThis.fetch = (async () => {
+    counter.n += 1;
+    return new Response(
+      JSON.stringify({
+        ok: false,
+        error_code: 429,
+        description: `Too Many Requests: retry after ${retryAfter}`,
+        parameters: { retry_after: retryAfter },
+      }),
+      { status: 429, statusText: "Too Many Requests" },
+    );
+  }) as typeof fetch;
+}
+
+describe("createTelegramApi — per-chat flood cooldown", () => {
+  it("short-circuits a flooded chat without re-hitting the API", async () => {
+    const counter = { n: 0 };
+    stub429(100, counter);
+    const api = createTelegramApi("test-token");
+
+    // First send reaches Telegram and gets the 429 (records the cooldown).
+    await expect(api.sendMessage({ chat_id: 42, text: "hi" })).rejects.toThrow(/429/);
+    expect(counter.n).toBe(1);
+
+    // Second send to the SAME chat is rejected locally — no new fetch.
+    await expect(api.sendMessage({ chat_id: 42, text: "again" })).rejects.toThrow(/flood cooldown/);
+    expect(counter.n).toBe(1);
+  });
+
+  it("does not block a different chat", async () => {
+    const counter = { n: 0 };
+    stub429(100, counter);
+    const api = createTelegramApi("test-token");
+
+    await expect(api.sendMessage({ chat_id: 42, text: "hi" })).rejects.toThrow(/429/);
+    expect(counter.n).toBe(1);
+
+    // A different chat is unaffected — it still reaches the API.
+    await expect(api.sendMessage({ chat_id: 99, text: "hi" })).rejects.toThrow(/429/);
+    expect(counter.n).toBe(2);
+  });
+
+  it("surfaces retry_after in the thrown error for observability", async () => {
+    const counter = { n: 0 };
+    stub429(1730, counter);
+    const api = createTelegramApi("test-token");
+    await expect(api.editMessageText({ chat_id: 7, message_id: 1, text: "x" })).rejects.toThrow(
+      /retry_after 1730s/,
+    );
+  });
+});

--- a/src/adapters/telegram/api.ts
+++ b/src/adapters/telegram/api.ts
@@ -35,11 +35,29 @@ const API_BASE = "https://api.telegram.org/bot";
  *     adapter's `safe*` wrappers can log a useful one-liner.
  */
 export function createTelegramApi(token: string): TelegramApi {
+  // Per-chat flood cooldown. Telegram answers a flooded chat with HTTP 429 and
+  // a `parameters.retry_after` (seconds). Until that window passes, every
+  // further send to that chat is rejected too — and each rejected attempt can
+  // extend the ban. We record the deadline and short-circuit subsequent sends
+  // to that chat WITHOUT hitting the API, so a misbehaving caller (e.g. a
+  // progress spinner) can't sustain the ban and it clears on its own.
+  const floodUntil = new Map<string, number>();
   async function call<T>(
     method: string,
     body: Record<string, unknown>,
     signal?: AbortSignal,
   ): Promise<T> {
+    const chatVal = (body as { chat_id?: unknown }).chat_id;
+    const chatKey = chatVal === undefined || chatVal === null ? "" : String(chatVal);
+    if (chatKey) {
+      const until = floodUntil.get(chatKey) ?? 0;
+      const remaining = until - Date.now();
+      if (remaining > 0) {
+        throw new Error(
+          `Telegram API ${method}: 429 flood cooldown, ${Math.ceil(remaining / 1000)}s remaining for chat ${chatKey}`,
+        );
+      }
+    }
     const res = await fetch(`${API_BASE}${token}/${method}`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -47,7 +65,21 @@ export function createTelegramApi(token: string): TelegramApi {
       signal,
     });
     if (!res.ok) {
-      throw new Error(`Telegram API ${method}: ${res.status} ${res.statusText}`);
+      let retryAfter = 0;
+      try {
+        const errBody = (await res.json()) as { parameters?: { retry_after?: number } };
+        retryAfter = errBody?.parameters?.retry_after ?? 0;
+      } catch {
+        /* error body was not JSON — ignore */
+      }
+      if (res.status === 429 && chatKey && retryAfter > 0) {
+        floodUntil.set(chatKey, Date.now() + retryAfter * 1000);
+      }
+      throw new Error(
+        `Telegram API ${method}: ${res.status} ${res.statusText}${
+          retryAfter ? ` (retry_after ${retryAfter}s)` : ""
+        }`,
+      );
     }
     return (await res.json()) as T;
   }

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -559,7 +559,16 @@ export class TelegramAdapter {
 
   /** Braille spinner frames — classic CLI animation. */
   private static readonly SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-  private static readonly SPINNER_INTERVAL_MS = 1100;
+  private static readonly SPINNER_INTERVAL_MS = 2500;
+  /**
+   * Max animation ticks per turn. Bounds total `editMessageText` calls so a
+   * long claude turn can't fire an unbounded edit stream. At 1.1s/edit with no
+   * cap, a multi-minute turn issued ~100+ edits and triggered an escalated
+   * Telegram flood-ban (`retry_after` ~1730s) that blocked ALL replies. With
+   * a 2.5s interval and a 12-tick cap the spinner animates for ~30s then goes
+   * static; real text still arrives via `response.text` / `edit_message`.
+   */
+  private static readonly SPINNER_MAX_TICKS = 12;
 
   private stopSpinner(key: string): void {
     const s = this.spinnerState.get(key);
@@ -572,6 +581,7 @@ export class TelegramAdapter {
   private startSpinner(key: string, baseText: string, chat_id: number, message_id: number): void {
     this.stopSpinner(key);
     const FRAMES = TelegramAdapter.SPINNER_FRAMES;
+    let ticks = 0;
     this.spinnerState.set(key, {
       baseText,
       frame: 0,
@@ -580,6 +590,14 @@ export class TelegramAdapter {
       timer: setInterval(() => {
         const cur = this.spinnerState.get(key);
         if (!cur) return;
+        // Cap total animation so a long turn can't fire an unbounded edit
+        // stream (Telegram flood-ban risk). After the cap the message stays
+        // static; real text still arrives via response.text / edit_message.
+        ticks += 1;
+        if (ticks > TelegramAdapter.SPINNER_MAX_TICKS) {
+          this.stopSpinner(key);
+          return;
+        }
         cur.frame = (cur.frame + 1) % FRAMES.length;
         void this.api
           .editMessageText({
@@ -587,13 +605,12 @@ export class TelegramAdapter {
             message_id: cur.message_id,
             text: `${FRAMES[cur.frame]} ${cur.baseText}`,
           })
-          .catch((err) => {
-            // 429 is a transient rate-limit — keep animating. Any other
-            // error is terminal (e.g. 400 "message to edit not found"
-            // when the user deletes the placeholder); stop the spinner
-            // so the 1.1s interval doesn't hammer the API with a
-            // forever-failing edit loop.
-            if (!isTelegramRateLimit(err)) this.stopSpinner(key);
+          .catch(() => {
+            // Stop the spinner on ANY API error, 429 included. A periodic edit
+            // loop on a rate-limited chat self-sustains the 429 and starves the
+            // real reply; the per-chat flood cooldown in `createTelegramApi`
+            // then short-circuits further sends until it clears.
+            this.stopSpinner(key);
           });
       }, TelegramAdapter.SPINNER_INTERVAL_MS),
     });


### PR DESCRIPTION
Follow-up to #141. Found in production on a live deployment.

## The incident

The inline-progress spinner from #141 edits the live Telegram message every
1.1s for the **entire duration** of a claude turn. A multi-minute turn issues
100+ `editMessageText` calls to a single chat. Telegram answered with an
escalated flood-ban — captured live:

```
FAIL sendMessage 429 {"ok":false,"error_code":429,
  "description":"Too Many Requests: retry after 1730",
  "parameters":{"retry_after":1730}}
```

Once banned, **every** send to that chat 429'd (placeholder, edits, the final
reply), so the bot silently stopped responding. The 1.1s edit loop kept firing
into the ban, and each attempt risked extending it — the chat never recovered
on its own.

## The fix

**1. Bound the spinner (`src/adapters/telegram/index.ts`)**
- Interval `1100ms` → `2500ms`.
- Hard cap `SPINNER_MAX_TICKS = 12` (~30s of animation), after which the message
  goes static. Real text still flows via `response.text` / `edit_message`
  events, which are bounded by the agent's output rather than a wall-clock timer.
- The spinner now stops on **any** API error (429 included) instead of looping
  through rate-limits.

A long turn now issues ≤12 edits instead of 100+.

**2. Per-chat flood cooldown (`src/adapters/telegram/api.ts`)**
- On a `429` carrying `parameters.retry_after`, record the deadline per chat.
- Subsequent sends to that chat are short-circuited **locally** (no API call)
  until it clears, so a misbehaving caller can't sustain the ban.
- `retry_after` is surfaced in the thrown error for observability.

## Validation

Reproduced and verified live on a real deployment: after the fix, a ~21s turn
produced **10** spinner edits (under the cap), ~2.5s apart, with **zero** 429s,
and replies delivered normally. Before the fix the same usage triggered the
~1730s ban.

## Tests

`src/adapters/telegram/__tests__/api.test.ts` (new) covers the cooldown:
same-chat short-circuit (no second fetch), other chats unaffected, `retry_after`
surfaced. `bun test src/adapters/telegram` — green; `bun run lint` clean.