### PR TITLE
docs: reframe runtime: "pty" as permanent first-class option

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.92",
+      "version": "2.2.93",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.92",
+  "version": "2.2.93",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ If you see a PR titled **"chore: sync upstream"** — that's the robot doing its
 
 ## What's new in v2.0 — Bus runtime is the default
 
-As of v2.0 (May 2026), ClaudeClaw+ runs on a new **event-bus architecture**. The legacy `claude -p` subprocess path (`runtime: "pty"`) still exists as a one-release-cycle opt-out, but every new install defaults to `runtime: "bus"`.
+As of v2.0 (May 2026), ClaudeClaw+ runs on a new **event-bus architecture** by default. The `claude -p` subprocess path (`runtime: "pty"`) remains a **permanent first-class option** — especially for enterprise deployments where API billing is the safer or only viable route (audit trails, cost ceilings, regulatory constraints). Operators pick per deployment: bus for subscription-billed interactive work, `claude -p` for API-billed programmatic work. Both are fully supported, side by side.
 
-Here's what changes:
+Here's what changes when you pick the bus runtime:
 
 - **One long-lived `claude` process per declared agent**, not a fresh subprocess per event. Subscription billing covers daemon work; the Agent SDK credit pool stays untouched.
 - **Typed event bus (`BusCore`)** sits between adapters (Discord, Telegram, Slack, web UI, cron, REST, CLI) and agents. Inbound events publish to topics; agents subscribe; replies flow back as `response.text`, `channel.permission_request`, or `system.request_human`.
@@ -217,19 +217,31 @@ Adapter coverage as of v2.0:
 
 These features originated as PRs to `moazbuilds/claudeclaw` and have been closed upstream — they're out of scope for the lightweight core and live here permanently. Links below point to the originating PRs so you can read the full rationale.
 
