### PR TITLE
feat(config): bump default sessionTimeoutMs from 30 min to 120 min (#179)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.99",
+      "version": "2.2.100",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.99",
+  "version": "2.2.100",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/docs/Bus_Runtime_Staging_Guide.md
+++ b/docs/Bus_Runtime_Staging_Guide.md
@@ -184,9 +184,12 @@ don't waste time investigating:
   the job to a different agent instead (declare a second agent with the
   model you want, set `job.agent: "<that-id>"`). Cleaner architectural
   fit; documented in PR #126. The global per-session cap defaults to
-  **120 minutes** (`sessionTimeoutMs`); override in
-  `~/.claude/claudeclaw/settings.json` if you want a tighter or looser
-  cap.
+  **120 minutes** (`sessionTimeoutMs`); override in the daemon's
+  project-local settings file (`<cwd>/.claude/claudeclaw/settings.json`
+  — for the Hetzner staging flow that's
+  `/home/claw/project/.claude/claudeclaw/settings.json`) if you want a
+  tighter or looser cap. The `~/.claude/` path is the Claude CLI's
+  user-scope config, not where this daemon reads.
 - **Upstream Slack features pending.** Issue #121 (allowBots, block /
   attachment text extraction, replyThreadTs) is queued as a separate
   port into the Bus Slack adapter. Not blocking for the

--- a/docs/Bus_Runtime_Staging_Guide.md
+++ b/docs/Bus_Runtime_Staging_Guide.md
@@ -183,7 +183,10 @@ don't waste time investigating:
 - **Per-job model / timeout overrides not honoured.** Under Bus, route
   the job to a different agent instead (declare a second agent with the
   model you want, set `job.agent: "<that-id>"`). Cleaner architectural
-  fit; documented in PR #126.
+  fit; documented in PR #126. The global per-session cap defaults to
+  **120 minutes** (`sessionTimeoutMs`); override in
+  `~/.claude/claudeclaw/settings.json` if you want a tighter or looser
+  cap.
 - **Upstream Slack features pending.** Issue #121 (allowBots, block /
   attachment text extraction, replyThreadTs) is queued as a separate
   port into the Bus Slack adapter. Not blocking for the

--- a/src/__tests__/runtime-config.test.ts
+++ b/src/__tests__/runtime-config.test.ts
@@ -9,7 +9,7 @@ import { join } from "path";
 import { mkdir, copyFile, unlink } from "fs/promises";
 import { existsSync } from "fs";
 
-import { reloadSettings, getSettings } from "../config";
+import { DEFAULT_SESSION_TIMEOUT_MS, reloadSettings, getSettings } from "../config";
 
 const SETTINGS_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const SETTINGS_FILE = join(SETTINGS_DIR, "settings.json");
@@ -281,5 +281,49 @@ describe("parseSettings — bus routing (Sprint 5.2b)", () => {
     });
     await reloadSettings();
     expect(getSettings().discord.busRouting).toEqual({ channels: { valid: "agent-a" } });
