### PR TITLE
telegram(api): #154 follow-ups — flood-map eviction, per-chat serialization, dead-code removal

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.89",
+      "version": "2.2.90",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.89",
+  "version": "2.2.90",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/telegram/__tests__/api.test.ts
+++ b/src/adapters/telegram/__tests__/api.test.ts
@@ -67,3 +67,38 @@ describe("createTelegramApi — per-chat flood cooldown", () => {
     );
   });
 });
+
+describe("createTelegramApi — per-chat send serialization (#154)", () => {
+  function stubConcurrencyTracker(): { maxConcurrent: number } {
+    const state = { inFlight: 0, maxConcurrent: 0 };
+    globalThis.fetch = (async () => {
+      state.inFlight += 1;
+      state.maxConcurrent = Math.max(state.maxConcurrent, state.inFlight);
+      await new Promise((r) => setTimeout(r, 25));
+      state.inFlight -= 1;
+      return new Response(JSON.stringify({ ok: true, result: {} }), { status: 200 });
+    }) as typeof fetch;
+    return state;
+  }
+
+  it("never has two in-flight sends to the same chat at once", async () => {
+    const tracker = stubConcurrencyTracker();
+    const api = createTelegramApi("test-token");
+    await Promise.all([
+      api.sendMessage({ chat_id: 1, text: "a" }),
+      api.sendMessage({ chat_id: 1, text: "b" }),
+      api.sendMessage({ chat_id: 1, text: "c" }),
+    ]);
+    expect(tracker.maxConcurrent).toBe(1);
+  });
+
+  it("lets different chats send concurrently", async () => {
+    const tracker = stubConcurrencyTracker();
+    const api = createTelegramApi("test-token");
+    await Promise.all([
+      api.sendMessage({ chat_id: 1, text: "a" }),
+      api.sendMessage({ chat_id: 2, text: "b" }),
+    ]);
+    expect(tracker.maxConcurrent).toBe(2);
+  });
+});

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -14,7 +14,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { randomUUID } from "node:crypto";
-import { TelegramAdapter, extractReactionDirectives, isTelegramRateLimit } from "../index";
+import { TelegramAdapter, extractReactionDirectives } from "../index";
 import type { BusCore, SendPromptRequest } from "../../../bus/core";
 import type {
   Subscription,
@@ -303,25 +303,6 @@ describe("extractReactionDirectives", () => {
   it("collapses runs of blank lines after tag removal", () => {
     const { cleanedText } = extractReactionDirectives("a\n\n\n\nb [react:👌]");
     expect(cleanedText).toBe("a\n\nb");
-  });
-});
-
-describe("isTelegramRateLimit (#141 review — spinner stop)", () => {
-  it("treats a 429 as a transient rate-limit (keep spinning)", () => {
-    expect(
-      isTelegramRateLimit(new Error("Telegram API editMessageText: 429 Too Many Requests")),
-    ).toBe(true);
-  });
-
-  it("treats a 400 (deleted/not-modified) as terminal (stop spinning)", () => {
-    expect(isTelegramRateLimit(new Error("Telegram API editMessageText: 400 Bad Request"))).toBe(
-      false,
-    );
-  });
-
-  it("treats non-Error values and unparseable messages as terminal", () => {
-    expect(isTelegramRateLimit("boom")).toBe(false);
-    expect(isTelegramRateLimit(new Error("network down"))).toBe(false);
   });
 });
 

--- a/src/adapters/telegram/api.ts
+++ b/src/adapters/telegram/api.ts
@@ -42,20 +42,29 @@ export function createTelegramApi(token: string): TelegramApi {
   // to that chat WITHOUT hitting the API, so a misbehaving caller (e.g. a
   // progress spinner) can't sustain the ban and it clears on its own.
   const floodUntil = new Map<string, number>();
-  async function call<T>(
+  // Per-chat send serialization (#154). Telegram rate-limits per chat, so two
+  // concurrent in-flight sends to the same chat would race the flood-cooldown
+  // write (neither's 429 blocks the other) and risk a burst. Chaining sends per
+  // chat keeps at most one in flight; `getUpdates` (no chat_id) is never chained.
+  const chatTail = new Map<string, Promise<unknown>>();
+
+  async function dispatch<T>(
     method: string,
     body: Record<string, unknown>,
-    signal?: AbortSignal,
+    signal: AbortSignal | undefined,
+    chatKey: string,
   ): Promise<T> {
-    const chatVal = (body as { chat_id?: unknown }).chat_id;
-    const chatKey = chatVal === undefined || chatVal === null ? "" : String(chatVal);
     if (chatKey) {
-      const until = floodUntil.get(chatKey) ?? 0;
-      const remaining = until - Date.now();
-      if (remaining > 0) {
-        throw new Error(
-          `Telegram API ${method}: 429 flood cooldown, ${Math.ceil(remaining / 1000)}s remaining for chat ${chatKey}`,
-        );
+      const until = floodUntil.get(chatKey);
+      if (until !== undefined) {
+        const remaining = until - Date.now();
+        if (remaining > 0) {
+          throw new Error(
+            `Telegram API ${method}: 429 flood cooldown, ${Math.ceil(remaining / 1000)}s remaining for chat ${chatKey}`,
+          );
+        }
+        // Cooldown elapsed — evict so the map doesn't grow unbounded (#154).
+        floodUntil.delete(chatKey);
       }
     }
     const res = await fetch(`${API_BASE}${token}/${method}`, {
@@ -82,6 +91,34 @@ export function createTelegramApi(token: string): TelegramApi {
       );
     }
     return (await res.json()) as T;
+  }
+
+  async function call<T>(
+    method: string,
+    body: Record<string, unknown>,
+    signal?: AbortSignal,
+  ): Promise<T> {
+    const chatVal = (body as { chat_id?: unknown }).chat_id;
+    const chatKey = chatVal === undefined || chatVal === null ? "" : String(chatVal);
+    if (!chatKey) {
+      return dispatch<T>(method, body, signal, "");
+    }
+    // Chain this send after the chat's previous one (success or failure).
+    const prev = chatTail.get(chatKey) ?? Promise.resolve();
+    const run = prev.then(
+      () => dispatch<T>(method, body, signal, chatKey),
+      () => dispatch<T>(method, body, signal, chatKey),
+    );
+    const tail = run.then(
+      () => {},
+      () => {},
+    );
+    chatTail.set(chatKey, tail);
+    // Drop the tail once it settles and nothing newer chained (bounded growth).
+    void tail.then(() => {
+      if (chatTail.get(chatKey) === tail) chatTail.delete(chatKey);
+    });
+    return run;
   }
 
   return {

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -85,18 +85,6 @@ function eventBelongsToTelegram(event: BusEvent): boolean {
   return !CHANNEL_DRIVEN_ORIGINS.has(origin as BusOrigin);
 }
 
-/**
- * Whether a failed Telegram API call is a transient 429 rate-limit (worth
- * retrying) versus a terminal error. `createTelegramApi` throws errors of
- * the form `Telegram API <method>: <status> <statusText>`, so the HTTP
- * status is recoverable from the message. Used by the spinner loop to
- * decide whether to keep animating or stop — a deleted placeholder yields
- * a 400 that would otherwise loop forever.
- */
-export function isTelegramRateLimit(err: unknown): boolean {
-  return err instanceof Error && /: 429\b/.test(err.message);
-}
-
 export class TelegramAdapter {
   private readonly bus: BusCore;
   private readonly api: TelegramApi;


### PR DESCRIPTION
Closes #154. The three non-blocking hardening items carried over from the #152 review.

## 1. `floodUntil` eviction
Entries are deleted once their cooldown elapses (checked on the next send to that chat), so the map no longer grows unbounded.

## 2. Per-chat send serialization
Sends to a given `chat_id` are chained so at most one is in flight at a time. This closes the concurrent-in-flight race on the cooldown write that #154 flagged — a 429 from one send now lands in `floodUntil` before the next send starts — and is rate-limit-friendly (no same-chat bursts, which is what caused the original #152 incident). `getUpdates` (no `chat_id`) is never chained, so the long-poll is unaffected. The per-chat tail entry is dropped once it settles and nothing newer chained.

## 3. Remove dead `isTelegramRateLimit`
After #152 the spinner stops on any API error (429 included), so the helper had no remaining caller. Deleted it and its tests.

## Tests
`api.test.ts` gains two cases: same-chat sends never overlap (max 1 in-flight), and different chats still send concurrently. `bun test src/adapters/telegram` green; `bun run lint` clean. Version 2.2.89 → 2.2.90.