### PR TITLE
fix(webui): Host validation by hostname only — restore tunnelled dashboard (regression from #189)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.115",
+      "version": "2.2.116",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.114",
+      "version": "2.2.115",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.115",
+  "version": "2.2.116",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.114",
+  "version": "2.2.115",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/ui/__tests__/host-validation.test.ts
+++ b/src/ui/__tests__/host-validation.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Tests for isHostAllowed — DNS-rebinding Host validation (issue #164
+ * item 2), hotfixed after #189 took the live dashboard offline with
+ * "Bad Host" because the original check matched host:PORT and tunnelled
+ * access sends the client-side forwarded port.
+ *
+ * Run with: bun test src/ui/__tests__/host-validation.test.ts
+ */
+import { describe, it, expect } from "bun:test";
+import { isHostAllowed } from "../server";
+
+describe("isHostAllowed (loopback bind 127.0.0.1)", () => {
+  const bind = "127.0.0.1";
+
+  it("allows the exact bind host:port", () => {
+    expect(isHostAllowed("127.0.0.1:4632", bind)).toBe(true);
+  });
+
+  it("allows localhost on the bind port", () => {
+    expect(isHostAllowed("localhost:4632", bind)).toBe(true);
+  });
+
+  it("allows a tunnelled / forwarded MISMATCHED port (the #189 regression)", () => {
+    // ssh -L 8080:127.0.0.1:4632 → browser hits localhost:8080 → Host
+    // carries 8080, not the bind port 4632. Must still be allowed.
+    expect(isHostAllowed("localhost:8080", bind)).toBe(true);
+    expect(isHostAllowed("127.0.0.1:55123", bind)).toBe(true);
+  });
+
+  it("allows a bare hostname with no port", () => {
+    expect(isHostAllowed("localhost", bind)).toBe(true);
+    expect(isHostAllowed("127.0.0.1", bind)).toBe(true);
+  });
+
+  it("allows the IPv6 loopback in bracket form", () => {
+    expect(isHostAllowed("[::1]:4632", bind)).toBe(true);
+    expect(isHostAllowed("[::1]", bind)).toBe(true);
+  });
+
+  it("is case-insensitive on the hostname", () => {
+    expect(isHostAllowed("LOCALHOST:4632", bind)).toBe(true);
+  });
+
+  it("rejects a foreign hostname (DNS-rebinding attacker domain)", () => {
+    expect(isHostAllowed("attacker.com:4632", bind)).toBe(false);
+    expect(isHostAllowed("evil.example:8080", bind)).toBe(false);
+  });
+
+  it("rejects an empty Host header", () => {
+    expect(isHostAllowed("", bind)).toBe(false);
+  });
+});
+
+describe("isHostAllowed (specific LAN bind)", () => {
+  it("allows the configured bind host on any port", () => {
+    expect(isHostAllowed("192.168.1.50:4632", "192.168.1.50")).toBe(true);
+    expect(isHostAllowed("192.168.1.50:9090", "192.168.1.50")).toBe(true);
+  });
+
+  it("still allows loopback names when bound to a LAN IP", () => {
+    expect(isHostAllowed("localhost:4632", "192.168.1.50")).toBe(true);
+  });
+
+  it("rejects a different LAN IP", () => {
+    expect(isHostAllowed("192.168.1.99:4632", "192.168.1.50")).toBe(false);
+  });
+});
+
+describe("isHostAllowed (wildcard bind)", () => {
+  it("allows any host when bound to 0.0.0.0 (operator opted into remote access)", () => {
+    expect(isHostAllowed("anything.example:1234", "0.0.0.0")).toBe(true);
+    expect(isHostAllowed("", "0.0.0.0")).toBe(true);
+  });
+
+  it("allows any host when bound to ::", () => {
+    expect(isHostAllowed("whatever:80", "::")).toBe(true);
+  });
+});

--- a/src/ui/__tests__/host-validation.test.ts
+++ b/src/ui/__tests__/host-validation.test.ts
@@ -37,6 +37,12 @@ describe("isHostAllowed (loopback bind 127.0.0.1)", () => {
     expect(isHostAllowed("[::1]", bind)).toBe(true);
   });
 
+  it("allows the bare IPv6 loopback ::1 (not mangled by port strip)", () => {
+    // Regression guard: a naive /:\d+$/ strip would turn `::1` into `:`
+    // and reject it even though `::1` is in the allowlist.
+    expect(isHostAllowed("::1", bind)).toBe(true);
+  });
+
   it("is case-insensitive on the hostname", () => {
     expect(isHostAllowed("LOCALHOST:4632", bind)).toBe(true);
   });
@@ -63,6 +69,13 @@ describe("isHostAllowed (specific LAN bind)", () => {
 
   it("rejects a different LAN IP", () => {
     expect(isHostAllowed("192.168.1.99:4632", "192.168.1.50")).toBe(false);
+  });
+
+  it("allows a bare IPv6 LAN bind host (not mangled by port strip)", () => {
+    // `fe80::1` would strip to `fe80:` under a naive /:\d+$/ — the
+    // IPv6-aware hostnameOf leaves bare IPv6 intact.
+    expect(isHostAllowed("fe80::1", "fe80::1")).toBe(true);
+    expect(isHostAllowed("fe80::2", "fe80::1")).toBe(false);
   });
 });
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -122,9 +122,29 @@ function getOrCreateSessionId(req: Request): { sessionId: string; setCookie?: st
  */
 export function isHostAllowed(hostHeader: string, bindHost: string): boolean {
   if (bindHost === "0.0.0.0" || bindHost === "::") return true;
-  const hostname = hostHeader.replace(/:\d+$/, "").toLowerCase();
+  const hostname = hostnameOf(hostHeader);
   const allowed = new Set(["127.0.0.1", "localhost", "[::1]", "::1", bindHost.toLowerCase()]);
   return allowed.has(hostname);
+}
+
+/**
+ * Extract the hostname from a Host header, dropping the optional `:port`.
+ * IPv6-aware so a bare `::1` or a LAN bind like `fe80::1` isn't mangled
+ * by a naive `:\d+$` strip (which would turn `::1` into `:`):
+ *   - `[::1]:4632` / `[::1]`     → `[::1]`   (bracketed IPv6; strip after `]`)
+ *   - `::1` / `fe80::1`          → unchanged (bare IPv6 — 2+ colons, no port)
+ *   - `localhost:8080` / `1.2.3.4:80` / `host` → port stripped if present
+ */
+function hostnameOf(hostHeader: string): string {
+  const h = hostHeader.toLowerCase();
+  if (h.startsWith("[")) {
+    const close = h.indexOf("]");
+    return close === -1 ? h : h.slice(0, close + 1);
+  }
+  // A valid Host header never carries a port on a bare (unbracketed) IPv6,
+  // so 2+ colons means bare IPv6 — leave it intact.
+  if ((h.match(/:/g)?.length ?? 0) > 1) return h;
+  return h.replace(/:\d+$/, "");
 }
 
 /** Returns a 403 Response if the CSRF token is missing or invalid, otherwise null. */
@@ -162,7 +182,8 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
       // or VS Code forward sends the CLIENT-side port (8080) in Host,
       // not the bind port (4632), so the daemon 421'd its own dashboard.
       // Runs before the plugin gateway so /mcp/* and /api/plugin/* are
-      // covered too; the local MCP bridge calls with Host `127.0.0.1`.
+      // covered too; the local MCP bridge calls with Host
+      // `127.0.0.1:<port>`, whose hostname (127.0.0.1) is allowlisted.
       const host = req.headers.get("host") ?? "";
       if (!isHostAllowed(host, opts.host)) {
         return new Response("Bad Host", { status: 421 });

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -107,6 +107,26 @@ function getOrCreateSessionId(req: Request): { sessionId: string; setCookie?: st
   };
 }
 
+/**
+ * Hostname allowlist check for DNS-rebinding defense (issue #164 item 2,
+ * hotfixed after #189). Compares the Host header's HOSTNAME only (port
+ * stripped) against the loopback names + the configured bind host. A
+ * wildcard bind (0.0.0.0 / ::) returns `true` unconditionally — the
+ * operator opted into remote access.
+ *
+ * Port is deliberately ignored: DNS-rebinding hinges on the hostname,
+ * and matching the port broke tunnelled access (the Host carries the
+ * client-side forwarded port, not the bind port).
+ *
+ * Exported for unit testing.
+ */
+export function isHostAllowed(hostHeader: string, bindHost: string): boolean {
+  if (bindHost === "0.0.0.0" || bindHost === "::") return true;
+  const hostname = hostHeader.replace(/:\d+$/, "").toLowerCase();
+  const allowed = new Set(["127.0.0.1", "localhost", "[::1]", "::1", bindHost.toLowerCase()]);
+  return allowed.has(hostname);
+}
+
 /** Returns a 403 Response if the CSRF token is missing or invalid, otherwise null. */
 function requireCsrf(req: Request): Response | null {
   const csrfToken = req.headers.get(CSRF_HEADER_NAME);
@@ -132,22 +152,20 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
       // validation. A wildcard bind (0.0.0.0 / ::) means the operator
       // opted into remote access and the browser Host won't match the
       // bind address, so the check is skipped there. For a specific
-      // bind (loopback / LAN IP) we enforce an allowlist. Runs before
-      // the plugin gateway so /mcp/* and /api/plugin/* are covered too;
-      // the local MCP bridge calls with Host `127.0.0.1:<port>`, which
-      // is in the allowlist.
+      // bind (loopback / LAN IP) we enforce a HOSTNAME allowlist.
+      //
+      // We compare the hostname ONLY, ignoring the port — DNS-rebinding
+      // turns on the malicious HOSTNAME (attacker.com resolving to
+      // 127.0.0.1), never the port, so the port is irrelevant to the
+      // defense. Matching host:port (the original #189 port) broke every
+      // tunnelled / port-forwarded deployment: an `ssh -L 8080:…:4632`
+      // or VS Code forward sends the CLIENT-side port (8080) in Host,
+      // not the bind port (4632), so the daemon 421'd its own dashboard.
+      // Runs before the plugin gateway so /mcp/* and /api/plugin/* are
+      // covered too; the local MCP bridge calls with Host `127.0.0.1`.
       const host = req.headers.get("host") ?? "";
-      const isWildcardBind = opts.host === "0.0.0.0" || opts.host === "::";
-      if (!isWildcardBind) {
-        const expectedHosts = new Set([
-          `127.0.0.1:${opts.port}`,
-          `localhost:${opts.port}`,
-          `[::1]:${opts.port}`,
-          `${opts.host}:${opts.port}`,
-        ]);
-        if (!expectedHosts.has(host)) {
-          return new Response("Bad Host", { status: 421 });
-        }
+      if (!isHostAllowed(host, opts.host)) {
+        return new Response("Bad Host", { status: 421 });
       }
 
       // Issue #164 item 3: CSRF defense-in-depth — reject cross-origin


### PR DESCRIPTION
## Summary

**Production hotfix.** PR #189's Host-header DNS-rebinding defense matched the full `host:port` against a bind-port allowlist. That 421'd every tunnelled / port-forwarded deployment and took the live Hetzner dashboard offline with "Bad Host".

## Root cause

`ssh -L 8080:127.0.0.1:4632` (or a VS Code port forward) makes the browser send the **client-side** port (8080) in the Host header, not the bind port (4632). The allowlist only had `:4632` entries, so the daemon rejected its own dashboard.

Confirmed live: `curl -H "Host: localhost:9999" …/api/health` → 421; `Host: 127.0.0.1:4632` → 200.

## Fix

Compare the Host **hostname only**, port stripped — DNS-rebinding turns on the malicious hostname (`attacker.com` → 127.0.0.1), never the port, so ignoring the port keeps the defense while supporting tunnels/forwards on any local port. Extracted to an exported pure helper `isHostAllowed(hostHeader, bindHost)`.

Port stripping is IPv6-aware (`hostnameOf`): bracketed `[::1]:4632` → `[::1]`, bare `::1` / `fe80::1` left intact, IPv4/hostname `:port` stripped. Wildcard binds (0.0.0.0 / ::) still skip the check.

## Operator note

Until this deploys, access via a port-matched tunnel: `ssh -L 4632:127.0.0.1:4632 claw` then `http://localhost:4632` (sends `Host: localhost:4632`, which passes).

## Test plan

- [x] `bun test src/ui/__tests__/host-validation.test.ts` — 15/15 (exact match, forwarded mismatched port = the regression, bare hostname, IPv6 bracket + bare, case-insensitivity, foreign-hostname rejection, LAN bind, bare IPv6 LAN bind, wildcard pass-through)
- [x] `bun run lint` — clean
- [x] Dedicated security review — confirms DNS-rebinding defense preserved, no HIGH/CRITICAL
- [x] 5-agent review — 2 HIGH (IPv6 bare strip, stale comment) caught + fixed in 73ab5cb

## Deploy

Merging to main triggers the Hetzner auto-deploy and restores the dashboard.