### PR TITLE
feat(webui): enforce web token on /api/* + dashboard auto-token UX (#164 PR B)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.118",
+      "version": "2.2.119",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.117",
+      "version": "2.2.118",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.116",
+      "version": "2.2.117",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.118",
+  "version": "2.2.119",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.117",
+  "version": "2.2.118",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.116",
+  "version": "2.2.117",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1,5 +1,6 @@
 import { writeFile, unlink, mkdir } from "fs/promises";
 import { existsSync } from "fs";
+import { randomBytes } from "crypto";
 import { homedir } from "os";
 import { extractErrorDetail } from "../messaging";
 import { join } from "path";
@@ -998,7 +999,11 @@ export async function start(args: string[] = []) {
     return code === "EADDRINUSE" || message.includes("EADDRINUSE");
   }
 
-  function startWebWithFallback(host: string, preferredPort: number): WebServerHandle {
+  function startWebWithFallback(
+    host: string,
+    preferredPort: number,
+    token: string,
+  ): WebServerHandle {
     const maxAttempts = 10;
     let lastError: unknown;
     for (let i = 0; i < maxAttempts; i++) {
@@ -1007,6 +1012,7 @@ export async function start(args: string[] = []) {
         return startWebUi({
           host,
           port: candidatePort,
+          token,
           getSnapshot: () => ({
             pid: process.pid,
             startedAt: daemonStartedAt,
@@ -1129,16 +1135,23 @@ export async function start(args: string[] = []) {
 
   if (webEnabled) {
     currentSettings.web.enabled = true;
-    // Issue #164 item 1: mint + persist a 256-bit web token at
-    // .claude/claudeclaw/web.token (0600) on first start. PR A only
-    // provisions the file; enforcement on /api/* + the dashboard
-    // auto-token UX land in PR B (with a browser soak test).
+    // Issue #164: mint + persist a 256-bit web token at
+    // .claude/claudeclaw/web.token (0600) on first start, then enforce it
+    // on every /api/* route. On the rare chance provisioning fails (e.g.
+    // unwritable .claude dir) we fall back to an in-memory random token so
+    // the server still boots WITH auth rather than unauthenticated — the
+    // operator just won't have the file to read; they can restart once the
+    // dir is writable.
+    let webToken: string;
     try {
-      await getOrCreateWebToken();
+      webToken = await getOrCreateWebToken();
     } catch (err) {
-      console.warn(`[${ts()}] could not provision web.token: ${extractErrorDetail(err)}`);
+      console.warn(
+        `[${ts()}] could not persist web.token, using in-memory token: ${extractErrorDetail(err)}`,
+      );
+      webToken = randomBytes(32).toString("base64url");
     }
-    web = startWebWithFallback(currentSettings.web.host, webPort);
+    web = startWebWithFallback(currentSettings.web.host, webPort, webToken);
     currentSettings.web.port = web.port;
     console.log(
       `[${new Date().toLocaleTimeString()}] Web UI listening on http://${web.host}:${web.port}` +

--- a/src/ui/__tests__/api-auth-enforcement.test.ts
+++ b/src/ui/__tests__/api-auth-enforcement.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Integration test for issue #164 PR B: the web token is enforced on
+ * every /api/* route. Boots a real startWebUi server on an ephemeral
+ * port and exercises the auth gate end-to-end.
+ *
+ * Run with: bun test src/ui/__tests__/api-auth-enforcement.test.ts
+ */
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { startWebUi } from "../server";
+import type { WebServerHandle, WebSnapshot } from "../types";
+
+const TOKEN = "test-web-token-abcdefghijklmnop";
+
+function snapshot(): WebSnapshot {
+  return {
+    pid: 1234,
+    startedAt: Date.now(),
+    heartbeatNextAt: 0,
+    // Minimal settings shape the routes read; apiToken stays undefined so
+    // the /api/inject legacy path isn't accidentally satisfied.
+    settings: {
+      apiToken: undefined,
+      heartbeat: { enabled: false, interval: 30, prompt: "" },
+      security: {},
+      telegram: { token: "", allowedUserIds: [] },
+      discord: { token: "", allowedUserIds: [] },
+      web: { enabled: true, host: "127.0.0.1", port: 0 },
+    } as unknown as WebSnapshot["settings"],
+    jobs: [],
+  };
+}
+
+let handle: WebServerHandle;
+let base: string;
+
+beforeAll(() => {
+  handle = startWebUi({
+    host: "127.0.0.1",
+    port: 0, // ephemeral
+    token: TOKEN,
+    getSnapshot: snapshot,
+  });
+  base = `http://127.0.0.1:${handle.port}`;
+});
+
+afterAll(() => {
+  handle.stop();
+});
+
+describe("/api/* web token enforcement (issue #164 PR B)", () => {
+  it("serves the HTML shell pre-auth", async () => {
+    const res = await fetch(`${base}/`, { headers: { Host: `127.0.0.1:${handle.port}` } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type") ?? "").toContain("text/html");
+  });
+
+  it("allows /api/health pre-auth", async () => {
+    const res = await fetch(`${base}/api/health`, {
+      headers: { Host: `127.0.0.1:${handle.port}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects /api/state without a token (401)", async () => {
+    const res = await fetch(`${base}/api/state`, {
+      headers: { Host: `127.0.0.1:${handle.port}` },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("allows /api/state with a valid Bearer token", async () => {
+    const res = await fetch(`${base}/api/state`, {
+      headers: { Host: `127.0.0.1:${handle.port}`, Authorization: `Bearer ${TOKEN}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("allows /api/state with the token via ?token= query", async () => {
+    const res = await fetch(`${base}/api/state?token=${TOKEN}`, {
+      headers: { Host: `127.0.0.1:${handle.port}` },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects /api/state with a wrong token (401)", async () => {
+    const res = await fetch(`${base}/api/state`, {
+      headers: { Host: `127.0.0.1:${handle.port}`, Authorization: "Bearer wrong-token" },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects /api/settings without a token (401)", async () => {
+    const res = await fetch(`${base}/api/settings`, {
+      headers: { Host: `127.0.0.1:${handle.port}` },
+    });
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/ui/__tests__/auth.test.ts
+++ b/src/ui/__tests__/auth.test.ts
@@ -29,40 +29,6 @@ function req(
   return new Request(url, { headers });
 }
 
-describe("checkBearer (issue #164 item 4 — byte-safe)", () => {
-  it("returns 503 when no token configured", async () => {
-    const { checkBearer } = await import("../auth");
-    const res = checkBearer(req({ Authorization: "Bearer x" }), undefined);
-    expect(res?.status).toBe(503);
-  });
-
-  it("accepts a matching Bearer token", async () => {
-    const { checkBearer } = await import("../auth");
-    const res = checkBearer(req({ Authorization: "Bearer sekret" }), "sekret");
-    expect(res).toBeNull();
-  });
-
-  it("rejects a wrong token with 401", async () => {
-    const { checkBearer } = await import("../auth");
-    const res = checkBearer(req({ Authorization: "Bearer nope" }), "sekret");
-    expect(res?.status).toBe(401);
-  });
-
-  it("rejects a missing header with 401", async () => {
-    const { checkBearer } = await import("../auth");
-    const res = checkBearer(req({}), "sekret");
-    expect(res?.status).toBe(401);
-  });
-
-  it("does NOT throw on a non-ASCII provided token of different byte length", async () => {
-    const { checkBearer } = await import("../auth");
-    // "café" is 4 chars but 5 bytes — the old char-length compare could
-    // mismatch buffer lengths and (with raw timingSafeEqual) throw.
-    const res = checkBearer(req({ Authorization: "Bearer café" }), "test");
-    expect(res?.status).toBe(401);
-  });
-});
-
 describe("checkToken (issue #164 — byte-safe, header + query)", () => {
   it("accepts the token via Authorization header", async () => {
     const { checkToken } = await import("../auth");

--- a/src/ui/auth.ts
+++ b/src/ui/auth.ts
@@ -2,7 +2,6 @@ import { readFile, writeFile, chmod, mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import { randomBytes, timingSafeEqual } from "crypto";
 import { dirname, join } from "path";
-import { json } from "./http";
 
 /**
  * Resolved lazily (not at module load) so it tracks the daemon's actual
@@ -48,23 +47,6 @@ export function checkToken(req: Request, expected: string): boolean {
   const provided = m?.[1] ?? new URL(req.url).searchParams.get("token") ?? "";
   if (!provided) return false;
   return safeEqual(provided, expected);
-}
-
-/**
- * Bearer-header auth guard for the legacy `/api/inject` route. Hardened
- * for issue #164 item 4: the previous implementation used a plain `!==`
- * string compare which is neither constant-time nor byte-length safe.
- * Now routes through `safeEqual`.
- */
-export function checkBearer(req: Request, token: string | undefined): Response | null {
-  if (!token) return json({ ok: false, error: "API token not configured" }, 503);
-  const header = req.headers.get("Authorization") ?? "";
-  const m = header.match(/^Bearer\s+(.+)$/i);
-  const provided = m?.[1] ?? "";
-  if (!provided || !safeEqual(provided, token)) {
-    return json({ ok: false, error: "Unauthorized" }, 401);
-  }
-  return null;
 }
 
 function safeEqual(provided: string, expected: string): boolean {

--- a/src/ui/auth.ts
+++ b/src/ui/auth.ts
@@ -16,8 +16,8 @@ function tokenFilePath(): string {
  * start (issue #164, ported from upstream #185). Stored at
  * `.claude/claudeclaw/web.token` mode 0600 so a daemon that the operator
  * never gave an explicit `settings.apiToken` still has a strong token to
- * enforce with. PR A (this change) generates + persists it; enforcement
- * on `/api/*` lands in PR B alongside the dashboard auto-token UX.
+ * enforce with. Enforced on every `/api/*` route by `server.ts`; the
+ * dashboard reads it from `?token=` on first load.
  */
 export async function getOrCreateWebToken(): Promise<string> {
   const tokenFile = tokenFilePath();
@@ -38,8 +38,8 @@ export async function getOrCreateWebToken(): Promise<string> {
  * byte lengths (not JS string character lengths) so a non-ASCII
  * `provided` value can never make `timingSafeEqual` throw `RangeError`.
  * Accepts the token via `Authorization: Bearer <t>` or `?token=<t>`
- * (the query-param path is what the dashboard auto-token UX in PR B
- * will use on first load).
+ * (the query-param path is how the dashboard bootstraps on first load
+ * before it strips the token from the URL).
  */
 export function checkToken(req: Request, expected: string): boolean {
   const auth = req.headers.get("authorization") ?? "";

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -29,7 +29,13 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     }
     const _origFetch = window.fetch.bind(window);
     window.fetch = function (input, init) {
-      init = init || {};
+      // Work on a SHALLOW COPY — never mutate the caller's init object.
+      // mutatingFetch reuses its opts object across a CSRF-retry and reads
+      // opts.headers back as a plain object; if we converted that to a
+      // Headers instance in place, its retry bracket-assignment
+      // (opts.headers["X-CSRF-Token"]=…) would silently no-op and re-send
+      // the stale token. Copying keeps the caller's headers untouched.
+      const opts = init ? { ...init } : {};
       const url = typeof input === "string" ? input : (input && input.url) || "";
       const isApi =
         url.indexOf("/api/") === 0 || url.indexOf(window.location.origin + "/api/") === 0;
@@ -37,13 +43,13 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
         const tok = getWebToken();
         if (tok) {
           const h = new Headers(
-            init.headers || (typeof input !== "string" && input.headers) || {},
+            opts.headers || (typeof input !== "string" && input.headers) || {},
           );
           if (!h.has("Authorization")) h.set("Authorization", "Bearer " + tok);
-          init.headers = h;
+          opts.headers = h;
         }
       }
-      return _origFetch(input, init);
+      return _origFetch(input, opts);
     };
 
     // --- CSRF token management for mutating requests ---

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -1,5 +1,51 @@
 export const pageScript = String.raw`    const $ = (id) => document.getElementById(id);
 
+    // --- Web token auth (issue #164 PR B) ---
+    // All /api/* routes now require the 256-bit web token. On first load
+    // we read it from the ?token= query param (how the operator opens the
+    // dashboard), persist it to sessionStorage, then strip it from the URL
+    // so it doesn't linger in history / Referer headers. Every same-origin
+    // /api/ fetch then carries it as an Authorization: Bearer header via
+    // the wrapper below — covering both raw fetch() and mutatingFetch.
+    (function initWebToken() {
+      try {
+        const u = new URL(window.location.href);
+        const t = u.searchParams.get("token");
+        if (t) {
+          sessionStorage.setItem("ccaw_web_token", t);
+          u.searchParams.delete("token");
+          window.history.replaceState({}, document.title, u.pathname + u.search + u.hash);
+        }
+      } catch (e) {
+        /* sessionStorage / URL unavailable — fall through unauthenticated */
+      }
+    })();
+    function getWebToken() {
+      try {
+        return sessionStorage.getItem("ccaw_web_token") || "";
+      } catch (e) {
+        return "";
+      }
+    }
+    const _origFetch = window.fetch.bind(window);
+    window.fetch = function (input, init) {
+      init = init || {};
+      const url = typeof input === "string" ? input : (input && input.url) || "";
+      const isApi =
+        url.indexOf("/api/") === 0 || url.indexOf(window.location.origin + "/api/") === 0;
+      if (isApi) {
+        const tok = getWebToken();
+        if (tok) {
+          const h = new Headers(
+            init.headers || (typeof input !== "string" && input.headers) || {},
+          );
+          if (!h.has("Authorization")) h.set("Authorization", "Bearer " + tok);
+          init.headers = h;
+        }
+      }
+      return _origFetch(input, init);
+    };
+
     // --- CSRF token management for mutating requests ---
     let _csrfToken = null;
     async function getCsrfToken() {
@@ -980,6 +1026,43 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
     startTypewriter();
     updateQuickJobUi();
     setQuickView(quickView);
+
+    // Issue #164 PR B: if the dashboard was opened without a ?token= and
+    // none is cached, /api/* calls will 401. Show a non-blocking banner
+    // with a paste field instead of leaving a silently broken page. No
+    // prompt()/alert() — those block the page and break browser tooling.
+    function showTokenBanner() {
+      if (document.getElementById("ccaw-token-banner")) return;
+      const bar = document.createElement("div");
+      bar.id = "ccaw-token-banner";
+      bar.style.cssText =
+        "position:fixed;top:0;left:0;right:0;z-index:9999;background:#b91c1c;color:#fff;" +
+        "padding:10px 14px;font:14px system-ui,sans-serif;display:flex;gap:8px;align-items:center;justify-content:center;";
+      const label = document.createElement("span");
+      label.textContent = "Web token required. Paste it (from .claude/claudeclaw/web.token):";
+      const input = document.createElement("input");
+      input.type = "password";
+      input.style.cssText = "flex:0 1 320px;padding:4px 8px;border-radius:4px;border:0;color:#111;";
+      const btn = document.createElement("button");
+      btn.textContent = "Save";
+      btn.style.cssText =
+        "padding:4px 12px;border-radius:4px;border:0;background:#fff;color:#b91c1c;cursor:pointer;font-weight:600;";
+      btn.onclick = function () {
+        const v = input.value.trim();
+        if (!v) return;
+        try {
+          sessionStorage.setItem("ccaw_web_token", v);
+        } catch (e) {}
+        bar.remove();
+        loadSettings();
+        refreshState();
+      };
+      bar.appendChild(label);
+      bar.appendChild(input);
+      bar.appendChild(btn);
+      document.body.appendChild(bar);
+    }
+    if (!getWebToken()) showTokenBanner();
 
     loadSettings();
     refreshState();

--- a/src/ui/page/template.ts
+++ b/src/ui/page/template.ts
@@ -18,6 +18,15 @@ export function htmlPage(): string {
 <html lang="en">
 <head>
   <meta charset="utf-8" />
+  <!-- Issue #164 PR B (Codex P1): the dashboard bootstraps with the web
+       token in ?token=. This MUST be the first head element so the
+       no-referrer policy is in force before the Google Fonts preconnect /
+       stylesheet below fire — otherwise a browser defaulting to
+       no-referrer-when-downgrade would leak the full URL (token included)
+       to fonts.googleapis.com via the Referer header. The /-route HTTP
+       response also sets Referrer-Policy: no-referrer as the authoritative
+       belt-and-suspenders. -->
+  <meta name="referrer" content="no-referrer" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>ClaudeClaw+</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -217,7 +217,18 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
 
       if (url.pathname === "/" || url.pathname === "/index.html") {
         return new Response(htmlPage(), {
-          headers: { "Content-Type": "text/html; charset=utf-8" },
+          headers: {
+            "Content-Type": "text/html; charset=utf-8",
+            // Issue #164 PR B (Codex P1): the dashboard is opened with the
+            // web token in ?token=. no-referrer guarantees the token is
+            // never sent in a Referer header to the Google Fonts (or any
+            // cross-origin) subresource requests fired during head parse,
+            // regardless of the browser's default Referrer-Policy. Safe
+            // here — nothing in the dashboard relies on Referer (CSRF uses
+            // X-CSRF-Token; the Origin gate uses the Origin header, which
+            // this policy does not affect).
+            "Referrer-Policy": "no-referrer",
+          },
         });
       }
 

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -2,7 +2,7 @@ import { timingSafeEqual, randomUUID } from "crypto";
 import { tmpdir } from "node:os";
 import { htmlPage } from "./page/html";
 import { clampInt, json } from "./http";
-import { checkBearer } from "./auth";
+import { checkToken } from "./auth";
 import type { StartWebUiOptions, WebServerHandle } from "./types";
 import { buildState, buildTechnicalInfo, sanitizeSettings } from "./services/state";
 import { readHeartbeatSettings, updateHeartbeatSettings } from "./services/settings";
@@ -17,15 +17,14 @@ import { getHttpGateway } from "../plugins/http-gateway.js";
 
 // --- Security: layered defenses ---
 // The Web UI has several layers:
-//   - Per-session CSRF tokens (below) on state-changing routes.
+//   - A persisted 256-bit web token (`getOrCreateWebToken`, issue #164)
+//     with byte-safe `checkToken`, ENFORCED on every `/api/*` route in
+//     the fetch handler below (`/api/health` is the only pre-auth API
+//     route; `/api/inject` also accepts the legacy `settings.apiToken`).
+//     The dashboard reads the token from `?token=` on first load.
 //   - Host-header validation + cross-origin POST/DELETE rejection in the
 //     fetch handler (issue #164 items 2/3).
-//   - A persisted 256-bit web token (`getOrCreateWebToken`, issue #164
-//     item 1) with byte-safe `checkToken`. NOTE: as of PR A the token is
-//     generated but NOT yet enforced on `/api/*` — enforcement + the
-//     dashboard auto-token UX land in PR B. Until then, treat direct
-//     `/api/*` access as unauthenticated and, for untrusted networks,
-//     still deploy behind a reverse proxy with authentication.
+//   - Per-session CSRF tokens (below) on state-changing routes.
 const CSRF_HEADER_NAME = "X-CSRF-Token";
 const MAX_CSRF_TOKENS = 10000;
 
@@ -222,8 +221,27 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
         });
       }
 
+      // Health check is intentionally pre-auth so monitors / load balancers
+      // work unauthenticated.
       if (url.pathname === "/api/health") {
         return json({ ok: true, now: Date.now() });
+      }
+
+      // Issue #164 PR B: require the web token for every /api/* route.
+      // The HTML shell ("/" above) and /api/health (above) stay pre-auth;
+      // the dashboard JS reads the token from `?token=` on first load and
+      // attaches it as `Authorization: Bearer` to every subsequent fetch.
+      // /api/inject ALSO accepts the legacy settings.apiToken so existing
+      // automation keeps working. (Plugin gateway + /mcp/* routes are
+      // handled earlier in the fetch handler and never reach here.)
+      if (url.pathname.startsWith("/api/")) {
+        const validWebToken = checkToken(req, opts.token);
+        const apiToken = opts.getSnapshot().settings.apiToken;
+        const validApiToken =
+          url.pathname === "/api/inject" && !!apiToken && checkToken(req, apiToken);
+        if (!validWebToken && !validApiToken) {
+          return json({ ok: false, error: "unauthorized" }, 401);
+        }
       }
 
       if (url.pathname === "/api/csrf-token") {
@@ -475,8 +493,9 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
       }
 
       if (url.pathname === "/api/inject" && req.method === "POST") {
-        const authErr = checkBearer(req, opts.getSnapshot().settings.apiToken);
-        if (authErr) return authErr;
+        // Auth already enforced by the /api/* block above (web token OR
+        // the legacy settings.apiToken). No extra checkBearer here — it
+        // would wrongly reject a valid web-token-only request.
         try {
           const body = await req.json();
           const message = typeof body.message === "string" ? body.message.trim() : "";

--- a/src/ui/types.ts
+++ b/src/ui/types.ts
@@ -19,6 +19,14 @@ export interface WebServerHandle {
 export interface StartWebUiOptions {
   host: string;
   port: number;
+  /**
+   * The persisted 256-bit web token (issue #164). All `/api/*` routes
+   * require it via `Authorization: Bearer <token>` or `?token=<token>`,
+   * except `/api/health` (pre-auth) and `/api/inject` (which also accepts
+   * the legacy `settings.apiToken`). Minted by `getOrCreateWebToken()` in
+   * `start.ts` before the server boots.
+   */
+  token: string;
   getSnapshot: () => WebSnapshot;
   onHeartbeatEnabledChanged?: (enabled: boolean) => void | Promise<void>;
   onHeartbeatSettingsChanged?: (patch: {


### PR DESCRIPTION
## Summary

Second of two PRs for #164. PR A (#189) landed the hardening (token generation, Host/Origin validation, byte-safe compare, recursive redact) **without** flipping enforcement. This PR flips it on and wires the dashboard to carry the token — **soak-tested in Chrome**.

## What changed

**Server** (`src/ui/server.ts`, `types.ts`, `commands/start.ts`):
- `StartWebUiOptions.token` threaded from `getOrCreateWebToken()` through `startWebWithFallback` into `startWebUi`. On the rare provisioning failure, falls back to an in-memory `randomBytes(32)` token so the daemon boots **with** auth (fails closed, not open).
- Every `/api/*` route now requires the web token via `checkToken` (Bearer or `?token=`). `/api/health` stays pre-auth for monitors; `/api/inject` also accepts the legacy `settings.apiToken`. Plugin gateway + `/mcp/*` are handled earlier and unaffected.
- Removed the now-redundant `checkBearer` on `/api/inject` (the `/api/*` block supersedes it). `checkBearer` was the only other consumer → deleted as dead code along with its tests.

**Dashboard** (`src/ui/page/script.ts`):
- Reads the token from `?token=` on load → sessionStorage → strips it from the URL via `history.replaceState`.
- Wraps `window.fetch` (non-mutating) to attach `Authorization: Bearer` to same-origin `/api/` requests — covers raw `fetch()` and `mutatingFetch` without touching each call site.
- Non-blocking paste-token banner if opened with no token (no `prompt()`/`alert()`).

## Test plan

- [x] `bun test src/ui/__tests__/` — 30 pass (7 new integration tests boot a real `startWebUi` and verify the gate: shell + `/api/health` pre-auth; `/api/state` 401 without token, 200 with Bearer or `?token=`, 401 wrong token; `/api/settings` 401)
- [x] `bun run lint` — clean
- [x] **Browser soak (Claude in Chrome)**: no-token banner shown; paste→Save stores token + removes banner; stored token → `/api/state`/`/api/settings`/`/api/technical-info` all 200; `?token=` bootstrap stores + strips URL; fetch wrapper non-mutation verified; real heartbeat-save mutatingFetch round-trip 200; no console errors
- [x] Dedicated security review — APPROVE (no bypass, no cross-origin token leak, fails closed)
- [x] 5-agent review — 2 issues caught + fixed (non-mutating wrapper for the CSRF-retry path, stale docstrings)

## Operator note

Open the dashboard once as `https://claudeclaw.poview.ai/?token=<contents of .claude/claudeclaw/web.token>`; the token is cached in sessionStorage and stripped from the URL. The cloudflared `httpHostHeader` rewrite from the #191 incident is independent and still in place.