-### PTY runtime — legacy fallback (was the v1 path; bus is now default)
+### `claude -p` runtime — permanent first-class option for API-billed deployments
 
 **Tracking issue: [#61](https://github.com/TerrysPOV/ClaudeClaw-Plus/issues/61) · Merged PR: [#62](https://github.com/TerrysPOV/ClaudeClaw-Plus/pull/62)**
 
-The PTY runtime kicked off the work to escape `claude -p` billing (Anthropic's 2026-06-15 split routes non-interactive calls to a separate Agent SDK credit pool). It graduated into the bus runtime — the bus uses the same PTY supervision internally but adds the typed event bus, multi-channel routing, per-agent isolation, and the MCP multiplexer on top.
+`runtime: "pty"` selects the `claude -p` subprocess path — one `claude -p` invocation per event. From 2026-06-15 onwards this routes through Anthropic's Agent SDK credit pool (API billing), separate from the Pro/Max subscription pool used by interactive sessions.
 
-If you're on a v1 deployment and not yet ready to migrate, you can opt back for one release cycle:
+This path is **not** going away. For many production deployments — particularly enterprise installs with audit, cost-ceiling, or regulatory constraints — API billing is the safer or only viable route. We keep `claude -p` as a permanent, fully supported first-class option:
 
 ```json
 "runtime": "pty"
 ```
 
-The PTY-only path keeps the v1 behaviour byte-identical (`claude -p` subprocesses for every event). No bus, no multi-channel routing, no per-agent isolation. New deployments should not pick this — use `runtime: "bus"` (the default).
+**When to pick `claude -p` over bus:**
+
+- **Audit / compliance**: every invocation is its own subprocess with a clean stdin/stdout boundary — easier to log, intercept, and reason about than a long-lived interactive session.
+- **Predictable cost ceilings**: API billing is metered per-token; subscription billing is harder to attribute per-request.
+- **Regulatory / data-residency**: some setups require the API path specifically because of vendor contract scope.
+- **No long-lived processes**: each event is a clean subprocess; no per-agent state to manage, no PTY supervision, no MCP multiplexer.
+
+**When to pick bus over `claude -p`:**
+
+- **Subscription billing**: daemon work bills against your existing Pro/Max subscription, not the Agent SDK pool.
+- **Lower latency**: long-lived `claude` sessions skip the per-event cold start.
+- **Multi-channel routing**: same agent reachable from Discord/Telegram/Slack/web UI with origin-aware replies.
+- **Permission gate inline**: tool calls prompt for approval in whichever channel you're on.
 
 #### Settings block (defaults shown)
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Here's what changes when you pick the bus runtime:
 
 Architecture spec: [`docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md`](docs/ClaudeClaw_Plus_Bus_Architecture_Spec.md).
 
+Huge thanks to [@Nibbler1250](https://github.com/Nibbler1250) for landing many of the heavy adapter pieces that made the bus runtime production-ready — composite-keyed routing, inline progress UX, the per-chat flood protection, the Windows host validation, and the getUpdates timeout recovery. The bus is shipping today because of that work.
+
 ---
 
 ## Getting Started in 5 Minutes

--- a/src/config.ts
+++ b/src/config.ts
@@ -200,8 +200,10 @@ const DEFAULT_SETTINGS: Settings = {
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
   session: { autoRotate: false, maxMessages: 50, maxAgeHours: 24, summaryPath: "" },
   // Default runtime: `bus` (Sprint 5.4 flip after Hetzner staging soak ended
-  // 2026-05-25). Operators on existing v1 deployments who haven't migrated
-  // can opt back to `runtime: "pty"` in settings.json for one release cycle.
+  // 2026-05-25). `runtime: "pty"` remains as a permanent first-class option
+  // for operators who need the `claude -p` / API-billed path — particularly
+  // enterprise deployments where audit, cost-ceiling, or regulatory
+  // constraints make API billing the safer or only viable route.
   runtime: "bus",
   // Default no agents. Operators who opt in to `runtime: "bus"` declare
   // agents explicitly. Spec §5.3 / §10 Sprint 5.2.
@@ -604,10 +606,12 @@ export interface Settings {
   timeouts: TimeoutsConfig;
   /**
    * Daemon runtime selector. Defaults to `"bus"` (event-bus + per-agent
-   * processes, multi-channel routing, MCP multiplexer). Operators on
-   * pre-v2 deployments can opt back to `"pty"` in `settings.json` for the
-   * legacy `claude -p` subprocess path — the migration window stays open
-   * for one release cycle.
+   * processes, multi-channel routing, MCP multiplexer) — subscription-billed
+   * interactive mode. `"pty"` selects the `claude -p` subprocess path —
+   * API-billed (Agent SDK pool post-2026-06-15), kept as a permanent
+   * first-class option for enterprise deployments where API billing is the
+   * safer or only viable route (audit trails, predictable cost ceilings,
+   * regulatory constraints).
    */
   runtime: RuntimeMode;
   /**


### PR DESCRIPTION
Follow-up to #159. The previous PR framed `runtime: "pty"` (the `claude -p` subprocess path) as a one-release-cycle legacy fallback. That framing was wrong.

`claude -p` is a permanent first-class option, not a deprecation candidate. Enterprise deployments where API billing is the safer or only viable route — audit trails, predictable cost ceilings, regulatory or data-residency constraints — rely on it. We keep it as a fully supported runtime, indefinitely.

## Changes

- `src/config.ts` DEFAULT_SETTINGS comment: drop "one release cycle" language, document the audit/compliance/regulatory rationale.
- `src/config.ts` RuntimeMode interface JSDoc: same reframing.
- README "What's new in v2.0": reframes both runtimes as first-class with "operators pick per deployment" language.
- README PTY-runtime section: retitled "permanent first-class option for API-billed deployments". Adds explicit "when to pick `claude -p` vs bus" decision criteria.

## Non-changes

- No code paths touched.
- No tests touched (runtime-config.test.ts still passes 23/23).
- Default remains `runtime: "bus"`.
- `claude -p` mode remains operator-selectable via `"runtime": "pty"`.

## Why now

Surfaced after the upstream comment on moazbuilds/claudeclaw#216 — the framing matters for the enterprise-install audience reading both repos.