### PR TITLE
feat(telegram): route by origin_id like discord/slack for multi-chat-per-agent (#139)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.104",
+      "version": "2.2.105",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.105",
+      "version": "2.2.106",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.105",
+  "version": "2.2.106",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.104",
+  "version": "2.2.105",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -636,6 +636,57 @@ describe("TelegramAdapter — response.text outbound", () => {
     expect(api.sendMessages[0]?.text).toBe("reply for 100");
   });
 
+  it("preserves message_thread_id for the origin chat via lastTopicPerChat (Codex P2)", async () => {
+    // Codex review on the original #139 commit: when chat A (forum topic 5)
+    // and chat B share the same agent and prompts interleave, lastChatPerAgent
+    // only holds one chat at a time. The origin_id route for the OTHER chat
+    // would drop its message_thread_id and reply to the supergroup's general
+    // topic instead of the originating thread.
+    adapter = await startAdapter({
+      routing: { chats: { "100": "triage", "200": "triage" } },
+    });
+    // Prime chat 100 inside forum topic 5.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 50,
+          from: { id: 42 },
+          chat: { id: 100, type: "supergroup" },
+          message_thread_id: 5,
+          text: "from chat 100 topic 5",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length === 1);
+
+    // Interleave: chat 200 (no thread) sends a prompt. Cache now points at
+    // 200 with NO thread — exactly the scenario Codex flagged.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 51,
+          from: { id: 42 },
+          chat: { id: 200, type: "private" },
+          text: "from chat 200",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length === 2);
+
+    // Reply to chat 100's prompt. Without the lastTopicPerChat fallback,
+    // message_thread_id would be undefined.
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "reply for 100 topic 5", origin: "telegram", origin_id: "100" },
+    });
+    await waitFor(() => api.sendMessages.length > 0);
+    expect(api.sendMessages[0]?.chat_id).toBe(100);
+    expect(api.sendMessages[0]?.message_thread_id).toBe(5);
+  });
+
   it("falls back to targetForAgent when origin is absent (cron/heartbeat)", async () => {
     adapter = await startAdapter();
     await feedInbound();

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -590,6 +590,67 @@ describe("TelegramAdapter — response.text outbound", () => {
     expect(api.editMessages.length).toBe(editsAfterFinal);
     expect(api.sendMessages[1]?.text).toBe("afterthought");
   });
+
+  it("routes response.text to origin_id when origin is telegram (issue #139)", async () => {
+    adapter = await startAdapter({
+      routing: { chats: { "100": "triage", "200": "triage" } },
+    });
+    // Prime the per-agent cache from chat 100 first — the bug this guards
+    // against is the cache leaking across chats sharing one agent.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 50,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          text: "from chat 100",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length === 1);
+
+    // Interleave: chat 200 sends a prompt. Now lastChatPerAgent[triage] = 200.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 51,
+          from: { id: 42 },
+          chat: { id: 200, type: "private" },
+          text: "from chat 200",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length === 2);
+
+    // The reply to chat 100's prompt arrives. Without origin_id routing,
+    // targetForAgent would return the cached 200 entry and misroute.
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "reply for 100", origin: "telegram", origin_id: "100" },
+    });
+    await waitFor(() => api.sendMessages.length > 0);
+    expect(api.sendMessages[0]?.chat_id).toBe(100);
+    expect(api.sendMessages[0]?.text).toBe("reply for 100");
+  });
+
+  it("falls back to targetForAgent when origin is absent (cron/heartbeat)", async () => {
+    adapter = await startAdapter();
+    await feedInbound();
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "heartbeat tick", origin: "heartbeat", origin_id: "hb" },
+    });
+    await waitFor(() => api.sendMessages.length > 0);
+    // No telegram origin → fall through to cached last inbound (chat 100).
+    expect(api.sendMessages[0]?.chat_id).toBe(100);
+  });
 });
 
 /* ────────────────────────────────────────────────────────────────────── */

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -745,14 +745,19 @@ export class TelegramAdapter {
    * Pick an outbound chat for the agent honoring the event's
    * `origin_id` when `origin === "telegram"` (issue #139). When the
    * cached `lastChatPerAgent[agent]` chat_id matches the event's
-   * origin_id we prefer the cached `PendingPrompt` because it preserves
-   * `message_thread_id` for threaded chats; otherwise we build a bare
-   * target from the origin_id alone. Falls back to {@link targetForAgent}
-   * for events without an origin (cron / heartbeat / cli / rest) or
-   * when the origin isn't telegram.
+   * origin_id we borrow the cached `message_thread_id` so threaded
+   * chats still reply in their forum topic — but we always zero out
+   * `source_message_id` because the cache tracks the *most recent*
+   * inbound, not the one this reply corresponds to. Letting the cached
+   * source_message_id leak through here would react on a newer
+   * (unrelated) message when two prompts arrive from the same chat
+   * before the first response lands.
+   *
+   * Falls back to {@link targetForAgent} for events without an origin
+   * (cron / heartbeat / cli / rest) or when the origin isn't telegram.
    *
    * Mirrors Discord (`src/adapters/discord/index.ts` ~L411) and Slack
-   * (`src/adapters/slack/index.ts` ~L577) — see issue #139 for context.
+   * (`src/adapters/slack/index.ts` ~L615) — see issue #139 for context.
    */
   private targetForOriginOrAgent(agentId: string, event: BusEvent): PendingPrompt | null {
     const payloadWithOrigin = event.payload as { origin?: string; origin_id?: string } | undefined;
@@ -760,10 +765,18 @@ export class TelegramAdapter {
     const originId = payloadWithOrigin?.origin_id;
     if (origin === "telegram" && typeof originId === "string" && originId.length > 0) {
       const chatId = Number(originId);
-      if (Number.isFinite(chatId)) {
+      // Telegram chat ids are always integers (and can be negative for
+      // groups/channels). `Number.isInteger` rejects NaN, floats, and
+      // Infinity in one check — tighter than `isFinite`.
+      if (Number.isInteger(chatId)) {
         const cached = this.lastChatPerAgent.get(agentId);
-        if (cached && cached.chat_id === chatId) return cached;
-        return { chat_id: chatId, source_message_id: 0 };
+        const threadId =
+          cached && cached.chat_id === chatId ? cached.message_thread_id : undefined;
+        return {
+          chat_id: chatId,
+          source_message_id: 0,
+          ...(threadId !== undefined ? { message_thread_id: threadId } : {}),
+        };
       }
     }
     return this.targetForAgent(agentId);

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -107,6 +107,17 @@ export class TelegramAdapter {
 
   /** Last inbound per agent — target for outbound + reaction message id. */
   private readonly lastChatPerAgent = new Map<string, PendingPrompt>();
+  /**
+   * Last-known forum-topic id per chat. Codex review on #139: when chat A
+   * (forum topic 5) and chat B share the same agent and prompts interleave,
+   * `lastChatPerAgent` only holds one chat at a time, so the origin_id route
+   * for the OTHER chat would drop its `message_thread_id` and reply to the
+   * supergroup's general topic instead of the originating thread. Populated
+   * on every inbound; read by {@link targetForOriginOrAgent} when the cache
+   * doesn't match the origin_id chat. Holds `undefined` for non-forum chats
+   * so the difference between "never seen" and "non-threaded" is observable.
+   */
+  private readonly lastTopicPerChat = new Map<number, number | undefined>();
   /** Last outbound bot message per agent — target for edit_message + spinner. */
   private readonly lastBotMessage = new Map<
     string,
@@ -348,6 +359,7 @@ export class TelegramAdapter {
       message_thread_id: message.message_thread_id,
     };
     this.lastChatPerAgent.set(agentId, pending);
+    this.lastTopicPerChat.set(chatId, message.message_thread_id);
 
     // Typing indicator + auto-spinner: the instant a message arrives, post a
     // braille placeholder and animate it so the user sees activity before
@@ -743,15 +755,21 @@ export class TelegramAdapter {
 
   /**
    * Pick an outbound chat for the agent honoring the event's
-   * `origin_id` when `origin === "telegram"` (issue #139). When the
-   * cached `lastChatPerAgent[agent]` chat_id matches the event's
-   * origin_id we borrow the cached `message_thread_id` so threaded
-   * chats still reply in their forum topic — but we always zero out
-   * `source_message_id` because the cache tracks the *most recent*
-   * inbound, not the one this reply corresponds to. Letting the cached
-   * source_message_id leak through here would react on a newer
-   * (unrelated) message when two prompts arrive from the same chat
-   * before the first response lands.
+   * `origin_id` when `origin === "telegram"` (issue #139). We always
+   * zero out `source_message_id` because the cache tracks the *most
+   * recent* inbound, not the one this reply corresponds to — letting it
+   * leak would react on a newer (unrelated) message when two prompts
+   * arrive from the same chat before the first response lands.
+   *
+   * For `message_thread_id`: prefer the cached `lastChatPerAgent[agent]`
+   * value when its chat_id matches the origin_id (most accurate — same
+   * agent, same chat, last inbound). Otherwise fall back to
+   * `lastTopicPerChat[origin_id]` so forum threading still works when
+   * two chats sharing the same agent interleave prompts (Codex P2 on
+   * the original #139 commit). A perfect fix would carry the originating
+   * thread id through the bus payload as `origin_thread_id`; that's
+   * upstream work in BusCore + every adapter, and this two-level cache
+   * covers the common-case routing without it.
    *
    * Falls back to {@link targetForAgent} for events without an origin
    * (cron / heartbeat / cli / rest) or when the origin isn't telegram.
@@ -770,7 +788,10 @@ export class TelegramAdapter {
       // Infinity in one check — tighter than `isFinite`.
       if (Number.isInteger(chatId)) {
         const cached = this.lastChatPerAgent.get(agentId);
-        const threadId = cached && cached.chat_id === chatId ? cached.message_thread_id : undefined;
+        const threadId =
+          cached && cached.chat_id === chatId
+            ? cached.message_thread_id
+            : this.lastTopicPerChat.get(chatId);
         return {
           chat_id: chatId,
           source_message_id: 0,

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -410,7 +410,7 @@ export class TelegramAdapter {
     const rawText = typeof payload?.text === "string" ? payload.text : "";
     if (rawText.length === 0) return;
 
-    const target = this.targetForAgent(agentId);
+    const target = this.targetForOriginOrAgent(agentId, event);
     if (!target) {
       this.logger.warn(
         `[telegram-adapter] no target chat for agent ${agentId}; dropping response.text`,
@@ -620,7 +620,7 @@ export class TelegramAdapter {
     const req = event.payload as PermissionRequest | undefined;
     if (!req || typeof req.request_id !== "string") return;
 
-    const target = this.targetForAgent(agentId);
+    const target = this.targetForOriginOrAgent(agentId, event);
     if (!target) {
       this.logger.warn(
         `[telegram-adapter] no target chat for permission_request on agent ${agentId}`,
@@ -661,7 +661,7 @@ export class TelegramAdapter {
     if (typeof payload?.ask_id !== "string" || typeof payload?.question !== "string") {
       return;
     }
-    const target = this.targetForAgent(agentId);
+    const target = this.targetForOriginOrAgent(agentId, event);
     if (!target) {
       this.logger.warn(`[telegram-adapter] no target chat for request_human on agent ${agentId}`);
       return;
@@ -742,10 +742,46 @@ export class TelegramAdapter {
   }
 
   /**
-   * Pick an outbound chat for the agent. Prefers the last inbound (so
-   * replies thread back); falls back to the first chat routed to the
-   * agent so spontaneous events (cron, background tools) still reach
-   * a surface.
+   * Pick an outbound chat for the agent honoring the event's
+   * `origin_id` when `origin === "telegram"` (issue #139). When the
+   * cached `lastChatPerAgent[agent]` chat_id matches the event's
+   * origin_id we prefer the cached `PendingPrompt` because it preserves
+   * `message_thread_id` for threaded chats; otherwise we build a bare
+   * target from the origin_id alone. Falls back to {@link targetForAgent}
+   * for events without an origin (cron / heartbeat / cli / rest) or
+   * when the origin isn't telegram.
+   *
+   * Mirrors Discord (`src/adapters/discord/index.ts` ~L411) and Slack
+   * (`src/adapters/slack/index.ts` ~L577) — see issue #139 for context.
+   */
+  private targetForOriginOrAgent(agentId: string, event: BusEvent): PendingPrompt | null {
+    const payloadWithOrigin = event.payload as { origin?: string; origin_id?: string } | undefined;
+    const origin = payloadWithOrigin?.origin;
+    const originId = payloadWithOrigin?.origin_id;
+    if (origin === "telegram" && typeof originId === "string" && originId.length > 0) {
+      const chatId = Number(originId);
+      if (Number.isFinite(chatId)) {
+        const cached = this.lastChatPerAgent.get(agentId);
+        if (cached && cached.chat_id === chatId) return cached;
+        return { chat_id: chatId, source_message_id: 0 };
+      }
+    }
+    return this.targetForAgent(agentId);
+  }
+
+  /**
+   * Pick an outbound chat for the agent based purely on routing —
+   * used as the fallback when an event has no origin (cron, heartbeat,
+   * cli, rest) or when origin-derived routing can't pin a chat.
+   *
+   * Prefers the last inbound for the agent (so replies thread back);
+   * otherwise the first routed chat so spontaneous events still reach
+   * a surface. Issue #139: outbound `response.text` /
+   * `channel.permission_request` / `system.request_human` with
+   * `origin === "telegram"` now route via {@link targetForOriginOrAgent}
+   * which prefers `origin_id` over this fan-out cache, so two chats
+   * routed to the same agent no longer cross-wire on interleaved
+   * prompts.
    */
   private targetForAgent(agentId: string): PendingPrompt | null {
     const last = this.lastChatPerAgent.get(agentId);

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -770,8 +770,7 @@ export class TelegramAdapter {
       // Infinity in one check — tighter than `isFinite`.
       if (Number.isInteger(chatId)) {
         const cached = this.lastChatPerAgent.get(agentId);
-        const threadId =
-          cached && cached.chat_id === chatId ? cached.message_thread_id : undefined;
+        const threadId = cached && cached.chat_id === chatId ? cached.message_thread_id : undefined;
         return {
           chat_id: chatId,
           source_message_id: 0,


### PR DESCRIPTION
## Summary

Closes #139.

Telegram's `handleResponseText` / `handlePermissionRequest` / `handleRequestHuman` all routed via `targetForAgent(agentId)` — which returns `lastChatPerAgent.get(agentId)`, a single target tracking the last inbound chat for that agent. Invisible in production today (one Telegram chat per agent), but the moment two chats route to one agent like Discord/Slack support, Telegram misroutes on interleaved prompts: chat A's reply lands in chat B because chat B's prompt came in last.

PR #138 surfaced this as Finding A2 (confidence 75) when fixing the foreign-origin fan-out bug. This PR closes that deferral.

## Approach

Mirrors the Discord (`src/adapters/discord/index.ts` ~L411) and Slack (`src/adapters/slack/index.ts` ~L615) pattern: a new private helper `targetForOriginOrAgent(agentId, event)` reads `event.payload.origin` + `origin_id`, and when `origin === "telegram"` and `origin_id` parses as a Telegram chat id (integer — `Number.isInteger`), routes there exclusively. If the cached `lastChatPerAgent[agent].chat_id` matches the origin_id, the cached `message_thread_id` is borrowed (preserves forum topic). `source_message_id` is always zeroed — the cache tracks the most recent inbound, not the one the reply corresponds to, so letting it leak would react on a newer (unrelated) message.

For events with no origin (cron / heartbeat / cli / rest) or non-telegram origins, the new helper falls through to `targetForAgent` — preserving the existing fan-out semantics + the foreign-origin drop guard (`eventBelongsToTelegram`).

## Test plan

- [x] 2 regression tests in `src/adapters/telegram/__tests__/telegram.test.ts`:
  - **"routes response.text to origin_id when origin is telegram"** — primes chat 100, interleaves chat 200 (poisons the cache → 200), then emits a reply with `origin_id: "100"`. Without the fix, `targetForAgent` returns 200; with the fix, lands in 100.
  - **"falls back to targetForAgent when origin is absent"** — confirms heartbeat/cron events still route via the existing cache.
- [x] `bun test src/adapters/telegram/__tests__/telegram.test.ts` — 29/29 pass
- [x] `bun run lint` — clean (0 errors)
- [x] Pattern parity with discord-outbound.test.ts and slack-outbound.test.ts
- [x] 5-agent review at HEAD `9caea9e0e793` — 3 HIGH findings caught and applied as follow-up commits
- [x] Security review: APPROVE, no HIGH/CRITICAL

## Review findings (resolved during cycle)

1. Stale `source_message_id` in cache match → reaction on newer unrelated message. Fixed.
2. `Number.isFinite` accepts floats — tightened to `Number.isInteger`. Fixed.
3. JSDoc Slack line ref (L577 → L615). Fixed.

## Acceptance criteria (from #139)

- [x] `handleResponseText` routes to `origin_id`-derived chat when `origin === "telegram"`
- [x] `handlePermissionRequest` does the same
- [x] `handleRequestHuman` does the same
- [x] Fan-out (`targetForAgent`) remains the fallback for events with no origin
- [x] Regression test covers multi-chat interleaved prompts not crossing wires