### PR TITLE
fix(pty-supervisor): retry respawnEntry on failure (#175)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.100",
+      "version": "2.2.101",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.100",
+  "version": "2.2.101",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/pty-config.test.ts
+++ b/src/__tests__/pty-config.test.ts
@@ -172,6 +172,7 @@ describe("parseSettings — pty defaults", () => {
         enabled: true,
         idleReapMinutes: 30,
         maxRetries: 5,
+        respawnRetries: 3,
         backoffMs: [1000, 2000, 4000, 8000, 16000],
         namedAgentsAlwaysAlive: true,
         turnIdleTimeoutMs: 5000,
@@ -185,6 +186,50 @@ describe("parseSettings — pty defaults", () => {
     await writeRawSettings(explicitDefaults);
     await reloadSettings();
     expect(getSettings().pty).toEqual(explicitDefaults.pty);
+  });
+
+  it("defaults respawnRetries to 3 when omitted (#175)", async () => {
+    await writeRawSettings({});
+    await reloadSettings();
+    expect(getSettings().pty.respawnRetries).toBe(3);
+  });
+
+  it("accepts custom respawnRetries when finite and >= 1", async () => {
+    await writeRawSettings({ pty: { respawnRetries: 5 } });
+    await reloadSettings();
+    expect(getSettings().pty.respawnRetries).toBe(5);
+
+    await writeRawSettings({ pty: { respawnRetries: 1 } });
+    await reloadSettings();
+    expect(getSettings().pty.respawnRetries).toBe(1);
+  });
+
+  it("rejects invalid respawnRetries, falls back to default", async () => {
+    await writeRawSettings({ pty: { respawnRetries: 0 } });
+    await reloadSettings();
+    expect(getSettings().pty.respawnRetries).toBe(3);
+
+    await writeRawSettings({ pty: { respawnRetries: -1 } });
+    await reloadSettings();
+    expect(getSettings().pty.respawnRetries).toBe(3);
+
+    await writeRawSettings({ pty: { respawnRetries: "lots" as unknown as number } });
+    await reloadSettings();
+    expect(getSettings().pty.respawnRetries).toBe(3);
+  });
+
+  it("caps respawnRetries at 20 (footgun guard per security review on #175)", async () => {
+    await writeRawSettings({ pty: { respawnRetries: 100 } });
+    await reloadSettings();
+    expect(getSettings().pty.respawnRetries).toBe(20);
+
+    await writeRawSettings({ pty: { respawnRetries: 20 } });
+    await reloadSettings();
+    expect(getSettings().pty.respawnRetries).toBe(20);
+
+    await writeRawSettings({ pty: { respawnRetries: 21 } });
+    await reloadSettings();
+    expect(getSettings().pty.respawnRetries).toBe(20);
   });
 
   it("defaults maxConcurrent to 32 when omitted", async () => {

--- a/src/__tests__/pty-supervisor.test.ts
+++ b/src/__tests__/pty-supervisor.test.ts
@@ -24,6 +24,7 @@ import {
   injectEnsureAgentDir,
   injectMaxConcurrentForTests,
   injectMaxRetriesForTests,
+  injectRespawnRetriesForTests,
   injectNewSessionId,
   injectIsSessionResumable,
   killAllPtys,
@@ -510,6 +511,122 @@ describe("pty-supervisor retry and backoff", () => {
     expect(result.sessionId).toBeUndefined();
     expect(result.stderr).toMatch(/max retries/);
     expect(result.stderr).toMatch(/global/);
+  });
+
+  it("retries respawnEntry on failure (issue #175 — was: 1 attempt = give up)", async () => {
+    // Reproduce the production failure: the long-lived claude died on a
+    // turn (PtyClosedError → retryable), supervisor tries to respawn, but
+    // the fresh claude "exits before TUI settled" — the spawn throws.
+    // Pre-#175 behaviour: supervisor gave up after one bad respawn,
+    // truncating the 5-retry envelope. Post-#175: it retries the respawn
+    // itself respawnRetries=3 times.
+    const sleeps: number[] = [];
+    injectSleep(async (ms) => {
+      sleeps.push(ms);
+    });
+
+    let globalCalls = 0;
+    let spawnIndex = 0;
+    const spawned: FakePtyHandle[] = [];
+    const spawn: SpawnPty = async () => {
+      const idx = spawnIndex++;
+      // Initial spawn (idx=0) succeeds. First respawn (idx=1) throws —
+      // simulating "PTY for claude exited before TUI settled". Second
+      // respawn (idx=2) succeeds.
+      if (idx === 1) {
+        throw new Error("PTY for claude exited before TUI settled (pid=99999)");
+      }
+      const handle = makeFakePty(`respawn-retry-${idx}`, {
+        onTurn: async (prompt) => {
+          const callNum = globalCalls++;
+          if (callNum === 0) {
+            throw new PtyClosedError(`respawn-retry-${idx}`, 1, "SIGPIPE");
+          }
+          return {
+            text: `recovered:${prompt}`,
+            bytesCaptured: 0,
+            cleanBoundary: true,
+            sessionId: "s",
+          };
+        },
+      });
+      spawned.push(handle);
+      return handle;
+    };
+    injectSpawnPty(spawn);
+    await initSupervisor();
+
+    const result = await runOnPty("global", "hi", { timeoutMs: 1000 });
+    expect(result.exitCode).toBe(0);
+    expect(result.rawStdout).toBe("recovered:hi");
+    // 3 spawn calls observed: initial + first (failing) respawn + second
+    // (succeeding) respawn. Only 2 reached the FakePty stage (the failing
+    // one threw before reaching makeFakePty).
+    expect(spawnIndex).toBe(3);
+    expect(spawned.length).toBe(2);
+    // Sleeps:
+    // - 1× outer backoff (between turn fail and respawn) = 1000ms
+    // - 1× inner backoff (between failed respawn and retry) = 1000ms
+    expect(sleeps).toEqual([1000, 1000]);
+  });
+
+  it("bails after respawnRetries exhaustions with a structured error", async () => {
+    injectSleep(async () => {});
+    // Bound the test: maxRetries=1 outer turn-retry, respawnRetries=2 inner.
+    // The first respawn fails, the retry also fails → bail after 2 attempts.
+    injectMaxRetriesForTests(1);
+    injectRespawnRetriesForTests(2);
+
+    let spawnIndex = 0;
+    const spawn: SpawnPty = async () => {
+      const idx = spawnIndex++;
+      if (idx === 0) {
+        return makeFakePty("permabad-0", {
+          onTurn: async () => {
+            throw new PtyClosedError("permabad-0", 1, "SIGPIPE");
+          },
+        });
+      }
+      // Every respawn attempt fails fast.
+      throw new Error("PTY for claude exited before TUI settled (pid=12345)");
+    };
+    injectSpawnPty(spawn);
+    await initSupervisor();
+
+    const result = await runOnPty("global", "hi", { timeoutMs: 1000 });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/respawn failed.*2 attempt\(s\)/);
+    expect(result.stderr).toMatch(/exited before TUI settled/);
+    // 1 initial spawn + 2 inner respawn attempts = 3 total spawn calls.
+    expect(spawnIndex).toBe(3);
+  });
+
+  it("respects respawnRetries=1 (one attempt only — pre-#175 behaviour, configurable)", async () => {
+    // Operators who want to opt back into the old "give up fast" behaviour
+    // can set pty.respawnRetries = 1.
+    injectSleep(async () => {});
+    injectMaxRetriesForTests(1);
+    injectRespawnRetriesForTests(1);
+
+    let spawnIndex = 0;
+    const spawn: SpawnPty = async () => {
+      const idx = spawnIndex++;
+      if (idx === 0) {
+        return makeFakePty("once-bad-0", {
+          onTurn: async () => {
+            throw new PtyClosedError("once-bad-0", 1, null);
+          },
+        });
+      }
+      throw new Error("respawn fail");
+    };
+    injectSpawnPty(spawn);
+    await initSupervisor();
+
+    const result = await runOnPty("global", "hi", { timeoutMs: 1000 });
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toMatch(/respawn failed.*1 attempt\(s\)/);
+    expect(spawnIndex).toBe(2); // initial + 1 respawn attempt
   });
 
   it("does NOT retry on non-retryable errors", async () => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -174,6 +174,7 @@ const DEFAULT_SETTINGS: Settings = {
     enabled: false,
     idleReapMinutes: 30,
     maxRetries: 5,
+    respawnRetries: 3,
     backoffMs: [1000, 2000, 4000, 8000, 16000],
     namedAgentsAlwaysAlive: true,
     turnIdleTimeoutMs: 5000,
@@ -508,8 +509,17 @@ export interface PtyConfig {
   /** Maximum number of crash-respawn-replay attempts per event.
    *  Default: 5. */
   maxRetries: number;
+  /** Maximum number of `respawnEntry()` attempts after each retryable
+   *  `runTurn` failure. The outer `maxRetries` budget controls how many
+   *  turn replays we attempt; this inner budget controls how many times
+   *  we try to bring the PTY back up between turns. Before this was
+   *  introduced (issue #175), a single failed respawn would truncate the
+   *  outer envelope to one attempt, causing production cron jobs to give
+   *  up after one bad respawn. Default: 3. */
+  respawnRetries: number;
   /** Backoff between retries (ms). Cycles through this list; if maxRetries
-   *  exceeds the list length, the last value is reused.
+   *  exceeds the list length, the last value is reused. The same array is
+   *  reused for inner respawn retries.
    *  Default: [1000, 2000, 4000, 8000, 16000]. */
   backoffMs: number[];
   /** When true, agents under agents/*\/ get a PTY pre-spawned at startup and
@@ -922,6 +932,14 @@ function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Set
         Number.isFinite(raw.pty?.maxRetries) && Number(raw.pty.maxRetries) >= 0
           ? Number(raw.pty.maxRetries)
           : 5,
+      respawnRetries:
+        Number.isFinite(raw.pty?.respawnRetries) && Number(raw.pty.respawnRetries) >= 1
+          ? // Cap at 20 to prevent footgun config (security review on #175):
+            // every inner attempt sleeps the backoff schedule (max 16s after
+            // the array runs out), so an operator who sets a huge value can
+            // wedge a cron turn for hours waiting on hopeless respawns.
+            Math.min(20, Number(raw.pty.respawnRetries))
+          : 3,
       backoffMs:
         Array.isArray(raw.pty?.backoffMs) &&
         raw.pty.backoffMs.length > 0 &&

--- a/src/runner/pty-supervisor.ts
+++ b/src/runner/pty-supervisor.ts
@@ -24,9 +24,14 @@
  *   - Crash-respawn-replay: on PtyClosedError or PtyTurnTimeoutError, the
  *     supervisor disposes the dead PTY, sleeps `backoffMs[i]`, respawns
  *     (via cached spawn options + last-known sessionId for --resume), and
- *     retries the SAME prompt up to `maxRetries` times. After exhaustion the
- *     supervisor surfaces a structured error in RunOnPtyResult.stderr and
- *     exitCode=1; execClaude treats this as any other non-zero exit.
+ *     retries the SAME prompt up to `maxRetries` times (outer loop). Each
+ *     outer retry first tries to respawn the PTY up to `respawnRetries`
+ *     times (inner loop — issue #175). If the inner loop is exhausted the
+ *     outer loop terminates early with a "respawn failed after N attempts"
+ *     error rather than consuming the remaining outer budget. After
+ *     exhaustion the supervisor surfaces a structured error in
+ *     RunOnPtyResult.stderr and exitCode=1; execClaude treats this as any
+ *     other non-zero exit.
  *
  *   - Settings are re-read via getSettings() on every call — never cached
  *     across calls — so hot-reload works. The reap interval is rebuilt
@@ -208,6 +213,9 @@ export function injectCleanSpawnEnv(fn: CleanSpawnEnvFn | null): void {
 export interface SupervisorOptions {
   idleReapMinutes: number;
   maxRetries: number;
+  /** Inner retry budget for `respawnEntry()` after a retryable `runTurn`
+   *  failure. Issue #175. */
+  respawnRetries: number;
   backoffMs: number[];
   namedAgentsAlwaysAlive: boolean;
 }
@@ -379,6 +387,7 @@ export function __resetSupervisorForTests(): void {
   _buildChildEnv = null;
   _maxConcurrentOverride = null;
   _maxRetriesOverride = null;
+  _respawnRetriesOverride = null;
   _newSessionId = () => crypto.randomUUID();
   _mcpIssueIdentity = null;
   _mcpRevokeIdentity = null;
@@ -471,6 +480,7 @@ export async function initSupervisor(): Promise<void> {
   const opts: SupervisorOptions = {
     idleReapMinutes: settings.pty.idleReapMinutes,
     maxRetries: settings.pty.maxRetries,
+    respawnRetries: settings.pty.respawnRetries,
     backoffMs: settings.pty.backoffMs,
     namedAgentsAlwaysAlive: settings.pty.namedAgentsAlwaysAlive,
   };
@@ -663,6 +673,8 @@ function readSupervisorOptions(): SupervisorOptions {
   return {
     idleReapMinutes: settings.pty.idleReapMinutes,
     maxRetries: _maxRetriesOverride != null ? _maxRetriesOverride : settings.pty.maxRetries,
+    respawnRetries:
+      _respawnRetriesOverride != null ? _respawnRetriesOverride : settings.pty.respawnRetries,
     backoffMs: settings.pty.backoffMs,
     namedAgentsAlwaysAlive: settings.pty.namedAgentsAlwaysAlive,
   };
@@ -711,6 +723,8 @@ async function getOrCreateEntry(
 let _maxConcurrentOverride: number | null = null;
 /** Test-only override for maxRetries. */
 let _maxRetriesOverride: number | null = null;
+/** Test-only override for respawnRetries. Issue #175. */
+let _respawnRetriesOverride: number | null = null;
 
 /** For tests only. Override the maxConcurrent cap without writing to disk. */
 export function injectMaxConcurrentForTests(cap: number | null): void {
@@ -720,6 +734,11 @@ export function injectMaxConcurrentForTests(cap: number | null): void {
 /** For tests only. Override maxRetries without writing to disk. */
 export function injectMaxRetriesForTests(n: number | null): void {
   _maxRetriesOverride = n;
+}
+
+/** For tests only. Override respawnRetries without writing to disk. */
+export function injectRespawnRetriesForTests(n: number | null): void {
+  _respawnRetriesOverride = n;
 }
 
 /**
@@ -1194,6 +1213,45 @@ async function respawnEntry(entry: PtyEntry): Promise<void> {
   entry.lastSpawnedAt = _clock();
 }
 
+/**
+ * Issue #175: retry `respawnEntry()` itself.
+ *
+ * The outer `runTurnWithRetries` loop catches retryable `runTurn` failures
+ * (PTY closed, turn timeout) and respawns the PTY between turns. Before this
+ * helper existed, a single failed respawn would `return errorResult(...)`
+ * and truncate the outer `maxRetries` envelope (default 5) to 1 attempt —
+ * production observed 26% of `daily-digest` / `daily-content-research`
+ * cron runs giving up after the first respawn failure with *"PTY for claude
+ * exited before TUI settled"*.
+ *
+ * This helper retries `respawnEntry()` up to `max(1, opts.respawnRetries)`
+ * times (the floor guards against accidental 0 from a test injection; the
+ * config parser separately enforces ≥ 1 with default 3) with the existing
+ * backoff schedule. On total exhaustion it throws the last error; the outer
+ * loop wraps the thrown error in a "respawn failed after N attempts"
+ * message and returns `errorResult(...)` for the operator.
+ *
+ * Issue #177 (separate) tracks dropping `--resume <sessionId>` on the final
+ * attempt as a corrupted-session escape hatch. This helper does the retry
+ * envelope; the resume fallback is layered on top.
+ */
+async function respawnEntryWithRetries(entry: PtyEntry, opts: SupervisorOptions): Promise<void> {
+  const attempts = Math.max(1, opts.respawnRetries);
+  let lastErr: unknown = new Error("respawnEntryWithRetries: no attempts made");
+  for (let i = 0; i < attempts; i++) {
+    try {
+      await respawnEntry(entry);
+      return;
+    } catch (err) {
+      lastErr = err;
+      if (i === attempts - 1) break;
+      const delay = pickBackoff(opts.backoffMs, i);
+      await _sleep(delay);
+    }
+  }
+  throw lastErr;
+}
+
 async function runTurnWithRetries(
   entry: PtyEntry,
   prompt: string,
@@ -1264,10 +1322,10 @@ async function runTurnWithRetries(
       attempt += 1;
       await _sleep(delay);
       try {
-        await respawnEntry(entry);
+        await respawnEntryWithRetries(entry, supervisorOpts);
       } catch (respawnErr) {
         return errorResult(
-          `[pty-supervisor] respawn failed for ${entry.sessionKey} after ${attempt} attempt(s): ${(respawnErr as Error).message}`,
+          `[pty-supervisor] respawn failed for ${entry.sessionKey} after ${supervisorOpts.respawnRetries} attempt(s) (outer turn-retry ${attempt}): ${(respawnErr as Error).message}`,
         );
       }
     }


### PR DESCRIPTION
## Summary

Closes #175. The root-cause fix for Reg/Suzy's 26% cron failure rate.

## Problem

Production observed 36 cron failures since 2026-05-19 with:

```
[pty-supervisor] respawn failed for thread:agent:reg after 1 attempt(s):
PTY for claude exited before TUI settled (pid=...)
```

`runTurnWithRetries` correctly catches retryable `runTurn` failures (`PtyClosedError`, `PtyTurnTimeoutError`) and respawns the PTY between turns under a `maxRetries=5` envelope. But the inner `respawnEntry()` call lived in a try/catch that **returned `errorResult(...)` on the first failure** — silently truncating the 5-retry envelope to 1 attempt. One bad respawn = the agent gives up on the whole job.

## Fix

Wrap `respawnEntry()` in `respawnEntryWithRetries()`, a small loop that retries up to `pty.respawnRetries` (default 3, capped at 20) times with the existing backoff schedule. On final exhaustion it throws the last error so the outer loop can surface a clear "respawn failed after N attempts" message.

## Changes

- `src/config.ts` — new `pty.respawnRetries` field (default 3, validated `Number.isFinite && >= 1`, capped at 20 per security review).
- `src/runner/pty-supervisor.ts`:
  - `SupervisorOptions.respawnRetries: number`
  - `respawnEntryWithRetries(entry, opts)` helper next to `respawnEntry()`
  - `injectRespawnRetriesForTests()` test hook + reset
  - File-header "Crash-respawn-replay" bullet updated to describe the two-level retry
  - `runTurnWithRetries` now calls the helper; error message names the inner attempt count
- Tests: 3 supervisor integration tests + 4 config parser tests (default, valid, invalid, cap-at-20).
- Versions bumped to 2.2.101.

## Review

**5-agent code review:** 4/5 converged on a critical finding — `initSupervisor()` was constructing `SupervisorOptions` without the newly-required `respawnRetries` field (TypeScript compile error, hidden by the no-tsc CI). Fixed. Agent #5 also flagged a stale file-header bullet and a "5-retry envelope" hardcode in the JSDoc — both fixed.

**Security review:** APPROVE-WITH-NOTES. Bounded DoS surface (worst case ~35s sleep budget per turn at defaults), operator-controlled input only, MCP identity rotation safe across retries. Recommended cap at 20 to prevent footgun; applied as `Math.min(20, ...)` in parser + new test.

## Test plan

- [x] `bun test src/__tests__/pty-supervisor.test.ts src/__tests__/pty-config.test.ts src/__tests__/runtime-config.test.ts` — 118 / 118 pass.
- [x] `bun run lint` clean.
- [x] Existing 41 supervisor tests unchanged (no regression).
- [x] New: "retries respawnEntry on failure" — succeeds on 2nd attempt (the production scenario).
- [x] New: "bails after respawnRetries exhaustions with a structured error".
- [x] New: "respects respawnRetries=1 (pre-#175 opt-back-in)".

## Follow-ups

- Issue #177 (drop `--resume` on final respawn attempt as corrupted-session escape hatch) depends on this.
- Issue #176 (capture exit reason on "exited before TUI settled") is independent and pairs naturally with this — once landed, the operator will see *why* claude exited fast, in addition to the new retry behavior.

Closes #175
