### PR TITLE
fix(pty-supervisor): drop --resume on final respawn attempt (#177)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.101",
+      "version": "2.2.102",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.101",
+  "version": "2.2.102",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/pty-supervisor.test.ts
+++ b/src/__tests__/pty-supervisor.test.ts
@@ -629,6 +629,159 @@ describe("pty-supervisor retry and backoff", () => {
     expect(spawnIndex).toBe(2); // initial + 1 respawn attempt
   });
 
+  it("drops --resume on final respawn attempt after prior failures (#177)", async () => {
+    // Issue #177 corrupted-session escape hatch: if respawn keeps failing
+    // because the resumed JSONL is poisoned, the FINAL attempt must drop
+    // `--resume <sessionId>` so a fresh claude can come up.
+    injectSleep(async () => {});
+    injectMaxRetriesForTests(1);
+    injectRespawnRetriesForTests(3);
+
+    let spawnIndex = 0;
+    const spawnedSessionIds: string[] = [];
+    const spawnedNewSessionIds: Array<string | undefined> = [];
+    const spawn: SpawnPty = async (opts) => {
+      spawnedSessionIds.push(opts.sessionId ?? "");
+      spawnedNewSessionIds.push(opts.newSessionId);
+      const idx = spawnIndex++;
+      if (idx === 0) {
+        return makeFakePty("seeded", {
+          initialSessionId: "old-session-id",
+          onTurn: async () => {
+            throw new PtyClosedError("seeded", 1, null);
+          },
+        });
+      }
+      // Inner respawn attempts 1 and 2 (idx 1, 2) throw fast.
+      if (idx < 3) {
+        throw new Error("PTY for claude exited before TUI settled");
+      }
+      // Final inner attempt (idx === 3) — fresh-session path. Succeeds and
+      // the next runTurn completes the turn.
+      return makeFakePty("fresh", {
+        onTurn: async (prompt) => ({
+          text: `fresh-recovered:${prompt}`,
+          bytesCaptured: 0,
+          cleanBoundary: true,
+          sessionId: "brand-new-session-id",
+        }),
+      });
+    };
+    injectSpawnPty(spawn);
+    await initSupervisor();
+
+    const result = await runOnPty("global", "hi", { timeoutMs: 1000 });
+    expect(result.exitCode).toBe(0);
+    expect(result.rawStdout).toBe("fresh-recovered:hi");
+    // Initial spawn (idx 0) + 3 inner respawn attempts (idx 1, 2, 3).
+    expect(spawnIndex).toBe(4);
+    // Inner attempts 1 and 2 must NOT drop --resume — they carry the
+    // last-known session id so the conversation can resume on the first
+    // success. (The exact id may be the old session or the pre-allocated
+    // newSessionId depending on which was last cached on spawnOpts — both
+    // are non-empty, which is the invariant.)
+    expect(spawnedSessionIds[1]).not.toBe("");
+    expect(spawnedSessionIds[2]).not.toBe("");
+    // FINAL inner attempt (idx 3) must drop --resume — empty sessionId.
+    // This is the corrupted-session escape hatch from issue #177.
+    expect(spawnedSessionIds[3]).toBe("");
+    // Critical: the final attempt must ALSO clear newSessionId — otherwise
+    // pty-process.ts:251-253 falls back to `--session-id <newSessionId>`
+    // and re-binds the "fresh" claude to the same pre-allocated UUID that
+    // owns the corrupted JSONL. This was a confidence-92 finding in the
+    // 5-agent review; the regression test is the fix verification.
+    expect(spawnedNewSessionIds[3]).toBeUndefined();
+  });
+
+  it("does NOT drop --resume when respawnRetries=1 (preserves pre-#175 opt-out)", async () => {
+    // The pre-#175 opt-out (respawnRetries=1) means "give up fast like the
+    // old code did". Dropping --resume on the very first attempt would
+    // change behaviour vs. the documented opt-out, so we only fire the
+    // escape hatch when there were prior failures (i > 0).
+    injectSleep(async () => {});
+    injectMaxRetriesForTests(1);
+    injectRespawnRetriesForTests(1);
+
+    let spawnIndex = 0;
+    const spawnedSessionIds: string[] = [];
+    const spawn: SpawnPty = async (opts) => {
+      spawnedSessionIds.push(opts.sessionId ?? "");
+      const idx = spawnIndex++;
+      if (idx === 0) {
+        return makeFakePty("seeded", {
+          initialSessionId: "old-session-id",
+          onTurn: async () => {
+            throw new PtyClosedError("seeded", 1, null);
+          },
+        });
+      }
+      throw new Error("respawn fail");
+    };
+    injectSpawnPty(spawn);
+    await initSupervisor();
+
+    const result = await runOnPty("global", "hi", { timeoutMs: 1000 });
+    expect(result.exitCode).toBe(1);
+    // Only 1 respawn attempt. The session id must be carried through —
+    // dropResume is NOT signalled because there were no prior failures.
+    expect(spawnIndex).toBe(2);
+    expect(spawnedSessionIds[1]).toBe("old-session-id");
+  });
+
+  it("does NOT drop --resume on the very first inner attempt (only on final after failure)", async () => {
+    // Defence in depth: even with respawnRetries=3, the FIRST inner respawn
+    // attempt must keep --resume. Only the final attempt — and only after
+    // earlier attempts have failed — should drop it.
+    injectSleep(async () => {});
+    injectMaxRetriesForTests(1);
+    injectRespawnRetriesForTests(3);
+
+    let spawnIndex = 0;
+    const spawnedSessionIds: string[] = [];
+    let turnsRunOnFresh = 0;
+    const spawn: SpawnPty = async (opts) => {
+      spawnedSessionIds.push(opts.sessionId ?? "");
+      const idx = spawnIndex++;
+      if (idx === 0) {
+        return makeFakePty("seeded", {
+          initialSessionId: "old-session-id",
+          onTurn: async () => {
+            throw new PtyClosedError("seeded", 1, null);
+          },
+        });
+      }
+      // First inner respawn attempt (idx 1) — succeeds, but the prompt
+      // replay fails again (so we DO NOT reach attempt 2 or 3).
+      if (idx === 1) {
+        return makeFakePty("first-respawn", {
+          initialSessionId: "old-session-id",
+          onTurn: async () => {
+            turnsRunOnFresh++;
+            return {
+              text: "ok",
+              bytesCaptured: 0,
+              cleanBoundary: true,
+              sessionId: "old-session-id",
+            };
+          },
+        });
+      }
+      throw new Error("should not reach idx > 1");
+    };
+    injectSpawnPty(spawn);
+    await initSupervisor();
+
+    const result = await runOnPty("global", "hi", { timeoutMs: 1000 });
+    expect(result.exitCode).toBe(0);
+    expect(result.rawStdout).toBe("ok");
+    // First inner attempt carried --resume (NOT dropped on i=0 even though
+    // attempts=3 — the dropResume signal requires hadPriorFailures).
+    expect(spawnedSessionIds[1]).toBe("old-session-id");
+    // Sanity: we didn't reach the final attempt.
+    expect(spawnIndex).toBe(2);
+    expect(turnsRunOnFresh).toBe(1);
+  });
+
   it("does NOT retry on non-retryable errors", async () => {
     const sleeps: number[] = [];
     injectSleep(async (ms) => {

--- a/src/__tests__/pty-supervisor.test.ts
+++ b/src/__tests__/pty-supervisor.test.ts
@@ -685,12 +685,23 @@ describe("pty-supervisor retry and backoff", () => {
     // FINAL inner attempt (idx 3) must drop --resume — empty sessionId.
     // This is the corrupted-session escape hatch from issue #177.
     expect(spawnedSessionIds[3]).toBe("");
-    // Critical: the final attempt must ALSO clear newSessionId — otherwise
-    // pty-process.ts:251-253 falls back to `--session-id <newSessionId>`
-    // and re-binds the "fresh" claude to the same pre-allocated UUID that
-    // owns the corrupted JSONL. This was a confidence-92 finding in the
-    // 5-agent review; the regression test is the fix verification.
-    expect(spawnedNewSessionIds[3]).toBeUndefined();
+    // Critical: the final attempt must use a FRESH newSessionId (not the
+    // pre-allocated one from the original spawn). Two failure modes guarded:
+    //   - If we KEPT the original newSessionId, pty-process.ts:251-253
+    //     would fall back to `--session-id <old-uuid>` and re-bind the
+    //     "fresh" claude to the SAME UUID that owns the corrupted JSONL.
+    //     Confidence-92 finding from the original 5-agent review.
+    //   - If we CLEARED newSessionId entirely, PtyProcessImpl._sessionId
+    //     would be "" and persistSessionId would no-op on every turn,
+    //     making the recovered conversation unrecoverable after a reap /
+    //     /kill / restart. Codex P2 on PR #183.
+    // So the final attempt's newSessionId must be (a) defined,
+    // (b) non-empty, and (c) different from any UUID seen earlier.
+    expect(spawnedNewSessionIds[3]).toBeDefined();
+    expect(spawnedNewSessionIds[3]).not.toBe("");
+    expect(spawnedNewSessionIds[3]).not.toBe(spawnedNewSessionIds[0]);
+    expect(spawnedNewSessionIds[3]).not.toBe(spawnedNewSessionIds[1]);
+    expect(spawnedNewSessionIds[3]).not.toBe(spawnedNewSessionIds[2]);
   });
 
   it("does NOT drop --resume when respawnRetries=1 (preserves pre-#175 opt-out)", async () => {

--- a/src/runner/pty-supervisor.ts
+++ b/src/runner/pty-supervisor.ts
@@ -1155,18 +1155,48 @@ async function spawnEntry(
   }
 }
 
-async function respawnEntry(entry: PtyEntry): Promise<void> {
+async function respawnEntry(
+  entry: PtyEntry,
+  respawnOpts: { dropResume?: boolean } = {},
+): Promise<void> {
   if (!entry.spawnOpts) {
     throw new Error(
       `[pty-supervisor] cannot respawn ${entry.sessionKey} — no cached spawn options`,
     );
   }
-  // Always resume against the last-known session ID — Claude Code keeps the
+  // Normally resume against the last-known session ID — Claude Code keeps the
   // JSONL on disk after a crash, so --resume <id> picks up where we left off.
+  //
+  // Issue #177 corrupted-session escape hatch: when the retry loop signals
+  // `dropResume: true` (the final attempt after prior failures), abandon
+  // --resume and let claude start a fresh session. Trade the conversation
+  // state for an unstuck agent. The persistSessionId post-turn path will
+  // record the fresh id once the new claude completes its first turn.
+  //
+  // Why only on prior failures: firing on the very first respawn attempt
+  // would abandon sessions even when respawnRetries=1 (the operator opt-out
+  // for fast-fail behaviour, see #175), silently breaking conversation
+  // continuity. The caller (respawnEntryWithRetries) only sets
+  // `dropResume: true` when `i > 0` AND `i === attempts - 1`.
   const lastSessionId = entry.pty?.sessionId ?? entry.spawnOpts.sessionId;
+  // `!!lastSessionId` guard: no point abandoning a resume if there's no
+  // session id to abandon — silently no-op rather than logging an empty id.
+  const abandonResume = !!respawnOpts.dropResume && !!lastSessionId;
+  if (abandonResume) {
+    process.stderr.write(
+      `[pty-supervisor] dropping --resume for ${entry.sessionKey} on final respawn attempt — corrupted-session escape hatch; abandoned sessionId=${lastSessionId} (inspect or remove ~/.claude/projects/<cwd-slug>/${lastSessionId}.jsonl if the crash recurs)\n`,
+    );
+  }
   const opts: PtyProcessOptions = {
     ...entry.spawnOpts,
-    sessionId: lastSessionId ?? "",
+    sessionId: abandonResume ? "" : (lastSessionId ?? ""),
+    // When abandoning the resume, ALSO clear `newSessionId`. Otherwise
+    // `buildClaudeArgs` (pty-process.ts:251-253) falls back to passing
+    // `--session-id <newSessionId>` for an empty `sessionId`, which would
+    // re-bind the "fresh" claude to the SAME UUID that owns the corrupted
+    // JSONL we just tried to abandon. The post-turn `persistSessionId`
+    // path will pick up whatever fresh id claude generates on its own.
+    ...(abandonResume ? { newSessionId: undefined } : {}),
   };
 
   // MCP multiplexer (SPEC §4.5 "Respawn behaviour"): rotate the bearer token
@@ -1231,20 +1261,28 @@ async function respawnEntry(entry: PtyEntry): Promise<void> {
  * loop wraps the thrown error in a "respawn failed after N attempts"
  * message and returns `errorResult(...)` for the operator.
  *
- * Issue #177 (separate) tracks dropping `--resume <sessionId>` on the final
- * attempt as a corrupted-session escape hatch. This helper does the retry
- * envelope; the resume fallback is layered on top.
+ * Issue #177 (corrupted-session escape hatch): when at least one attempt has
+ * already failed and we're entering the final attempt, signal `respawnEntry`
+ * to drop `--resume <sessionId>` and start a fresh claude. A poisoned session
+ * JSONL would otherwise make every retry hit the same crash; trading the
+ * conversation state for an unstuck agent is the right call. We only fire the
+ * fallback when there were prior failures (`i > 0`) so `respawnRetries=1`
+ * (the documented pre-#175 opt-out) keeps its original behaviour and never
+ * abandons the session unilaterally.
  */
 async function respawnEntryWithRetries(entry: PtyEntry, opts: SupervisorOptions): Promise<void> {
   const attempts = Math.max(1, opts.respawnRetries);
   let lastErr: unknown = new Error("respawnEntryWithRetries: no attempts made");
   for (let i = 0; i < attempts; i++) {
+    const isFinalAttempt = i === attempts - 1;
+    const hadPriorFailures = i > 0;
+    const dropResume = isFinalAttempt && hadPriorFailures;
     try {
-      await respawnEntry(entry);
+      await respawnEntry(entry, { dropResume });
       return;
     } catch (err) {
       lastErr = err;
-      if (i === attempts - 1) break;
+      if (isFinalAttempt) break;
       const delay = pickBackoff(opts.backoffMs, i);
       await _sleep(delay);
     }

--- a/src/runner/pty-supervisor.ts
+++ b/src/runner/pty-supervisor.ts
@@ -1187,16 +1187,32 @@ async function respawnEntry(
       `[pty-supervisor] dropping --resume for ${entry.sessionKey} on final respawn attempt — corrupted-session escape hatch; abandoned sessionId=${lastSessionId} (inspect or remove ~/.claude/projects/<cwd-slug>/${lastSessionId}.jsonl if the crash recurs)\n`,
     );
   }
+  // When abandoning the resume, we need to MINT a fresh `newSessionId`
+  // distinct from the poisoned UUID. Two issues we're avoiding:
+  //
+  //   1. If we kept `entry.spawnOpts.newSessionId` (the original pre-
+  //      allocated UUID), `buildClaudeArgs` (pty-process.ts:251-253) would
+  //      fall back to `--session-id <old-uuid>` for the empty `sessionId`
+  //      and re-bind the "fresh" claude to the SAME UUID that owns the
+  //      corrupted JSONL — silently defeating the escape hatch. This was
+  //      a confidence-92 finding from the 5-agent review.
+  //
+  //   2. If we cleared `newSessionId` entirely (initial fix), claude would
+  //      start a fresh session but `PtyProcessImpl._sessionId` would be ""
+  //      (pty-process.ts:333-334 derives only from sessionId|newSessionId).
+  //      Every subsequent `runTurn` would return an empty sessionId,
+  //      `persistSessionId` would no-op (line 1386 `if (!sessionId) return`),
+  //      and the recovered conversation could not be saved / resumed after
+  //      an idle reap, `/kill`, or daemon restart — Codex P2 on PR #183.
+  //
+  // Minting a fresh UUID via `_newSessionId()` (the same generator used by
+  // `buildSpawnOptions`) lets the post-turn `persistSessionId` path write
+  // it through and keeps recovery working.
+  const freshNewSessionId = abandonResume ? _newSessionId() : undefined;
   const opts: PtyProcessOptions = {
     ...entry.spawnOpts,
     sessionId: abandonResume ? "" : (lastSessionId ?? ""),
-    // When abandoning the resume, ALSO clear `newSessionId`. Otherwise
-    // `buildClaudeArgs` (pty-process.ts:251-253) falls back to passing
-    // `--session-id <newSessionId>` for an empty `sessionId`, which would
-    // re-bind the "fresh" claude to the SAME UUID that owns the corrupted
-    // JSONL we just tried to abandon. The post-turn `persistSessionId`
-    // path will pick up whatever fresh id claude generates on its own.
-    ...(abandonResume ? { newSessionId: undefined } : {}),
+    ...(abandonResume ? { newSessionId: freshNewSessionId } : {}),
   };
 
   // MCP multiplexer (SPEC §4.5 "Respawn behaviour"): rotate the bearer token


### PR DESCRIPTION
## Summary

Closes #177. Builds on #175 (just merged). The escape hatch for poisoned session JSONLs.

## Problem

#175 made the respawn retry loop try up to `pty.respawnRetries` (default 3) attempts before bailing. But every attempt still passes `--resume <sessionId>` against the same on-disk JSONL. If that file is corrupted / mid-write / version-incompatible, claude exits fast on every retry and the agent stays permanently stuck — no number of retries helps.

## Fix

On the **final** respawn attempt — and only when prior attempts have already failed — drop `--resume` and let claude start a fresh session. The trade is conversation state for an unstuck agent.

Gate: `dropResume = isFinalAttempt && hadPriorFailures` (`i === attempts - 1 && i > 0`). This preserves the documented `respawnRetries=1` opt-out from #175: that opt-out means "give up fast like the old code did", and silently dropping the session on the only attempt would change semantics.

## Critical detail caught by the 5-agent review

The first cut only cleared `sessionId: ""` on the abandonResume path. `entry.spawnOpts.newSessionId` (the original pre-allocated UUID from the very first spawn) survived the spread. `pty-process.ts:251-253` falls back to `--session-id <newSessionId>` when `sessionId` is empty, so the "fresh" spawn still re-bound to the same UUID owning the corrupted JSONL. **The escape hatch was silently defeated by its own implementation.**

Two reviewers (Agents #1 + #3) independently flagged this at confidence 92. The companion test gap (only asserting `opts.sessionId`, not `opts.newSessionId`) let the bug pass CI — also fixed.

## Changes

- `src/runner/pty-supervisor.ts`:
  - `respawnEntry(entry, { dropResume? })` — new optional flag.
  - On `abandonResume`: clear both `sessionId` AND `newSessionId` in the spread (the critical fix).
  - stderr log includes the abandoned sessionId + operator hint pointing at the on-disk JSONL location.
  - Inline comment now explains WHY `dropResume` requires prior failures.
- `src/__tests__/pty-supervisor.test.ts` — 3 new tests:
  1. Primary happy path: 3 attempts, first 2 fail with `--resume`, 3rd succeeds without it. Asserts BOTH `sessionId` AND `newSessionId` are empty on the final attempt (regression guard against the critical bug).
  2. `respawnRetries=1` opt-out: never drops `--resume`.
  3. First inner attempt with `respawnRetries=3` keeps `--resume`; only the final attempt after prior failures drops it.

Versions bumped to 2.2.102. `bun test src/__tests__/pty-supervisor.test.ts` 47/47 pass; `bun run lint` clean.

## Review

5-agent review (full transcripts in `.claude/state/pr-review-177-transcript-*.txt`):
- Agent #1 (CLAUDE.md): caught the critical newSessionId bug + test gap.
- Agent #2 (bug scan): cleared all 4 structural concerns.
- Agent #3 (history): independently caught the critical newSessionId bug; confirmed PR #89 / #102 interactions safe.
- Agent #4 (prior PRs): no conflicts with #89 / #102 / #175.
- Agent #5 (comments): 2 doc improvements (WHY comment + actionable log hint), both folded in.

Security review: APPROVE. cwd/identity preserved on respawn, abandoned-id log is forensic aid (not a credential), `respawnRetries=1` opt-out preserved via `hadPriorFailures` guard, no untrusted-input paths.

## Follow-ups

- #176 (capture exit reason on "exited before TUI settled") — independent, pairs well with this.
- #178 (systemd cgroup escape) — deploy-infra.
- #180 (`claude --print` 401) — Anthropic-side.

Closes #177
