### PR TITLE
fix(cli): auto-load .claudeclaw-env for send/fire (#180 docs/ux)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.103",
+      "version": "2.2.104",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.103",
+  "version": "2.2.104",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/cli-env-autoload.test.ts
+++ b/src/__tests__/cli-env-autoload.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for src/cli-env-autoload.ts
+ *
+ * Run with: bun test src/__tests__/cli-env-autoload.test.ts
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, chmodSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { applyDotenv, autoLoadClaudeClawEnv } from "../cli-env-autoload";
+
+describe("applyDotenv", () => {
+  const sentinels = ["TEST_FOO_KEY_A", "TEST_FOO_KEY_B", "TEST_FOO_KEY_C", "TEST_FOO_KEY_D"];
+
+  beforeEach(() => {
+    for (const k of sentinels) delete process.env[k];
+  });
+
+  afterEach(() => {
+    for (const k of sentinels) delete process.env[k];
+  });
+
+  it("parses well-formed KEY=value lines", () => {
+    const count = applyDotenv("TEST_FOO_KEY_A=alpha\nTEST_FOO_KEY_B=beta\n");
+    expect(count).toBe(2);
+    expect(process.env.TEST_FOO_KEY_A).toBe("alpha");
+    expect(process.env.TEST_FOO_KEY_B).toBe("beta");
+  });
+
+  it("does NOT overwrite already-set vars", () => {
+    process.env.TEST_FOO_KEY_A = "preexisting";
+    const count = applyDotenv("TEST_FOO_KEY_A=replaced\nTEST_FOO_KEY_B=fresh\n");
+    expect(count).toBe(1);
+    expect(process.env.TEST_FOO_KEY_A).toBe("preexisting");
+    expect(process.env.TEST_FOO_KEY_B).toBe("fresh");
+  });
+
+  it("strips matching surrounding quotes", () => {
+    applyDotenv(`TEST_FOO_KEY_A="quoted-double"\nTEST_FOO_KEY_B='quoted-single'\n`);
+    expect(process.env.TEST_FOO_KEY_A).toBe("quoted-double");
+    expect(process.env.TEST_FOO_KEY_B).toBe("quoted-single");
+  });
+
+  it("does NOT strip mismatched quote pairs", () => {
+    applyDotenv(`TEST_FOO_KEY_A="mixed'\n`);
+    expect(process.env.TEST_FOO_KEY_A).toBe(`"mixed'`);
+  });
+
+  it("ignores comments and blank lines", () => {
+    const count = applyDotenv("# a comment\n\n  \nTEST_FOO_KEY_A=ok\n");
+    expect(count).toBe(1);
+    expect(process.env.TEST_FOO_KEY_A).toBe("ok");
+  });
+
+  it("ignores malformed lines", () => {
+    const count = applyDotenv(
+      "no equals sign\n=no key\n9STARTS_WITH_DIGIT=x\nTEST_FOO_KEY_A=good\n",
+    );
+    expect(count).toBe(1);
+    expect(process.env.TEST_FOO_KEY_A).toBe("good");
+  });
+
+  it("preserves '=' inside values", () => {
+    applyDotenv("TEST_FOO_KEY_A=key=with=equals\n");
+    expect(process.env.TEST_FOO_KEY_A).toBe("key=with=equals");
+  });
+
+  it("treats empty value as empty string and counts it", () => {
+    const count = applyDotenv("TEST_FOO_KEY_A=\n");
+    expect(count).toBe(1);
+    expect(process.env.TEST_FOO_KEY_A).toBe("");
+  });
+});
+
+describe("autoLoadClaudeClawEnv", () => {
+  let tmp: string;
+  const sentinels = [
+    "CLAUDECLAW_TEST_OAUTH",
+    "CLAUDECLAW_TEST_API_KEY",
+    "CLAUDECLAW_ENV_FILE",
+    "CLAUDECLAW_ENV_AUTOLOAD",
+  ];
+  const previous = new Map<string, string | undefined>();
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), "claudeclaw-env-autoload-"));
+    for (const k of sentinels) {
+      previous.set(k, process.env[k]);
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+    for (const k of sentinels) {
+      const prev = previous.get(k);
+      if (prev === undefined) delete process.env[k];
+      else process.env[k] = prev;
+    }
+    previous.clear();
+  });
+
+  it("loads from CLAUDECLAW_ENV_FILE override", () => {
+    const path = join(tmp, "override.env");
+    writeFileSync(path, "CLAUDECLAW_TEST_OAUTH=sk-ant-oat01-fake-token\n");
+    chmodSync(path, 0o600);
+    process.env.CLAUDECLAW_ENV_FILE = path;
+
+    const result = autoLoadClaudeClawEnv();
+
+    expect(result).not.toBeNull();
+    expect(result?.path).toBe(path);
+    expect(result?.loaded).toBe(1);
+    expect(process.env.CLAUDECLAW_TEST_OAUTH).toBe("sk-ant-oat01-fake-token");
+  });
+
+  it("returns null when no env file exists in any candidate path", () => {
+    process.env.CLAUDECLAW_ENV_FILE = join(tmp, "nonexistent.env");
+    const result = autoLoadClaudeClawEnv();
+    expect(result).toBeNull();
+  });
+
+  it("respects CLAUDECLAW_ENV_AUTOLOAD=0 opt-out", () => {
+    const path = join(tmp, "skipped.env");
+    writeFileSync(path, "CLAUDECLAW_TEST_OAUTH=should-not-load\n");
+    process.env.CLAUDECLAW_ENV_FILE = path;
+    process.env.CLAUDECLAW_ENV_AUTOLOAD = "0";
+
+    const result = autoLoadClaudeClawEnv();
+
+    expect(result).toBeNull();
+    expect(process.env.CLAUDECLAW_TEST_OAUTH).toBeUndefined();
+  });
+
+  it("does NOT overwrite already-set vars", () => {
+    const path = join(tmp, "override.env");
+    writeFileSync(path, "CLAUDECLAW_TEST_OAUTH=from-file\nCLAUDECLAW_TEST_API_KEY=fresh\n");
+    process.env.CLAUDECLAW_ENV_FILE = path;
+    process.env.CLAUDECLAW_TEST_OAUTH = "from-env";
+
+    const result = autoLoadClaudeClawEnv();
+
+    expect(result?.loaded).toBe(1);
+    expect(process.env.CLAUDECLAW_TEST_OAUTH).toBe("from-env");
+    expect(process.env.CLAUDECLAW_TEST_API_KEY).toBe("fresh");
+  });
+});

