### PR TITLE
feat(wizard): detect orphan agents/<name>/ dirs and offer to add them (#167 part B)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.111",
+      "version": "2.2.112",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.112",
+      "version": "2.2.113",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.109",
+      "version": "2.2.110",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.110",
+      "version": "2.2.111",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.111",
+  "version": "2.2.112",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.109",
+  "version": "2.2.110",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.112",
+  "version": "2.2.113",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.110",
+  "version": "2.2.111",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/commands/start.md
+++ b/commands/start.md
@@ -123,11 +123,11 @@ Start the heartbeat daemon for this project. Follow these steps exactly:
 
    The bus runtime only spawns processes for agents declared in `settings.agents[]`. If an `agents/<name>/` directory has scheduled jobs but `<name>` is not declared, the scheduler fires prompts to the bus with `agent_id: <name>` and they sit `status: "pending"` forever — silent job death. The daemon warns at startup (PR #168), but the wizard can offer to fix it inline.
 
-   Run this scan (only counts `*.md` files — matches what the daemon's loader and the orphan-detect warning treat as a "job"; see `src/bus/orphan-agent-detect.ts` + `src/jobs.ts:loadJobs`):
+   Run this scan (only counts `.md` files — matches what the daemon's loader and the orphan-detect warning treat as a "job"; see `src/bus/orphan-agent-detect.ts` + `src/jobs.ts:loadJobs`). Uses `ls -A | grep` so dot-prefixed `.md` files (e.g. `.draft.md`) are counted to match the daemon's `endsWith(".md")` check, but `.swp`/`.bak` editor files are excluded by the regex anchor:
    ```bash
    for d in agents/*/; do
      name=$(basename "$d")
-     job_count=$(ls -1 "${d}jobs/"*.md 2>/dev/null | wc -l | tr -d ' ')
+     job_count=$(ls -1A "${d}jobs/" 2>/dev/null | grep -cE '\.md$' | tr -d ' ')
      [ "$job_count" -gt 0 ] && echo "${name}:${job_count}"
    done
    ```
@@ -150,10 +150,11 @@ Start the heartbeat daemon for this project. Follow these steps exactly:
      - agents/suzy/  (3 jobs)
    ```
 
-   If "Yes": append each orphan to `settings.agents`. Match step 5's permission-mode convention exactly:
-   - If the wizard's headless answer was "Yes — headless (Recommended)" (or permissions were already configured for headless), write `{ "id": "<name>" }` with NO `permission_mode` field — the resolver default delivers headless behaviour.
-   - If the wizard's headless answer was "No — confirm each Bash/Write call", write `{ "id": "<name>", "permission_mode": "plan" }`, matching what step 5 does for existing entries.
-   - If permissions were not configured this wizard run AND no prior `.claude/claudeclaw/permission-mode.json` exists, default to no `permission_mode` (relies on resolver default).
+   If "Yes": append each orphan to `settings.agents`. Match step 5's permission-mode convention exactly — every orphan gets the SAME `permission_mode` treatment that step 5 would apply to a new agent in the current wizard state:
+
+   - **If the wizard asked about permissions this run AND the answer was "No — confirm each Bash/Write call"** → write `{ "id": "<name>", "permission_mode": "plan" }`.
+   - **If the wizard asked about permissions this run AND the answer was "Yes — headless (Recommended)"** → write `{ "id": "<name>" }` with NO `permission_mode` field (resolver default delivers headless).
+   - **If the wizard skipped the permissions question this run** (it was already configured), read `.claude/claudeclaw/permission-mode.json`. If it exists and `{ "mode": "plan" }`, write `{ "id": "<name>", "permission_mode": "plan" }` — matching what existing agents would have got under step 5's "No" branch on a prior run. Otherwise (file absent OR mode is anything else) write `{ "id": "<name>" }` with no `permission_mode` — resolver-default headless, matching prior-run "Yes".
 
    Write the updated `settings.json`. Tell the user "Added N orphan agent(s) to settings.agents."
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -119,6 +119,41 @@ Start the heartbeat daemon for this project. Follow these steps exactly:
 
    Update `.claude/claudeclaw/settings.json` with their answers.
 
+5a. **Detect orphan agent directories** (issue #167):
+
+   The bus runtime only spawns processes for agents declared in `settings.agents[]`. If an `agents/<name>/` directory has scheduled jobs but `<name>` is not declared, the scheduler fires prompts to the bus with `agent_id: <name>` and they sit `status: "pending"` forever — silent job death. The daemon warns at startup (PR #168), but the wizard can offer to fix it inline.
+
+   Run this scan:
+   ```bash
+   for d in agents/*/; do
+     name=$(basename "$d")
+     job_count=$(ls -1 "${d}jobs/" 2>/dev/null | wc -l | tr -d ' ')
+     [ "$job_count" -gt 0 ] && echo "${name}:${job_count}"
+   done
+   ```
+
+   Read `.claude/claudeclaw/settings.json` and parse `settings.agents[].id` (treat missing/empty as `[]`). For each `<name>:<count>` from the scan, if `<name>` is NOT in the declared id list, it's an orphan.
+
+   **If no orphans found**, proceed to step 6.
+
+   **If orphans found**, show the list and use AskUserQuestion:
+   - Question: "Found agent directories on disk with jobs but not declared in settings.agents. The bus runtime won't spawn them, so their scheduled jobs will silently fail. Add them?"
+   - Header: "Orphan agents"
+   - Options:
+     - "Yes — add with bypassPermissions (Recommended)" (description: "Adds `{ id: <name>, permission_mode: 'bypassPermissions' }` per orphan. Inherits the same headless default the wizard already applies.")
+     - "No — leave as-is" (description: "Jobs for the orphan agent(s) will continue to silently fail until you declare them manually.")
+
+   Show the orphan list in the question body, e.g.:
+   ```
+   Orphans detected:
+     - agents/reg/   (7 jobs)
+     - agents/suzy/  (3 jobs)
+   ```
+
+   If "Yes": append each orphan to `settings.agents` as `{ "id": "<name>", "permission_mode": "<wizard's permission_mode answer or 'bypassPermissions'>" }`. Write the updated `settings.json`. Tell the user "Added N orphan agent(s) to settings.agents."
+
+   If "No": write nothing — the daemon's startup warning will continue to flag them on every restart.
+
 6. **Launch/start action**:
    ```bash
    mkdir -p .claude/claudeclaw/logs && nohup bun run ${CLAUDE_PLUGIN_ROOT}/src/index.ts start --web > .claude/claudeclaw/logs/daemon.log 2>&1 & echo $!

--- a/commands/start.md
+++ b/commands/start.md
@@ -123,11 +123,11 @@ Start the heartbeat daemon for this project. Follow these steps exactly:
 
    The bus runtime only spawns processes for agents declared in `settings.agents[]`. If an `agents/<name>/` directory has scheduled jobs but `<name>` is not declared, the scheduler fires prompts to the bus with `agent_id: <name>` and they sit `status: "pending"` forever — silent job death. The daemon warns at startup (PR #168), but the wizard can offer to fix it inline.
 
-   Run this scan:
+   Run this scan (only counts `*.md` files — matches what the daemon's loader and the orphan-detect warning treat as a "job"; see `src/bus/orphan-agent-detect.ts` + `src/jobs.ts:loadJobs`):
    ```bash
    for d in agents/*/; do
      name=$(basename "$d")
-     job_count=$(ls -1 "${d}jobs/" 2>/dev/null | wc -l | tr -d ' ')
+     job_count=$(ls -1 "${d}jobs/"*.md 2>/dev/null | wc -l | tr -d ' ')
      [ "$job_count" -gt 0 ] && echo "${name}:${job_count}"
    done
    ```
@@ -140,7 +140,7 @@ Start the heartbeat daemon for this project. Follow these steps exactly:
    - Question: "Found agent directories on disk with jobs but not declared in settings.agents. The bus runtime won't spawn them, so their scheduled jobs will silently fail. Add them?"
    - Header: "Orphan agents"
    - Options:
-     - "Yes — add with bypassPermissions (Recommended)" (description: "Adds `{ id: <name>, permission_mode: 'bypassPermissions' }` per orphan. Inherits the same headless default the wizard already applies.")
+     - "Yes — add (Recommended)" (description: "Adds `{ id: <name> }` per orphan, mirroring step 5's permission-mode rule: nothing written for headless (resolver default applies), `permission_mode: \"plan\"` written if the headless answer was \"No — confirm each Bash/Write call\".")
      - "No — leave as-is" (description: "Jobs for the orphan agent(s) will continue to silently fail until you declare them manually.")
 
    Show the orphan list in the question body, e.g.:
@@ -150,7 +150,12 @@ Start the heartbeat daemon for this project. Follow these steps exactly:
      - agents/suzy/  (3 jobs)
    ```
 
-   If "Yes": append each orphan to `settings.agents` as `{ "id": "<name>", "permission_mode": "<wizard's permission_mode answer or 'bypassPermissions'>" }`. Write the updated `settings.json`. Tell the user "Added N orphan agent(s) to settings.agents."
+   If "Yes": append each orphan to `settings.agents`. Match step 5's permission-mode convention exactly:
+   - If the wizard's headless answer was "Yes — headless (Recommended)" (or permissions were already configured for headless), write `{ "id": "<name>" }` with NO `permission_mode` field — the resolver default delivers headless behaviour.
+   - If the wizard's headless answer was "No — confirm each Bash/Write call", write `{ "id": "<name>", "permission_mode": "plan" }`, matching what step 5 does for existing entries.
+   - If permissions were not configured this wizard run AND no prior `.claude/claudeclaw/permission-mode.json` exists, default to no `permission_mode` (relies on resolver default).
+
+   Write the updated `settings.json`. Tell the user "Added N orphan agent(s) to settings.agents."
 
    If "No": write nothing — the daemon's startup warning will continue to flag them on every restart.
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -47,7 +47,7 @@ Start the heartbeat daemon for this project. Follow these steps exactly:
    Use AskUserQuestion:
    - "Your settings are already configured. Want to change anything?" (header: "Settings", options: "Keep current settings", "Reconfigure")
 
-   If they choose "Keep current settings", skip to step 6 (first contact question).
+   If they choose "Keep current settings", skip to step 5a (orphan detection still runs — it's the most likely failure on re-runs of an existing setup) and then on to step 6.
    If they choose "Reconfigure", proceed to step 5 below as if nothing was configured.
 
    **If SOME sections are configured and others are not**, show the already-configured sections as a summary, then only ask about the unconfigured sections in step 5.
@@ -132,11 +132,15 @@ Start the heartbeat daemon for this project. Follow these steps exactly:
    done
    ```
 
-   Read `.claude/claudeclaw/settings.json` and parse `settings.agents[].id` (treat missing/empty as `[]`). For each `<name>:<count>` from the scan, if `<name>` is NOT in the declared id list, it's an orphan.
+   Read `.claude/claudeclaw/settings.json` and parse `settings.agents[].id` (treat missing/empty as `[]`). For each `<name>:<count>` from the scan, if `<name>` is NOT in the declared id list, it's an orphan candidate.
 
-   **If no orphans found**, proceed to step 6.
+   **Validate each orphan candidate against the bus agent id regex** `^[a-z0-9][a-z0-9_-]{0,35}$` (the same pattern `src/config.ts:1044` rejects with; an invalid id would be silently skipped by the runtime, so adding it to settings.agents accomplishes nothing). Split candidates into two buckets:
+   - **Valid orphans** — eligible to add via the AskUserQuestion below.
+   - **Invalid orphans** — surface a single warning to the user listing each invalid dir name + why (uppercase / special char / too long / starts with dash or underscore) and instructing them to rename the directory before re-running the wizard. Do NOT offer to add these.
 
-   **If orphans found**, show the list and use AskUserQuestion:
+   **If no valid orphans found**, proceed to step 6 (after the invalid-name warning if any).
+
+   **If valid orphans found**, show the list and use AskUserQuestion:
    - Question: "Found agent directories on disk with jobs but not declared in settings.agents. The bus runtime won't spawn them, so their scheduled jobs will silently fail. Add them?"
    - Header: "Orphan agents"
    - Options:


### PR DESCRIPTION
## Summary

Closes the remaining part of #167. PR #168 shipped Parts A (daemon startup warning) and C (README). This patch adds **Part B**: the `/claudeclaw:start` wizard scans `agents/` and offers to add orphan dirs (those with `.md` jobs but no matching `settings.agents[].id` entry) to the config inline.

## Why

Production incident 2026-05-26: three agents (`suzy`, `reg`, `publisher`) had jobs on disk but were not declared in `settings.agents[]`. The bus runtime only spawns processes for declared agents, so the scheduler fired their prompts into the bus with no subscriber — `status: "pending"` forever. Days of silent job death.

PR #168's startup warning catches this on every daemon restart; the wizard now catches it at first setup or reconfigure, before jobs are ever wired up.

## What

One new step `5a` in `commands/start.md`, between settings write (step 5) and daemon launch (step 6):

1. Scan `agents/*/jobs/` for `.md` files (matches what the daemon's loader treats as a "job"; see `src/bus/orphan-agent-detect.ts` + `src/jobs.ts:loadJobs`).
2. Cross-reference with `settings.agents[].id`.
3. If orphans exist, surface as `AskUserQuestion` with the orphan list and counts.
4. On "Yes": append each orphan to `settings.agents`, mirroring step 5's `permission_mode` convention (no field for headless; `"plan"` for the confirm-each-call branch; reads `.claude/claudeclaw/permission-mode.json` when the wizard skipped the permissions question this run so plan-mode from a prior run flows through).
5. On "No": leave the daemon's startup warning to keep flagging.

No new code — the wizard runs Bash + does the JSON write inline. The daemon-side detector is unchanged.

## Test plan

- [x] `bun test src/__tests__/plugin-wizard.test.ts src/bus/__tests__/orphan-agent-detect.test.ts` — 31/31 pass
- [x] `bun run lint` — clean (0 errors)
- [x] Smoke-tested the scan glob against fixtures with `.md`, `.draft.md`, `.swp.md.swp`, `.gitkeep` — counts only `.md` files (including dotfile-prefixed) matching daemon's `endsWith(".md")`
- [x] 5-agent review: 2 HIGH findings (scan-glob drift + permission_mode asymmetry) caught and fixed in `a055211`; 2 more HIGH findings (plan-mode persistence + dotfile .md drift) caught and fixed in `ad0e51c`
- [ ] Manual wizard run with a synthetic orphan dir (operator validation on the next setup)