### PR TITLE
fix(telegram): client-side timeout on getUpdates — recover from hung long-poll (bot goes silently deaf)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.92",
+      "version": "2.2.93",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.92",
+  "version": "2.2.93",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/telegram/__tests__/api.test.ts
+++ b/src/adapters/telegram/__tests__/api.test.ts
@@ -102,3 +102,67 @@ describe("createTelegramApi — per-chat send serialization (#154)", () => {
     expect(tracker.maxConcurrent).toBe(2);
   });
 });
+
+/**
+ * Hung long-poll recovery. A half-open connection (gateway 502/504 / network
+ * blip) leaves `fetch` neither resolving nor rejecting; without a client-side
+ * deadline `getUpdates` hangs forever and the poll loop freezes silently — the
+ * bot goes deaf with no error logged. `getUpdates` layers a client hard-timeout
+ * (`timeoutSeconds + buffer`) so a stuck request aborts and surfaces as a
+ * retryable error the loop can recover from.
+ */
+describe("createTelegramApi — getUpdates client timeout", () => {
+  /** Fetch that honors the abort signal like the real one but never resolves on its own. */
+  function stubHangingFetch(): { calls: number } {
+    const state = { calls: 0 };
+    globalThis.fetch = ((_url: string, init?: { signal?: AbortSignal }) => {
+      state.calls += 1;
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) return; // mimic a request that never settles
+        if (signal.aborted) {
+          reject(signal.reason);
+          return;
+        }
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+      });
+    }) as typeof fetch;
+    return state;
+  }
+
+  it("aborts a hung getUpdates within the client timeout instead of hanging forever", async () => {
+    const tracker = stubHangingFetch();
+    // timeoutSeconds=0 → client deadline is just the 80ms buffer.
+    const api = createTelegramApi("test-token", { getUpdatesTimeoutBufferMs: 80 });
+    const neverAbort = new AbortController();
+
+    const start = Date.now();
+    let caught: unknown;
+    await api.getUpdates(0, 0, neverAbort.signal).catch((e) => {
+      caught = e;
+    });
+    const elapsed = Date.now() - start;
+
+    expect(tracker.calls).toBe(1);
+    // The call rejected (did not hang) well inside a generous bound.
+    expect(elapsed).toBeLessThan(2000);
+    // A timeout abort surfaces as TimeoutError — distinct from stop()'s
+    // AbortError, so the poll loop logs + retries rather than treating it as
+    // a clean stop.
+    expect((caught as { name?: string })?.name).toBe("TimeoutError");
+  });
+
+  it("propagates the caller's stop() abort as AbortError (clean-stop path preserved)", async () => {
+    const tracker = stubHangingFetch();
+    // Large buffer so the timeout never fires first — the caller's abort wins.
+    const api = createTelegramApi("test-token", { getUpdatesTimeoutBufferMs: 60_000 });
+    const stop = new AbortController();
+
+    const p = api.getUpdates(0, 30, stop.signal).catch((e) => e);
+    stop.abort(); // mimic adapter stop()
+    const err = (await p) as { name?: string };
+
+    expect(tracker.calls).toBe(1);
+    expect(err?.name).toBe("AbortError");
+  });
+});

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -914,3 +914,66 @@ describe("TelegramAdapter — stop()", () => {
     expect(elapsed).toBeLessThan(500);
   });
 });
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* poll loop recovery from a hung / timed-out getUpdates                    */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe("TelegramAdapter — poll loop recovers from a timed-out getUpdates", () => {
+  it("logs the failure and keeps polling after a non-abort rejection", async () => {
+    // A getUpdates that rejects its FIRST call with a TimeoutError — exactly
+    // what the client-side hard-timeout throws when a long-poll hangs half-open
+    // — then delegates to the normal fake. A TimeoutError is NOT an AbortError,
+    // so the loop's catch must log + sleep + retry (self-heal) rather than
+    // break (which is reserved for stop()). Before the api.ts fix, the await
+    // simply never settled and the loop froze silently.
+    const inner = new FakeTelegramApi();
+    let calls = 0;
+    const flaky: TelegramApi = {
+      getUpdates: (offset, timeoutSeconds, signal) => {
+        calls += 1;
+        if (calls === 1) {
+          const err = new Error("The operation timed out.");
+          (err as Error & { name: string }).name = "TimeoutError";
+          return Promise.reject(err);
+        }
+        return inner.getUpdates(offset, timeoutSeconds, signal);
+      },
+      sendMessage: (p) => inner.sendMessage(p),
+      editMessageText: (p) => inner.editMessageText(p),
+      setMessageReaction: (p) => inner.setMessageReaction(p),
+      answerCallbackQuery: (p) => inner.answerCallbackQuery(p),
+    };
+
+    const errors: unknown[][] = [];
+    const logger = {
+      warn: () => {},
+      info: () => {},
+      error: (...a: unknown[]) => {
+        errors.push(a);
+      },
+    };
+
+    adapter = await startAdapter({ api: flaky, logger, pollIntervalMs: 5 });
+
+    // Loop must get past the first (rejected) call — proof it didn't freeze.
+    await waitFor(() => calls >= 2);
+
+    // And it dispatches a normal inbound update after recovering.
+    inner.enqueueUpdates([
+      {
+        message: {
+          message_id: 1,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          text: "after recovery",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length > 0);
+
+    expect(bus.prompts[0]?.text).toBe("after recovery");
+    // The timeout surfaced in the logs (observability), it wasn't swallowed.
+    expect(errors.some((a) => String(a[0]).includes("getUpdates failed"))).toBe(true);
+  });
+});

--- a/src/adapters/telegram/api.ts
+++ b/src/adapters/telegram/api.ts
@@ -16,6 +16,29 @@ import type { TelegramApi } from "./types";
 const API_BASE = "https://api.telegram.org/bot";
 
 /**
+ * Client-side hard-timeout buffer (ms) added on top of the `getUpdates`
+ * server-side long-poll window. The long-poll itself can legitimately hold
+ * the connection open for `timeoutSeconds`; we only want to abort a request
+ * that is genuinely stuck (half-open socket after a gateway 502/504 or a
+ * network blip), so the client timeout is `timeoutSeconds*1000 + BUFFER`.
+ * Without this, a stuck `await getUpdates(...)` never resolves and never
+ * rejects, freezing the poll loop silently — the bot goes deaf with no error
+ * logged until a manual restart. See `index.ts` `pollLoop`: a TimeoutError
+ * (distinct from stop()'s AbortError) falls through to the catch → sleep →
+ * retry, so the loop self-heals.
+ */
+export const GETUPDATES_TIMEOUT_BUFFER_MS = 5_000;
+
+/** Options for {@link createTelegramApi}. */
+export interface TelegramApiOptions {
+  /**
+   * Override the {@link GETUPDATES_TIMEOUT_BUFFER_MS} buffer. Primarily for
+   * tests that need a short client timeout; production uses the default.
+   */
+  getUpdatesTimeoutBufferMs?: number;
+}
+
+/**
  * Build a `TelegramApi` instance bound to a particular bot token.
  *
  * `allowed_updates` differences vs `src/commands/telegram.ts:2177`:
@@ -34,7 +57,8 @@ const API_BASE = "https://api.telegram.org/bot";
  *   - Errors throw with `${method}: ${status} ${statusText}` so the
  *     adapter's `safe*` wrappers can log a useful one-liner.
  */
-export function createTelegramApi(token: string): TelegramApi {
+export function createTelegramApi(token: string, options: TelegramApiOptions = {}): TelegramApi {
+  const getUpdatesBufferMs = options.getUpdatesTimeoutBufferMs ?? GETUPDATES_TIMEOUT_BUFFER_MS;
   // Per-chat flood cooldown. Telegram answers a flooded chat with HTTP 429 and
   // a `parameters.retry_after` (seconds). Until that window passes, every
   // further send to that chat is rejected too — and each rejected attempt can
@@ -123,6 +147,16 @@ export function createTelegramApi(token: string): TelegramApi {
 
   return {
     async getUpdates(offset, timeoutSeconds, signal) {
+      // `timeout` is the SERVER-side long-poll window; on its own there is no
+      // client-side deadline, so a half-open connection makes this await hang
+      // forever and freezes the poll loop. Layer a client hard-timeout that
+      // fires `timeoutSeconds + buffer` later. `AbortSignal.timeout` aborts
+      // with a TimeoutError (NOT the AbortError that stop()'s manual abort
+      // produces), and `AbortSignal.any` forwards whichever source fires
+      // first — so the loop's catch keeps treating stop() as a clean exit
+      // while a genuine hang surfaces as a retryable error.
+      const deadline = AbortSignal.timeout(timeoutSeconds * 1000 + getUpdatesBufferMs);
+      const combined = signal ? AbortSignal.any([signal, deadline]) : deadline;
       return call(
         "getUpdates",
         {
@@ -130,7 +164,7 @@ export function createTelegramApi(token: string): TelegramApi {
           timeout: timeoutSeconds,
           allowed_updates: ["message", "edited_message", "callback_query"],
         },
-        signal,
+        combined,
       );
     },
     async sendMessage(params) {


### PR DESCRIPTION
## Problem

`getUpdates(offset, timeoutSeconds, signal)` in `src/adapters/telegram/api.ts` passed only the Telegram **server-side** long-poll `timeout` param plus the `stop()` abort signal. There was **no client-side request deadline**.

When a long-poll connection goes half-open — gateway 502/504 flakiness or a network blip — the underlying `fetch` neither resolves nor rejects. `await getUpdates(...)` then hangs forever, and the poll loop in `index.ts` (`pollLoop`, the `while (running && generation === gen)` / `await this.api.getUpdates(...)`) **freezes silently on that await**:

- no error thrown (a hang doesn't throw), so the loop's `catch` never runs;
- no `"getUpdates failed"` / `"poll loop crashed"` log line;
- process otherwise healthy — web dashboard and cron keep running.

The bot just **stops receiving messages until a manual restart**. This bit us in production (Telegram adapter went deaf with zero log signal).

## Fix

Layer a **client-side hard timeout** onto the getUpdates request:

```ts
const deadline = AbortSignal.timeout(timeoutSeconds * 1000 + GETUPDATES_TIMEOUT_BUFFER_MS);
const combined = signal ? AbortSignal.any([signal, deadline]) : deadline;
```

- **Buffer (5000ms over the long-poll window)** keeps normal ~30s long-polls untouched — only a genuinely stuck request aborts.
- **`AbortSignal.timeout` rejects with a `TimeoutError`**, which is *distinct* from the `AbortError` that `stop()`'s manual abort produces. `AbortSignal.any` forwards whichever source fires first, so the distinction is preserved end-to-end.
- The poll loop's **existing** catch already does the right thing with each case:
  - `stop()` → `AbortError` → loop breaks (clean exit, unchanged);
  - hung request → `TimeoutError` → falls through to `logger.error("getUpdates failed", err)` → sleep → retry (**self-heals**).

Scoped to `getUpdates` (the only call with a long timeout). Other methods are unchanged.

## Tests

`src/adapters/telegram/__tests__/api.test.ts`
- a getUpdates whose `fetch` never settles **aborts within the client timeout** (rejects with `TimeoutError`) instead of hanging forever;
- `stop()`'s abort still propagates as `AbortError` (clean-stop path preserved).

`src/adapters/telegram/__tests__/telegram.test.ts`
- the poll loop **logs the failure and keeps polling** after a `TimeoutError` rejection, then dispatches the next inbound update (proves self-heal — before the fix the loop simply froze).

Telegram adapter suite green (34/34). Full-suite delta: **+3 passing tests, no new failures** (the pre-existing failures on `main` are environmental — mcp-multiplexer/escalation/session-persistence — and unrelated to this change).

## Versioning

`bump:plugin-version` + `bump:marketplace-version` run → `2.2.93` (`plugin-version-guard` / `marketplace-version-guard` satisfied). Rebased on top of current `main`.

## Why now — the Bus cutover (#159) just landed

#159 flipped the default runtime to the Bus, so the Telegram adapter is now on the **default** path for most installs. That makes this fix more urgent, not less: a poll loop that can freeze silently with zero log signal is exactly the failure mode you don't want load-bearing right after the cutover. Small, self-contained, rebased on top of #159.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
