### PR TITLE
fix(bus): Telegram adapter mounts on token alone, routing to the default agent (#197)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.124",
+      "version": "2.2.125",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.123",
+      "version": "2.2.124",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.123",
+  "version": "2.2.124",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.124",
+  "version": "2.2.125",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.planning/telegram-busrouting-default/SPEC.md
+++ b/.planning/telegram-busrouting-default/SPEC.md
@@ -1,0 +1,94 @@
+# SPEC — Telegram bus adapter mounts on token alone (#197)
+
+**Issue:** TerrysPOV/ClaudeClaw-Plus#197 — cause #2 of the 3-cause fresh-install
+breakage (#193). #195 fixed cause #3 (bypass-permissions dialog); #196 fixed
+cause #1 (no default agent declared). This is the last cause.
+
+## 1. Problem statement
+
+The bus Telegram adapter refuses to mount unless **both** `telegram.token` and
+`telegram.busRouting` are present. A fresh install sets the token (via the
+wizard / env) but never writes `busRouting`, so `mountTelegram` returns `null`,
+the startup banner reads `no adapters`, and the bot is silent despite a valid
+token. (Field trace: moazbuilds/claudeclaw#216, @GordonWu.)
+
+## 2. Current behaviour (as-is)
+
+- `src/bus/adapter-wiring.ts:168` — `mountTelegram`: `if (!cfg.token || !cfg.busRouting) return null;`.
+- `src/bus/adapter-wiring.ts:111` — `configuredBusAdapterNames`: telegram counted
+  only when `token && busRouting` (so the pre-spawn banner also reports it as
+  absent).
+- `TelegramBusRouting = { chats: Record<chatId,agentId>; defaultAgentId? }`
+  (`src/config.ts:258-261`). `parseTelegramBusRouting` returns `null` unless
+  `chats` or `defaultAgentId` is present (`config.ts:1167-1180`), so a fresh
+  install's absent block parses to `undefined`.
+- `TelegramAdapter.resolveAgent(chatId)` returns `routingChats[chatId] ?? defaultAgentId`
+  (`src/adapters/telegram/index.ts:750-753`) — so empty `chats` + a
+  `defaultAgentId` routes **every** chat to the default agent.
+- Allow-list: empty `allowedUserIds` = **allow all** (`index.ts:287-296`), so a
+  token-only install accepts inbound from any user.
+- `wireBusAdapters` is called with only `{ bus, settings }`
+  (`src/commands/start.ts:893`); it has no notion of the default agent id. The
+  scheduler wiring right after uses `busRuntimeHandle.spawnedAgentIds[0]`
+  (`start.ts:906`).
+
+Net: token set, `busRouting` absent → adapter never mounts → silent bot.
+
+## 3. Target behaviour (to-be)
+
+- When `telegram.token` is present and `telegram.busRouting` is **absent**, the
+  adapter mounts with a derived default routing `{ chats: {}, defaultAgentId }`
+  where `defaultAgentId` is the bus's default agent (first spawned agent — now
+  always present after #196). All inbound chats route to that agent; replies go
+  back to the originating chat.
+- When `telegram.busRouting` is **present**, behaviour is unchanged (explicit
+  config wins).
+- When `telegram.token` is present but there is **no** default agent to route to
+  (e.g. operator cleared `settings.agents` to `[]`), the adapter still skips —
+  there is genuinely nothing to route to. A one-line info log explains the
+  derive when it happens.
+- The pre-spawn startup banner (`configuredBusAdapterNames`) reflects the same
+  predicate so it doesn't under-report Telegram.
+
+## 4. Architecture decisions (frozen)
+
+- **Graceful-degrade in the adapter, not a wizard write.** The robust fix lives
+  in `mountTelegram`: it works regardless of how the token was supplied (wizard,
+  env, hand-edited settings). Writing a default `busRouting` block at wizard
+  time would only cover the wizard path and risks touching the token-write flow.
+  (Rejected: wizard-writes-busRouting as the primary fix.)
+- **Telegram only.** Cause #2 is Telegram. Discord and Slack are channel-routed
+  (`channels: Record<channelId,agentId>` is required; there is no single
+  "default chat"), so a default-agent degrade is a separate design. Their
+  `token && busRouting` guards are left unchanged. (Out of scope.)
+- **Thread the default agent id through `wireBusAdapters`.** Add
+  `defaultAgentId?: string` to `WireBusAdaptersOptions`; `start.ts` passes
+  `busRuntimeHandle.spawnedAgentIds[0]` (the same id the scheduler targets). The
+  banner passes `settings.agents[0]?.id` (declared default, pre-spawn).
+- **Derive only when there is an agent.** No default agent ⇒ no derived routing
+  ⇒ skip (don't mount an adapter whose messages would land on no consumer).
+- **Pairs with #196.** #196 guarantees a `default` agent exists on fresh install;
+  this routes Telegram to it. Both are required for the end-to-end fresh-install
+  path.
+
+## 5. Key file references
+
+- `src/bus/adapter-wiring.ts`:
+  - `WireBusAdaptersOptions` (~52-59) — add `defaultAgentId?`.
+  - `wireBusAdapters` (~66-96) — pass `defaultAgentId` to `mountTelegram`.
+  - `configuredBusAdapterNames` (~106-115) — telegram predicate `token && (busRouting || defaultAgentId)`.
+  - `mountTelegram` (~163-184) — derive `{ chats: {}, defaultAgentId }` when token set + busRouting absent + defaultAgentId present; log it.
+- `src/commands/start.ts`:
+  - `configuredBusAdapterNames(settings)` call (~570) → pass `settings.agents[0]?.id`.
+  - `wireBusAdapters({ bus, settings })` call (~893) → add `defaultAgentId: busRuntimeHandle.spawnedAgentIds[0]`.
+- `src/adapters/telegram/index.ts:750-753` (resolveAgent), `:287-296` (allow-list) — confirm derived routing reaches the default agent. No change.
+- Tests: `src/bus/__tests__/adapter-wiring.test.ts` (the gating suite).
+
+## 6. Out of scope (deferred)
+
+- Discord / Slack token-only degrade (channel-routed; separate design).
+- Wizard writing an explicit `telegram.busRouting` block.
+- Outbound cron/heartbeat → Telegram chat selection with empty `chats`
+  (`pickOutboundChat` needs a chat map; inbound-reply works without it). Same
+  limitation as any chat-less routing today; not part of this acceptance.
+- Per-user rate limiting (pre-existing TODO in the adapter).

--- a/src/bus/__tests__/adapter-wiring.test.ts
+++ b/src/bus/__tests__/adapter-wiring.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect } from "bun:test";
-import { wireBusAdapters, stopBusAdapters } from "../adapter-wiring";
+import { wireBusAdapters, stopBusAdapters, configuredBusAdapterNames } from "../adapter-wiring";
 import type { BusCore } from "../core";
 import type { Settings } from "../../config";
 
@@ -118,7 +118,10 @@ describe("wireBusAdapters — gating", () => {
     expect(result.adapters.find((a) => a.name === "discord")).toBeUndefined();
   });
 
-  it("skips Telegram when routing is absent", async () => {
+  it("skips Telegram when routing AND defaultAgentId are both absent", async () => {
+    // #197: a token alone is enough ONLY when a default agent exists to route
+    // to. With no busRouting and no defaultAgentId there is no consumer, so the
+    // adapter is still skipped (and never imported).
     const result = await wireBusAdapters({
       bus: stubBus(),
       settings: baseSettings({
@@ -130,6 +133,24 @@ describe("wireBusAdapters — gating", () => {
           dmIsolation: "shared",
         },
       }),
+      logger: SILENT_LOGGER,
+    });
+    expect(result.adapters.find((a) => a.name === "telegram")).toBeUndefined();
+  });
+
+  it("skips Telegram when token is absent even if a defaultAgentId is provided", async () => {
+    const result = await wireBusAdapters({
+      bus: stubBus(),
+      settings: baseSettings({
+        telegram: {
+          token: "",
+          allowedUserIds: [],
+          listenChats: [],
+          receiveEnabled: true,
+          dmIsolation: "shared",
+        },
+      }),
+      defaultAgentId: "default",
       logger: SILENT_LOGGER,
     });
     expect(result.adapters.find((a) => a.name === "telegram")).toBeUndefined();
@@ -168,6 +189,39 @@ describe("wireBusAdapters — gating", () => {
       logger: SILENT_LOGGER,
     });
     expect(result.adapters.find((a) => a.name === "webui")).toBeUndefined();
+  });
+});
+
+describe("configuredBusAdapterNames — Telegram token-only mount (#197)", () => {
+  const tgSettings = (token: string, busRouting?: { chats: Record<string, string> }) =>
+    baseSettings({
+      telegram: {
+        token,
+        allowedUserIds: [],
+        listenChats: [],
+        receiveEnabled: true,
+        dmIsolation: "shared",
+        ...(busRouting ? { busRouting } : {}),
+      } as Settings["telegram"],
+    });
+
+  it("counts Telegram when token + defaultAgentId are present (busRouting derived)", () => {
+    expect(configuredBusAdapterNames(tgSettings("123:abc"), "default")).toContain("telegram");
+  });
+
+  it("omits Telegram when token is set but there is no busRouting and no defaultAgentId", () => {
+    expect(configuredBusAdapterNames(tgSettings("123:abc"))).not.toContain("telegram");
+    expect(configuredBusAdapterNames(tgSettings("123:abc"), undefined)).not.toContain("telegram");
+  });
+
+  it("counts Telegram with explicit busRouting even when no defaultAgentId is passed", () => {
+    expect(
+      configuredBusAdapterNames(tgSettings("123:abc", { chats: { "100": "triage" } })),
+    ).toContain("telegram");
+  });
+
+  it("omits Telegram when token is absent even with a defaultAgentId", () => {
+    expect(configuredBusAdapterNames(tgSettings(""), "default")).not.toContain("telegram");
   });
 });
 

--- a/src/bus/__tests__/adapter-wiring.test.ts
+++ b/src/bus/__tests__/adapter-wiring.test.ts
@@ -138,6 +138,26 @@ describe("wireBusAdapters — gating", () => {
     expect(result.adapters.find((a) => a.name === "telegram")).toBeUndefined();
   });
 
+  it("skips a token-only Telegram mount when receiveEnabled is false (send-only)", async () => {
+    // Codex P2 on #197: the derive must not auto-mount a poll loop for a
+    // send-only config. The adapter is never imported on this path.
+    const result = await wireBusAdapters({
+      bus: stubBus(),
+      settings: baseSettings({
+        telegram: {
+          token: "123:abc",
+          allowedUserIds: [],
+          listenChats: [],
+          receiveEnabled: false,
+          dmIsolation: "shared",
+        },
+      }),
+      defaultAgentId: "default",
+      logger: SILENT_LOGGER,
+    });
+    expect(result.adapters.find((a) => a.name === "telegram")).toBeUndefined();
+  });
+
   it("skips Telegram when token is absent even if a defaultAgentId is provided", async () => {
     const result = await wireBusAdapters({
       bus: stubBus(),
@@ -222,6 +242,37 @@ describe("configuredBusAdapterNames — Telegram token-only mount (#197)", () =>
 
   it("omits Telegram when token is absent even with a defaultAgentId", () => {
     expect(configuredBusAdapterNames(tgSettings(""), "default")).not.toContain("telegram");
+  });
+
+  it("does not derive a token-only mount for a send-only config (receiveEnabled: false)", () => {
+    // Codex P2 on #197: the token-only derive must respect receiveEnabled so a
+    // send-only config doesn't start consuming inbound.
+    const sendOnly = baseSettings({
+      telegram: {
+        token: "123:abc",
+        allowedUserIds: [],
+        listenChats: [],
+        receiveEnabled: false,
+        dmIsolation: "shared",
+      } as Settings["telegram"],
+    });
+    expect(configuredBusAdapterNames(sendOnly, "default")).not.toContain("telegram");
+  });
+
+  it("still counts Telegram with explicit busRouting even when receiveEnabled is false", () => {
+    // Explicit busRouting is the operator opting in; the bus adapter's
+    // pre-existing receiveEnabled handling there is out of scope for #197.
+    const explicitSendOnly = baseSettings({
+      telegram: {
+        token: "123:abc",
+        allowedUserIds: [],
+        listenChats: [],
+        receiveEnabled: false,
+        dmIsolation: "shared",
+        busRouting: { chats: { "100": "triage" } },
+      } as Settings["telegram"],
+    });
+    expect(configuredBusAdapterNames(explicitSendOnly, "default")).toContain("telegram");
   });
 });
 

--- a/src/bus/adapter-wiring.ts
+++ b/src/bus/adapter-wiring.ts
@@ -130,7 +130,10 @@ export function configuredBusAdapterNames(
   if (settings.discord?.token && settings.discord?.busRouting) names.push("discord");
   // Telegram mounts on a token alone when a default agent exists: an absent
   // busRouting derives `{ chats: {}, defaultAgentId }` in mountTelegram (#197).
-  if (settings.telegram?.token && (settings.telegram?.busRouting || defaultAgentId))
+  // The token-only derive is skipped for send-only configs (receiveEnabled:
+  // false) — see mountTelegram — so the banner must not claim telegram there.
+  const tgDerives = !!defaultAgentId && settings.telegram?.receiveEnabled !== false;
+  if (settings.telegram?.token && (settings.telegram?.busRouting || tgDerives))
     names.push("telegram");
   if (settings.slack?.botToken && settings.slack?.busRouting) names.push("slack");
   if (settings.web?.bus) names.push("webui");
@@ -199,6 +202,19 @@ async function mountTelegram(
   let routing = cfg.busRouting;
   if (!routing) {
     if (!defaultAgentId) return null;
+    // Respect send-only configs (Codex P2 on #197). TelegramAdapter.start()
+    // unconditionally begins polling for inbound, so deriving a token-only
+    // mount when `receiveEnabled: false` would start consuming messages a
+    // send-only operator explicitly opted out of. The legacy path gates
+    // polling on receiveEnabled (start.ts initTelegram); mirror that here by
+    // not auto-mounting. (Explicit busRouting is left as-is — the bus
+    // adapter's pre-existing receiveEnabled handling is out of scope for #197.)
+    if (cfg.receiveEnabled === false) {
+      logger.info(
+        "[bus-adapters] telegram: token set but receiveEnabled=false and no busRouting — not mounting (send-only).",
+      );
+      return null;
+    }
     routing = { chats: {}, defaultAgentId };
     // Surface the derive. When allowedUserIds is empty the adapter accepts
     // inbound from ANY Telegram user (empty allow-list = allow-all, a

--- a/src/bus/adapter-wiring.ts
+++ b/src/bus/adapter-wiring.ts
@@ -8,7 +8,11 @@
  * instantiate every external adapter (Discord / Telegram / Slack /
  * Web UI) whose token AND routing config are both present. Adapters
  * with missing config are silently skipped — operators opt in to
- * specific surfaces by populating both halves.
+ * specific surfaces by populating both halves. Exception (#197):
+ * Telegram mounts on a token alone when a default agent exists — its
+ * `busRouting` is derived (`{ chats: {}, defaultAgentId }`) so a fresh
+ * install (token but no routing block) isn't left silent. Discord/Slack
+ * are channel-routed and keep the both-halves requirement.
  *
  * What this module is NOT:
  *   - Not responsible for `BusCore` / `SessionManager` lifecycle (that's
@@ -52,7 +56,11 @@ export interface WireBusAdaptersResult {
 export interface WireBusAdaptersOptions {
   /** The live BusCore — adapters subscribe and publish through this. */
   bus: BusCore;
-  /** Parsed settings. Adapters only mount when token + busRouting are both present. */
+  /**
+   * Parsed settings. Adapters mount when their token + routing config are both
+   * present — except Telegram, which mounts on a token alone when
+   * `defaultAgentId` is set (busRouting derived; see #197 and the field below).
+   */
   settings: Pick<Settings, "discord" | "telegram" | "slack" | "web">;
   /**
    * The bus's default agent id (first spawned agent). When set, the Telegram
@@ -192,9 +200,19 @@ async function mountTelegram(
   if (!routing) {
     if (!defaultAgentId) return null;
     routing = { chats: {}, defaultAgentId };
-    logger.info(
-      `[bus-adapters] telegram: no busRouting configured; routing all inbound chats to default agent "${defaultAgentId}"`,
-    );
+    // Surface the derive. When allowedUserIds is empty the adapter accepts
+    // inbound from ANY Telegram user (empty allow-list = allow-all, a
+    // pre-existing policy — see adapters/telegram allow-list gate), so a
+    // token-only mount is open by default; warn so the operator can lock it down.
+    if (cfg.allowedUserIds.length === 0) {
+      logger.warn(
+        `[bus-adapters] telegram: no busRouting configured — routing all inbound chats to default agent "${defaultAgentId}". telegram.allowedUserIds is empty, so ANY Telegram user can reach it; set telegram.allowedUserIds to restrict access.`,
+      );
+    } else {
+      logger.info(
+        `[bus-adapters] telegram: no busRouting configured; routing all inbound chats to default agent "${defaultAgentId}"`,
+      );
+    }
   }
   const { TelegramAdapter } = await import("../adapters/telegram");
   const adapter = new TelegramAdapter({

--- a/src/bus/adapter-wiring.ts
+++ b/src/bus/adapter-wiring.ts
@@ -54,6 +54,15 @@ export interface WireBusAdaptersOptions {
   bus: BusCore;
   /** Parsed settings. Adapters only mount when token + busRouting are both present. */
   settings: Pick<Settings, "discord" | "telegram" | "slack" | "web">;
+  /**
+   * The bus's default agent id (first spawned agent). When set, the Telegram
+   * adapter can mount on a token alone — `telegram.busRouting` absent derives
+   * `{ chats: {}, defaultAgentId }` so a fresh install (token but no routing
+   * block) still routes inbound to the default agent (#197). Discord/Slack are
+   * channel-routed and unaffected. Omit (or no agent) ⇒ token-only Telegram
+   * still skips, since there is nothing to route to.
+   */
+  defaultAgentId?: string;
   /** Logger override. Defaults to `console`. */
   logger?: Pick<Console, "warn" | "info" | "error">;
 }
@@ -88,7 +97,9 @@ export async function wireBusAdapters(
   };
 
   await tryMount("discord", () => mountDiscord(opts.bus, opts.settings.discord, logger));
-  await tryMount("telegram", () => mountTelegram(opts.bus, opts.settings.telegram, logger));
+  await tryMount("telegram", () =>
+    mountTelegram(opts.bus, opts.settings.telegram, logger, opts.defaultAgentId),
+  );
   await tryMount("slack", () => mountSlack(opts.bus, opts.settings.slack, logger));
   await tryMount("webui", () => mountWebUi(opts.bus, opts.settings.web, logger));
 
@@ -105,10 +116,14 @@ export async function wireBusAdapters(
  */
 export function configuredBusAdapterNames(
   settings: WireBusAdaptersOptions["settings"],
+  defaultAgentId?: string,
 ): MountedAdapter["name"][] {
   const names: MountedAdapter["name"][] = [];
   if (settings.discord?.token && settings.discord?.busRouting) names.push("discord");
-  if (settings.telegram?.token && settings.telegram?.busRouting) names.push("telegram");
+  // Telegram mounts on a token alone when a default agent exists: an absent
+  // busRouting derives `{ chats: {}, defaultAgentId }` in mountTelegram (#197).
+  if (settings.telegram?.token && (settings.telegram?.busRouting || defaultAgentId))
+    names.push("telegram");
   if (settings.slack?.botToken && settings.slack?.busRouting) names.push("slack");
   if (settings.web?.bus) names.push("webui");
   return names;
@@ -164,14 +179,29 @@ async function mountTelegram(
   bus: BusCore,
   cfg: TelegramConfig,
   logger: Pick<Console, "warn" | "info" | "error">,
+  defaultAgentId?: string,
 ): Promise<MountedAdapter | null> {
-  if (!cfg.token || !cfg.busRouting) return null;
+  if (!cfg.token) return null;
+  // #197: a fresh install sets `telegram.token` but never writes `busRouting`,
+  // which previously left the adapter unmounted ("no adapters") and the bot
+  // silent. When busRouting is absent, derive `{ chats: {}, defaultAgentId }`:
+  // an empty chats map routes every inbound chat to the default agent via
+  // TelegramAdapter.resolveAgent's fall-through. Explicit busRouting wins. With
+  // no default agent to route to, still skip — nothing would consume.
+  let routing = cfg.busRouting;
+  if (!routing) {
+    if (!defaultAgentId) return null;
+    routing = { chats: {}, defaultAgentId };
+    logger.info(
+      `[bus-adapters] telegram: no busRouting configured; routing all inbound chats to default agent "${defaultAgentId}"`,
+    );
+  }
   const { TelegramAdapter } = await import("../adapters/telegram");
   const adapter = new TelegramAdapter({
     bus,
     token: cfg.token,
     allowedUserIds: cfg.allowedUserIds,
-    routing: cfg.busRouting,
+    routing,
     logger,
   });
   await adapter.start();

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -566,8 +566,13 @@ export async function start(args: string[] = []) {
   // empty at the startup-banner + legacy-skip logs above this point. Use
   // the configured-intent list (same token/busRouting predicates
   // wireBusAdapters uses) so those logs report the right platforms.
+  // #197: pass the declared default agent id so the banner reflects the
+  // token-only Telegram mount (busRouting derived from the default agent).
   const configuredBusAdapters: readonly string[] = busRuntimeHandle
-    ? (await import("../bus/adapter-wiring")).configuredBusAdapterNames(settings)
+    ? (await import("../bus/adapter-wiring")).configuredBusAdapterNames(
+        settings,
+        settings.agents[0]?.id,
+      )
     : [];
 
   let mcpProxyStarted: Promise<void> = Promise.resolve();
@@ -893,6 +898,9 @@ export async function start(args: string[] = []) {
       const { adapters, errors } = await wireBusAdapters({
         bus: busRuntimeHandle.bus,
         settings: currentSettings,
+        // #197: lets the Telegram adapter mount on a token alone by routing to
+        // the bus's default agent when `telegram.busRouting` is unset.
+        defaultAgentId: busRuntimeHandle.spawnedAgentIds[0],
       });
       for (const [name, msg] of Object.entries(errors)) {
         console.warn(`[${ts()}] Bus adapter "${name}" failed to mount: ${msg}`);


### PR DESCRIPTION
Fixes #197 — the final cause of the 3-cause fresh-install breakage (#193). With #195 (dialog) and #196/#199 (default agent) merged, this closes the loop so a fresh install actually answers on Telegram.

## Problem
The bus Telegram adapter required **both** `telegram.token` and `telegram.busRouting`. A fresh install sets the token (wizard/env) but never writes `busRouting`, so `mountTelegram` returned `null`, the startup banner read `no adapters`, and the bot was silent despite a valid token. (Field trace: moazbuilds/claudeclaw#216, @GordonWu.)

## Fix
When `telegram.token` is present but `busRouting` is absent, derive `{ chats: {}, defaultAgentId }` from the bus's default agent (first spawned agent — guaranteed present after #196). An empty `chats` map routes every inbound chat to the default agent via `TelegramAdapter.resolveAgent`'s fall-through (`routingChats[chatId] ?? defaultAgentId`); replies go back to the originating chat. Explicit `busRouting` still wins. With **no** default agent to route to (operator cleared `settings.agents`), the adapter still skips — nothing would consume.

Plumbing: `WireBusAdaptersOptions` gains `defaultAgentId?`; `start.ts` passes `busRuntimeHandle.spawnedAgentIds[0]` at wiring (deferred-spawn ordering means it's populated then) and `settings.agents[0]?.id` to `configuredBusAdapterNames` so the pre-spawn banner reflects the mount.

## Scope
**Telegram only** (cause #2). Discord and Slack are channel-routed (a `channel→agent` map is required; there's no single default chat), so their `token && busRouting` guards are unchanged — a default-agent degrade there is a separate design.

## Security note
A token-only mount inherits the **pre-existing** empty-`allowedUserIds` = allow-all policy, so it's open to any Telegram user by default (same as any mounted Telegram adapter today — this change only affects *whether* it mounts, not the allow-list semantics). The derive now logs a **warn** with a lock-it-down hint when `allowedUserIds` is empty.

## Dependency
Relies on #196/#199 (a `default` agent is declared on fresh install) so `spawnedAgentIds[0]` is non-null. Without an agent, `mountTelegram` correctly returns `null`.

## Tests
`configuredBusAdapterNames` predicate matrix (token+defaultAgentId → mounts; token alone without an agent → skips; explicit busRouting → mounts regardless; no token → skips) + `wireBusAdapters` skip-path cases. Positive mount is covered by the adapter's own suite / integration (the gating tests deliberately avoid network). SPEC at `.planning/telegram-busrouting-default/SPEC.md`.

## Review
SPEC (Stage 1) + 5-agent review (clean bug scan, parity verified, history-consistent) — findings addressed in-branch (de-staled the "both halves" docs; escalated the open-mount log to warn). Security review: no CRITICAL/HIGH.

## Out of scope
Discord/Slack token-only degrade; wizard writing an explicit busRouting block; cron/heartbeat→Telegram outbound chat selection with empty `chats` (inbound-reply works; same limitation as any chat-less routing today).