### PR TITLE
fix(bus-mcp): JSON-stringify nested metadata values in channel notification (#169)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.97",
+      "version": "2.2.98",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.97",
+  "version": "2.2.98",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/flatten-channel-meta.test.ts
+++ b/src/bus/__tests__/flatten-channel-meta.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "bun:test";
+import { flattenChannelMeta } from "../mcp-server";
+
+describe("flattenChannelMeta (#169 — Discord attachment metadata)", () => {
+  it("passes primitives (string / number / boolean) through unchanged", () => {
+    const out = flattenChannelMeta({
+      origin: "discord",
+      origin_id: "channel-123",
+      message_id: "msg-456",
+      size: 4096,
+      isDM: true,
+    });
+    expect(out).toEqual({
+      origin: "discord",
+      origin_id: "channel-123",
+      message_id: "msg-456",
+      size: 4096,
+      isDM: true,
+    });
+  });
+
+  it("JSON-stringifies nested objects so they don't render as [object Object]", () => {
+    // Shape from src/adapters/discord/index.ts:286 — the real production
+    // metadata payload that triggered the bug.
+    const out = flattenChannelMeta({
+      origin: "discord",
+      origin_id: "channel-123",
+      attachments: {
+        images: [{ filename: "screenshot.png", url: "https://cdn..." }],
+        voices: [],
+        texts: [],
+      },
+    });
+    expect(typeof out.attachments).toBe("string");
+    const parsed = JSON.parse(out.attachments as string);
+    expect(parsed.images[0].filename).toBe("screenshot.png");
+    expect(parsed.images[0].url).toBe("https://cdn...");
+    expect(parsed.voices).toEqual([]);
+    expect(out.attachments).not.toBe("[object Object]");
+  });
+
+  it("JSON-stringifies arrays", () => {
+    const out = flattenChannelMeta({ tags: ["urgent", "billing"] });
+    expect(typeof out.tags).toBe("string");
+    expect(JSON.parse(out.tags as string)).toEqual(["urgent", "billing"]);
+  });
+
+  it("JSON-stringifies null (rather than dropping it)", () => {
+    const out = flattenChannelMeta({ parent_message_id: null });
+    expect(out.parent_message_id).toBe("null");
+  });
+
+  it("drops undefined values entirely", () => {
+    const out = flattenChannelMeta({ origin: "discord", parent_message_id: undefined });
+    expect(out).toEqual({ origin: "discord" });
+    expect("parent_message_id" in out).toBe(false);
+  });
+
+  it("handles unserializable values without throwing", () => {
+    // Circular reference — JSON.stringify throws TypeError; we fall back to
+    // "[unserializable]" rather than crashing the whole prompt delivery.
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const out = flattenChannelMeta({ origin: "discord", circular });
+    expect(out.origin).toBe("discord");
+    expect(out.circular).toBe("[unserializable]");
+  });
+
+  it("preserves empty-object input → empty-object output", () => {
+    expect(flattenChannelMeta({})).toEqual({});
+  });
+});

--- a/src/bus/mcp-server.ts
+++ b/src/bus/mcp-server.ts
@@ -79,6 +79,45 @@ export const CHANNEL_PERMISSION_CAPABILITY = "claude/channel/permission";
  */
 export const CHANNEL_ID = "plus-bus";
 
+/**
+ * Flatten a metadata object for the `notifications/claude/channel` `meta`
+ * payload (#169). Adapter metadata can carry nested objects or arrays — for
+ * example Discord attachment payloads at `adapters/discord/index.ts:286`
+ * land as:
+ *
+ *   { attachments: { images: [{ filename, url, ... }], voices: [...], ... } }
+ *
+ * Some downstream surfaces stringify each `meta` value with the default
+ * `String(v)` coercion, which produces the literal `"[object Object]"` for
+ * nested objects/arrays — Discord attachments stop being usable.
+ *
+ * This helper preserves primitives (string / number / boolean) verbatim and
+ * JSON-stringifies anything else (objects, arrays, null) so the agent can
+ * `JSON.parse` per-field when it needs structured access. Exported for
+ * tests.
+ */
+export function flattenChannelMeta(meta: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(meta)) {
+    if (v === undefined) continue;
+    if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
+      out[k] = v;
+    } else {
+      // Objects, arrays, null — everything claude would otherwise render as
+      // "[object Object]". JSON.stringify preserves structure as a string the
+      // agent can parse back.
+      try {
+        out[k] = JSON.stringify(v);
+      } catch {
+        // Circular reference or BigInt — fall back to a safe placeholder
+        // rather than throwing and breaking the whole prompt delivery.
+        out[k] = "[unserializable]";
+      }
+    }
+  }
+  return out;
+}
+
 /* ───────────────────────────────────────────────────────────────────── */
 /* IPC transport contract                                                */
 /* ───────────────────────────────────────────────────────────────────── */
@@ -380,16 +419,23 @@ export class BusMcpServer {
     // `{channel_id, payload: {text, metadata}}` shape from the v2 spec was
     // unverified speculation and would be rejected by the runtime. Sprint 1
     // integration corrected the spec to match aerolalit.
+    //
+    // #169: Adapter metadata can contain nested objects/arrays (e.g. Discord
+    // attachment payloads at adapters/discord/index.ts:286). Some downstream
+    // surfaces stringify these values directly and produce `[object Object]`.
+    // Flatten via `flattenChannelMeta` so object/array values land as JSON
+    // strings the agent can parse, rather than the default `String(v)`
+    // coercion which throws away structure entirely.
     void this.mcp
       .notification({
         method: "notifications/claude/channel",
         params: {
           content: msg.text,
-          meta: {
+          meta: flattenChannelMeta({
             origin: msg.origin,
             origin_id: msg.origin_id,
             ...(msg.metadata ?? {}),
-          },
+          }),
         },
       })
       .catch((err: unknown) => {


### PR DESCRIPTION
Closes #169. Production-reported by deployed bus agent: Discord attachment metadata renders as `[object Object]` in the channel tag because nested object values land in the channel notification raw, and downstream coercion to string produces the literal `[object Object]`.

## Problem

`adapters/discord/index.ts:286` builds metadata with a nested `attachments: { images: [...], voices: [...], texts: [...] }` object. `mcp-server.ts:deliverPrompt` spreads `msg.metadata` into the `notifications/claude/channel` `meta` payload verbatim. When downstream surfaces stringify the value with default `String(v)`, nested objects become `[object Object]` and the agent loses attachment access entirely.

## Patch

New `flattenChannelMeta` helper:

- Primitives (string / number / boolean) → pass through unchanged
- Objects, arrays, null → `JSON.stringify` (agent can `JSON.parse` for structured access)
- `undefined` → dropped
- Unserializable (circular / BigInt) → `"[unserializable]"` fallback so a malformed field doesn't crash prompt delivery

Applied at `deliverPrompt`. `deliverAskAnswer` left as-is — its `meta` only carries primitive `{ ask_id, kind }`.

## Test plan

- [x] `bun test src/bus/__tests__/flatten-channel-meta.test.ts` — 7/7 (primitives / nested objects / arrays / null / undefined / circular ref / empty input)
- [x] `bun run lint` — clean
- [x] Version bump 2.2.98
- [ ] Post-deploy: send a Discord attachment to the daemon, verify agent sees `attachments: '{"images":[...]}'` (string) rather than `attachments: [object Object]`

## Related

- #167 / PR #168 — orphan agent-dir detection (same incident-class as this — silent failures the agent can't self-diagnose)
- #166 — auto-generated `CCPLUS_ARCHITECTURE.md` (still queued, separate PR)