--- a/src/cli-env-autoload.ts
+++ b/src/cli-env-autoload.ts
@@ -24,6 +24,9 @@ export interface LoadResult {
  *   3. `/etc/claudeclaw/.claudeclaw-env` (system-wide install)
  *   4. `~/.claudeclaw-env` (dev/laptop)
  *
+ * Opt-out: set `CLAUDECLAW_ENV_AUTOLOAD=0` to disable entirely (returns
+ * `null` without scanning).
+ *
  * Returns the loaded file + count, or `null` if nothing was found.
  */
 export function autoLoadClaudeClawEnv(

--- a/src/cli-env-autoload.ts
+++ b/src/cli-env-autoload.ts
@@ -1,0 +1,88 @@
+import { existsSync, readFileSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const DEFAULT_PATHS = ["/home/claw/.claudeclaw-env", "/etc/claudeclaw/.claudeclaw-env"];
+
+export interface LoadResult {
+  path: string;
+  loaded: number;
+}
+
+/**
+ * Auto-load `.claudeclaw-env` into `process.env` for CLI subcommands that
+ * spawn `claude --print` (send, fire). Existing vars are NEVER overwritten —
+ * so a daemon launched via `set -a; source …; set +a` keeps its already
+ * exported values and this call is a no-op for it. Designed for the case
+ * where an operator runs `claudeclaw send …` from a terminal that hasn't
+ * sourced the env file: without this, `claude --print` falls back to a stale
+ * `~/.claude/.credentials.json` and 401s.
+ *
+ * Search order (first existing file wins):
+ *   1. `$CLAUDECLAW_ENV_FILE` (operator override)
+ *   2. `/home/claw/.claudeclaw-env` (production daemon host)
+ *   3. `/etc/claudeclaw/.claudeclaw-env` (system-wide install)
+ *   4. `~/.claudeclaw-env` (dev/laptop)
+ *
+ * Returns the loaded file + count, or `null` if nothing was found.
+ */
+export function autoLoadClaudeClawEnv(
+  opts: { log?: (msg: string) => void } = {},
+): LoadResult | null {
+  if (process.env.CLAUDECLAW_ENV_AUTOLOAD === "0") return null;
+
+  const candidates = [
+    process.env.CLAUDECLAW_ENV_FILE,
+    ...DEFAULT_PATHS,
+    join(homedir(), ".claudeclaw-env"),
+  ].filter((p): p is string => typeof p === "string" && p.length > 0);
+
+  for (const path of candidates) {
+    try {
+      if (!existsSync(path)) continue;
+      const st = statSync(path);
+      if (!st.isFile()) continue;
+      const text = readFileSync(path, "utf8");
+      const loaded = applyDotenv(text);
+      opts.log?.(`claudeclaw: loaded ${loaded} var(s) from ${path}`);
+      return { path, loaded };
+    } catch {
+      // ignore unreadable file, try next candidate
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse simple `KEY=value` lines and set them in `process.env` only when the
+ * key is currently `undefined`. Supports `#` comments, blank lines, and
+ * surrounding single/double quotes. Returns the count of keys set.
+ *
+ * Deliberately minimal: no variable interpolation, no `export` keyword
+ * handling, no multi-line values. Matches the format Doppler's
+ * `env-no-quotes` writer produces, which is what the daemon launcher uses.
+ */
+export function applyDotenv(text: string): number {
+  let count = 0;
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith("#")) continue;
+    const m = line.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (!m) continue;
+    const key = m[1];
+    if (!key) continue;
+    let value = m[2] ?? "";
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+      count++;
+    }
+  }
+  return count;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { discord } from "./commands/discord";
 import { slack } from "./commands/slack";
 import { send } from "./commands/send";
 import { runFireCommand } from "./commands/fire";
+import { autoLoadClaudeClawEnv } from "./cli-env-autoload";
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -49,8 +50,10 @@ if (command === "--help" || command === "-h" || command === "help") {
 } else if (command === "slack") {
   slack();
 } else if (command === "send") {
+  autoLoadClaudeClawEnv();
   send(args.slice(1));
 } else if (command === "fire") {
+  autoLoadClaudeClawEnv();
   runFireCommand(args.slice(1)).then((code) => process.exit(code));
 } else {
   start();


### PR DESCRIPTION
## Summary

Closes #180 (after re-scoping to docs/UX — production daemon paths are unaffected).

Auto-load `.claudeclaw-env` into `process.env` for `claudeclaw send` and `claudeclaw fire` so manual CLI invocations from a terminal that hasn't sourced the env file no longer 401 by falling back to a stale `~/.claude/.credentials.json`.

## Background

Issue #180 reported `claude --print` returning 401 on Hetzner. Investigation found the daemon paths are fine — `cleanSpawnEnv()` correctly preserves the long-lived OAuth token, and `/api/jobs/fire` already routes through `bus.sendPromptAndAwait` on runtime:bus (no `claude --print` involved). The 401 was reproduced only by manual CLI invocations from a terminal where `.claudeclaw-env` had been sourced **without** `set -a` (so vars weren't exported). The daemon launcher (`/usr/local/bin/claudeclaw-start`) uses `set -a; source …; set +a` correctly, so production is unaffected.

## Behavior

- Auto-load runs **only** for `send` and `fire` (the two paths that spawn `claude --print` outside the daemon). `start` already runs under the daemon launcher.
- Existing `process.env` vars are **never** overwritten — daemon-launched processes keep their already-exported values; this is a no-op for them.
- Search order (first match wins): `$CLAUDECLAW_ENV_FILE` → `/home/claw/.claudeclaw-env` → `/etc/claudeclaw/.claudeclaw-env` → `~/.claudeclaw-env`.
- Opt-out: `CLAUDECLAW_ENV_AUTOLOAD=0`.

Parser is intentionally minimal — matches Doppler `env-no-quotes` format (plain `KEY=value`, `#` comments, blank lines, optional matching single/double quotes). No variable interpolation, no `export` keyword, no multi-line values.

## Test plan

- [x] 12 unit tests cover `applyDotenv` parsing edges (quotes, malformed lines, `=` in values, comments, empty values, no-overwrite) and `autoLoadClaudeClawEnv` search behavior (override path, opt-out, non-overwrite, no-file)
- [x] `bun test src/__tests__/cli-env-autoload.test.ts` — 12/12 pass
- [x] `bun run lint` — clean (0 errors)
- [x] Manual smoke: confirmed Hetzner daemon's `claude --print` already works with daemon-shape env (CLAUDE_CODE_OAUTH_TOKEN only, post-`cleanSpawnEnv`)
- [ ] Manual smoke from a fresh terminal: `claudeclaw send "hi"` without sourcing env — should auto-load and succeed

## Review

5-agent code review run; 1 HIGH-confidence doc gap caught and fixed in commit 270caa5.