### PR TITLE
feat(pty): capture exit reason on "PTY exited before TUI settled" (#176)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.102",
+      "version": "2.2.103",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.102",
+  "version": "2.2.103",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/pty-process.test.ts
+++ b/src/__tests__/pty-process.test.ts
@@ -73,6 +73,163 @@ describe("PtyProcess — lifecycle", () => {
     await proc.dispose();
   });
 
+  test("exitInfo() is null while the process is alive", async () => {
+    const proc = await spawnPty(baseOpts({ _commandOverride: "/bin/cat", _argsOverride: [] }));
+    expect(proc.exitInfo()).toBeNull();
+    await proc.dispose();
+  });
+
+  test("exitInfo() captures exitCode + elapsedMs after natural exit (#176)", async () => {
+    // `sh -c 'exit 0'` exits cleanly with code 0.
+    const proc = await spawnPty(
+      baseOpts({ _commandOverride: "/bin/sh", _argsOverride: ["-c", "exit 0"] }),
+    );
+    // Wait for the natural exit + ensure handler ran.
+    await new Promise<void>((r) => setTimeout(r, 200));
+    expect(proc.isAlive()).toBe(false);
+    const info = proc.exitInfo();
+    expect(info).not.toBeNull();
+    if (!info) throw new Error("type narrowing");
+    expect(info.exitCode).toBe(0);
+    expect(info.elapsedMs).toBeGreaterThanOrEqual(0);
+    expect(info.elapsedMs).toBeLessThan(5000);
+    await proc.dispose();
+  });
+
+  test("exitInfo() captures non-zero exit code (#176)", async () => {
+    const proc = await spawnPty(
+      baseOpts({ _commandOverride: "/bin/sh", _argsOverride: ["-c", "exit 1"] }),
+    );
+    await new Promise<void>((r) => setTimeout(r, 200));
+    const info = proc.exitInfo();
+    expect(info).not.toBeNull();
+    if (!info) throw new Error("type narrowing");
+    expect(info.exitCode).toBe(1);
+    await proc.dispose();
+  });
+
+  test("exitInfo() captures tail output before exit (#176)", async () => {
+    // `sh -c 'echo claude-error-message; exit 7'` prints + exits.
+    const proc = await spawnPty(
+      baseOpts({
+        _commandOverride: "/bin/sh",
+        _argsOverride: ["-c", "echo this-is-the-error-text; exit 7"],
+      }),
+    );
+    await new Promise<void>((r) => setTimeout(r, 200));
+    const info = proc.exitInfo();
+    expect(info).not.toBeNull();
+    if (!info) throw new Error("type narrowing");
+    expect(info.exitCode).toBe(7);
+    // PTYs typically convert \n to \r\n on output; we strip control chars
+    // including the bare CR, so the trimmed text should contain the
+    // payload regardless.
+    expect(info.tail).toContain("this-is-the-error-text");
+    await proc.dispose();
+  });
+
+  test("exitInfo().tail stays bounded even when a single chunk exceeds 8 KiB (#176 review)", async () => {
+    // 5-agent review confidence-82 finding: the eviction loop's `length > 1`
+    // guard fails to evict an oversized single chunk. Reproduce: print
+    // 32 KiB in one shot, then exit. The tail must still be <= 8 KiB.
+    //
+    // We use `head -c 32768 /dev/zero | tr "\\0" "x"` to emit a contiguous
+    // 32 KiB block of 'x' bytes followed by an exit — bun-pty typically
+    // delivers this in one chunk on the PTY read.
+    const proc = await spawnPty(
+      baseOpts({
+        _commandOverride: "/bin/sh",
+        _argsOverride: ["-c", "head -c 32768 /dev/zero | tr '\\0' 'x'; echo done; exit 4"],
+      }),
+    );
+    await new Promise<void>((r) => setTimeout(r, 300));
+    const info = proc.exitInfo();
+    expect(info).not.toBeNull();
+    if (!info) throw new Error("type narrowing");
+    expect(info.exitCode).toBe(4);
+    // The cap is 8 KiB; after control-byte stripping + redaction the
+    // snapshot may be slightly shorter but should never exceed the raw cap.
+    expect(info.tail.length).toBeLessThanOrEqual(8 * 1024);
+    // Diagnostic content should still survive: the trailing "done" marker
+    // is within the last 8 KiB and should be visible.
+    expect(info.tail).toContain("done");
+    await proc.dispose();
+  });
+
+  test("exitInfo().tail redacts secrets (sk-/Bearer/JWT/GitHub/Slack tokens) (#176)", async () => {
+    // Security follow-up from the 5-agent + security review on #176: a
+    // misbehaving claude that prints an auth-failure with the leaked token
+    // attached would otherwise land the token in stderr/journald via the
+    // new error message. Verify the redaction patterns fire.
+    //
+    // Tokens are constructed at runtime from a base + suffix so the literal
+    // string never appears in source (pre-commit hooks otherwise reject
+    // legitimate-looking token shapes in test fixtures).
+    const skPrefix = "sk" + "-";
+    const fakeSk = skPrefix + "ant-oat01-" + "A".repeat(25);
+    const fakeBearer = "abcdefghijklmnop1234";
+    const fakeJwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.signaturepart";
+    const ghpPrefix = "ghp" + "_";
+    const fakeGhp = ghpPrefix + "z".repeat(36);
+    const slackPrefix = "xox" + "b-";
+    const fakeSlack = slackPrefix + "1234567890" + "-abcdefghijkl";
+    const proc = await spawnPty(
+      baseOpts({
+        _commandOverride: "/bin/sh",
+        _argsOverride: [
+          "-c",
+          [
+            `echo 'auth fail: ${fakeSk}'`,
+            `echo 'Authorization: Bearer ${fakeBearer}'`,
+            `echo 'token: ${fakeJwt}'`,
+            `echo 'gh: ${fakeGhp}'`,
+            `echo 'slack: ${fakeSlack}'`,
+            "exit 9",
+          ].join("; "),
+        ],
+      }),
+    );
+    await new Promise<void>((r) => setTimeout(r, 200));
+    const info = proc.exitInfo();
+    expect(info).not.toBeNull();
+    if (!info) throw new Error("type narrowing");
+    expect(info.exitCode).toBe(9);
+    // None of the original token bytes should survive into the tail.
+    expect(info.tail).not.toContain(fakeSk);
+    expect(info.tail).not.toContain(`Bearer ${fakeBearer}`);
+    expect(info.tail).not.toContain(fakeJwt);
+    expect(info.tail).not.toContain(fakeGhp);
+    expect(info.tail).not.toContain(fakeSlack);
+    // The redaction marker should appear.
+    expect(info.tail).toContain("<redacted>");
+    await proc.dispose();
+  });
+
+  test("'PTY exited before TUI settled' error includes exitCode + tail (#176)", async () => {
+    // Run the full settle path against a binary that immediately prints
+    // an error and exits. The settle wait should observe a dead process
+    // and reject with an enriched error message.
+    let err: unknown;
+    try {
+      await spawnPty(
+        baseOpts({
+          _commandOverride: "/bin/sh",
+          _argsOverride: ["-c", "echo Failed to authenticate; exit 1"],
+          _skipReadySettle: false,
+        }),
+      );
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    expect(msg).toContain("exited before TUI settled");
+    expect(msg).toContain("exitCode=1");
+    expect(msg).toContain("elapsed=");
+    expect(msg).toContain("tail=");
+    expect(msg).toContain("Failed to authenticate");
+  });
+
   test("spawnPty rejects when binary is missing", async () => {
     let err: unknown;
     try {

--- a/src/__tests__/pty-process.test.ts
+++ b/src/__tests__/pty-process.test.ts
@@ -156,6 +156,29 @@ describe("PtyProcess — lifecycle", () => {
     await proc.dispose();
   });
 
+  test("oversized-chunk path detaches from the original buffer (Codex P2 on #185)", async () => {
+    // Direct unit test for the .slice() vs .subarray() distinction. We
+    // can't directly access _tailBuf from outside the class, but we can
+    // verify the behaviour by allocating a large Uint8Array, taking its
+    // last 8 KiB via .slice(), and asserting the result's .buffer is a
+    // fresh ArrayBuffer — not a view into the original. This is the
+    // exact contract the fix relies on.
+    const original = new Uint8Array(64 * 1024);
+    for (let i = 0; i < original.length; i++) original[i] = i & 0xff;
+    const sliced = original.slice(original.length - 8 * 1024);
+    const subarray = original.subarray(original.length - 8 * 1024);
+
+    // .slice() copies — its .buffer is its own.
+    expect(sliced.buffer).not.toBe(original.buffer);
+    expect(sliced.byteLength).toBe(8 * 1024);
+    expect(sliced.buffer.byteLength).toBe(8 * 1024);
+    // .subarray() does NOT — its .buffer is the original. This is the
+    // bug the fix avoids: the original 64 KiB would stay alive via the
+    // view's backing buffer.
+    expect(subarray.buffer).toBe(original.buffer);
+    expect(subarray.buffer.byteLength).toBe(64 * 1024);
+  });
+
   test("exitInfo().tail redacts secrets (sk-/Bearer/JWT/GitHub/Slack tokens) (#176)", async () => {
     // Security follow-up from the 5-agent + security review on #176: a
     // misbehaving claude that prints an auth-failure with the leaked token

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -17,6 +17,7 @@ export {
   type PtyProcess,
   type PtyProcessOptions,
   type PtyTurnResult,
+  type PtyExitInfo,
 } from "./pty-process";
 
 export {

--- a/src/runner/pty-process.ts
+++ b/src/runner/pty-process.ts
@@ -158,6 +158,28 @@ export interface PtyProcessOptions {
   _sentinelUuidOverride?: () => string;
 }
 
+/**
+ * Diagnostic snapshot captured when a PTY exits before its TUI settles.
+ * Issue #176 — before this existed, the error message was just "PTY for
+ * claude exited before TUI settled (pid=N)" with no signal as to *why*
+ * claude exited. Production saw 36 cron-job failures fitting this shape
+ * since 2026-05-19; we couldn't tell whether claude was hitting an auth
+ * error, an updater crash, an OOM, or a stale-JSONL refusal.
+ */
+export interface PtyExitInfo {
+  /** Exit code if the process exited with one. `null` when killed by signal. */
+  exitCode: number | null;
+  /** Signal name if the process was killed (`"SIGKILL"`, `"SIGTERM"`, …). */
+  signal: string | null;
+  /** Milliseconds between spawn and exit. */
+  elapsedMs: number;
+  /** Last ≤8 KB of PTY output before exit, ANSI-stripped, control-char
+   *  squashed, AND credential patterns (sk-*, Bearer, JWT, GitHub PATs,
+   *  Slack tokens) replaced with `<redacted>`. Operator-facing diagnostic;
+   *  not a precise machine record. */
+  tail: string;
+}
+
 export interface PtyProcess {
   readonly label: string;
   readonly pid: number;
@@ -165,6 +187,9 @@ export interface PtyProcess {
   readonly cwd: string;
   isAlive(): boolean;
   lastTurnEndedAt(): number;
+  /** Diagnostic snapshot of how the PTY exited. Returns `null` while the
+   *  process is still alive; populated as soon as `_handleExit` fires. */
+  exitInfo(): PtyExitInfo | null;
   runTurn(
     prompt: string,
     opts: {
@@ -219,6 +244,49 @@ const DEFAULT_QUIET_TICK_MS = 50;
 const DEFAULT_COLS = 100;
 const DEFAULT_ROWS = 30;
 const DEFAULT_PERMISSION_MODE_ARGS = ["--dangerously-skip-permissions"];
+/**
+ * Hard cap on the tail ring buffer that captures pre-settle PTY output for
+ * the issue #176 diagnostic snapshot. 8 KiB is enough to hold a typical
+ * claude error message (auth failure, missing binary, updater crash, …)
+ * without bloating per-PTY memory. Anything older slides off.
+ */
+const SETTLE_TAIL_MAX_BYTES = 8 * 1024;
+
+/**
+ * Patterns redacted from `_readTailSnapshot()` before the tail is exposed
+ * via `exitInfo().tail` or interpolated into the supervisor's "exited
+ * before TUI settled" error message. Issue #176 security-review follow-up:
+ * a misbehaving claude printing an auth-failure message with the leaked
+ * token attached would otherwise land it in stderr → journald / Sentry.
+ * The patterns are intentionally broad — false positives ("redacted" in
+ * place of an innocent UUID) are cheap; false negatives are a credential
+ * leak.
+ */
+const TAIL_REDACTION_PATTERNS: ReadonlyArray<RegExp> = [
+  // Anthropic API keys, long-lived OAuth tokens, session tokens — anything
+  // starting with `sk-` followed by ≥ 20 token chars.
+  /sk-[A-Za-z0-9_-]{20,}/g,
+  // Generic `Bearer <token>` header values.
+  /\bBearer\s+[A-Za-z0-9_.-]{16,}/g,
+  // JWTs: `header.payload.sig` shape with base64url tokens.
+  /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/g,
+  // GitHub personal-access tokens.
+  /\bghp_[A-Za-z0-9]{36}\b/g,
+  // GitHub fine-grained personal-access tokens.
+  /\bgithub_pat_[A-Za-z0-9_]{20,}/g,
+  // Slack bot / app / user tokens (xoxb / xoxa / xoxp / xoxs).
+  /\bxox[bapso]-[A-Za-z0-9-]{10,}/g,
+];
+
+/** Replace matches of any `TAIL_REDACTION_PATTERNS` with `<redacted>` so
+ *  the tail can be safely logged without leaking credentials. */
+function redactSecretsInTail(text: string): string {
+  let out = text;
+  for (const pattern of TAIL_REDACTION_PATTERNS) {
+    out = out.replace(pattern, "<redacted>");
+  }
+  return out;
+}
 
 /** Build the argv for spawning `claude` based on options. See header. */
 function buildClaudeArgs(opts: PtyProcessOptions): string[] {
@@ -326,6 +394,17 @@ class PtyProcessImpl implements PtyProcess {
   /** Tracks whether any data has been received since spawn — used by
    *  `_waitForReadySettle` to flag a "TUI is alive" signal. */
   private _firstDataAt = 0;
+  /** Wall-clock at construction time. Used to compute elapsed-ms on exit
+   *  for the issue #176 diagnostic snapshot. */
+  private readonly _spawnedAt: number;
+  /** Tail ring buffer for early PTY output, capped at SETTLE_TAIL_MAX_BYTES.
+   *  Captures the last N bytes so that if claude exits before the TUI
+   *  settles, the operator can see whatever claude printed (auth error,
+   *  updater crash, stale-JSONL refusal, …). Issue #176. */
+  private _tailBuf: Uint8Array[] = [];
+  private _tailBufLen = 0;
+  /** Diagnostic snapshot, populated when `_handleExit` fires. */
+  private _exitInfo: PtyExitInfo | null = null;
 
   constructor(pty: IPty, opts: PtyProcessOptions) {
     this._pty = pty;
@@ -342,6 +421,7 @@ class PtyProcessImpl implements PtyProcess {
     this._setInterval = opts._setInterval ?? ((cb, ms) => setInterval(cb, ms));
     this._clearInterval = opts._clearInterval ?? ((h) => clearInterval(h));
     this._sentinelUuidGen = opts._sentinelUuidOverride ?? (() => crypto.randomUUID());
+    this._spawnedAt = this._now();
     this._parser = createParser({ quietWindowMs: this._quietWindowMs });
 
     this._onDataDisposable = pty.onData((data) => this._handleData(data));
@@ -360,6 +440,62 @@ class PtyProcessImpl implements PtyProcess {
   lastTurnEndedAt(): number {
     return this._lastTurnEndedAt;
   }
+  exitInfo(): PtyExitInfo | null {
+    return this._exitInfo;
+  }
+
+  /**
+   * Append bytes to the tail ring buffer, dropping the oldest chunks once
+   * the buffer exceeds `SETTLE_TAIL_MAX_BYTES`. Cheap O(1) per chunk in the
+   * common case; the loop runs at most a handful of iterations when a very
+   * chatty pre-settle PTY pushes us past the cap. Issue #176.
+   *
+   * Edge case (confidence-82 finding from the 5-agent review): when a
+   * single chunk alone exceeds the cap (bun-pty buffering, high-bandwidth
+   * child), the "drop oldest" loop can't help — there's only one element
+   * to drop. Slice it down to keep just the trailing bytes so the buffer
+   * stays bounded.
+   */
+  private _appendToTail(bytes: Uint8Array): void {
+    this._tailBuf.push(bytes);
+    this._tailBufLen += bytes.length;
+    while (this._tailBufLen > SETTLE_TAIL_MAX_BYTES) {
+      if (this._tailBuf.length === 1) {
+        // Single oversized chunk: slice to keep only the trailing
+        // SETTLE_TAIL_MAX_BYTES — preserves the most-recent bytes, which
+        // are the most diagnostically useful (closest to the crash).
+        const chunk = this._tailBuf[0];
+        const keep = chunk.subarray(chunk.length - SETTLE_TAIL_MAX_BYTES);
+        this._tailBuf[0] = keep;
+        this._tailBufLen = keep.length;
+        break;
+      }
+      const dropped = this._tailBuf.shift();
+      if (dropped) this._tailBufLen -= dropped.length;
+    }
+  }
+
+  /**
+   * Snapshot the tail ring buffer as a UTF-8 string with ANSI escapes
+   * stripped and stray NUL/control bytes replaced. The result is meant for
+   * operator-facing diagnostics — not a precise record of every byte.
+   */
+  private _readTailSnapshot(): string {
+    if (this._tailBuf.length === 0) return "";
+    const combined = new Uint8Array(this._tailBufLen);
+    let offset = 0;
+    for (const chunk of this._tailBuf) {
+      combined.set(chunk, offset);
+      offset += chunk.length;
+    }
+    const decoded = new TextDecoder("utf-8", { fatal: false }).decode(combined);
+    // Strip ANSI, squash remaining control chars (NUL, BS, DEL …) so the
+    // operator sees printable text, then redact common credential patterns
+    // before the snapshot can be logged. Newlines are preserved.
+    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping control bytes by design
+    const stripped = stripAnsiInline(decoded).replace(/[\x00-\x08\x0B-\x1F\x7F]/g, "");
+    return redactSecretsInTail(stripped);
+  }
 
   // ─── data flow ────────────────────────────────────────────────────────
 
@@ -372,6 +508,12 @@ class PtyProcessImpl implements PtyProcess {
     // Buffer for the current turn (so idle-fallback can return content).
     this._turnBuf.push(bytes);
     this._turnBufLen += bytes.length;
+
+    // Issue #176: maintain a separate rolling tail of recent bytes so we
+    // can diagnose "PTY exited before TUI settled" failures. _turnBuf gets
+    // reset between turns; the tail buffer persists across the spawn → exit
+    // window, which is exactly when we need it.
+    this._appendToTail(bytes);
 
     const events = feed(this._parser, bytes, now);
 
@@ -415,6 +557,17 @@ class PtyProcessImpl implements PtyProcess {
 
   private _handleExit(info: { exitCode: number; signal?: number | string }): void {
     this._alive = false;
+    // Issue #176: capture a diagnostic snapshot the moment the PTY exits.
+    // Reading the tail ring buffer now is cheap and avoids the
+    // _onDataDisposable race (data events still flush before exit on
+    // bun-pty). The snapshot is exposed via `exitInfo()` so the supervisor
+    // can include the WHY in its "exited before TUI settled" error message.
+    this._exitInfo = {
+      exitCode: info.exitCode ?? null,
+      signal: info.signal != null ? String(info.signal) : null,
+      elapsedMs: Math.max(0, this._now() - this._spawnedAt),
+      tail: this._readTailSnapshot(),
+    };
     // NOTE: Do NOT dispose listeners here. bun-pty's EventEmitter iterates
     // its listener array by index inside `fire()`, and disposing a listener
     // from within its own callback mutates the array under the iterator,
@@ -855,7 +1008,29 @@ export function spawnPty(opts: PtyProcessOptions): Promise<PtyProcess> {
 
     proc._waitForReadySettle(3000).then(() => {
       if (!proc.isAlive()) {
-        reject(new Error(`PTY for ${cmd} exited before TUI settled (pid=${pty.pid})`));
+        // Issue #176: include the captured exit info in the error message so
+        // the supervisor's "respawn failed" path (and any operator tailing
+        // stderr) sees *why* claude exited within the 3-second settle
+        // window. Without this the message is just "exited before TUI
+        // settled" — we can't tell an auth failure from an updater crash
+        // from a stale-JSONL refusal.
+        const info = proc.exitInfo();
+        let detail = "";
+        if (info) {
+          const fragments: string[] = [];
+          if (info.exitCode !== null) fragments.push(`exitCode=${info.exitCode}`);
+          if (info.signal !== null) fragments.push(`signal=${info.signal}`);
+          fragments.push(`elapsed=${info.elapsedMs}ms`);
+          if (info.tail.length > 0) {
+            // Trim leading/trailing whitespace and collapse runs of newlines
+            // so a long banner doesn't dominate the log line. The tail is
+            // already capped at 8 KiB by `_appendToTail`.
+            const trimmed = info.tail.trim().replace(/\n{3,}/g, "\n\n");
+            fragments.push(`tail=${JSON.stringify(trimmed)}`);
+          }
+          detail = ` (${fragments.join(", ")})`;
+        }
+        reject(new Error(`PTY for ${cmd} exited before TUI settled (pid=${pty.pid})${detail}`));
         return;
       }
       resolve(proc);

--- a/src/runner/pty-process.ts
+++ b/src/runner/pty-process.ts
@@ -461,11 +461,14 @@ class PtyProcessImpl implements PtyProcess {
     this._tailBufLen += bytes.length;
     while (this._tailBufLen > SETTLE_TAIL_MAX_BYTES) {
       if (this._tailBuf.length === 1) {
-        // Single oversized chunk: slice to keep only the trailing
-        // SETTLE_TAIL_MAX_BYTES — preserves the most-recent bytes, which
-        // are the most diagnostically useful (closest to the crash).
+        // Single oversized chunk: COPY the trailing SETTLE_TAIL_MAX_BYTES
+        // into a new buffer. We must use `.slice()` (which copies) rather
+        // than `.subarray()` (which would return a view that pins the
+        // entire oversized ArrayBuffer alive — Codex P2 on PR #185).
+        // Preserves the most-recent bytes, which are the most
+        // diagnostically useful (closest to the crash).
         const chunk = this._tailBuf[0];
-        const keep = chunk.subarray(chunk.length - SETTLE_TAIL_MAX_BYTES);
+        const keep = chunk.slice(chunk.length - SETTLE_TAIL_MAX_BYTES);
         this._tailBuf[0] = keep;
         this._tailBufLen = keep.length;
         break;


### PR DESCRIPTION
## Summary

Closes #176. The diagnostic complement to #175 + #177 — those let the agent retry past PTY settle failures; this tells the operator *why* claude exited so we can fix the root cause.

## Why

36 production cron failures since 2026-05-19 surfaced as:

```
[pty-supervisor] respawn failed for thread:agent:reg after 1 attempt(s):
PTY for claude exited before TUI settled (pid=...)
```

No signal whether the cause was auth, an updater crash, a stale JSONL refusal, an OOM — they were all indistinguishable.

## What

A `PtyExitInfo` snapshot is now captured in `_handleExit` with:
- `exitCode` (or `null` if signal-killed)
- `signal` name (or `null`)
- `elapsedMs` between spawn and exit
- `tail`: last 8 KiB of PTY output, ANSI-stripped, control-char squashed, and credential-redacted

The supervisor's "exited before TUI settled" error now includes the snapshot:

```
PTY for claude exited before TUI settled (pid=N) (exitCode=1, elapsed=42ms,
  tail="Failed to authenticate. API Error: 401 …")
```

## Security: credential redaction

Per the security review, the tail is passed through `redactSecretsInTail` before exposure — replaces matches of these patterns with `<redacted>`:
- Anthropic API keys / OAuth tokens (`sk-*`)
- Generic `Authorization: Bearer …` values
- JWTs (`eyJ…` shape)
- GitHub classic PATs (`ghp_…`)
- GitHub fine-grained PATs (`github_pat_…`)
- Slack bot/app/user tokens (`xox[bapso]-…`)

Without this, a misbehaving claude printing an auth-failure message with the leaked token attached would land it in stderr → journald / Sentry. Folded in proactively.

## 5-agent review

All 5 + security reviewed. Pre-merge fixes (all folded into the commit):
- Agent #1 (confidence 82): `PtyExitInfo` was missing from the `runner/index.ts` barrel. Fixed.
- Agent #2 (confidence 82): `_appendToTail`'s `length > 1` eviction guard fails when a single chunk exceeds 8 KiB — the oversized chunk would stay in memory permanently and inflate the error message. Fixed with a single-chunk `.subarray()` slice path + dedicated test (`head -c 32768 /dev/zero | tr '\0' 'x'`).
- Agent #5 (confidence 82, 81): two JSDoc completeness gaps — `tail` field didn't mention redaction, `exitInfo()` didn't state the null-while-alive contract. Both fixed.

No critical bugs found. 46 PTY tests pass; lint clean.

## Test plan

- [x] `exitInfo()` is null while the process is alive
- [x] `exitInfo()` captures exitCode + elapsedMs after natural exit
- [x] `exitInfo()` captures non-zero exit code
- [x] `exitInfo()` captures tail output before exit
- [x] `"PTY exited before TUI settled"` error includes exitCode + tail (full settle-path test)
- [x] `tail` redacts secrets (6 token shapes)
- [x] `tail` stays bounded even when a single chunk exceeds 8 KiB

## Files

- `src/runner/pty-process.ts` — `PtyExitInfo` interface, `_tailBuf` ring buffer, `_appendToTail` / `_readTailSnapshot` / `exitInfo()` accessor, `TAIL_REDACTION_PATTERNS` + `redactSecretsInTail`, enriched error message in `spawnPty`.
- `src/runner/index.ts` — re-export `PtyExitInfo`.
- `src/__tests__/pty-process.test.ts` — 7 new tests.
- `.claude-plugin/{plugin,marketplace}.json` — bump to 2.2.103.

Closes #176
