### PR TITLE
fix(bus): wire MCP multiplexer issuer before spawning bus agents (#165)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.108",
+      "version": "2.2.109",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.107",
+      "version": "2.2.108",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.106",
+      "version": "2.2.107",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.108",
+  "version": "2.2.109",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.107",
+  "version": "2.2.108",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.106",
+  "version": "2.2.107",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/mcp-config-synth.test.ts
+++ b/src/bus/__tests__/mcp-config-synth.test.ts
@@ -139,7 +139,7 @@ function writeArgvRecorder(dir: string): string {
   return path;
 }
 
-async function readArgvWhenReady(dir: string, timeoutMs = 2000): Promise<string[]> {
+async function readArgvWhenReady(dir: string, timeoutMs = 8000): Promise<string[]> {
   const path = join(dir, "argv.txt");
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {

--- a/src/bus/__tests__/mcp-config-synth.test.ts
+++ b/src/bus/__tests__/mcp-config-synth.test.ts
@@ -13,7 +13,15 @@
  *      `stop()` revokes the identity + deletes the 0600 config file.
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { PtyIdentity } from "../../runner/pty-mcp-config-writer";
@@ -100,6 +108,29 @@ describe("synthesizeBusMcpConfig (issue #165)", () => {
     expect(existsSync(configPathFor(cwd, "a"))).toBe(false);
   });
 
+  it("revokes the just-minted identity when writeConfigForPty throws", async () => {
+    // Maintainer follow-up on the PR #184 third re-review: synth.issue
+    // happens BEFORE writeConfigForPty, and the outer try/catch in
+    // spawnAgentInternal can't see the cwd because mcpConfigCwd is
+    // only assigned AFTER synthesizeBusMcpConfig returns. Without the
+    // inner rollback, an EACCES/ENOSPC during the file write leaks the
+    // multiplexer identity in the issuer's registry forever.
+    const { synth, issued, revoked } = makeSynth();
+    // Make the cwd read-only so writeConfigForPty hits EACCES on its
+    // internal writeFileSync.
+    chmodSync(cwd, 0o500);
+    try {
+      expect(() => synthesizeBusMcpConfig(agentCfg("triage", cwd), synth, cwd)).toThrow();
+    } finally {
+      // Restore for afterEach cleanup.
+      chmodSync(cwd, 0o700);
+    }
+    expect(issued).toEqual(["triage"]);
+    // `revoke` is fire-and-forget — give the microtask queue a tick.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(revoked).toEqual(["triage"]);
+  });
+
   it("writes a per-agent config listing the shared servers with bridge URLs + identity headers", () => {
     const { synth, issued } = makeSynth();
     const out = synthesizeBusMcpConfig(agentCfg("triage", cwd), synth, cwd);
@@ -179,7 +210,10 @@ describe("SessionManager spawn → synthesized --mcp-config in argv (issue #165)
 
     const idx = argv.indexOf("--mcp-config");
     expect(idx).toBeGreaterThanOrEqual(0);
-    expect(argv[idx + 1]).toBe(configPathFor(cwd, "a"));
+    // SessionManager resolves `cwd` through realpathSync, so on macOS the
+    // synthesized argv path is under `/private/var/...` while `cwd` itself
+    // is `/var/...`. Compare against the resolved-path variant.
+    expect(argv[idx + 1]).toBe(configPathFor(realpathSync(cwd), "a"));
     expect(issued).toEqual(["a"]);
     expect(existsSync(configPathFor(cwd, "a"))).toBe(true);
   });
@@ -224,6 +258,12 @@ describe("SessionManager spawn → synthesized --mcp-config in argv (issue #165)
     expect(existsSync(configPathFor(cwd, "a"))).toBe(false);
     // revoke is fire-and-forget on a microtask; let it settle.
     await new Promise((r) => setTimeout(r, 25));
-    expect(revoked).toEqual(["a"]);
+    // PR #184 re-review (commit df52157) added cleanup-in-onExit alongside
+    // the pre-existing stop()-path cleanup, so a clean stop() observes
+    // both paths firing. The double-call is documented as safe per the
+    // idempotency contract on `cleanupAgentMcpConfig`; assert the agent
+    // appears in the revoked list rather than that it appears exactly
+    // once.
+    expect(revoked).toContain("a");
   });
 });

--- a/src/bus/__tests__/mcp-config-synth.test.ts
+++ b/src/bus/__tests__/mcp-config-synth.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Issue #165 — the bus spawn path must synthesize a per-agent
+ * `--mcp-config` for `mcp.shared` servers (the legacy PTY supervisor
+ * already does; the bus's own `buildClaudeArgs` never did).
+ *
+ * Two layers of coverage:
+ *   1. `synthesizeBusMcpConfig` (pure): precedence + dormancy + the
+ *      synthesized JSON shape (shared servers, bridge URLs, identity
+ *      headers).
+ *   2. `SessionManager.spawnAgent` integration: the synthesized
+ *      `--mcp-config <path>` actually lands in the spawned process's argv
+ *      (graceful-degradation + regression branches included), and
+ *      `stop()` revokes the identity + deletes the 0600 config file.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { PtyIdentity } from "../../runner/pty-mcp-config-writer";
+import { configPathFor } from "../../runner/pty-mcp-config-writer";
+import {
+  type BusMcpConfigSynthesizer,
+  SessionManager,
+  synthesizeBusMcpConfig,
+} from "../session-manager";
+import type { AgentConfig } from "../types";
+
+function makeSynth(overrides: Partial<BusMcpConfigSynthesizer> = {}): {
+  synth: BusMcpConfigSynthesizer;
+  issued: string[];
+  revoked: string[];
+} {
+  const issued: string[] = [];
+  const revoked: string[] = [];
+  const synth: BusMcpConfigSynthesizer = {
+    sharedServers: ["alpha", "beta"],
+    bridgeBaseUrl: () => "http://127.0.0.1:4632",
+    issue: (ptyId): PtyIdentity => {
+      issued.push(ptyId);
+      return {
+        ptyId,
+        issuedAt: 1234,
+        headers: {
+          Authorization: `Bearer secret-${ptyId}`,
+          "X-Claudeclaw-Pty-Id": ptyId,
+          "X-Claudeclaw-Ts": "1234",
+        },
+      };
+    },
+    revoke: (ptyId) => {
+      revoked.push(ptyId);
+    },
+    ...overrides,
+  };
+  return { synth, issued, revoked };
+}
+
+function agentCfg(id: string, cwd: string, overrides: Partial<AgentConfig> = {}): AgentConfig {
+  return {
+    id,
+    cwd,
+    session_id: `sess-${id}`,
+    permission_mode: "bypassPermissions",
+    ...overrides,
+  };
+}
+
+describe("synthesizeBusMcpConfig (issue #165)", () => {
+  let cwd: string;
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "ccaw-synth-"));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("returns undefined and writes nothing when the agent has a static mcp_config", () => {
+    const { synth, issued } = makeSynth();
+    const out = synthesizeBusMcpConfig(
+      agentCfg("a", cwd, { mcp_config: "/operator/mcp.json" }),
+      synth,
+      cwd,
+    );
+    expect(out).toBeUndefined();
+    expect(issued).toEqual([]); // operator's static config wins; no identity minted
+    expect(existsSync(configPathFor(cwd, "a"))).toBe(false);
+  });
+
+  it("returns undefined when no synthesizer is wired (dormant multiplexer)", () => {
+    const out = synthesizeBusMcpConfig(agentCfg("a", cwd), null, cwd);
+    expect(out).toBeUndefined();
+    expect(existsSync(configPathFor(cwd, "a"))).toBe(false);
+  });
+
+  it("returns undefined when there are zero shared servers", () => {
+    const { synth, issued } = makeSynth({ sharedServers: [] });
+    const out = synthesizeBusMcpConfig(agentCfg("a", cwd), synth, cwd);
+    expect(out).toBeUndefined();
+    expect(issued).toEqual([]);
+    expect(existsSync(configPathFor(cwd, "a"))).toBe(false);
+  });
+
+  it("writes a per-agent config listing the shared servers with bridge URLs + identity headers", () => {
+    const { synth, issued } = makeSynth();
+    const out = synthesizeBusMcpConfig(agentCfg("triage", cwd), synth, cwd);
+
+    expect(out).toBe(configPathFor(cwd, "triage"));
+    expect(issued).toEqual(["triage"]); // keyed on the STABLE agent id
+    const json = JSON.parse(readFileSync(out as string, "utf8"));
+    expect(Object.keys(json.mcpServers).sort()).toEqual(["alpha", "beta"]);
+    expect(json.mcpServers.alpha).toMatchObject({
+      type: "http",
+      url: "http://127.0.0.1:4632/mcp/alpha",
+      headers: {
+        Authorization: "Bearer secret-triage",
+        "X-Claudeclaw-Pty-Id": "triage",
+      },
+    });
+    expect(json.mcpServers.beta.url).toBe("http://127.0.0.1:4632/mcp/beta");
+  });
+});
+
+/* ───────────────────────────────────────────────────────────────────── */
+/* Spawn integration: the synthesized flag lands in the child's argv.     */
+/* ───────────────────────────────────────────────────────────────────── */
+
+/**
+ * A stand-in for `claude` that records the argv it was launched with into
+ * `<cwd>/argv.txt`, then blocks on stdin so the PTY stays alive (mirrors a
+ * live REPL). `claude`'s flags are harmless to it — it ignores everything
+ * but recording them, which is exactly what we assert against.
+ */
+function writeArgvRecorder(dir: string): string {
+  const path = join(dir, "argv-recorder.sh");
+  writeFileSync(path, '#!/bin/sh\nprintf "%s\\n" "$@" > "$(pwd)/argv.txt"\ncat >/dev/null\n', {
+    mode: 0o755,
+  });
+  chmodSync(path, 0o755);
+  return path;
+}
+
+async function readArgvWhenReady(dir: string, timeoutMs = 2000): Promise<string[]> {
+  const path = join(dir, "argv.txt");
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(path)) {
+      const lines = readFileSync(path, "utf8").split("\n").filter(Boolean);
+      if (lines.length > 0) return lines;
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`argv recorder never wrote ${path}`);
+}
+
+describe("SessionManager spawn → synthesized --mcp-config in argv (issue #165)", () => {
+  let cwd: string;
+  let mgr: SessionManager;
+
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "ccaw-spawn-"));
+  });
+  afterEach(async () => {
+    try {
+      await mgr?.stop("a");
+    } catch {
+      /* ignore */
+    }
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("appends --mcp-config <synth path> when the multiplexer synthesizer is active", async () => {
+    const recorder = writeArgvRecorder(cwd);
+    const { synth, issued } = makeSynth();
+    mgr = new SessionManager({ commandOverride: recorder, sessionCollisionDetectMs: 0 });
+    mgr.setMcpConfigSynthesizer(synth);
+
+    await mgr.spawnAgent(agentCfg("a", cwd, { supervision: "pty-stdin" }), "cli");
+    const argv = await readArgvWhenReady(cwd);
+
+    const idx = argv.indexOf("--mcp-config");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    expect(argv[idx + 1]).toBe(configPathFor(cwd, "a"));
+    expect(issued).toEqual(["a"]);
+    expect(existsSync(configPathFor(cwd, "a"))).toBe(true);
+  });
+
+  it("graceful degradation: no synthesizer wired → no --mcp-config", async () => {
+    const recorder = writeArgvRecorder(cwd);
+    mgr = new SessionManager({ commandOverride: recorder, sessionCollisionDetectMs: 0 });
+    // No setMcpConfigSynthesizer call — multiplexer dormant / inactive.
+
+    await mgr.spawnAgent(agentCfg("a", cwd, { supervision: "pty-stdin" }), "cli");
+    const argv = await readArgvWhenReady(cwd);
+
+    expect(argv).not.toContain("--mcp-config");
+    expect(existsSync(configPathFor(cwd, "a"))).toBe(false);
+  });
+
+  it("regression: synthesizer with zero shared servers → no --mcp-config (byte-identical to dormant)", async () => {
+    const recorder = writeArgvRecorder(cwd);
+    const { synth } = makeSynth({ sharedServers: [] });
+    mgr = new SessionManager({ commandOverride: recorder, sessionCollisionDetectMs: 0 });
+    mgr.setMcpConfigSynthesizer(synth);
+
+    await mgr.spawnAgent(agentCfg("a", cwd, { supervision: "pty-stdin" }), "cli");
+    const argv = await readArgvWhenReady(cwd);
+
+    expect(argv).not.toContain("--mcp-config");
+    expect(existsSync(configPathFor(cwd, "a"))).toBe(false);
+  });
+
+  it("stop() revokes the identity and deletes the synthesized config file", async () => {
+    const recorder = writeArgvRecorder(cwd);
+    const { synth, revoked } = makeSynth();
+    mgr = new SessionManager({ commandOverride: recorder, sessionCollisionDetectMs: 0 });
+    mgr.setMcpConfigSynthesizer(synth);
+
+    await mgr.spawnAgent(agentCfg("a", cwd, { supervision: "pty-stdin" }), "cli");
+    await readArgvWhenReady(cwd);
+    expect(existsSync(configPathFor(cwd, "a"))).toBe(true);
+
+    await mgr.stop("a");
+
+    expect(existsSync(configPathFor(cwd, "a"))).toBe(false);
+    // revoke is fire-and-forget on a microtask; let it settle.
+    await new Promise((r) => setTimeout(r, 25));
+    expect(revoked).toEqual(["a"]);
+  });
+});

