### PR TITLE
fix(bus): answer the Bypass-Permissions startup dialog so fresh-install agents survive

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.121",
+      "version": "2.2.122",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.120",
+      "version": "2.2.121",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.119",
+      "version": "2.2.120",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.121",
+  "version": "2.2.122",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.120",
+  "version": "2.2.121",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.119",
+  "version": "2.2.120",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/pty-boot-dialog.test.ts
+++ b/src/__tests__/pty-boot-dialog.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Tests for the boot-dialog watcher (issue #193).
+ *
+ * PtyAgentProcess answers claude's interactive startup confirmation dialogs by
+ * inspecting early PTY output and sending the correct key per dialog: Enter for
+ * the dev-channels confirmation, and Down+Enter for the new "Bypass Permissions
+ * mode" dialog (whose default is "No, exit" — a blind Enter would kill the
+ * agent).
+ */
+import { describe, test, expect } from "bun:test";
+import { PtyAgentProcess, type PtyHandle } from "../bus/session-agent-process";
+
+function makeFakePty() {
+  const writes: string[] = [];
+  let dataCb: ((d: string) => void) | null = null;
+  const pty: PtyHandle = {
+    pid: 4242,
+    onData(cb) {
+      dataCb = cb;
+      return { dispose() {} };
+    },
+    onExit() {
+      return { dispose() {} };
+    },
+    write(d) {
+      writes.push(d);
+    },
+    kill() {},
+  };
+  return { pty, writes, emit: (s: string) => dataCb?.(s) };
+}
+
+describe("PtyAgentProcess boot-dialog watcher (issue #193)", () => {
+  test("answers the Bypass Permissions dialog with Down then Enter", async () => {
+    const { pty, writes, emit } = makeFakePty();
+    new PtyAgentProcess("main", pty);
+    emit(
+      "WARNING: Claude Code running in Bypass Permissions mode\n" +
+        "❯ 1. No, exit\n  2. Yes, I accept\nEnter to confirm · Esc to exit",
+    );
+    expect(writes).toContain("\x1b[B"); // down arrow → select "Yes, I accept"
+    await new Promise((r) => setTimeout(r, 260));
+    expect(writes).toContain("\r"); // then submit
+  });
+
+  test("answers the dev-channels dialog with a bare Enter (its default is accept)", () => {
+    const { pty, writes, emit } = makeFakePty();
+    new PtyAgentProcess("main", pty);
+    emit(
+      "WARNING: Loading development channels\n" +
+        "❯ 1. I am using this for local development\n  2. Exit",
+    );
+    expect(writes).toEqual(["\r"]);
+  });
+
+  test("does not trigger on the REPL footer that also says 'bypass permissions on'", () => {
+    const { pty, writes, emit } = makeFakePty();
+    new PtyAgentProcess("main", pty);
+    emit("⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents");
+    expect(writes).toEqual([]);
+  });
+
+  test("answers the bypass dialog only once even if it redraws", async () => {
+    const { pty, writes, emit } = makeFakePty();
+    new PtyAgentProcess("main", pty);
+    emit("...2. Yes, I accept...");
+    emit("...2. Yes, I accept... (redraw)");
+    await new Promise((r) => setTimeout(r, 260));
+    expect(writes.filter((w) => w === "\x1b[B").length).toBe(1);
+  });
+});

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -3,7 +3,7 @@
  *
  * Uses a fake `PtyHandle` that records every `write` so we can assert:
  *   - concurrent `send_prompt_stream` calls serialise (no byte interleave),
