### PR TITLE
fix(bus): Windows support for schema-probe (cwd encoding + claude spawn)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.89",
+      "version": "2.2.90",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.90",
+      "version": "2.2.91",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.89",
+  "version": "2.2.90",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.90",
+  "version": "2.2.91",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/schema-probe.test.ts
+++ b/src/bus/__tests__/schema-probe.test.ts
@@ -292,7 +292,10 @@ describe("encodeCwd", () => {
 describe("predictJsonlPath", () => {
   it("composes ~/.claude/projects/<encoded>/<sessionId>.jsonl", () => {
     const out = predictJsonlPath("/home/me", "/private/tmp/x", "abc-def");
-    expect(out).toBe("/home/me/.claude/projects/-private-tmp-x/abc-def.jsonl");
+    // predictJsonlPath uses path.join, so the separator is platform-native.
+    // On Windows claude writes the session JSONL under a native backslash
+    // path (verified on a Win11 host), which is exactly what the tailer reads.
+    expect(out).toBe(join("/home/me", ".claude", "projects", "-private-tmp-x", "abc-def.jsonl"));
   });
 });
 

--- a/src/bus/__tests__/schema-probe.test.ts
+++ b/src/bus/__tests__/schema-probe.test.ts
@@ -291,6 +291,8 @@ describe("encodeCwd", () => {
   it("encodes Windows separators and the drive colon on win32", () => {
     // Verified against claude.exe on a Win11 host: C:\Users\foo\bar -> C--Users-foo-bar.
     expect(encodeCwd("C:\\Users\\foo\\bar", "win32")).toBe("C--Users-foo-bar");
+    // Forward-slash Windows paths encode the same way.
+    expect(encodeCwd("C:/Users/foo/bar", "win32")).toBe("C--Users-foo-bar");
     // POSIX must NOT touch ':' (a legal path char) — only '/' becomes '-'.
     expect(encodeCwd("/home/foo:bar/baz", "linux")).toBe("-home-foo:bar-baz");
   });

--- a/src/bus/__tests__/schema-probe.test.ts
+++ b/src/bus/__tests__/schema-probe.test.ts
@@ -29,6 +29,7 @@ import {
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
+  __captureClaudeVersionForTests,
   encodeCwd,
   predictJsonlPath,
   type ProbeRunner,
@@ -37,6 +38,8 @@ import {
   SchemaProbeFailure,
   SCHEMA_VERSION,
 } from "../schema-probe";
+import type { ChildProcess, SpawnOptions } from "node:child_process";
+import { EventEmitter } from "node:events";
 
 const IS_UNIX = process.platform !== "win32";
 
@@ -676,6 +679,54 @@ describe("SchemaProbe — homeOverride threads to default cache file", () => {
     } finally {
       h.cleanup();
     }
+  });
+});
+
+/* ───────────────────────────────────────────────────────────────────── */
+/* captureClaudeVersion — injectable platform + spawn (#157 follow-up)   */
+/* ───────────────────────────────────────────────────────────────────── */
+
+describe("captureClaudeVersion — win32 shell-true branch is platform-injectable", () => {
+  function makeFakeSpawn(): {
+    spawn: (cmd: string, args: ReadonlyArray<string>, opts: SpawnOptions) => ChildProcess;
+    calls: Array<{ cmd: string; args: ReadonlyArray<string>; opts: SpawnOptions }>;
+  } {
+    const calls: Array<{ cmd: string; args: ReadonlyArray<string>; opts: SpawnOptions }> = [];
+    const spawn = (cmd: string, args: ReadonlyArray<string>, opts: SpawnOptions): ChildProcess => {
+      calls.push({ cmd, args, opts });
+      const ee = new EventEmitter() as ChildProcess;
+      // Minimal ChildProcess shape: emit exit code 0 on next tick so the
+      // promise resolves cleanly. stdout/stderr left undefined — the
+      // capture path tolerates missing streams.
+      ee.kill = (() => true) as ChildProcess["kill"];
+      queueMicrotask(() => ee.emit("exit", 0, null));
+      return ee;
+    };
+    return { spawn, calls };
+  }
+
+  it("passes shell: true when platform === 'win32'", async () => {
+    const { spawn, calls } = makeFakeSpawn();
+    await __captureClaudeVersionForTests("/fake/claude.cmd", 1000, "win32", spawn);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.cmd).toBe("/fake/claude.cmd");
+    expect(calls[0]?.args).toEqual(["--version"]);
+    expect(calls[0]?.opts.shell).toBe(true);
+  });
+
+  it("passes shell: false on POSIX platforms (no shell injection surface)", async () => {
+    const { spawn, calls } = makeFakeSpawn();
+    await __captureClaudeVersionForTests("/usr/local/bin/claude", 1000, "linux", spawn);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.opts.shell).toBe(false);
+  });
+
+  it("defaults to process.platform when platform omitted (shell matches host)", async () => {
+    const { spawn, calls } = makeFakeSpawn();
+    // Omit platform; pass injected spawn so we can read what was sent.
+    await __captureClaudeVersionForTests("/fake/claude", 1000, undefined, spawn);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.opts.shell).toBe(process.platform === "win32");
   });
 });
 

