### PR TITLE
fix(wizard): ship one default bus agent so fresh installs mount an agent (#196)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.122",
+      "version": "2.2.123",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.122",
+  "version": "2.2.123",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.planning/wizard-default-agent/SPEC.md
+++ b/.planning/wizard-default-agent/SPEC.md
@@ -1,0 +1,98 @@
+# SPEC — Fresh install must declare a default bus agent (#196)
+
+**Issue:** TerrysPOV/ClaudeClaw-Plus#196 — cause #1 of the 3-cause fresh-install
+breakage tracked in #193. (#195 fixed cause #3, the bypass-permissions dialog;
+#197 tracks cause #2, the Telegram `busRouting` mount gap.)
+
+## 1. Problem statement
+
+On a fresh install the daemon writes a default `settings.json` whose `runtime`
+is `"bus"` but whose `agents` list is **empty**. The bus runtime then mounts
+with zero agents — the startup banner reads `no agents declared` — so nothing
+is ever spawned to answer on any channel. Every surface looks healthy (daemon
+up, web UI listening, channels polling), which is why the failure is hard to
+spot: there is simply no agent behind the bus.
+
+The empty default was correct when `runtime` defaulted to `"pty"`. The
+`runtime` default flipped to `"bus"` on 2026-05-25 (Sprint 5.4), but the
+`agents: []` default did not follow — leaving the shipped default config
+internally inconsistent: a runtime that requires ≥1 agent, paired with zero
+agents.
+
+## 2. Current behaviour (as-is)
+
+- `src/config.ts:222` — `DEFAULT_SETTINGS.runtime = "bus"`.
+- `src/config.ts:225` — `DEFAULT_SETTINGS.agents = []` (comment at 223-224 still
+  says "Default no agents … opt in to bus … declare explicitly" — stale).
+- `src/config.ts:709-717` — `initConfig()` writes `DEFAULT_SETTINGS` verbatim to
+  `<cwd>/.claude/claudeclaw/settings.json` **only when the file does not yet
+  exist** (fresh install).
+- `src/config.ts:972` — `parseSettings` builds `agents` from
+  `parseBusAgents(raw.agents)`; `parseBusAgents(undefined)` returns `[]`
+  (config.ts:1061-1062). It never falls back to `DEFAULT_SETTINGS.agents`.
+- `src/commands/start.ts:472-543, 613-626` — when `runtime === "bus"`,
+  `resolveBusAgentConfigs(settings.agents, …)` runs and the banner reports
+  `settings.agents.length === 0 ? "no agents declared" : …`.
+
+Net: fresh `settings.json` → `agents: []` → bus mounts, spawns nothing.
+
+## 3. Target behaviour (to-be)
+
+- A fresh `initConfig()` writes `settings.json` with exactly one declared agent:
+  `agents: [{ "id": "default" }]`.
+- On boot the bus resolves that single entry (cwd ← `process.cwd()`,
+  `permission_mode` ← `"bypassPermissions"`, `supervision` ← `"pty-stdin"`,
+  session_id created on demand — see `agent-resolver.ts:62-80, 116-122`; no
+  pre-existing `agents/default/` dir required) and spawns one `claude`. The
+  banner reads `1 agent(s) declared`, not `no agents declared`.
+- Existing installs are unchanged: a `settings.json` that omits `agents`, or
+  sets `agents: []` explicitly, still parses to `[]` (the parse path is
+  untouched). The "empty list = operator wires agents later" escape hatch
+  remains valid for anyone who has set it deliberately.
+
+## 4. Architecture decisions (frozen)
+
+- **Fix the default, not the parser.** Change `DEFAULT_SETTINGS.agents` to
+  `[{ id: "default" }]`. Because `parseSettings` reads `raw.agents` directly and
+  `parseBusAgents` never consults `DEFAULT_SETTINGS.agents`, this changes only
+  what `initConfig` writes to a brand-new file — it does **not** retroactively
+  inject an agent into existing installs or override an explicit `agents: []`.
+  Rationale: scopes the behaviour change to the exact case the issue names
+  (fresh `/start` on a clean project) and preserves the deliberate "wire later"
+  semantics for existing operators.
+- **Agent id `"default"`.** Matches `AGENT_ID_PATTERN`
+  (`/^[a-z0-9][a-z0-9_-]{0,35}$/`), is self-describing, and collides with
+  nothing. Single-agent is the common case the terse-defaults design targets
+  (config.ts:586-587).
+- **No new wizard prompt / no interactive step.** The issue frames this as "the
+  wizard must write agents[]"; the daemon's first-run config writer
+  (`initConfig`) *is* that write path. Adding an interactive question is out of
+  scope and heavier than the defect warrants.
+- **Update the stale comments** at config.ts:223-224 and the `Settings.agents`
+  docstring (config.ts:642-646) so they describe the bus-default + one-agent
+  coherence instead of "default no agents".
+
+## 5. Key file references
+
+- `src/config.ts:222-225` — `DEFAULT_SETTINGS.runtime`/`.agents` (the change).
+- `src/config.ts:642-646` — `Settings.agents` docstring (comment update).
+- `src/config.ts:709-717` — `initConfig()` fresh-write path (unchanged logic;
+  now emits the default agent).
+- `src/config.ts:1061-1126` — `parseBusAgents` (unchanged; confirms no leak to
+  existing installs).
+- `src/bus/agent-resolver.ts:62-122` — resolves a bare `{id}` entry; creates the
+  session dir on demand.
+- `src/commands/start.ts:472-543, 613-626` — bus mount + `no agents declared`
+  banner (verification surface).
+- Tests: `src/__tests__/runtime-config.test.ts` (parse path — must stay green);
+  new coverage for the fresh-`initConfig` write default.
+
+## 6. Out of scope (deferred)
+
+- Telegram `busRouting` mount gap — #197 (cause #2 of #193).
+- Bypass-permissions dialog — #195 (cause #3, already merged).
+- Auto-healing existing zero-agent installs (e.g. a startup warning or migration
+  that injects a default agent when `runtime==="bus"` and `agents` is empty).
+  Considered, deferred: it changes behaviour for operators who set `agents: []`
+  on purpose; the startup banner already states `no agents declared`.
+- Any interactive wizard question for naming/configuring the default agent.

--- a/src/__tests__/config-init-default-agent.test.ts
+++ b/src/__tests__/config-init-default-agent.test.ts
@@ -1,0 +1,62 @@
+/**
+ * Fresh-install default agent (#196 — cause #1 of #193).
+ *
+ * `initConfig()` writes DEFAULT_SETTINGS to settings.json only when the file
+ * does not yet exist. With `runtime: "bus"` as the default, the shipped
+ * default must also declare one agent, otherwise the bus mounts with zero
+ * agents and nothing answers on any channel.
+ *
+ * These tests exercise the real on-disk write path, so they back up and
+ * restore the project's settings.json around the run.
+ */
+import { describe, it, expect, beforeAll, afterAll } from "bun:test";
+import { join } from "path";
+import { mkdir, copyFile, unlink } from "fs/promises";
+import { existsSync } from "fs";
+
+import { initConfig, reloadSettings, getSettings } from "../config";
+
+const SETTINGS_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const SETTINGS_FILE = join(SETTINGS_DIR, "settings.json");
+const BACKUP_FILE = join(SETTINGS_DIR, "settings.json.init-default-agent-backup");
+
+beforeAll(async () => {
+  await mkdir(SETTINGS_DIR, { recursive: true });
+  if (existsSync(SETTINGS_FILE)) {
+    await copyFile(SETTINGS_FILE, BACKUP_FILE);
+  }
+});
+
+afterAll(async () => {
+  if (existsSync(BACKUP_FILE)) {
+    await copyFile(BACKUP_FILE, SETTINGS_FILE);
+    await unlink(BACKUP_FILE);
+  } else if (existsSync(SETTINGS_FILE)) {
+    await unlink(SETTINGS_FILE);
+  }
+  try {
+    await reloadSettings();
+  } catch {
+    /* ok — restore may have removed the file */
+  }
+});
+
+describe("initConfig — fresh install default agent (#196)", () => {
+  it("writes one default agent so the bus mounts a working agent out of the box", async () => {
+    if (existsSync(SETTINGS_FILE)) await unlink(SETTINGS_FILE);
+
+    await initConfig();
+
+    expect(existsSync(SETTINGS_FILE)).toBe(true);
+    const written = (await Bun.file(SETTINGS_FILE).json()) as {
+      runtime?: unknown;
+      agents?: unknown;
+    };
+    expect(written.runtime).toBe("bus");
+    expect(written.agents).toEqual([{ id: "default" }]);
+
+    // And it parses back through loadSettings to exactly one mountable agent.
+    await reloadSettings();
+    expect(getSettings().agents).toEqual([{ id: "default" }]);
+  });
+});

--- a/src/__tests__/runtime-config.test.ts
+++ b/src/__tests__/runtime-config.test.ts
@@ -81,6 +81,11 @@ describe("parseSettings — runtime field (Sprint 5.4 flip — bus is default)",
 });
 
 describe("parseSettings — agents field (Sprint 5.2a)", () => {
+  // This is the PARSE-path default (an existing settings.json that omits
+  // `agents`), NOT the fresh-install default. `parseBusAgents` returns [] for
+  // a missing/empty field and never reads DEFAULT_SETTINGS.agents — whereas a
+  // brand-new install ships one `{ id: "default" }` via initConfig (#196). See
+  // config-init-default-agent.test.ts for the fresh-install write path.
   it("defaults to empty array when the field is absent", async () => {
     await writeRawSettings({});
     await reloadSettings();

--- a/src/config.ts
+++ b/src/config.ts
@@ -220,9 +220,14 @@ const DEFAULT_SETTINGS: Settings = {
   // enterprise deployments where audit, cost-ceiling, or regulatory
   // constraints make API billing the safer or only viable route.
   runtime: "bus",
-  // Default no agents. Operators who opt in to `runtime: "bus"` declare
-  // agents explicitly. Spec §5.3 / §10 Sprint 5.2.
-  agents: [],
+  // One default agent so a fresh install actually mounts something. The
+  // runtime default is `bus`, which spawns one `claude` per `agents[]` entry;
+  // an empty default would mount the bus with zero agents — daemon up,
+  // channels polling, but nothing behind them ("no agents declared"). This is
+  // the *fresh-install* default only: `parseBusAgents` builds from `raw.agents`
+  // and never reads this list (config.ts:1061), so existing installs that omit
+  // `agents` or set `agents: []` are unaffected (#196 / cause #1 of #193).
+  agents: [{ id: "default" }],
   plugins: {},
   memorySearch: {},
 };
@@ -642,7 +647,10 @@ export interface Settings {
    * Bus runtime agent declarations. Only consulted when `runtime: "bus"`;
    * `runtime: "pty"` ignores this field entirely. Empty list = the daemon
    * mounts the Bus stack but spawns no agents (operator wires them via
-   * REST/CLI later). See `BusAgentSettings` for the per-agent shape.
+   * REST/CLI later). A fresh install ships one `{ id: "default" }` entry
+   * (see `DEFAULT_SETTINGS`) so the bus mounts a working agent out of the box;
+   * clearing the list back to `[]` is a deliberate "wire later" opt-out.
+   * See `BusAgentSettings` for the per-agent shape.
    */
   agents: BusAgentSettings[];
   pty: PtyConfig;

--- a/src/config.ts
+++ b/src/config.ts
@@ -225,8 +225,8 @@ const DEFAULT_SETTINGS: Settings = {
   // an empty default would mount the bus with zero agents — daemon up,
   // channels polling, but nothing behind them ("no agents declared"). This is
   // the *fresh-install* default only: `parseBusAgents` builds from `raw.agents`
-  // and never reads this list (config.ts:1061), so existing installs that omit
-  // `agents` or set `agents: []` are unaffected (#196 / cause #1 of #193).
+  // and never reads this list, so existing installs that omit `agents` or set
+  // `agents: []` are unaffected (#196 / cause #1 of #193).
   agents: [{ id: "default" }],
   plugins: {},
   memorySearch: {},


### PR DESCRIPTION
Fixes #196 — cause #1 of the 3-cause fresh-install breakage (#193).

## Problem
On a clean install the daemon writes `DEFAULT_SETTINGS` to `settings.json`. `runtime` defaults to `"bus"` (flipped 2026-05-25, Sprint 5.4) but `agents` was still `[]`. The bus then mounts with **zero agents** — daemon up, web UI listening, channels polling, but nothing behind them (banner: `no agents declared`) — so no surface ever answers. The empty default was correct when `runtime` defaulted to `"pty"`; the runtime flip left the shipped default internally inconsistent.

## Fix
`DEFAULT_SETTINGS.agents = [{ id: "default" }]`.

This changes **only** the fresh-install write path: `initConfig()` writes `DEFAULT_SETTINGS` verbatim when `settings.json` is absent. `parseSettings` builds `agents` from `raw.agents` via `parseBusAgents`, which never reads `DEFAULT_SETTINGS.agents` — so existing installs that omit `agents` or set `agents: []` are **unaffected**; the deliberate "wire agents later" opt-out still works. A bare `{ id: "default" }` resolves with `cwd=process.cwd()`, `permission_mode=bypassPermissions`, `supervision=pty-stdin`, and a session created on demand (no pre-existing `agents/default/` dir required).

## Supersedes #159's stance (intentional)
PR #159 introduced `agents: []` with "operators who opt in to bus declare agents explicitly" — correct when bus was opt-in. Bus is now the **unconditional default**, so an empty default is the defect, not a stance. This change supersedes that rationale.

## Known interaction (bounded, non-blocking)
The orphan-agent detection from #188 warns on a declared agent with no on-disk dir (`orphanedDecls`). On a **clean** fresh install this never fires — `detectOrphanAgents` early-returns on an empty `agents/` dir, so #196's acceptance scenario is silent. It can emit a one-time soft warning only in a *mixed* project (other `agents/<name>/` dirs already present, no `agents/default/` yet), and self-heals once the first spawn creates `agents/default/`. Possible follow-up: suppress the `orphanedDecls` warning for the well-known `default` id.

## Tests
- New `src/__tests__/config-init-default-agent.test.ts`: a clean `initConfig()` writes exactly one `{ id: "default" }` agent and it round-trips through `loadSettings`.
- Existing `runtime-config` parse tests stay green (absent/empty `agents` → `[]`); added a note distinguishing the parser-default from the fresh-install default.

## Review
- SPEC: `.planning/wizard-default-agent/SPEC.md`.
- 5-agent code review (clean bug scan; CLAUDE.md adherence clean; history-consistent) — findings addressed in-branch (dropped a rot-prone line ref, added the parser-vs-init test note). Security review: no CRITICAL/HIGH (`bypassPermissions` default is pre-existing for any declared agent, not introduced here).

## Out of scope
Telegram `busRouting` mount gap (#197, cause #2). Auto-healing existing zero-agent installs.