### PR TITLE
fix(bus): warn at startup on orphan agents/<name>/jobs/ dirs not in settings.agents

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.96",
+      "version": "2.2.97",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.95",
+      "version": "2.2.96",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.96",
+  "version": "2.2.97",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.95",
+  "version": "2.2.96",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ At least one agent is **required** under bus runtime — without it the daemon m
 
 Each agent has its own working directory, system prompt file, and memory file. See `BusAgentSettings` in [`src/config.ts`](src/config.ts) for the full per-agent shape.
 
+> ⚠ **Important if you have an `agents/` directory on disk.** Every directory under `agents/<name>/` with jobs in it MUST have a matching entry in `settings.agents[]`. If not, the bus runtime publishes prompts targeting `agent_id: <name>` but no process is subscribed, and your jobs silently fail. The daemon now logs `[bus-runtime] WARN: agent dir "<name>" has N scheduled job(s) ... but is not declared in settings.agents` at startup when a mismatch is detected — fix the warning either by adding `{ "id": "<name>" }` to `settings.agents` or by removing the orphan `agents/<name>/jobs/` directory.
+
 ### 5. Primary channel per agent (Discord + Slack)
 
 Without this, cron/heartbeat replies fan out to **every** channel routed to the agent. With it, those non-channel-driven events go to one designated channel only. Highly recommended on Discord/Slack with multi-channel setups:

--- a/src/bus/__tests__/orphan-agent-detect.test.ts
+++ b/src/bus/__tests__/orphan-agent-detect.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "bun:test";
+import { afterAll, describe, expect, it } from "bun:test";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { detectOrphanAgents, formatOrphanWarnings } from "../orphan-agent-detect";
 
 const IO = (dirs: Record<string, string[]>) => ({
@@ -62,6 +65,42 @@ describe("detectOrphanAgents", () => {
     });
     expect(r.orphanedDirs).toEqual([]);
     expect(r.orphanedDecls).toEqual([]);
+  });
+});
+
+describe("detectOrphanAgents — real FS (default I/O honours *.md filter, Codex P2 on #168)", () => {
+  const root = join(
+    tmpdir(),
+    `orphan-detect-fs-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  );
+
+  afterAll(() => {
+    try {
+      rmSync(root, { recursive: true, force: true });
+    } catch {
+      /* best-effort */
+    }
+  });
+
+  it("ignores non-.md files in agents/<name>/jobs/ when counting", () => {
+    // Layout:
+    //   agents/reg/jobs/daily.md        ← counts
+    //   agents/reg/jobs/README          ← should NOT count
+    //   agents/reg/jobs/.gitkeep        ← should NOT count
+    //   agents/quiet/jobs/README        ← only non-.md → not orphaned
+    mkdirSync(join(root, "agents", "reg", "jobs"), { recursive: true });
+    writeFileSync(join(root, "agents", "reg", "jobs", "daily.md"), "# job");
+    writeFileSync(join(root, "agents", "reg", "jobs", "README"), "ignore me");
+    writeFileSync(join(root, "agents", "reg", "jobs", ".gitkeep"), "");
+    mkdirSync(join(root, "agents", "quiet", "jobs"), { recursive: true });
+    writeFileSync(join(root, "agents", "quiet", "jobs", "README"), "no schedulable jobs here");
+
+    const r = detectOrphanAgents([{ id: "default" }], root);
+    // reg is orphaned with EXACTLY 1 schedulable job (the .md), not 3 raw files.
+    expect(r.orphanedDirs).toEqual([{ name: "reg", jobCount: 1 }]);
+    // quiet has only README — it's NOT flagged as orphaned because it has
+    // no schedulable jobs (matches what the actual scheduler would load).
+    expect(r.orphanedDirs.find((o) => o.name === "quiet")).toBeUndefined();
   });
 });
 

--- a/src/bus/__tests__/orphan-agent-detect.test.ts
+++ b/src/bus/__tests__/orphan-agent-detect.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "bun:test";
+import { detectOrphanAgents, formatOrphanWarnings } from "../orphan-agent-detect";
+
+const IO = (dirs: Record<string, string[]>) => ({
+  listDir: (path: string) => {
+    // The detector calls listDir on `<projectRoot>/agents` only.
+    const trimmed = path.endsWith("/agents") ? path.slice(0, -"/agents".length) : path;
+    return dirs[`${trimmed}/agents`] ?? [];
+  },
+  countJobs: (path: string) => {
+    return dirs[path]?.length ?? 0;
+  },
+});
+
+describe("detectOrphanAgents", () => {
+  it("returns empty report when agents/ directory doesn't exist", () => {
+    const r = detectOrphanAgents([{ id: "default" }], "/proj", IO({}));
+    expect(r.orphanedDirs).toEqual([]);
+    expect(r.orphanedDecls).toEqual([]);
+  });
+
+  it("flags on-disk agent with jobs but no declaration", () => {
+    const r = detectOrphanAgents([{ id: "default" }], "/proj", {
+      listDir: () => ["default", "reg"],
+      countJobs: (path) => (path === "/proj/agents/reg/jobs" ? 3 : 0),
+    });
+    expect(r.orphanedDirs).toEqual([{ name: "reg", jobCount: 3 }]);
+    expect(r.orphanedDecls).toEqual([]);
+  });
+
+  it("ignores on-disk agent dir with NO jobs (operator may use it as workspace)", () => {
+    const r = detectOrphanAgents([{ id: "default" }], "/proj", {
+      listDir: () => ["default", "alice"],
+      countJobs: () => 0,
+    });
+    expect(r.orphanedDirs).toEqual([]);
+    expect(r.orphanedDecls).toEqual([]);
+  });
+
+  it("flags declared agent missing its on-disk dir", () => {
+    const r = detectOrphanAgents([{ id: "default" }, { id: "ghost" }], "/proj", {
+      listDir: () => ["default"],
+      countJobs: () => 0,
+    });
+    expect(r.orphanedDirs).toEqual([]);
+    expect(r.orphanedDecls).toEqual([{ id: "ghost" }]);
+  });
+
+  it("reports both directions when they coexist", () => {
+    const r = detectOrphanAgents([{ id: "default" }, { id: "ghost" }], "/proj", {
+      listDir: () => ["default", "reg"],
+      countJobs: (path) => (path === "/proj/agents/reg/jobs" ? 7 : 0),
+    });
+    expect(r.orphanedDirs).toEqual([{ name: "reg", jobCount: 7 }]);
+    expect(r.orphanedDecls).toEqual([{ id: "ghost" }]);
+  });
+
+  it("clean state (declarations match on-disk exactly) returns empty report", () => {
+    const r = detectOrphanAgents([{ id: "default" }, { id: "suzy" }, { id: "reg" }], "/proj", {
+      listDir: () => ["default", "suzy", "reg"],
+      countJobs: (path) => (path === "/proj/agents/reg/jobs" ? 3 : 0),
+    });
+    expect(r.orphanedDirs).toEqual([]);
+    expect(r.orphanedDecls).toEqual([]);
+  });
+});
+
+describe("formatOrphanWarnings", () => {
+  it("emits a directive line per orphan dir", () => {
+    const lines = formatOrphanWarnings({
+      orphanedDirs: [{ name: "reg", jobCount: 7 }],
+      orphanedDecls: [],
+    });
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('agent dir "reg"');
+    expect(lines[0]).toContain("7 scheduled job(s)");
+    expect(lines[0]).toContain('"id": "reg"');
+  });
+
+  it("emits a directive line per orphan declaration", () => {
+    const lines = formatOrphanWarnings({
+      orphanedDirs: [],
+      orphanedDecls: [{ id: "ghost" }],
+    });
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('agent "ghost"');
+    expect(lines[0]).toContain("no matching agents/ghost/ directory");
+  });
+
+  it("empty report → no lines", () => {
+    expect(formatOrphanWarnings({ orphanedDirs: [], orphanedDecls: [] })).toEqual([]);
+  });
+
+  it("reports both kinds in one pass with stable ordering (dirs then decls)", () => {
+    const lines = formatOrphanWarnings({
+      orphanedDirs: [{ name: "reg", jobCount: 7 }],
+      orphanedDecls: [{ id: "ghost" }],
+    });
+    expect(lines).toHaveLength(2);
+    expect(lines[0]).toContain('agent dir "reg"');
+    expect(lines[1]).toContain('agent "ghost"');
+  });
+});

--- a/src/bus/orphan-agent-detect.ts
+++ b/src/bus/orphan-agent-detect.ts
@@ -133,8 +133,13 @@ function defaultListDir(path: string): string[] {
 }
 
 function defaultCountJobs(jobsPath: string): number {
+  // Only count `*.md` files — that matches the filter the scheduler itself
+  // applies in `src/jobs.ts:loadJobs` (line 183), so the warning count is
+  // accurate. README, .gitkeep, editor backups etc. would otherwise inflate
+  // the count and trip the warning for dirs that have no schedulable jobs.
   try {
     return readdirSync(jobsPath).filter((name) => {
+      if (!name.endsWith(".md")) return false;
       try {
         return statSync(join(jobsPath, name)).isFile();
       } catch {

--- a/src/bus/orphan-agent-detect.ts
+++ b/src/bus/orphan-agent-detect.ts
@@ -1,0 +1,147 @@
+/**
+ * Detect mismatches between declared bus agents (`settings.agents[]`) and
+ * on-disk agent directories (`agents/<name>/jobs/*.md`).
+ *
+ * Bus runtime only spawns processes for agents in `settings.agents[]`. If an
+ * `agents/<name>/` directory has scheduled jobs but `<name>` is not declared,
+ * the scheduler fires prompts to the bus with `agent_id: <name>` and they sit
+ * `status: "pending"` forever — silent job death. This module surfaces the
+ * mismatch at daemon startup so the operator gets a loud warning instead of
+ * jobs that disappear without a trace.
+ *
+ * Production incident 2026-05-26: three agents (`suzy`, `reg`, `publisher`)
+ * had jobs on disk but were not declared. Prompts published, nothing
+ * consumed, days of "daily" jobs silently missed. This check would have
+ * caught it the first time the daemon restarted after the disk state went
+ * out of sync. See issue #167.
+ */
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+import type { BusAgentSettings } from "../config";
+
+export interface OrphanAgentDir {
+  /** Directory name under `agents/`, e.g. `"reg"`. */
+  name: string;
+  /** Count of files under `agents/<name>/jobs/` (any extension). */
+  jobCount: number;
+}
+
+export interface OrphanAgentDecl {
+  /** Agent id from `settings.agents[].id`. */
+  id: string;
+}
+
+export interface OrphanAgentReport {
+  /** On-disk dirs with at least one job file but no matching declaration. */
+  orphanedDirs: OrphanAgentDir[];
+  /** Declared agents with no matching on-disk directory. */
+  orphanedDecls: OrphanAgentDecl[];
+}
+
+/**
+ * Pure function — no I/O when given an injected directory listing. The
+ * default `listDir`/`countJobs` read the filesystem; tests pass fakes.
+ *
+ * Behaviour:
+ *   - If `agents/` doesn't exist or isn't a directory → return empty
+ *     report (greenfield deployments aren't a mismatch).
+ *   - Only directories with at least one file under `agents/<name>/jobs/`
+ *     count as orphan dirs. Empty `agents/<name>/` (no jobs subdir, or
+ *     jobs dir empty) doesn't trip the warning — operator might just have
+ *     a workspace dir for that agent without scheduled work.
+ *   - Declared agents missing their on-disk dir are reported separately;
+ *     these are softer (a declared agent with no jobs is fine if the
+ *     operator just hasn't written any yet) but still surfaced so the
+ *     operator can spot stale declarations.
+ */
+export function detectOrphanAgents(
+  declared: readonly BusAgentSettings[],
+  projectRoot: string,
+  io: { listDir?: (path: string) => string[]; countJobs?: (path: string) => number } = {},
+): OrphanAgentReport {
+  const listDir = io.listDir ?? defaultListDir;
+  const countJobs = io.countJobs ?? defaultCountJobs;
+
+  const agentsRoot = join(projectRoot, "agents");
+  const onDisk = listDir(agentsRoot);
+
+  if (onDisk.length === 0) {
+    return { orphanedDirs: [], orphanedDecls: [] };
+  }
+
+  const declaredIds = new Set(declared.map((a) => a.id));
+  const onDiskNames = new Set(onDisk);
+
+  const orphanedDirs: OrphanAgentDir[] = [];
+  for (const name of onDisk) {
+    if (declaredIds.has(name)) continue;
+    const jobCount = countJobs(join(agentsRoot, name, "jobs"));
+    if (jobCount > 0) {
+      orphanedDirs.push({ name, jobCount });
+    }
+  }
+
+  const orphanedDecls: OrphanAgentDecl[] = [];
+  for (const decl of declared) {
+    if (!onDiskNames.has(decl.id)) {
+      orphanedDecls.push({ id: decl.id });
+    }
+  }
+
+  return { orphanedDirs, orphanedDecls };
+}
+
+/**
+ * Format the report as one or more `[bus-runtime] WARN: ...` lines, one
+ * per orphan, ready to feed to a logger. Empty report → empty array.
+ */
+export function formatOrphanWarnings(report: OrphanAgentReport): string[] {
+  const lines: string[] = [];
+  for (const o of report.orphanedDirs) {
+    lines.push(
+      `[bus-runtime] WARN: agent dir "${o.name}" has ${o.jobCount} scheduled job(s) in ` +
+        `agents/${o.name}/jobs/ but is not declared in settings.agents. ` +
+        `Prompts for this agent will publish to the bus with no consumer. ` +
+        `Add { "id": "${o.name}" } to settings.agents or remove agents/${o.name}/jobs/.`,
+    );
+  }
+  for (const o of report.orphanedDecls) {
+    lines.push(
+      `[bus-runtime] WARN: agent "${o.id}" is declared in settings.agents but has no ` +
+        `matching agents/${o.id}/ directory. A claude process is spawned but no jobs are ` +
+        `configured for it. Either add agents/${o.id}/jobs/ or remove the declaration.`,
+    );
+  }
+  return lines;
+}
+
+/* ───────────────────────────────── I/O defaults ───────────────────────────── */
+
+function defaultListDir(path: string): string[] {
+  try {
+    return readdirSync(path).filter((name) => {
+      try {
+        return statSync(join(path, name)).isDirectory();
+      } catch {
+        return false;
+      }
+    });
+  } catch {
+    return [];
+  }
+}
+
+function defaultCountJobs(jobsPath: string): number {
+  try {
+    return readdirSync(jobsPath).filter((name) => {
+      try {
+        return statSync(join(jobsPath, name)).isFile();
+      } catch {
+        return false;
+      }
+    }).length;
+  } catch {
+    return 0;
+  }
+}

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -33,6 +33,7 @@ import { SessionManager } from "./session-manager";
 import { wireSlashCommands } from "./wiring";
 import type { MountedAdapter } from "./adapter-wiring";
 import { stopBusAdapters } from "./adapter-wiring";
+import { detectOrphanAgents, formatOrphanWarnings } from "./orphan-agent-detect";
 
 export interface BusRuntimeHandle {
   /** The mounted BusCore. Adapters / tests subscribe via this. */
@@ -126,6 +127,13 @@ export interface MountBusRuntimeOptions {
    * stays predictable for agents that DO leave supervision unset.
    */
   spawnOrigin?: BusOrigin;
+  /**
+   * Project root used by the orphan-agent detector (issue #167) to scan
+   * `agents/<name>/jobs/` for directories the operator has populated but
+   * not declared in `settings.agents[]`. Defaults to `process.cwd()`.
+   * Tests inject a fixture root.
+   */
+  projectRoot?: string;
   /**
    * Adapters already mounted by the daemon (Sprint 5.2b). The mount
    * function does not construct adapters itself — the daemon wires
@@ -245,6 +253,15 @@ export async function mountBusRuntime(
     // fold-in lets the caller register adapters AFTER mount returns via
     // `attachAdapters`. Backwards-compatible: `opts.adapters` still
     // accepted for callers that wired before mount.
+    // Issue #167: catch the silent-job-death class (operator has
+    // agents/<name>/jobs/* on disk but didn't declare <name> in
+    // settings.agents[], so prompts publish with no consumer). Pure scan,
+    // fires once at startup.
+    const orphanReport = detectOrphanAgents(opts.agents ?? [], opts.projectRoot ?? process.cwd());
+    for (const line of formatOrphanWarnings(orphanReport)) {
+      logger.warn(line);
+    }
+
     const adapters: MountedAdapter[] = opts.adapters ? [...opts.adapters] : [];
     // Sprint 5.2c (PR #125): the daemon attaches a `BusScheduler`
     // handle after mount so heartbeat + cron triggers are torn down

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -507,6 +507,7 @@ export async function start(args: string[] = []) {
         bus,
         sessionManager,
         agents: agentConfigs,
+        projectRoot: process.cwd(),
       });
       // The mount succeeded — from here on, ANY error must call
       // handle.stop() before falling through to legacy, otherwise the


### PR DESCRIPTION
Closes part of #167. Production incident 2026-05-26: three agents (`suzy`, `reg`, `publisher`) had jobs on disk but were not declared in `settings.agents[]`. The bus scheduler fired prompts every day, they published to the bus with no subscriber, sat `status: "pending"` forever. Daily jobs silently dead for nearly a week.

This patch catches the mismatch at startup so the next operator never hits it silently.

## Patch

- `src/bus/orphan-agent-detect.ts` — pure scan with injectable I/O. Returns `{ orphanedDirs, orphanedDecls }`. Only flags on-disk dirs that actually have jobs (empty `agents/<name>/` is allowed — operator may use it as a workspace dir).
- `src/bus/runtime-mount.ts` — calls the detector after the spawn loop, logs `[bus-runtime] WARN: ...` lines per orphan. Fires once at startup.
- `src/commands/start.ts` — passes `projectRoot: process.cwd()` so the detector knows where to scan.
- `README.md` — adds a callout under "4. Agents" explaining the load-bearing rule and the warning shape.
- `src/bus/__tests__/orphan-agent-detect.test.ts` — covers six scenarios + formatter shape.

## Sample warning

```
[bus-runtime] WARN: agent dir "reg" has 7 scheduled job(s) in agents/reg/jobs/ but is not declared in settings.agents. Prompts for this agent will publish to the bus with no consumer. Add { "id": "reg" } to settings.agents or remove agents/reg/jobs/.
[bus-runtime] WARN: agent "ghost" is declared in settings.agents but has no matching agents/ghost/ directory. A claude process is spawned but no jobs are configured for it. Either add agents/ghost/jobs/ or remove the declaration.
```

## Not in this PR

Issue #167 also proposed a wizard piece (`/claudeclaw:start` detecting on-disk agents and offering to add them). Separate UX surface worth its own PR — deferred to a follow-up.

## Test plan

- [x] `bun test src/bus/__tests__/orphan-agent-detect.test.ts` — 10/10.
- [x] `bun run lint` — clean.
- [x] Version bump 2.2.96.
- [ ] Post-deploy: confirm warning fires on Hetzner if a `settings.agents[]` entry is removed.

## Related

- #166 — auto-generated `CCPLUS_ARCHITECTURE.md` for runtime-aware agent context (separate PR coming).