- *   - a real prompt cancels the pending boot dialog-dismiss CR timers.
+ *   - a real prompt disengages the boot-dialog watcher (issue #193).
  */
 import { describe, expect, it } from "bun:test";
 import { PtyAgentProcess, type PtyHandle } from "../session-agent-process";
@@ -38,22 +38,29 @@ describe("PtyAgentProcess.send_prompt_stream", () => {
     expect(writes).toEqual(["first", "\r", "second", "\r"]);
   });
 
-  it("cancels pending dialog-dismiss timers on the first prompt", async () => {
-    const { handle, writes } = fakePty();
-    let stray = 0;
-    const timers = [10, 20, 30].map((ms) =>
-      setTimeout(() => {
-        stray += 1;
-        handle.write("\r");
-      }, ms),
-    );
-    const proc = new PtyAgentProcess("alpha", handle, timers);
+  it("disengages the boot-dialog watcher once a real prompt is dispatched", async () => {
+    const writes: string[] = [];
+    let dataCb: ((d: string) => void) | null = null;
+    const handle: PtyHandle = {
+      pid: 1234,
+      onData: (cb) => {
+        dataCb = cb;
+        return { dispose() {} };
+      },
+      onExit: () => ({ dispose() {} }),
+      write: (data: string) => {
+        writes.push(data);
+      },
+      kill: () => {},
+    };
+    const proc = new PtyAgentProcess("alpha", handle);
 
-    await proc.send_prompt_stream("hi");
-    // Wait well past the longest timer; none should have fired.
+    await proc.send_prompt_stream("hi"); // claude has reached the REPL
+    writes.length = 0;
+    // A dialog-looking chunk arriving AFTER the first prompt must be ignored —
+    // the watcher disengages so it can't inject keys mid-session.
+    dataCb?.("...\u276f 2. Yes, I accept...");
     await new Promise((r) => setTimeout(r, 60));
-
-    expect(stray).toBe(0);
-    expect(writes).toEqual(["hi", "\r"]);
+    expect(writes).toEqual([]);
   });
 });

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -68,9 +68,12 @@ describe("PtyAgentProcess.send_prompt_stream", () => {
     await new Promise((r) => setTimeout(r, 260));
     expect(writes).toContain("\r"); // then Enter
 
-    // Once the REPL footer marker appears, the watcher disengages — a later
-    // dialog-looking chunk must be ignored (no keys injected mid-session).
-    dataCb?.("bypass permissions on (shift+tab to cycle)");
+    // Once the REPL footer appears the watcher disengages — and the marker is
+    // mode-independent (Codex P2 #2 on #195): a non-bypass agent shows a
+    // mode-specific footer like "plan mode on", but every mode footer carries
+    // the "shift+tab to cycle" hint. A later dialog-looking chunk must then be
+    // ignored (no keys injected into a live REPL).
+    dataCb?.("⏸ plan mode on (shift+tab to cycle)");
     writes.length = 0;
     dataCb?.("stray redraw with 2. Yes, I accept text");
     await new Promise((r) => setTimeout(r, 60));

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -3,7 +3,8 @@
  *
  * Uses a fake `PtyHandle` that records every `write` so we can assert:
  *   - concurrent `send_prompt_stream` calls serialise (no byte interleave),
- *   - a real prompt disengages the boot-dialog watcher (issue #193).
+ *   - the boot-dialog watcher answers late dialogs and disengages on the
+ *     REPL-ready marker, not on first prompt (issue #193 / Codex P2 on #195).
  */
 import { describe, expect, it } from "bun:test";
 import { PtyAgentProcess, type PtyHandle } from "../session-agent-process";
@@ -38,7 +39,7 @@ describe("PtyAgentProcess.send_prompt_stream", () => {
     expect(writes).toEqual(["first", "\r", "second", "\r"]);
   });
 
-  it("disengages the boot-dialog watcher once a real prompt is dispatched", async () => {
+  it("keeps answering dialogs after an early prompt until the REPL is ready, then disengages (Codex P2 on #195)", async () => {
     const writes: string[] = [];
     let dataCb: ((d: string) => void) | null = null;
     const handle: PtyHandle = {
@@ -55,11 +56,23 @@ describe("PtyAgentProcess.send_prompt_stream", () => {
     };
     const proc = new PtyAgentProcess("alpha", handle);
 
-    await proc.send_prompt_stream("hi"); // claude has reached the REPL
+    // An early prompt is dispatched BEFORE the boot dialog renders (slow
+    // fresh-install boot). The old code disengaged the watcher here, leaving
+    // the later dialog unanswered. The watcher must stay engaged.
+    await proc.send_prompt_stream("hi");
     writes.length = 0;
-    // A dialog-looking chunk arriving AFTER the first prompt must be ignored —
-    // the watcher disengages so it can't inject keys mid-session.
-    dataCb?.("...\u276f 2. Yes, I accept...");
+
+    // The bypass dialog renders AFTER the prompt — it must still be answered.
+    dataCb?.("WARNING: Bypass Permissions mode\n  2. Yes, I accept\n");
+    expect(writes).toContain("\x1b[B"); // watcher still active -> Down
+    await new Promise((r) => setTimeout(r, 260));
+    expect(writes).toContain("\r"); // then Enter
+
+    // Once the REPL footer marker appears, the watcher disengages — a later
+    // dialog-looking chunk must be ignored (no keys injected mid-session).
+    dataCb?.("bypass permissions on (shift+tab to cycle)");
+    writes.length = 0;
+    dataCb?.("stray redraw with 2. Yes, I accept text");
     await new Promise((r) => setTimeout(r, 60));
     expect(writes).toEqual([]);
   });

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -76,20 +76,22 @@ export class PtyAgentProcess implements AgentProcess {
   /** Serializes the write/settle/CR sequence so concurrent prompts can't
    *  interleave in the PTY input buffer (review #141 P1). */
   private writeChain: Promise<void> = Promise.resolve();
-  /** Boot dialog-dismiss CR timers, owned so we can cancel them once a real
-   *  prompt is dispatched (review #141 P2). */
-  private dialogDismissTimers: ReturnType<typeof setTimeout>[];
+  /** Boot-dialog watcher state (issue #193). Claude shows interactive
+   *  confirmation dialogs at startup (the dev-channels prompt, and the newer
+   *  "Bypass Permissions mode" prompt). We answer them by inspecting early PTY
+   *  output and sending the correct key per dialog, then disengage once a real
+   *  prompt is dispatched. */
+  private bootDialogActive = true;
+  private bootDialogBuffer = "";
+  private answeredBypassPrompt = false;
+  private answeredDevChannelsPrompt = false;
 
-  constructor(
-    agent_id: string,
-    pty: PtyHandle,
-    dialogDismissTimers: ReturnType<typeof setTimeout>[] = [],
-  ) {
+  constructor(agent_id: string, pty: PtyHandle) {
     this.agent_id = agent_id;
     this.pty = pty;
     this.pid = pty.pid;
-    this.dialogDismissTimers = dialogDismissTimers;
     pty.onData((chunk) => {
+      if (this.bootDialogActive) this.handleBootDialog(chunk);
       // Crash-signal observation ONLY (spec §5.3). Never parsed as model output.
       for (const h of this.dataHandlers) {
         try {
@@ -125,7 +127,7 @@ export class PtyAgentProcess implements AgentProcess {
     // A real prompt means claude has reached the REPL, so the boot dialog (if
     // any) is already dismissed. Cancel the pending dialog-dismiss CR writes
     // so a late one can't submit this prompt — or a follow-up — mid-turn.
-    this.cancelDialogDismissTimers();
+    this.endBootDialogPhase();
     // Deliver an inbound prompt by typing it into claude's REPL via the PTY.
     //
     // Why not rely on `notifications/claude/channel` (the MCP path)? In a
@@ -157,10 +159,47 @@ export class PtyAgentProcess implements AgentProcess {
     return run;
   }
 
-  /** Cancel any pending boot dialog-dismiss timers. Idempotent. */
-  private cancelDialogDismissTimers(): void {
-    for (const t of this.dialogDismissTimers) clearTimeout(t);
-    this.dialogDismissTimers = [];
+  /** Stop answering boot dialogs — called once a real prompt is dispatched
+   *  (claude has reached the REPL) or on kill. Idempotent. */
+  private endBootDialogPhase(): void {
+    this.bootDialogActive = false;
+    this.bootDialogBuffer = "";
+  }
+
+  /** Answer claude's interactive startup confirmation dialogs by inspecting
+   *  early PTY output (issue #193). Sends the *correct* key per dialog: Enter
+   *  for the dev-channels confirmation (whose default IS the accept option),
+   *  and Down+Enter for the "Bypass Permissions mode" dialog (whose default is
+   *  "No, exit" — a blind Enter would select exit and kill the agent). Matches
+   *  on text unique to each dialog so the REPL footer (which also contains
+   *  "bypass permissions on") cannot false-trigger. */
+  private handleBootDialog(chunk: string): void {
+    this.bootDialogBuffer = (this.bootDialogBuffer + chunk).slice(-4000);
+    const buf = this.bootDialogBuffer;
+    if (!this.answeredBypassPrompt && buf.includes("Yes, I accept")) {
+      this.answeredBypassPrompt = true;
+      try {
+        this.pty.write("\x1b[B"); // move selection to "2. Yes, I accept"
+        setTimeout(() => {
+          try {
+            this.pty.write("\r");
+          } catch {
+            /* pty may have exited — non-fatal */
+          }
+        }, 200);
+      } catch {
+        /* pty may have exited — non-fatal */
+      }
+      return;
+    }
+    if (!this.answeredDevChannelsPrompt && buf.includes("development channels")) {
+      this.answeredDevChannelsPrompt = true;
+      try {
+        this.pty.write("\r");
+      } catch {
+        /* pty may have exited — non-fatal */
+      }
+    }
   }
 
   onExit(handler: ExitHandler): void {
@@ -173,7 +212,7 @@ export class PtyAgentProcess implements AgentProcess {
 
   /** Internal — called by SessionManager.stop(). */
   _kill(signal?: string): void {
-    this.cancelDialogDismissTimers();
+    this.endBootDialogPhase();
     try {
       this.pty.kill(signal);
     } catch {

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -195,8 +195,8 @@ export class PtyAgentProcess implements AgentProcess {
    *  for the dev-channels confirmation (whose default IS the accept option),
    *  and Down+Enter for the "Bypass Permissions mode" dialog (whose default is
    *  "No, exit" — a blind Enter would select exit and kill the agent). Matches
-   *  on text unique to each dialog so the REPL footer (which also contains
-   *  "bypass permissions on") cannot false-trigger. */
+   *  on text unique to each dialog so the REPL footer (which contains the
+   *  "shift+tab to cycle" hint) cannot false-trigger. */
   private handleBootDialog(chunk: string): void {
     this.bootDialogBuffer = (this.bootDialogBuffer + chunk).slice(-4000);
     const buf = this.bootDialogBuffer;
@@ -225,12 +225,17 @@ export class PtyAgentProcess implements AgentProcess {
       }
       return;
     }
-    // REPL-ready marker (issue #193 / Codex P2). The REPL footer shows
-    // "bypass permissions on" once claude has reached the prompt — distinct
-    // from the dialog's "Yes, I accept". Seeing it means any startup dialog is
-    // already dismissed, so disengage the watcher (stops buffering + cancels
-    // the timeout). Writes nothing.
-    if (buf.includes("bypass permissions on")) {
+    // REPL-ready marker (issue #193 / Codex P2 ×2). Every REPL mode footer
+    // ends with the "shift+tab to cycle" mode-cycler hint, regardless of the
+    // agent's permission_mode ("bypass permissions on", "plan mode on",
+    // "accept edits on", etc.). Matching the generic hint — rather than the
+    // bypass-specific footer — means the watcher disengages promptly in ALL
+    // modes, not only bypass. (The bypass-only marker left non-bypass agents
+    // watching until the 15s timeout, during which a stray "Yes, I accept"
+    // model echo could inject Down/Enter into a live REPL.) No dialog contains
+    // this hint, so it cannot false-trigger. Disengaging stops buffering +
+    // cancels the timeout; writes nothing.
+    if (buf.includes("shift+tab to cycle")) {
       this.endBootDialogPhase();
     }
   }

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -79,17 +79,31 @@ export class PtyAgentProcess implements AgentProcess {
   /** Boot-dialog watcher state (issue #193). Claude shows interactive
    *  confirmation dialogs at startup (the dev-channels prompt, and the newer
    *  "Bypass Permissions mode" prompt). We answer them by inspecting early PTY
-   *  output and sending the correct key per dialog, then disengage once a real
-   *  prompt is dispatched. */
+   *  output and sending the correct key per dialog. The watcher stays engaged
+   *  until claude actually reaches the REPL (detected via the footer marker) or
+   *  a bounded timeout — NOT until the first prompt. Codex P2 on PR #195: a
+   *  dialog can render AFTER an early heartbeat/scheduler prompt on a slow
+   *  fresh-install boot, so disengaging on first-prompt left late dialogs
+   *  unanswered and the agent stuck at "No, exit". */
   private bootDialogActive = true;
   private bootDialogBuffer = "";
   private answeredBypassPrompt = false;
   private answeredDevChannelsPrompt = false;
+  /** Hard cap on the boot-dialog watch window (issue #193 / Codex P2). If no
+   *  REPL-ready marker is observed within this window (e.g. a future CLI
+   *  changes the footer text), the watcher disengages anyway so it never
+   *  buffers PTY output for the whole process lifetime. */
+  private static readonly BOOT_DIALOG_MAX_MS = 15_000;
+  private bootDialogTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(agent_id: string, pty: PtyHandle) {
     this.agent_id = agent_id;
     this.pty = pty;
     this.pid = pty.pid;
+    this.bootDialogTimer = setTimeout(
+      () => this.endBootDialogPhase(),
+      PtyAgentProcess.BOOT_DIALOG_MAX_MS,
+    );
     pty.onData((chunk) => {
       if (this.bootDialogActive) this.handleBootDialog(chunk);
       // Crash-signal observation ONLY (spec §5.3). Never parsed as model output.
@@ -124,10 +138,15 @@ export class PtyAgentProcess implements AgentProcess {
 
   send_prompt_stream(line: string): Promise<void> {
     if (this._exited) return Promise.reject(new Error(`agent ${this.agent_id} has exited`));
-    // A real prompt means claude has reached the REPL, so the boot dialog (if
-    // any) is already dismissed. Cancel the pending dialog-dismiss CR writes
-    // so a late one can't submit this prompt — or a follow-up — mid-turn.
-    this.endBootDialogPhase();
+    // NOTE (Codex P2 on PR #195): we deliberately do NOT disengage the
+    // boot-dialog watcher here. An early heartbeat/scheduler prompt can be
+    // dispatched before a slow fresh-install boot has rendered its
+    // bypass-permissions dialog; disengaging on first-prompt left that later
+    // dialog unanswered (default "No, exit") and killed the agent. The watcher
+    // now disengages on the REPL-ready footer marker or the bounded timeout
+    // instead (see handleBootDialog / endBootDialogPhase). The watcher only
+    // ever writes in response to specific dialog text, so leaving it engaged
+    // cannot inject keys mid-turn once the REPL is up.
     // Deliver an inbound prompt by typing it into claude's REPL via the PTY.
     //
     // Why not rely on `notifications/claude/channel` (the MCP path)? In a
@@ -159,11 +178,16 @@ export class PtyAgentProcess implements AgentProcess {
     return run;
   }
 
-  /** Stop answering boot dialogs — called once a real prompt is dispatched
-   *  (claude has reached the REPL) or on kill. Idempotent. */
+  /** Stop answering boot dialogs — called when the REPL-ready footer marker is
+   *  observed, the bounded timeout fires, or on kill. Idempotent. */
   private endBootDialogPhase(): void {
+    if (!this.bootDialogActive) return;
     this.bootDialogActive = false;
     this.bootDialogBuffer = "";
+    if (this.bootDialogTimer) {
+      clearTimeout(this.bootDialogTimer);
+      this.bootDialogTimer = undefined;
+    }
   }
 
   /** Answer claude's interactive startup confirmation dialogs by inspecting
@@ -199,6 +223,15 @@ export class PtyAgentProcess implements AgentProcess {
       } catch {
         /* pty may have exited — non-fatal */
       }
+      return;
+    }
+    // REPL-ready marker (issue #193 / Codex P2). The REPL footer shows
+    // "bypass permissions on" once claude has reached the prompt — distinct
+    // from the dialog's "Yes, I accept". Seeing it means any startup dialog is
+    // already dismissed, so disengage the watcher (stops buffering + cancels
+    // the timeout). Writes nothing.
+    if (buf.includes("bypass permissions on")) {
+      this.endBootDialogPhase();
     }
   }
 

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -678,31 +678,12 @@ export class SessionManager {
         env,
       }),
     );
-    // Dismiss the WARNING: Loading development channels TUI dialog claude
-    // shows when `--dangerously-load-development-channels` is set AND the
-    // `tengu_harbor` feature flag is on for the account. Default selection is
-    // "I am using this for local development" so a single Enter accepts it.
-    //
-    // On accounts WITH the flag, the dialog blocks claude at boot — it never
-    // reaches the REPL, so no prompt ever lands and the surface looks dead.
-    // The original 1.5s + 4s pair was insufficient: on slower boots the dialog
-    // renders after 4s, so both writes land before it exists and are lost.
-    // Retry across a wider window. Each `\r` after the dialog is gone is an
-    // empty REPL submit (no-op turn), harmless. Accounts WITHOUT the flag
-    // never render the dialog and the writes are cheap insurance.
-    // Hand the timer handles to the process so the first real prompt cancels
-    // any still-pending CR — otherwise a 5s/8s dismiss write could submit a
-    // mid-turn prompt now that the same PTY carries real prompts (#141 P2).
-    const dialogDismissTimers = [1000, 2500, 5000, 8000].map((ms) =>
-      setTimeout(() => {
-        try {
-          pty.write("\r");
-        } catch {
-          /* pty may have exited already — non-fatal */
-        }
-      }, ms),
-    );
-    return new PtyAgentProcess(agent.id, pty, dialogDismissTimers);
+    // Boot-dialog handling lives in PtyAgentProcess's output-driven watcher
+    // (issue #193): it answers the dev-channels confirmation with Enter and the
+    // new "Bypass Permissions mode" confirmation by selecting "Yes, I accept"
+    // (Down + Enter). A blind Enter — the previous approach — selects that
+    // dialog's default "No, exit" and kills the agent at boot.
+    return new PtyAgentProcess(agent.id, pty);
   }
 
   private spawnChild(


### PR DESCRIPTION
## Problem

On a fresh install (bus runtime, the default), the agent spawns but **dies immediately** and never responds on any channel — the log shows `No MCP connection for agent_id=<name>` and `pgrep -f 'claude --plugin-dir'` finds nothing.

Root cause: recent Claude CLI shows a `WARNING: Bypass Permissions mode` confirmation whose **default selection is "No, exit"**:

```
❯ 1. No, exit
  2. Yes, I accept
```

The bus spawn dismissed startup dialogs with a **blind Enter** (`pty.write("\r")` on fixed timers) — a handler written for the older `--dangerously-load-development-channels` dialog, whose default IS the accept option. On this new dialog the blind Enter selects **"No, exit"**, killing every spawned agent at boot.

Confirmed in the field via moazbuilds/claudeclaw#216 (thanks @GordonWu for the breakdown). Tracked as #193.

## Fix

Replace the blind dialog-dismiss timers with an **output-driven watcher** in `PtyAgentProcess`. It inspects early PTY output and sends the **correct key per dialog**:

- dev-channels confirmation (default = accept) → `Enter`
- "Bypass Permissions mode" (default = "No, exit") → `Down` + `Enter` to land on "Yes, I accept"

Scoped to the daemon's own spawn — **no global `~/.claude/settings.json` mutation**, so a user's interactive `claude` sessions keep their safety prompts. Matches on text unique to each dialog (`"Yes, I accept"` / `"development channels"`) so the REPL footer — which also contains "bypass permissions on" — can't false-trigger. Disengages once a real prompt is dispatched.

- `src/bus/session-manager.ts` — drop the blind `[1000,2500,5000,8000]ms` `\r` timers.
- `src/bus/session-agent-process.ts` — `handleBootDialog()` watcher + `endBootDialogPhase()`.
- tests — new `pty-boot-dialog.test.ts` (per-dialog keys, footer no-false-trigger, once-only); existing `session-agent-process.test.ts` updated to assert the watcher disengages on the first prompt.

## Verification

- The accept keystroke (`Down`+`Enter`) was verified against the **real** Bypass-Permissions dialog (reproduced on a fresh authed install): it selects "Yes, I accept" and reaches the REPL.
- `bun test` → boot-dialog (4) + session-agent-process (2) + watchdog smoke (17) all green.
- `bun run lint` (biome) clean.

## Scope

Surgical fix for the agent-killer. The companion setup-wizard gaps from #193 (auto-writing `agents[]` + `telegram.busRouting` when Telegram is configured) are a follow-up.

Refs #193