--- a/src/bus/__tests__/runtime-mount.test.ts
+++ b/src/bus/__tests__/runtime-mount.test.ts
@@ -469,6 +469,100 @@ describe("mountBusRuntime — auto-spawn rollback", () => {
   });
 });
 
+describe("mountBusRuntime — deferred spawn (issue #165)", () => {
+  let handle: BusRuntimeHandle | null = null;
+
+  afterEach(async () => {
+    if (handle) {
+      await handle.stop();
+      handle = null;
+    }
+  });
+
+  it("deferSpawn: true mounts the bus but does NOT spawn any agent", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    handle = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      agents: [cfg("triage"), cfg("research")],
+      deferSpawn: true,
+      logger: SILENT_LOGGER,
+    });
+    // The bus is live...
+    expect(bus.startCalls()).toBe(1);
+    // ...but the issuer-before-spawn guarantee means nothing spawned yet.
+    expect(sm.spawnLog).toEqual([]);
+    expect(handle.spawnedAgentIds).toEqual([]);
+  });
+
+  it("handle.spawnAgents() spawns the declared agents in order after mount", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    handle = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      agents: [cfg("triage"), cfg("research"), cfg("ops")],
+      deferSpawn: true,
+      logger: SILENT_LOGGER,
+    });
+    expect(sm.spawnLog).toEqual([]);
+
+    await handle.spawnAgents();
+
+    expect(sm.spawnLog.map((r) => r.config.id)).toEqual(["triage", "research", "ops"]);
+    expect(handle.spawnedAgentIds).toEqual(["triage", "research", "ops"]);
+  });
+
+  it("handle.spawnAgents(batch) spawns an explicit batch with an origin override", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    handle = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      agents: [cfg("declared")],
+      deferSpawn: true,
+      logger: SILENT_LOGGER,
+    });
+    await handle.spawnAgents([cfg("explicit")], "discord");
+    expect(sm.spawnLog.map((r) => r.config.id)).toEqual(["explicit"]);
+    expect(sm.spawnLog[0]?.origin).toBe("discord");
+  });
+
+  it("handle.spawnAgents() rolls back this batch (reverse order) when a spawn throws", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager({ failSpawnAtIndex: 2 });
+    handle = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      agents: [cfg("a"), cfg("b"), cfg("c"), cfg("d")],
+      deferSpawn: true,
+      logger: SILENT_LOGGER,
+    });
+    await expect(handle.spawnAgents()).rejects.toThrow(/failed to spawn agent="c"/);
+    // Agents a + b were rolled back in reverse order; none remain registered.
+    expect(sm.stopLog).toEqual(["b", "a"]);
+    expect(handle.spawnedAgentIds).toEqual([]);
+    // The bus is still up — the daemon decides whether to tear it down.
+    expect(bus.stopCalls()).toBe(0);
+  });
+
+  it("handle.spawnAgents() throws once the handle has been stopped", async () => {
+    const bus = createFakeBus();
+    const sm = new FakeSessionManager();
+    handle = await mountBusRuntime({
+      bus,
+      sessionManager: sm,
+      agents: [cfg("a")],
+      deferSpawn: true,
+      logger: SILENT_LOGGER,
+    });
+    await handle.stop();
+    await expect(handle.spawnAgents()).rejects.toThrow(/stopped handle/);
+    handle = null; // already stopped
+  });
+});
+
 describe("mountBusRuntime — stop() with agents", () => {
   it("stops every spawned agent in reverse order before bus.stop", async () => {
     const bus = createFakeBus();

--- a/src/bus/adapter-wiring.ts
+++ b/src/bus/adapter-wiring.ts
@@ -96,6 +96,25 @@ export async function wireBusAdapters(
 }
 
 /**
+ * The adapter names `wireBusAdapters` WOULD mount for these settings —
+ * computed from the same token/busRouting predicates the per-adapter mount
+ * functions use, without constructing or starting anything. Single source
+ * of truth for "which bus adapters are configured", so startup logs that
+ * run BEFORE the (now deferred, issue #165) wiring can report intent
+ * accurately. Order matches `wireBusAdapters`.
+ */
+export function configuredBusAdapterNames(
+  settings: WireBusAdaptersOptions["settings"],
+): MountedAdapter["name"][] {
+  const names: MountedAdapter["name"][] = [];
+  if (settings.discord?.token && settings.discord?.busRouting) names.push("discord");
+  if (settings.telegram?.token && settings.telegram?.busRouting) names.push("telegram");
+  if (settings.slack?.botToken && settings.slack?.busRouting) names.push("slack");
+  if (settings.web?.bus) names.push("webui");
+  return names;
+}
+
+/**
  * Stop every adapter in reverse-construction order. Errors from one
  * adapter's stop() are logged and the loop continues so a single
  * misbehaving adapter can't block daemon shutdown.

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -11,13 +11,17 @@
  *   - Slash-command relay via `wireSlashCommands`.
  *   - Teardown handle.
  *
- * Sprint 5.2a (this PR) adds:
+ * Sprint 5.2a adds:
  *   - Auto-spawn of named agents from `settings.agents` (resolved into
- *     `AgentConfig` via `resolveBusAgentConfigs`).
+ *     `AgentConfig` via `resolveBusAgentConfigs`). Issue #165: this spawn
+ *     is now skippable at mount via `deferSpawn: true` — the daemon then
+ *     calls `handle.spawnAgents()` after the MCP multiplexer issuer is
+ *     wired, so spawned agents get a synthesized `--mcp-config`.
  *   - `BusRuntimeHandle.stop()` now stops every spawned agent in addition
  *     to tearing down BusCore.
  *   - Rollback of partial mounts: if agent N+1 fails to spawn, agents
- *     0..N are stopped before the error is re-thrown.
+ *     0..N are stopped before the error is re-thrown. The same batch
+ *     rollback backs `handle.spawnAgents()`.
  *
  * Sprint 5.2b will follow with adapter wiring (Discord / Telegram /
  * Slack / WebUi) using a routing-config schema; Sprint 5.2c adds

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -59,6 +59,18 @@ export interface BusRuntimeHandle {
    */
   mountedAdapterNames: readonly MountedAdapter["name"][];
   /**
+   * Spawn agents after mount (issue #165). Used with `deferSpawn: true`:
+   * the daemon mounts the bus, wires the MCP multiplexer identity issuer,
+   * then calls this so the spawned `claude` PTYs get a synthesized
+   * `--mcp-config` for `mcp.shared` servers.
+   *
+   * `batch` defaults to the `agents` passed at mount. Spawns sequentially;
+   * on the first failure rolls back the agents THIS call spawned and
+   * re-throws (the daemon's catch then calls `handle.stop()` + falls back
+   * to legacy surfaces). Throws if the handle has already been stopped.
+   */
+  spawnAgents(batch?: readonly AgentConfig[], spawnOriginOverride?: BusOrigin): Promise<void>;
+  /**
    * Register adapters with the handle's stop lifecycle. Sprint 5.2b
    * (PR #123) Codex P1/P2 fold-in: callers wire adapters AFTER the
    * bus is mounted; this method lets the handle own teardown even
@@ -115,6 +127,24 @@ export interface MountBusRuntimeOptions {
    * they need to.
    */
   agents?: readonly AgentConfig[];
+  /**
+   * Defer the eager agent spawn (issue #165). When true, `mountBusRuntime`
+   * brings up the bus + slash relay + orphan scan but does NOT spawn the
+   * `agents` at mount time — the caller spawns them later via
+   * `handle.spawnAgents()`, once the MCP multiplexer issuer is wired.
+   *
+   * Why this exists: the daemon wires the multiplexer identity issuer
+   * AFTER `mountBusRuntime` (it depends on `pluginManager.startServices()`).
+   * If agents spawn at mount, their `claude` PTYs are built before the
+   * issuer exists, so `buildClaudeArgs` synthesizes no `--mcp-config` and
+   * every `mcp.shared` server is unreachable for the agent's whole life.
+   * Deferring the spawn lets the daemon wire the issuer first.
+   *
+   * `agents` is still passed (so the orphan-agent scan + startup log see
+   * the full declared set); only the spawn is held back. Backward
+   * compatible: callers that don't set this keep the eager-spawn behaviour.
+   */
+  deferSpawn?: boolean;
   /**
    * `BusOrigin` tag passed to `sessionManager.spawnAgent(agent, origin)`.
    * The agent's resolved `supervision` field takes precedence over the
@@ -223,30 +253,50 @@ export async function mountBusRuntime(
       }
     });
 
-    // Auto-spawn declared agents. Sequential rather than parallel so
-    // log output stays readable + spawn failures surface against a
-    // known agent id rather than an unrelated parallel reject.
-    for (const agent of opts.agents ?? []) {
-      try {
-        await sessionManager.spawnAgent(agent, origin);
-        spawned.push(agent.id);
-        logger.info(`[bus-runtime] spawned agent=${agent.id}`);
-      } catch (err) {
-        // Stop any already-spawned agents in reverse order before
-        // bubbling. The outer catch handles bus teardown.
-        for (let i = spawned.length - 1; i >= 0; i--) {
-          try {
-            await sessionManager.stop(spawned[i]);
-          } catch (stopErr) {
-            logger.error(`[bus-runtime] rollback: failed to stop agent=${spawned[i]}`, stopErr);
+    const declaredAgents = opts.agents ?? [];
+
+    // Spawn a batch of agents sequentially (readable logs + failures
+    // surface against a known id rather than an unrelated parallel
+    // reject). On the first failure, roll back ONLY the agents this batch
+    // spawned (reverse order) and re-throw — agents from an earlier
+    // successful batch stay up; the caller decides whether to tear the
+    // whole handle down. Shared by the eager mount path and the deferred
+    // `handle.spawnAgents()` path (issue #165).
+    async function spawnAgentBatch(
+      batch: readonly AgentConfig[],
+      batchOrigin: BusOrigin,
+    ): Promise<void> {
+      const spawnedThisBatch: string[] = [];
+      for (const agent of batch) {
+        try {
+          await sessionManager.spawnAgent(agent, batchOrigin);
+          spawned.push(agent.id);
+          spawnedThisBatch.push(agent.id);
+          logger.info(`[bus-runtime] spawned agent=${agent.id}`);
+        } catch (err) {
+          for (let i = spawnedThisBatch.length - 1; i >= 0; i--) {
+            const id = spawnedThisBatch[i];
+            try {
+              await sessionManager.stop(id);
+            } catch (stopErr) {
+              logger.error(`[bus-runtime] rollback: failed to stop agent=${id}`, stopErr);
+            }
+            const idx = spawned.lastIndexOf(id);
+            if (idx >= 0) spawned.splice(idx, 1);
           }
+          throw new Error(
+            `[bus-runtime] failed to spawn agent="${agent.id}": ${err instanceof Error ? err.message : String(err)}`,
+            { cause: err },
+          );
         }
-        spawned.length = 0;
-        throw new Error(
-          `[bus-runtime] failed to spawn agent="${agent.id}": ${err instanceof Error ? err.message : String(err)}`,
-          { cause: err },
-        );
       }
+    }
+
+    // Eager spawn unless the caller deferred it (issue #165). When
+    // deferred, the daemon calls `handle.spawnAgents()` after wiring the
+    // MCP multiplexer issuer.
+    if (!opts.deferSpawn) {
+      await spawnAgentBatch(declaredAgents, origin);
     }
 
     // Adapters list is now MUTABLE — Sprint 5.2b (PR #123) Codex P2
@@ -287,6 +337,12 @@ export async function mountBusRuntime(
       },
       get mountedAdapterNames() {
         return adapters.map((a) => a.name);
+      },
+      async spawnAgents(batch, spawnOriginOverride) {
+        if (stopped) {
+          throw new Error("[bus-runtime] spawnAgents called on a stopped handle");
+        }
+        await spawnAgentBatch(batch ?? declaredAgents, spawnOriginOverride ?? origin);
       },
       attachAdapters(more) {
         if (stopped) {

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -567,6 +567,12 @@ export class SessionManager {
         ((agentId: string, sessionId: string) => createSession(sessionId, agentId));
       await persist(agent.id, fresh);
       agent.session_id = fresh;
+      // Issue #165 (PR #184 review): this attempt may have synthesized an
+      // --mcp-config (minted a multiplexer identity + wrote a 0600 file).
+      // The retry below re-synthesizes from scratch, so revoke this
+      // attempt's identity + delete its file first — otherwise the identity
+      // leaks and a stale file lingers if the retry fails before rewriting.
+      this.cleanupAgentMcpConfig(mcpConfigCwd, agent.id);
       // The proc that emitted the collision marker has exited; clear
       // its registry slot so the recursive respawn doesn't trip the
       // `already spawned` guard (the `onExit` cleanup above may not
@@ -580,7 +586,8 @@ export class SessionManager {
     if (collision) {
       // Retried once and still colliding — surface a real error so the
       // operator notices instead of silently looping. Same registry-
-      // slot cleanup as the rotation path.
+      // slot + MCP-config cleanup as the rotation path.
+      this.cleanupAgentMcpConfig(mcpConfigCwd, agent.id);
       const current = this.agents.get(agent.id);
       if (current && current.proc === proc) {
         this.agents.delete(agent.id);
@@ -729,34 +736,43 @@ export class SessionManager {
    * channel; observe process exit; the caller (Bus core) publishes
    * `session.end` AFTER the process exit fires — not before.
    */
+  /**
+   * Release the multiplexer identity + delete the synthesized per-agent
+   * `--mcp-config` (0600 bearer-token file) for an agent that synthesized
+   * one (issue #165). `cwd` is the agent's resolved cwd, or undefined when
+   * no config was synthesized (then this is a no-op). Best-effort: revoke
+   * is documented idempotent and `deleteConfigForPty` swallows ENOENT, so a
+   * double-call (e.g. stop() racing the onExit auto-cleanup, or a
+   * collision-retry followed by stop()) is safe.
+   */
+  private cleanupAgentMcpConfig(cwd: string | undefined, agentId: string): void {
+    if (!cwd) return;
+    try {
+      deleteConfigForPty(cwd, agentId);
+    } catch (err) {
+      (this.options.logger ?? console).warn(
+        `[bus-session] agent=${agentId} mcp-config cleanup failed`,
+        err,
+      );
+    }
+    if (this.mcpSynth) {
+      Promise.resolve(this.mcpSynth.revoke(agentId)).catch((err) =>
+        (this.options.logger ?? console).warn(
+          `[bus-session] agent=${agentId} mcp identity revoke failed`,
+          err,
+        ),
+      );
+    }
+  }
+
   stop(agent_id: string): Promise<void> {
     const record = this.agents.get(agent_id);
     if (!record) return Promise.resolve();
     return new Promise<void>((resolve) => {
       const finalise = (): void => {
         // Issue #165: release the multiplexer identity + delete the
-        // synthesized per-agent --mcp-config (0600 bearer-token file) when
-        // this spawn had one. Best-effort: revoke is documented idempotent
-        // and deleteConfigForPty swallows ENOENT, so a double-call (stop()
-        // racing the onExit auto-cleanup) is safe.
-        if (record.mcpConfigCwd) {
-          try {
-            deleteConfigForPty(record.mcpConfigCwd, agent_id);
-          } catch (err) {
-            (this.options.logger ?? console).warn(
-              `[bus-session] agent=${agent_id} mcp-config cleanup failed`,
-              err,
-            );
-          }
-          if (this.mcpSynth) {
-            Promise.resolve(this.mcpSynth.revoke(agent_id)).catch((err) =>
-              (this.options.logger ?? console).warn(
-                `[bus-session] agent=${agent_id} mcp identity revoke failed`,
-                err,
-              ),
-            );
-          }
-        }
+        // synthesized per-agent --mcp-config when this spawn had one.
+        this.cleanupAgentMcpConfig(record.mcpConfigCwd, agent_id);
         // Drop from registry (the onExit handler installed in spawnAgent()
         // will also do this; harmless to do twice).
         this.agents.delete(agent_id);

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -511,15 +511,26 @@ export class SessionManager {
       }
     }
 
+    // Issue #165 (PR #184 re-review): the synthesized identity + 0600
+    // bearer file are minted ABOVE, before the spawn primitive runs. If the
+    // primitive throws (bun-pty native fault, ENOENT on commandOverride,
+    // tmux not on PATH), unwinding skips registry insertion + the onExit
+    // cleanup, so without this the just-failed agent's identity is never
+    // revoked and its file never deleted. Clean up then re-throw.
     let proc: PtyAgentProcess | ChildAgentProcess;
-    if (mode === "pty-stdin") {
-      proc = await this.spawnPty(agent, args, env, realCwd);
-    } else if (mode === "process-stream-json" || mode === "process") {
-      proc = this.spawnChild(agent, mode, args, env, realCwd);
-    } else if (mode === "tmux") {
-      proc = this.spawnTmux(agent, args, env, realCwd);
-    } else {
-      throw new Error(`unsupported supervision mode: ${mode satisfies never}`);
+    try {
+      if (mode === "pty-stdin") {
+        proc = await this.spawnPty(agent, args, env, realCwd);
+      } else if (mode === "process-stream-json" || mode === "process") {
+        proc = this.spawnChild(agent, mode, args, env, realCwd);
+      } else if (mode === "tmux") {
+        proc = this.spawnTmux(agent, args, env, realCwd);
+      } else {
+        throw new Error(`unsupported supervision mode: ${mode satisfies never}`);
+      }
+    } catch (err) {
+      this.cleanupAgentMcpConfig(mcpConfigCwd, agent.id);
+      throw err;
     }
 
     // Register the proc + attach the cleanup `onExit` BEFORE awaiting
@@ -537,6 +548,12 @@ export class SessionManager {
     proc.onExit(() => {
       const current = this.agents.get(agent.id);
       if (current && current.proc === proc) {
+        // Issue #165 (PR #184 re-review): a natural exit (crash, OOM,
+        // claude-side auth failure, operator kill) never routes through
+        // stop(), so release the multiplexer identity + delete the 0600
+        // bearer file here too. Idempotent, so it's safe if stop() also
+        // ran (e.g. stop() racing the process's own exit).
+        this.cleanupAgentMcpConfig(current.mcpConfigCwd, agent.id);
         this.agents.delete(agent.id);
       }
     });
@@ -732,11 +749,6 @@ export class SessionManager {
   }
 
   /**
-   * Stop an agent. Per Spike 0.5: write `/quit` via the active supervision
-   * channel; observe process exit; the caller (Bus core) publishes
-   * `session.end` AFTER the process exit fires — not before.
-   */
-  /**
    * Release the multiplexer identity + delete the synthesized per-agent
    * `--mcp-config` (0600 bearer-token file) for an agent that synthesized
    * one (issue #165). `cwd` is the agent's resolved cwd, or undefined when
@@ -765,6 +777,11 @@ export class SessionManager {
     }
   }
 
+  /**
+   * Stop an agent. Per Spike 0.5: write `/quit` via the active supervision
+   * channel; observe process exit; the caller (Bus core) publishes
+   * `session.end` AFTER the process exit fires — not before.
+   */
   stop(agent_id: string): Promise<void> {
     const record = this.agents.get(agent_id);
     if (!record) return Promise.resolve();

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -160,14 +160,29 @@ export function synthesizeBusMcpConfig(
   if (synth.sharedServers.length === 0) return undefined;
 
   const identity = synth.issue(agent.id);
-  const { path } = writeConfigForPty({
-    ptyId: agent.id,
-    cwd,
-    sharedServers: synth.sharedServers.map((name) => ({ name })),
-    perPtyServers: [],
-    bridgeBaseUrl: synth.bridgeBaseUrl(),
-    identity,
-  });
+  // Roll back the just-minted identity if the on-disk write fails
+  // (EACCES, ENOSPC, EROFS, mkdir failure). Without this, the throw
+  // escapes the spawn-dispatch try/catch in `spawnAgentInternal`
+  // because `mcpConfigCwd` is only assigned AFTER this function
+  // returns — `cleanupAgentMcpConfig(undefined, ...)` then short-
+  // circuits via its `if (!cwd) return` guard and the identity stays
+  // alive in the issuer's registry.
+  let path: string;
+  try {
+    ({ path } = writeConfigForPty({
+      ptyId: agent.id,
+      cwd,
+      sharedServers: synth.sharedServers.map((name) => ({ name })),
+      perPtyServers: [],
+      bridgeBaseUrl: synth.bridgeBaseUrl(),
+      identity,
+    }));
+  } catch (err) {
+    Promise.resolve(synth.revoke(agent.id)).catch(() => {
+      // Fire-and-forget; the throw below is the operator-visible signal.
+    });
+    throw err;
+  }
   return path.length > 0 ? path : undefined;
 }
 

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -34,6 +34,11 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { cleanSpawnEnv, withCleanProcessEnv } from "../runner";
+import {
+  deleteConfigForPty,
+  type PtyIdentity,
+  writeConfigForPty,
+} from "../runner/pty-mcp-config-writer";
 import { createSession } from "../sessions";
 import {
   type AgentProcess,
@@ -101,6 +106,69 @@ export interface SessionManagerOptions {
    * Optional logger override. Defaults to `console`.
    */
   logger?: Pick<Console, "warn" | "info" | "error">;
+}
+
+/**
+ * MCP multiplexer synthesizer seam (issue #165). The daemon injects this
+ * AFTER it has started the MCP multiplexer plugin and confirmed
+ * `plugin.isActive()`, so the bus spawn path can synthesize a per-agent
+ * `--mcp-config` for `mcp.shared` servers — the same servers the legacy
+ * PTY supervisor reaches via `synthesizeMcpConfigIfActive`. Without this
+ * the bus's `buildClaudeArgs` only emits `--mcp-config` for a statically
+ * configured `agent.mcp_config`, so multiplexed servers are unreachable
+ * for every bus agent.
+ *
+ * Left `null` when the multiplexer is dormant (`mcp.shared` empty, web
+ * disabled, or `plugin.isActive() === false`) — synthesis is then skipped
+ * and agents spawn with no `--mcp-config`, byte-identical to the
+ * pre-#165 dormant path.
+ */
+export interface BusMcpConfigSynthesizer {
+  /** Mint the per-agent HMAC identity (headers) for the bridge. */
+  issue: (ptyId: string) => PtyIdentity;
+  /** Drop the per-agent identity when the agent is stopped. Idempotent. */
+  revoke: (ptyId: string) => void | Promise<void>;
+  /** The HTTP base URL the multiplexer bound to, e.g. http://127.0.0.1:4632. */
+  bridgeBaseUrl: () => string;
+  /** Names of the multiplexed shared servers (`settings.mcp.shared`). */
+  sharedServers: readonly string[];
+}
+
+/**
+ * Synthesize a per-agent `--mcp-config` path for the bus spawn path
+ * (issue #165), or `undefined` when synthesis doesn't apply.
+ *
+ * Precedence + dormancy rules (mirrors the supervisor):
+ *   - An operator-supplied static `agent.mcp_config` ALWAYS wins — return
+ *     `undefined` so `buildClaudeArgs`'s own pass-through is the single
+ *     source of that flag (never emit two `--mcp-config`).
+ *   - No synthesizer wired, or zero shared servers → `undefined` (dormant,
+ *     no flag, byte-identical to pre-#165).
+ *
+ * Keys the identity + config file on the STABLE `agent.id` rather than
+ * `agent.session_id`: the session id can rotate on a collision respawn,
+ * which would orphan the issued identity + on-disk file. One agent = one
+ * long-lived PTY = one identity.
+ */
+export function synthesizeBusMcpConfig(
+  agent: AgentConfig,
+  synth: BusMcpConfigSynthesizer | null,
+  cwd: string,
+): string | undefined {
+  if (agent.mcp_config) return undefined;
+  if (!synth) return undefined;
+  if (synth.sharedServers.length === 0) return undefined;
+
+  const identity = synth.issue(agent.id);
+  const { path } = writeConfigForPty({
+    ptyId: agent.id,
+    cwd,
+    sharedServers: synth.sharedServers.map((name) => ({ name })),
+    perPtyServers: [],
+    bridgeBaseUrl: synth.bridgeBaseUrl(),
+    identity,
+  });
+  return path.length > 0 ? path : undefined;
 }
 
 /* ───────────────────────────────────────────────────────────────────── */
@@ -364,14 +432,32 @@ interface AgentRecord {
   origin: BusOrigin;
   mode: SupervisionMode;
   proc: PtyAgentProcess | ChildAgentProcess;
+  /**
+   * Set to the agent's cwd when this spawn synthesized a multiplexer
+   * `--mcp-config` (issue #165). Presence drives identity revoke + config
+   * file cleanup on stop(). Absent when no synthesis happened (static
+   * `agent.mcp_config`, or dormant multiplexer).
+   */
+  mcpConfigCwd?: string;
 }
 
 export class SessionManager {
   private readonly options: SessionManagerOptions;
   private readonly agents = new Map<string, AgentRecord>();
+  private mcpSynth: BusMcpConfigSynthesizer | null = null;
 
   constructor(options: SessionManagerOptions = {}) {
     this.options = options;
+  }
+
+  /**
+   * Wire (or clear) the MCP multiplexer synthesizer (issue #165). The
+   * daemon calls this AFTER the multiplexer issuer is wired and BEFORE it
+   * spawns agents, so every subsequently-spawned agent gets a synthesized
+   * `--mcp-config` for `mcp.shared` servers. Pass `null` to disable.
+   */
+  setMcpConfigSynthesizer(synth: BusMcpConfigSynthesizer | null): void {
+    this.mcpSynth = synth;
   }
 
   async spawnAgent(agent: AgentConfig, origin: BusOrigin): Promise<AgentProcess> {
@@ -411,6 +497,20 @@ export class SessionManager {
     const env = buildChildEnv(agent, busSock);
     const args = this.options.argsOverride ?? buildClaudeArgs(agent, mode);
 
+    // Issue #165: synthesize the multiplexer `--mcp-config` for this agent
+    // when the daemon has wired a synthesizer (active multiplexer) and the
+    // agent has no static `mcp_config`. Skipped when `argsOverride` is set
+    // — that test seam replaces the entire args list with a stand-in
+    // process's flags, so appending claude flags would corrupt it.
+    let mcpConfigCwd: string | undefined;
+    if (this.options.argsOverride === undefined) {
+      const synthesizedPath = synthesizeBusMcpConfig(agent, this.mcpSynth, realCwd);
+      if (synthesizedPath) {
+        args.push("--mcp-config", synthesizedPath);
+        mcpConfigCwd = realCwd;
+      }
+    }
+
     let proc: PtyAgentProcess | ChildAgentProcess;
     if (mode === "pty-stdin") {
       proc = await this.spawnPty(agent, args, env, realCwd);
@@ -431,7 +531,7 @@ export class SessionManager {
     // `ChildAgentProcess.onExit` are push-only and don't replay past
     // exits. The cleanup never fires, leaving a dead entry in
     // `this.agents` that breaks the next `already spawned` guard.
-    const record: AgentRecord = { agent, origin, mode, proc };
+    const record: AgentRecord = { agent, origin, mode, proc, mcpConfigCwd };
     this.agents.set(agent.id, record);
     // Auto-cleanup: drop registry entry on exit so restart() can reuse the id.
     proc.onExit(() => {
@@ -634,6 +734,29 @@ export class SessionManager {
     if (!record) return Promise.resolve();
     return new Promise<void>((resolve) => {
       const finalise = (): void => {
+        // Issue #165: release the multiplexer identity + delete the
+        // synthesized per-agent --mcp-config (0600 bearer-token file) when
+        // this spawn had one. Best-effort: revoke is documented idempotent
+        // and deleteConfigForPty swallows ENOENT, so a double-call (stop()
+        // racing the onExit auto-cleanup) is safe.
+        if (record.mcpConfigCwd) {
+          try {
+            deleteConfigForPty(record.mcpConfigCwd, agent_id);
+          } catch (err) {
+            (this.options.logger ?? console).warn(
+              `[bus-session] agent=${agent_id} mcp-config cleanup failed`,
+              err,
+            );
+          }
+          if (this.mcpSynth) {
+            Promise.resolve(this.mcpSynth.revoke(agent_id)).catch((err) =>
+              (this.options.logger ?? console).warn(
+                `[bus-session] agent=${agent_id} mcp identity revoke failed`,
+                err,
+              ),
+            );
+          }
+        }
         // Drop from registry (the onExit handler installed in spawnAgent()
         // will also do this; harmless to do twice).
         this.agents.delete(agent_id);

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -825,11 +825,21 @@ export async function start(args: string[] = []) {
         // (spawned below) get a synthesized --mcp-config too. Only inside
         // this isActive() branch, so the dormant path stays byte-identical.
         if (busRuntimeHandle) {
+          // Codex P2 on PR #184: use the ACTUALLY claimed server names, not
+          // the operator's requested list. When the multiplexer starts
+          // partially (e.g. one shared server failed to claim, another
+          // succeeded), `plugin.isActive()` is true as soon as any one
+          // claimed, but `settings.mcp.shared` still lists the failures.
+          // Writing those names into bus agents' --mcp-config would point
+          // them at /mcp/<server> routes that were never registered. The
+          // multiplexer already caches the claimed set explicitly for this
+          // case (see `sharedServerNames()` + the "ACTUALLY claimed"
+          // comment in src/plugins/mcp-multiplexer/index.ts).
           busRuntimeHandle.sessionManager.setMcpConfigSynthesizer({
             issue: (ptyId) => plugin.issueIdentity(ptyId),
             revoke: (ptyId) => plugin.releaseIdentity(ptyId),
             bridgeBaseUrl: () => plugin.bridgeBaseUrl(),
-            sharedServers: settings.mcp.shared,
+            sharedServers: plugin.sharedServerNames(),
           });
         }
         console.log("[mcp-multiplexer] started");

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -471,7 +471,6 @@ export async function start(args: string[] = []) {
     try {
       const { mountBusRuntime, resolveDaemonSocketPath } = await import("../bus/runtime-mount");
       const { resolveBusAgentConfigs } = await import("../bus/agent-resolver");
-      const { wireBusAdapters } = await import("../bus/adapter-wiring");
       const { BusCoreImpl } = await import("../bus/core");
       const { SessionManager } = await import("../bus/session-manager");
 
@@ -487,19 +486,19 @@ export async function start(args: string[] = []) {
         .map((r) => r.config)
         .filter((c): c is NonNullable<typeof c> => c !== null);
 
-      // Boot order matters. PR #123 Codex P1+P2 fold-in:
+      // Boot order matters. PR #123 Codex P1+P2 + issue #165:
       //   1. Build BusCore + SessionManager (no I/O yet).
-      //   2. mountBusRuntime — starts the IPC server + spawns agents.
-      //      Bus is now live and addressable.
-      //   3. wireBusAdapters — adapters call `adapter.start()` which
-      //      kicks off their poll loops / opens HTTP listeners.
-      //      MUST come AFTER step 2 so prompts that arrive during the
-      //      adapter's first poll have a live bus + agents to dispatch
-      //      to (Codex P2: prompt-loss race).
-      //   4. handle.attachAdapters — the handle's stop() lifecycle now
-      //      owns the adapters; any error in step 5+ that falls
-      //      through to the catch tears them down (Codex P1: adapter
-      //      leak on partial mount failure).
+      //   2. mountBusRuntime with `deferSpawn: true` — starts the IPC
+      //      server + slash relay + orphan scan, but does NOT spawn agents
+      //      yet. The bus is live and addressable; no agents registered.
+      //   3. (after the MCP multiplexer block below) wire the synthesizer,
+      //      `handle.spawnAgents()`, THEN `wireBusAdapters` +
+      //      `handle.attachAdapters`. Issue #165: agents must spawn after
+      //      the multiplexer issuer is wired (so they get `--mcp-config`),
+      //      and adapters must start AFTER agents exist (Codex P2:
+      //      prompt-loss race — adapters polling with zero registered
+      //      agents would silently drop inbound prompts).
+      // Search "Issue #165: deferred bus agent spawn" for step 3.
       const socketPath = resolveDaemonSocketPath();
       const bus = new BusCoreImpl({ socketPath });
       const sessionManager = new SessionManager({ busSocketPath: socketPath });
@@ -507,46 +506,12 @@ export async function start(args: string[] = []) {
         bus,
         sessionManager,
         agents: agentConfigs,
-        // Issue #165: defer the agent spawn. The MCP multiplexer identity
-        // issuer is wired AFTER this mount (it depends on
-        // pluginManager.startServices()). Spawning agents now would build
-        // their claude PTYs before the issuer exists, so buildClaudeArgs
-        // would synthesize no `--mcp-config` and every mcp.shared server
-        // would be unreachable for the agent's whole lifetime. We spawn
-        // below, after the multiplexer block, via handle.spawnAgents().
         deferSpawn: true,
         projectRoot: process.cwd(),
       });
-      // The mount succeeded — from here on, ANY error must call
-      // handle.stop() before falling through to legacy, otherwise the
-      // bus IPC server + spawned agents leak.
-      try {
-        const { adapters, errors } = await wireBusAdapters({ bus, settings });
-        for (const [name, msg] of Object.entries(errors)) {
-          console.warn(`[${ts()}] Bus adapter "${name}" failed to mount: ${msg}`);
-        }
-        handle.attachAdapters(adapters);
-
-        // Issue #165: agent spawn, BusScheduler wiring, and the
-        // architecture-doc write all moved to AFTER the MCP multiplexer
-        // block (search "Issue #165: deferred bus agent spawn"). The
-        // scheduler targets the first spawned agent id, and the arch doc
-        // reports the spawned set — both depend on the spawn, which now
-        // happens once the multiplexer issuer is wired.
-      } catch (wireErr) {
-        // Adapter / scheduler wiring threw — stop the handle (which
-        // already owns the bus + agents + whatever was attached
-        // before this throw) before re-throwing to the outer catch.
-        try {
-          await handle.stop();
-        } catch (stopErr) {
-          console.error(`[${ts()}] handle.stop() during wire rollback failed`, stopErr);
-        }
-        throw wireErr;
-      }
       busRuntimeHandle = handle;
-      busRuntimeSpawnedAgents = handle.spawnedAgentIds;
-      busRuntimeAdapterNames = handle.mountedAdapterNames;
+      busRuntimeSpawnedAgents = handle.spawnedAgentIds; // [] until deferred spawn
+      busRuntimeAdapterNames = handle.mountedAdapterNames; // [] until adapters wired
       busCoreForWebUi = bus;
     } catch (err) {
       console.error(
@@ -593,6 +558,15 @@ export async function start(args: string[] = []) {
   // which means flipping this back to false so the legacy adapter + legacy
   // heartbeat paths re-engage.
   let skipLegacyAdapters = busRuntimeHandle !== null;
+
+  // Issue #165: bus adapters are now wired AFTER the deferred agent spawn
+  // (below the multiplexer block), so `busRuntimeAdapterNames` is still
+  // empty at the startup-banner + legacy-skip logs above this point. Use
+  // the configured-intent list (same token/busRouting predicates
+  // wireBusAdapters uses) so those logs report the right platforms.
+  const configuredBusAdapters: readonly string[] = busRuntimeHandle
+    ? (await import("../bus/adapter-wiring")).configuredBusAdapterNames(settings)
+    : [];
 
   let mcpProxyStarted: Promise<void> = Promise.resolve();
 
@@ -644,9 +618,9 @@ export async function start(args: string[] = []) {
         ? "no agents declared"
         : `${settings.agents.length} agent(s) declared (spawn deferred until MCP issuer wired)`;
     const adaptersLabel =
-      busRuntimeAdapterNames.length === 0
-        ? "no adapters"
-        : `adapters=[${busRuntimeAdapterNames.join(", ")}]`;
+      configuredBusAdapters.length === 0
+        ? "no adapters configured"
+        : `adapters=[${configuredBusAdapters.join(", ")}] (wired after agents)`;
     console.log(`  Runtime: bus (Bus stack mounted, ${agentsLabel}, ${adaptersLabel})`);
   } else if (settings.runtime === "bus") {
     console.log(`  Runtime: bus (Bus mount failed; legacy surfaces only)`);
@@ -712,7 +686,7 @@ export async function start(args: string[] = []) {
 
   if (skipLegacyAdapters) {
     console.log(
-      `  Telegram: handled by Bus adapter${busRuntimeAdapterNames.includes("telegram") ? "" : " (not configured)"}`,
+      `  Telegram: handled by Bus adapter${configuredBusAdapters.includes("telegram") ? "" : " (not configured)"}`,
     );
   } else {
     await initTelegram(currentSettings.telegram.token, currentSettings.telegram.receiveEnabled);
@@ -754,7 +728,7 @@ export async function start(args: string[] = []) {
 
   if (skipLegacyAdapters) {
     console.log(
-      `  Discord: handled by Bus adapter${busRuntimeAdapterNames.includes("discord") ? "" : " (not configured)"}`,
+      `  Discord: handled by Bus adapter${configuredBusAdapters.includes("discord") ? "" : " (not configured)"}`,
     );
   } else {
     await initDiscord(currentSettings.discord.token);
@@ -788,7 +762,7 @@ export async function start(args: string[] = []) {
 
   if (skipLegacyAdapters) {
     console.log(
-      `  Slack: handled by Bus adapter${busRuntimeAdapterNames.includes("slack") ? "" : " (not configured)"}`,
+      `  Slack: handled by Bus adapter${configuredBusAdapters.includes("slack") ? "" : " (not configured)"}`,
     );
   } else {
     await initSlack(currentSettings.slack.botToken, currentSettings.slack.appToken);
@@ -872,6 +846,16 @@ export async function start(args: string[] = []) {
         `[mcp-multiplexer] startup failed (non-fatal, falling back to per-PTY MCP discovery): ${msg}`,
       );
     }
+  } else if (settings.mcp.shared.length > 0 && !settings.web.enabled) {
+    // Issue #165 (PR #184 review): mcp.shared is configured but web is
+    // disabled, so the multiplexer never starts and the synthesizer is
+    // never wired — bus agents launch with NO --mcp-config and every
+    // mcp.shared server is silently unreachable. Warn loudly so the
+    // operator isn't left with the exact silent-failure mode this fix
+    // set out to kill. (Enable web, or clear mcp.shared.)
+    console.warn(
+      `[mcp-multiplexer] settings.mcp.shared is set (${settings.mcp.shared.join(", ")}) but web.enabled is false — the multiplexer cannot mount its HTTP routes, so bus agents will spawn WITHOUT --mcp-config and these servers will be unreachable. Set web.enabled: true to use mcp.shared.`,
+    );
   }
 
   // Issue #165: deferred bus agent spawn. The MCP multiplexer issuer is now
@@ -887,6 +871,22 @@ export async function start(args: string[] = []) {
     try {
       await busRuntimeHandle.spawnAgents();
       busRuntimeSpawnedAgents = busRuntimeHandle.spawnedAgentIds;
+
+      // Issue #165 / PR #123 Codex P2: wire adapters AFTER agents are
+      // spawned. Adapters call adapter.start() (poll loops / HTTP
+      // listeners) on mount, so wiring them before any agent is registered
+      // would let an inbound prompt hit a live bus with zero targets and be
+      // silently dropped during the multiplexer-start window.
+      const { wireBusAdapters } = await import("../bus/adapter-wiring");
+      const { adapters, errors } = await wireBusAdapters({
+        bus: busRuntimeHandle.bus,
+        settings: currentSettings,
+      });
+      for (const [name, msg] of Object.entries(errors)) {
+        console.warn(`[${ts()}] Bus adapter "${name}" failed to mount: ${msg}`);
+      }
+      busRuntimeHandle.attachAdapters(adapters);
+      busRuntimeAdapterNames = busRuntimeHandle.mountedAdapterNames;
 
       const { wireBusScheduler } = await import("../bus/scheduler-wiring");
       const schedulerHandle = await wireBusScheduler({

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -507,6 +507,14 @@ export async function start(args: string[] = []) {
         bus,
         sessionManager,
         agents: agentConfigs,
+        // Issue #165: defer the agent spawn. The MCP multiplexer identity
+        // issuer is wired AFTER this mount (it depends on
+        // pluginManager.startServices()). Spawning agents now would build
+        // their claude PTYs before the issuer exists, so buildClaudeArgs
+        // would synthesize no `--mcp-config` and every mcp.shared server
+        // would be unreachable for the agent's whole lifetime. We spawn
+        // below, after the multiplexer block, via handle.spawnAgents().
+        deferSpawn: true,
         projectRoot: process.cwd(),
       });
       // The mount succeeded — from here on, ANY error must call
@@ -519,50 +527,12 @@ export async function start(args: string[] = []) {
         }
         handle.attachAdapters(adapters);
 
-        // Sprint 5.2c: wire BusScheduler with heartbeat + jobs against
-        // the first spawned agent (matches legacy single-global-agent
-        // shape). The handle's stop() lifecycle owns scheduler
-        // teardown alongside adapters.
-        const { wireBusScheduler } = await import("../bus/scheduler-wiring");
-        const schedulerHandle = await wireBusScheduler({
-          bus,
-          defaultAgentId: handle.spawnedAgentIds[0] ?? null,
-          heartbeat: settings.heartbeat,
-          jobs,
-          timezoneOffsetMinutes: settings.timezoneOffsetMinutes,
-        });
-        handle.attachScheduler(schedulerHandle);
-
-        // Issue #166: write the daemon-generated architecture doc so the
-        // spawned agent reads its own runtime state at bootstrap.
-        //
-        // Codex P1 on PR #171: must run AFTER all bus startup steps
-        // (including wireBusScheduler) have succeeded. If we wrote earlier
-        // and a later step threw, the outer catch falls back to legacy
-        // surfaces but the on-disk doc still says `Mode: bus` — agents
-        // would diagnose against stale architecture. Place this at the
-        // tail of the try block so the file only persists when the bus
-        // really did boot end-to-end.
-        //
-        // Best-effort: failures here log but do not block startup. A
-        // missing arch doc degrades agent diagnostic quality but doesn't
-        // break operation.
-        try {
-          const { collectArchitectureSnapshot } = await import("../architecture-doc-snapshot");
-          const { writeArchitectureDoc, defaultArchitectureDocPath } = await import(
-            "../architecture-doc"
-          );
-          const snapshot = await collectArchitectureSnapshot({
-            settings,
-            spawnedAgentIds: handle.spawnedAgentIds,
-            adapters: adapters.map((a) => ({ name: a.name })),
-          });
-          const path = defaultArchitectureDocPath(process.cwd());
-          writeArchitectureDoc(snapshot, path);
-          console.log(`[${ts()}] wrote architecture doc: ${path}`);
-        } catch (docErr) {
-          console.warn(`[${ts()}] architecture doc write failed:`, docErr);
-        }
+        // Issue #165: agent spawn, BusScheduler wiring, and the
+        // architecture-doc write all moved to AFTER the MCP multiplexer
+        // block (search "Issue #165: deferred bus agent spawn"). The
+        // scheduler targets the first spawned agent id, and the arch doc
+        // reports the spawned set — both depend on the spawn, which now
+        // happens once the multiplexer issuer is wired.
       } catch (wireErr) {
         // Adapter / scheduler wiring threw — stop the handle (which
         // already owns the bus + agents + whatever was attached
@@ -618,7 +588,11 @@ export async function start(args: string[] = []) {
   // bus's per-agent claude. Sprint 5.2b's old behaviour (skip legacy
   // web) left operators with a "not_found" page because the bus webui
   // adapter at `/health` + `/prompt` is not a dashboard replacement.
-  const skipLegacyAdapters = busRuntimeHandle !== null;
+  // `let`, not `const` (issue #165): if the DEFERRED agent spawn below
+  // fails, we tear the bus down and fall back to legacy command surfaces,
+  // which means flipping this back to false so the legacy adapter + legacy
+  // heartbeat paths re-engage.
+  let skipLegacyAdapters = busRuntimeHandle !== null;
 
   let mcpProxyStarted: Promise<void> = Promise.resolve();
 
@@ -661,10 +635,14 @@ export async function start(args: string[] = []) {
     );
   }
   if (settings.runtime === "bus" && busRuntimeHandle) {
+    // Issue #165: agents spawn AFTER the multiplexer block below, so at
+    // banner time they're declared-but-not-yet-spawned. Report the
+    // declared count here; the per-agent `[bus-runtime] spawned agent=…`
+    // lines confirm the actual spawn a few steps later.
     const agentsLabel =
-      busRuntimeSpawnedAgents.length === 0
+      settings.agents.length === 0
         ? "no agents declared"
-        : `agents=[${busRuntimeSpawnedAgents.join(", ")}]`;
+        : `${settings.agents.length} agent(s) declared (spawn deferred until MCP issuer wired)`;
     const adaptersLabel =
       busRuntimeAdapterNames.length === 0
         ? "no adapters"
@@ -866,6 +844,20 @@ export async function start(args: string[] = []) {
           revoke: (ptyId) => plugin.releaseIdentity(ptyId),
           bridgeBaseUrl: () => plugin.bridgeBaseUrl(),
         });
+        // Issue #165: the legacy PTY supervisor reaches mcp.shared via the
+        // issuer wired just above, but the BUS spawn path has its own
+        // buildClaudeArgs that never synthesized from mcp.shared. Wire the
+        // same issuer into the bus SessionManager so deferred bus agents
+        // (spawned below) get a synthesized --mcp-config too. Only inside
+        // this isActive() branch, so the dormant path stays byte-identical.
+        if (busRuntimeHandle) {
+          busRuntimeHandle.sessionManager.setMcpConfigSynthesizer({
+            issue: (ptyId) => plugin.issueIdentity(ptyId),
+            revoke: (ptyId) => plugin.releaseIdentity(ptyId),
+            bridgeBaseUrl: () => plugin.bridgeBaseUrl(),
+            sharedServers: settings.mcp.shared,
+          });
+        }
         console.log("[mcp-multiplexer] started");
       } else {
         console.warn(
@@ -879,6 +871,82 @@ export async function start(args: string[] = []) {
       console.warn(
         `[mcp-multiplexer] startup failed (non-fatal, falling back to per-PTY MCP discovery): ${msg}`,
       );
+    }
+  }
+
+  // Issue #165: deferred bus agent spawn. The MCP multiplexer issuer is now
+  // wired (or confirmed dormant) above, so spawning here means each agent's
+  // claude PTY is built with the synthesizer in place — buildClaudeArgs/spawn
+  // can attach a --mcp-config for mcp.shared servers. We also wire the
+  // BusScheduler (targets the first spawned agent id) and write the
+  // architecture doc (reports the spawned set) here, since both depend on the
+  // spawn. On failure we tear the bus down and fall back to legacy surfaces,
+  // matching a mount failure (the legacy adapter init was skipped at the gate
+  // because busRuntimeHandle was non-null — re-run it here).
+  if (busRuntimeHandle) {
+    try {
+      await busRuntimeHandle.spawnAgents();
+      busRuntimeSpawnedAgents = busRuntimeHandle.spawnedAgentIds;
+
+      const { wireBusScheduler } = await import("../bus/scheduler-wiring");
+      const schedulerHandle = await wireBusScheduler({
+        bus: busRuntimeHandle.bus,
+        defaultAgentId: busRuntimeHandle.spawnedAgentIds[0] ?? null,
+        heartbeat: currentSettings.heartbeat,
+        jobs: currentJobs,
+        timezoneOffsetMinutes: currentSettings.timezoneOffsetMinutes,
+      });
+      busRuntimeHandle.attachScheduler(schedulerHandle);
+
+      // Issue #166: write the architecture doc only after the bus booted
+      // end-to-end (spawn + scheduler), so a doc on disk always reflects a
+      // genuinely-running bus. Best-effort — a missing doc degrades agent
+      // diagnostics but doesn't break operation.
+      try {
+        const { collectArchitectureSnapshot } = await import("../architecture-doc-snapshot");
+        const { writeArchitectureDoc, defaultArchitectureDocPath } = await import(
+          "../architecture-doc"
+        );
+        const snapshot = await collectArchitectureSnapshot({
+          settings: currentSettings,
+          spawnedAgentIds: busRuntimeHandle.spawnedAgentIds,
+          adapters: busRuntimeAdapterNames.map((name) => ({ name })),
+        });
+        const path = defaultArchitectureDocPath(process.cwd());
+        writeArchitectureDoc(snapshot, path);
+        console.log(`[${ts()}] wrote architecture doc: ${path}`);
+      } catch (docErr) {
+        console.warn(`[${ts()}] architecture doc write failed:`, docErr);
+      }
+    } catch (spawnErr) {
+      console.error(
+        `[${ts()}] Bus runtime: deferred agent spawn failed — tearing down and falling back to legacy command surfaces`,
+        spawnErr,
+      );
+      try {
+        await busRuntimeHandle.stop();
+      } catch (stopErr) {
+        console.error(`[${ts()}] handle.stop() during deferred-spawn rollback failed`, stopErr);
+      }
+      busRuntimeHandle = null;
+      busRuntimeSpawnedAgents = [];
+      busRuntimeAdapterNames = [];
+      busCoreForWebUi = null;
+      skipLegacyAdapters = false;
+      // A prior bus boot may have left a CCPLUS_ARCHITECTURE.md saying
+      // "Mode: bus"; now that we've fallen back to legacy it's misleading.
+      try {
+        const { defaultArchitectureDocPath } = await import("../architecture-doc");
+        const { existsSync: exists, unlinkSync: unlink } = await import("node:fs");
+        const docPath = defaultArchitectureDocPath(process.cwd());
+        if (exists(docPath)) unlink(docPath);
+      } catch {
+        /* best-effort */
+      }
+      // Re-engage the legacy adapters that were skipped at the gate above.
+      await initTelegram(currentSettings.telegram.token, currentSettings.telegram.receiveEnabled);
+      await initDiscord(currentSettings.discord.token);
+      await initSlack(currentSettings.slack.botToken, currentSettings.slack.appToken);
     }
   }
 


### PR DESCRIPTION
Fixes #165.

## Problem
Bus-runtime agents spawned at mount time (`start.ts` → `mountBusRuntime` → `runtime-mount.ts` synchronous spawn loop), **before** the MCP multiplexer identity issuer was wired (the issuer depends on `pluginManager.startServices()`, which runs after the mount). On top of that, the bus's own `buildClaudeArgs` (`session-manager.ts`) only emitted `--mcp-config` for a statically-configured `agent.mcp_config` — it never synthesized from `settings.mcp.shared` at all.

Net effect: every bus agent without a static `mcp_config` was launched with **no `--mcp-config`**, so all `mcp.shared` servers (`brave-search`, `gws-gmail`, `claudeclaw-tuner`, `mistral-brain`, …) were silently unreachable for the agent's entire lifetime. Latent because deployments often route work to CLI scripts instead of those MCP tools.

## Fix (Option A — defer the spawn, per your review on #165)
- **`runtime-mount.ts`** — add `deferSpawn` + `handle.spawnAgents()`. The daemon mounts the bus (slash relay, orphan scan, adapters) without spawning, then spawns agents after the issuer is wired. The spawn loop is refactored into a reusable batch helper with per-batch rollback. `mountBusRuntime` already accepted `agents: []`, so no API break.
- **`session-manager.ts`** — `setMcpConfigSynthesizer()` + `synthesizeBusMcpConfig()`. When the multiplexer is active and the agent has no static `mcp_config`, the bus spawn mints a per-agent HMAC identity, writes a per-PTY `--mcp-config` via the shared `pty-mcp-config-writer`, and revokes the identity + deletes the `0600` file on `stop()`. Static `mcp_config` still wins; a dormant multiplexer stays byte-identical (no flag).
- **`start.ts`** — mount with `deferSpawn`; wire the synthesizer + spawn agents + `BusScheduler` (deferred too — it targets the first spawned agent id) after the multiplexer block. On deferred-spawn failure, tear the bus down and fall back to legacy command surfaces, matching a mount failure.

## Tests
+13 tests, all green:
- `deferSpawn` / `spawnAgents()` ordering + rollback (issuer-before-spawn guarantee).
- `synthesizeBusMcpConfig` precedence (static wins), dormancy, and synthesized JSON shape (shared servers, bridge URLs, identity headers).
- Spawn integration asserting `--mcp-config <path>` lands in the child argv; **graceful-degradation** branch (multiplexer inactive → no flag, byte-identical to dormant) and zero-shared regression.
- `stop()` revokes the identity + deletes the synthesized config file.

Version guards bumped. Build + lint clean. Full suite adds 13 passing tests with zero new failures vs `origin/main`.

## Validated live
Deployed a downstream variant to a real `runtime: bus` daemon (`mcp.shared: [brave-search, claudeclaw-tuner, gws-gmail]`, `default` agent, no static config). After the change the agent spawns with `--mcp-config` listing all three servers (HTTP routes through the bridge, `0600`), and the multiplexer bridge accepts the synthesized per-PTY identity (401 without auth → request reaches the MCP server with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)