--- a/src/bus/__tests__/schema-probe.test.ts
+++ b/src/bus/__tests__/schema-probe.test.ts
@@ -287,6 +287,13 @@ describe("encodeCwd", () => {
     // against Spike 0.5 fixture `~/.claude/projects/-private-tmp-spike-0.2/...`.
     expect(encodeCwd("/Users/a.b_c/Foo")).toBe("-Users-a.b_c-Foo");
   });
+
+  it("encodes Windows separators and the drive colon on win32", () => {
+    // Verified against claude.exe on a Win11 host: C:\Users\foo\bar -> C--Users-foo-bar.
+    expect(encodeCwd("C:\\Users\\foo\\bar", "win32")).toBe("C--Users-foo-bar");
+    // POSIX must NOT touch ':' (a legal path char) — only '/' becomes '-'.
+    expect(encodeCwd("/home/foo:bar/baz", "linux")).toBe("-home-foo:bar-baz");
+  });
 });
 
 describe("predictJsonlPath", () => {

--- a/src/bus/jsonl-line-types.ts
+++ b/src/bus/jsonl-line-types.ts
@@ -220,16 +220,24 @@ export type JsonlLine =
 
 /**
  * Encode an absolute realpath'd cwd into the directory name Claude Code
- * uses under `~/.claude/projects/`. Empirically:
- *   `/Users/foo/bar` → `-Users-foo-bar`
- * i.e. `/` → `-`. No other transformation — case is preserved.
+ * uses under `~/.claude/projects/`. Claude replaces the platform's path
+ * separators with `-`; case is preserved. Empirically:
+ *   POSIX:   `/Users/foo/bar`        → `-Users-foo-bar`   (`/` only)
+ *   Windows: `C:\Users\foo\bar`      → `C--Users-foo-bar` (`\`, `/` and the
+ *            drive `:`) — verified against claude.exe on a Win11 host.
+ * `:` must NOT be replaced on POSIX, where it is a legal path character.
+ *
+ * `platform` is injectable so both branches are testable off-Windows.
  *
  * Session Manager already calls `fs.realpathSync(cwd)` before passing
  * cwd to the Tailer (resolves macOS `/tmp` → `/private/tmp` symlink per
  * Spike 0.5). Tailer trusts that contract.
  */
-export function encodeCwdForProjectsDir(cwd: string): string {
-  return cwd.replace(/\//g, "-");
+export function encodeCwdForProjectsDir(
+  cwd: string,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  return platform === "win32" ? cwd.replace(/[/\\:]/g, "-") : cwd.replace(/\//g, "-");
 }
 
 /* ───────────────────────────────────────────────────────────────────── */

--- a/src/bus/schema-probe.ts
+++ b/src/bus/schema-probe.ts
@@ -140,7 +140,13 @@ function writeCache(path: string, entry: CacheEntry): void {
  */
 async function captureClaudeVersion(claudeBin: string, timeoutMs = 5000): Promise<string | null> {
   return new Promise((resolve) => {
-    const child = nodeSpawn(claudeBin, ["--version"], { stdio: ["ignore", "pipe", "pipe"] });
+    const child = nodeSpawn(claudeBin, ["--version"], {
+      stdio: ["ignore", "pipe", "pipe"],
+      // On Windows `claude` resolves to `claude.cmd`; since the CVE-2024-27980
+      // fix Node refuses to spawn a .cmd/.bat without a shell (EINVAL/EFTYPE),
+      // so route through the shell there. Args are static — no injection risk.
+      shell: process.platform === "win32",
+    });
     let out = "";
     let settled = false;
     const settle = (v: string | null): void => {

--- a/src/bus/schema-probe.ts
+++ b/src/bus/schema-probe.ts
@@ -144,7 +144,9 @@ async function captureClaudeVersion(claudeBin: string, timeoutMs = 5000): Promis
       stdio: ["ignore", "pipe", "pipe"],
       // On Windows `claude` resolves to `claude.cmd`; since the CVE-2024-27980
       // fix Node refuses to spawn a .cmd/.bat without a shell (EINVAL/EFTYPE),
-      // so route through the shell there. Args are static — no injection risk.
+      // so route through the shell there. Args are static and `claudeBin` is
+      // operator config (never request-derived) — no injection surface; keep
+      // it that way so this win32 shell path never becomes a sink.
       // (runner.ts resolves the underlying claude.exe instead — that's for
       // Bun.spawn + long argvs; here we're on node:child_process with `--version`.)
       shell: process.platform === "win32",

--- a/src/bus/schema-probe.ts
+++ b/src/bus/schema-probe.ts
@@ -145,6 +145,8 @@ async function captureClaudeVersion(claudeBin: string, timeoutMs = 5000): Promis
       // On Windows `claude` resolves to `claude.cmd`; since the CVE-2024-27980
       // fix Node refuses to spawn a .cmd/.bat without a shell (EINVAL/EFTYPE),
       // so route through the shell there. Args are static — no injection risk.
+      // (runner.ts resolves the underlying claude.exe instead — that's for
+      // Bun.spawn + long argvs; here we're on node:child_process with `--version`.)
       shell: process.platform === "win32",
     });
     let out = "";

--- a/src/bus/schema-probe.ts
+++ b/src/bus/schema-probe.ts
@@ -15,7 +15,13 @@
  * `jsonl-tailer.ts`); a parser bump auto-invalidates the cache and re-probes.
  */
 
-import { spawn as nodeSpawn } from "node:child_process";
+import { spawn as nodeSpawn, type SpawnOptions } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+
+// Injectable for tests so the win32 `shell: true` branch in
+// `captureClaudeVersion` is verifiable off-Windows. Defaults to the real
+// `node:child_process` `spawn`.
+type SpawnFn = (cmd: string, args: ReadonlyArray<string>, opts: SpawnOptions) => ChildProcess;
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
@@ -137,10 +143,20 @@ function writeCache(path: string, entry: CacheEntry): void {
  * Run `<claudeBin> --version` and return the trimmed first line. Returns
  * `null` on any failure (binary missing, non-zero exit) so callers can
  * decide whether that warrants a warn or a throw.
+ *
+ * `platform` is injectable so the win32 `shell: true` branch is testable
+ * off-Windows, mirroring the pattern used by `encodeCwdForProjectsDir`
+ * in `jsonl-line-types.ts`. Production callers omit it and pick up
+ * `process.platform` by default.
  */
-async function captureClaudeVersion(claudeBin: string, timeoutMs = 5000): Promise<string | null> {
+async function captureClaudeVersion(
+  claudeBin: string,
+  timeoutMs = 5000,
+  platform: NodeJS.Platform = process.platform,
+  spawn: SpawnFn = nodeSpawn,
+): Promise<string | null> {
   return new Promise((resolve) => {
-    const child = nodeSpawn(claudeBin, ["--version"], {
+    const child = spawn(claudeBin, ["--version"], {
       stdio: ["ignore", "pipe", "pipe"],
       // On Windows `claude` resolves to `claude.cmd`; since the CVE-2024-27980
       // fix Node refuses to spawn a .cmd/.bat without a shell (EINVAL/EFTYPE),
@@ -149,7 +165,7 @@ async function captureClaudeVersion(claudeBin: string, timeoutMs = 5000): Promis
       // it that way so this win32 shell path never becomes a sink.
       // (runner.ts resolves the underlying claude.exe instead — that's for
       // Bun.spawn + long argvs; here we're on node:child_process with `--version`.)
-      shell: process.platform === "win32",
+      shell: platform === "win32",
     });
     let out = "";
     let settled = false;
@@ -503,3 +519,6 @@ export { ASSERTION_DEFS, runAssertions };
 export type { AssertionResult, CollectedJsonl };
 export { defaultPtyRunnerFactory };
 export type { ProbeRunner, ProbeRunnerFactory, ProbeRunnerSpawnArgs };
+
+/** For tests only — verifies the win32 `shell: true` branch off-Windows. */
+export { captureClaudeVersion as __captureClaudeVersionForTests };


### PR DESCRIPTION
## Summary
Two **Windows runtime bugs** in the bus schema-probe / JSONL tailer, found via a real Windows 11 host validation:

1. **cwd encoding (core read path).** `encodeCwdForProjectsDir` replaced only `/`. On Windows the cwd (`C:\Users\...`) was left intact, so `predictJsonlPath` produced a malformed path that never matched the directory claude.exe actually writes (`C--Users-...`) — the tailer could not locate the session on Windows. Now replaces `\`, `/` and the drive `:` on win32 (verified claude.exe maps `C:\Users\foo\bar` -> `C--Users-foo-bar`); POSIX still keeps `:` (a legal path char). `platform` is injectable so both branches are covered on Linux CI.

2. **claude spawn.** `captureClaudeVersion` spawned `claude` directly; on Windows that's `claude.cmd`, and Node refuses to spawn a `.cmd` without a shell since CVE-2024-27980 (EFTYPE) — crashing the probe at startup. Routed through the shell on win32 only (static `--version` args, no injection).

Also makes the `predictJsonlPath` test OS-aware (it hardcoded a POSIX separator).

## Validation
- **Linux** (ARM64 proot + x86_64 Ubuntu): probe + tailer suites **40 pass / 0 fail**.
- **Windows 11** (build 26200, claude 2.1.150): reproduced both failures; after the fixes the probe resolves and reads the session JSONL (the cwd-encoding ENOENT crash is gone) and `captureClaudeVersion` succeeds.

## Known follow-up (out of scope)
Full green of the `SchemaProbe.run()` *unit* suite on Windows needs test-harness portability (the `.sh` claude stub + the non-zero-exit test's bad-bin stub aren't runnable on Windows). Test-only — CI (Linux) is green.

## Test plan
- [ ] CI green (biome / build / plugin + marketplace version-guards)
- [ ] Reviewer sanity-check the two `win32` branches