+  });
+});
+
+describe("parseSettings — sessionTimeoutMs default (#179)", () => {
+  it("defaults DEFAULT_SESSION_TIMEOUT_MS to 120 minutes", () => {
+    // 120 * 60 * 1000 = 7,200,000 ms
+    expect(DEFAULT_SESSION_TIMEOUT_MS).toBe(120 * 60 * 1000);
+  });
+
+  it("falls back to the 120-minute default when the field is absent", async () => {
+    await writeRawSettings({});
+    await reloadSettings();
+    expect(getSettings().sessionTimeoutMs).toBe(120 * 60 * 1000);
+  });
+
+  it("honours an explicit positive sessionTimeoutMs override", async () => {
+    await writeRawSettings({ sessionTimeoutMs: 90_000 });
+    await reloadSettings();
+    expect(getSettings().sessionTimeoutMs).toBe(90_000);
+  });
+
+  it("falls back to the default when sessionTimeoutMs is zero or negative", async () => {
+    await writeRawSettings({ sessionTimeoutMs: 0 });
+    await reloadSettings();
+    expect(getSettings().sessionTimeoutMs).toBe(120 * 60 * 1000);
+
+    await writeRawSettings({ sessionTimeoutMs: -1 });
+    await reloadSettings();
+    expect(getSettings().sessionTimeoutMs).toBe(120 * 60 * 1000);
+  });
+
+  it("falls back to the default when sessionTimeoutMs is the wrong type", async () => {
+    await writeRawSettings({ sessionTimeoutMs: "120000" });
+    await reloadSettings();
+    expect(getSettings().sessionTimeoutMs).toBe(120 * 60 * 1000);
+  });
+
+  it("falls back to the default when sessionTimeoutMs is Infinity or NaN", async () => {
+    // JSON serialises Infinity/NaN as null on write but operators editing
+    // the file by hand might attempt them as bare tokens. The parser must
+    // reject them either way — `Number.isFinite` guards both cases.
+    await writeRawSettings({ sessionTimeoutMs: null });
+    await reloadSettings();
+    expect(getSettings().sessionTimeoutMs).toBe(120 * 60 * 1000);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,8 +22,10 @@ const LOGS_DIR = join(HEARTBEAT_DIR, "logs");
  * NotebookLM source loading + 6 insight queries, an SEO-optimised content
  * suite across 7 surfaces, fact-check pass, image generation, and Discord
  * notification. The legacy 30-minute cap fired mid-pipeline. Operators with
- * shorter workloads can still override via `sessionTimeoutMs` in
- * `~/.claude/claudeclaw/settings.json`.
+ * shorter workloads can override via `sessionTimeoutMs` in the project-local
+ * settings file the daemon reads — `<cwd>/.claude/claudeclaw/settings.json`,
+ * i.e. relative to the directory the daemon was started in. The `~/.claude/`
+ * path is the Claude CLI's user-scope config, not where this daemon reads.
  *
  * Exported so runner.ts can reference the same value.
  */

--- a/src/config.ts
+++ b/src/config.ts
@@ -14,8 +14,20 @@ const SETTINGS_FILE = join(HEARTBEAT_DIR, "settings.json");
 const DEFAULT_JOBS_DIR = join(HEARTBEAT_DIR, "jobs");
 const LOGS_DIR = join(HEARTBEAT_DIR, "logs");
 
-/** Default Claude session timeout (30 minutes). Exported so runner.ts can reference the same value. */
-export const DEFAULT_SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+/**
+ * Default Claude session timeout (120 minutes).
+ *
+ * Bumped from 30 minutes (issue #179): named agents like Reg and Suzy run
+ * long pipelines by design — daily-content-research does 8–15 web searches,
+ * NotebookLM source loading + 6 insight queries, an SEO-optimised content
+ * suite across 7 surfaces, fact-check pass, image generation, and Discord
+ * notification. The legacy 30-minute cap fired mid-pipeline. Operators with
+ * shorter workloads can still override via `sessionTimeoutMs` in
+ * `~/.claude/claudeclaw/settings.json`.
+ *
+ * Exported so runner.ts can reference the same value.
+ */
+export const DEFAULT_SESSION_TIMEOUT_MS = 120 * 60 * 1000;
 
 export const DEFAULT_IMAGE_OUTPUT_ROOT = join(HEARTBEAT_DIR, "outbox", "discord");
 
@@ -873,8 +885,8 @@ function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Set
         : {}),
     },
     sessionTimeoutMs:
-      typeof raw.sessionTimeoutMs === "number" && raw.sessionTimeoutMs > 0
-        ? raw.sessionTimeoutMs
+      Number.isFinite(raw.sessionTimeoutMs) && (raw.sessionTimeoutMs as number) > 0
+        ? (raw.sessionTimeoutMs as number)
         : DEFAULT_SESSION_TIMEOUT_MS,
     timeouts: {
       telegram:


### PR DESCRIPTION
## Summary

Closes #179. Bump `DEFAULT_SESSION_TIMEOUT_MS` in `src/config.ts` from `30 * 60 * 1000` to `120 * 60 * 1000`.

## Why

Reg's `daily-content-research` and Suzy's `daily-digest` are long pipelines by design — 8–15 web searches, NotebookLM source loading + 6 insight queries, an SEO-optimised content suite across 7 surfaces, fact-check pass, image generation, and a Discord notification. The legacy 30-minute cap was firing mid-pipeline. Operators with shorter workloads can still override via `sessionTimeoutMs` in `~/.claude/claudeclaw/settings.json`.

## What

- `src/config.ts:30` — constant bumped, JSDoc updated with the rationale.
- `src/config.ts:887-890` — parser guard hardened: `Number.isFinite()` now also rejects `Infinity` / `NaN` (matches the sibling `timeouts.*` validators). Per the security review.
- `src/__tests__/runtime-config.test.ts:287-329` — 6 new tests pinning the new default and parser edge cases (positive override, zero/negative, wrong-type, null).
- `docs/Bus_Runtime_Staging_Guide.md:186-189` — Limitations section names the new default and points operators at the override.
- Versions bumped to 2.2.100.

## Scope

This changes only `settings.sessionTimeoutMs`. The per-surface category timeouts in `settings.timeouts.*` (`telegram` 5 min, `discord` 5 min, `heartbeat` 15 min, `job` 30 min) are independent and unchanged. **Bus-runtime cron jobs** (production) route via `bus.sendPrompt` → long-lived PTY via MCP — they hit the session wall-clock, so this bump fixes their behaviour. **Legacy-runtime cron jobs** route through `resolveTimeoutMs()` with `settings.timeouts.job` (default 30 min) and are unaffected by this change; operators on the legacy runtime who need longer cron windows should also bump `settings.timeouts.job` in their config.

## Test plan

- [x] `DEFAULT_SESSION_TIMEOUT_MS` pinned to `120 * 60 * 1000` (unit test).
- [x] Absent field → falls back to default (round-trip via `reloadSettings`).
- [x] Positive override honoured (`sessionTimeoutMs: 90_000` → 90,000).
- [x] Zero / negative / wrong-type / `null` → falls back to default.
- [x] `bun test src/__tests__/runtime-config.test.ts` — 29 / 29 pass.
- [x] `bun run lint` — clean.

## SDC

Four markers in place for HEAD `a6906bde7378`. 5-agent code review found no blocking issues — one non-blocking note (legacy-runtime `timeouts.job` is a separate knob) is called out in the Scope section above.
