### PR TITLE
feat(plugins): LLM router MCP plugin — multi-provider routing (#70 Phase B)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.126",
+      "version": "2.2.127",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.127",
+      "version": "2.2.128",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.128",
+      "version": "2.2.129",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.126",
+  "version": "2.2.127",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.128",
+  "version": "2.2.129",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.127",
+  "version": "2.2.128",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.planning/llm-router/SPEC-DELTA-2026-05-29.md
+++ b/.planning/llm-router/SPEC-DELTA-2026-05-29.md
@@ -1,0 +1,64 @@
+# SPEC-DELTA — LLM router Phase B scope (#70)
+
+**Date:** 2026-05-29. Amends `.planning/llm-router/SPEC.md` (Phase A, merged in #202).
+**Driver:** Stage-3 review with Terrence. Model selection is the operator's choice,
+not a baked-in opinion; the catalogue should be discoverable.
+
+## Changes to the frozen design
+
+### D1 — Tiers are operator-configured; no hardcoded model defaults
+`DEFAULT_SETTINGS.llmRouter.tiers` ships **empty**. The router does not bundle an
+opinion about which model is "fast"/"balanced"/"reasoning". An `llm_call({ tier })`
+against an unconfigured tier returns a clear, actionable error
+("tier 'fast' has no models configured — search with `llm_models` and add ids to
+settings.llmRouter.tiers.fast"), never a silent default.
+
+Supersedes Phase A §3's "Tier → model resolution from a new `settings.llmRouter`
+section" only in that the section starts empty — the resolution mechanism is
+unchanged.
+
+### D2 — Per-call `model` override (full catalogue, immediately)
+`llm_call` accepts an optional `model` (any OpenRouter model id, e.g.
+`"anthropic/claude-opus"`). When present it bypasses tier resolution entirely and
+calls that model directly. This is the "full selection" path — it works before any
+tier is configured. `tier` and `model` are mutually exclusive; if both are given,
+`model` wins and a note is added to the result.
+
+### D3 — New discovery tool: `llm_models`
+A second MCP tool on the same plugin proxies OpenRouter's `GET /api/v1/models`
+catalogue (cached ~1h in-process), making the full selection **searchable**:
+
+```
+llm_models({ query?: string, maxPromptPrice?: number, minContext?: number, limit?: number })
+  -> { models: Array<{ id, name, context_length, pricing: { prompt, completion } }>, cachedAt }
+```
+
+`query` is a case-insensitive substring/fuzzy match over `id` + `name`; the price /
+context filters are optional. Agents (and, later, the dashboard) search the
+catalogue, then either populate `settings.llmRouter.tiers` or pass a per-call
+`model`.
+
+### D4 — Audit via own-process bridge
+The standalone stdio server is its own process and cannot share the in-process
+`mcp-bridge` singleton. It instantiates its own `getMcpBridge()` which appends to
+the shared `~/.config/plus/plugin-audit.jsonl`. Events: `llm_call_dispatched`,
+`llm_call_failed`, `llm_call_fallback_taken`, `llm_models_listed` (caller, tier,
+provider, model, latency, token usage). Confirmed acceptable (Terrence, 2026-05-29).
+
+### D5 — `schema` → `response_format` best-effort (v1)
+When `llm_call({ schema })` is supplied, it's passed as an OpenRouter
+`response_format: { type: "json_schema", json_schema }`. If the chosen model doesn't
+support structured output, the call proceeds without it and the result carries a
+`schemaApplied: false` note. No client-side validation in v1. Confirmed (Terrence).
+
+## Deferred to Phase C (not this PR)
+- **Dashboard model picker** — a searchable model list in the web UI settings that
+  assigns models to tiers, calling the same catalogue proxy that backs `llm_models`.
+  Terrence chose "tool now, UI later": the `llm_models` tool is the substrate the UI
+  will reuse.
+
+## Unchanged from Phase A
+Standalone stdio MCP server hosted as a multiplexer shared server (no multiplexer
+changes); OpenRouter breadth (+ optional Ollama); keys from env/Doppler only
+(`OPENROUTER_API_KEY`); non-streaming v1; tier-ordered 429/5xx fallback; billing
+nuance.

--- a/.planning/llm-router/SPEC-DELTA-2026-05-29.md
+++ b/.planning/llm-router/SPEC-DELTA-2026-05-29.md
@@ -42,8 +42,16 @@ catalogue, then either populate `settings.llmRouter.tiers` or pass a per-call
 The standalone stdio server is its own process and cannot share the in-process
 `mcp-bridge` singleton. It instantiates its own `getMcpBridge()` which appends to
 the shared `~/.config/plus/plugin-audit.jsonl`. Events: `llm_call_dispatched`,
-`llm_call_failed`, `llm_call_fallback_taken`, `llm_models_listed` (caller, tier,
-provider, model, latency, token usage). Confirmed acceptable (Terrence, 2026-05-29).
+`llm_call_failed`, `llm_call_fallback_taken`, `llm_models_listed` — each carrying
+tier, provider, model, latency, and token usage. Confirmed acceptable (Terrence,
+2026-05-29).
+
+**`caller` attribution deferred.** The per-agent bearer identity that
+`synthesizeBusMcpConfig` injects is an HTTP-transport artifact; it does not reach
+the shared server over stdio without multiplexer plumbing, which Phase A froze
+out ("zero multiplexer changes"). So audit events omit `caller` for now.
+Per-caller cost attribution is the natural pairing with the cost-accounting
+milestone (#68) and will add the identity plumbing there.
 
 ### D5 — `schema` → `response_format` best-effort (v1)
 When `llm_call({ schema })` is supplied, it's passed as an OpenRouter

--- a/src/__tests__/runtime-config.test.ts
+++ b/src/__tests__/runtime-config.test.ts
@@ -289,6 +289,42 @@ describe("parseSettings — bus routing (Sprint 5.2b)", () => {
   });
 });
 
+describe("parseSettings — llmRouter (#70)", () => {
+  it("defaults to empty tiers + the OpenRouter base when absent", async () => {
+    await writeRawSettings({});
+    await reloadSettings();
+    expect(getSettings().llmRouter).toEqual({
+      tiers: { fast: [], balanced: [], reasoning: [] },
+      openRouterBaseUrl: "https://openrouter.ai/api/v1",
+    });
+  });
+
+  it("parses configured tier model lists + custom base + ollama", async () => {
+    await writeRawSettings({
+      llmRouter: {
+        tiers: { fast: ["groq/llama"], balanced: ["a/b", "c/d"], reasoning: ["anthropic/opus"] },
+        openRouterBaseUrl: "https://proxy.example/api/v1",
+        ollamaBaseUrl: "http://127.0.0.1:11434/v1",
+      },
+    });
+    await reloadSettings();
+    expect(getSettings().llmRouter).toEqual({
+      tiers: { fast: ["groq/llama"], balanced: ["a/b", "c/d"], reasoning: ["anthropic/opus"] },
+      openRouterBaseUrl: "https://proxy.example/api/v1",
+      ollamaBaseUrl: "http://127.0.0.1:11434/v1",
+    });
+  });
+
+  it("drops non-string / empty tier entries and trims", async () => {
+    await writeRawSettings({
+      llmRouter: { tiers: { fast: ["  groq/llama  ", "", 42, null], balanced: "nope" } },
+    });
+    await reloadSettings();
+    expect(getSettings().llmRouter.tiers.fast).toEqual(["groq/llama"]);
+    expect(getSettings().llmRouter.tiers.balanced).toEqual([]);
+  });
+});
+
 describe("parseSettings — sessionTimeoutMs default (#179)", () => {
   it("defaults DEFAULT_SESSION_TIMEOUT_MS to 120 minutes", () => {
     // 120 * 60 * 1000 = 7,200,000 ms

--- a/src/config.ts
+++ b/src/config.ts
@@ -230,6 +230,15 @@ const DEFAULT_SETTINGS: Settings = {
   agents: [{ id: "default" }],
   plugins: {},
   memorySearch: {},
+  // LLM router (#70). Tiers ship EMPTY — no opinionated model defaults; the
+  // operator searches the OpenRouter catalogue (llm_models tool) and assigns
+  // ids, or passes a per-call model. Only consulted by the llm-router MCP
+  // plugin when registered as a shared server. The secret OPENROUTER_API_KEY
+  // is env-only and never stored here.
+  llmRouter: {
+    tiers: { fast: [], balanced: [], reasoning: [] },
+    openRouterBaseUrl: "https://openrouter.ai/api/v1",
+  },
 };
 
 export interface HeartbeatExcludeWindow {
@@ -659,7 +668,23 @@ export interface Settings {
   plugins: Record<string, PluginEntry>;
   session: SessionConfig;
   memorySearch: MemorySearchSettings;
+  llmRouter: LlmRouterConfig;
   jobsDir?: string;
+}
+
+/**
+ * LLM router config (#70). Non-secret only — `OPENROUTER_API_KEY` is read from
+ * the environment by the llm-router plugin, never stored here. `tiers` maps each
+ * cost tier to an ordered list of OpenRouter model ids (fallback order). Empty
+ * by default: the operator chooses models via the `llm_models` search tool or a
+ * per-call `model`.
+ */
+export interface LlmRouterConfig {
+  tiers: { fast: string[]; balanced: string[]; reasoning: string[] };
+  /** OpenRouter API base. Default https://openrouter.ai/api/v1. */
+  openRouterBaseUrl: string;
+  /** Optional local Ollama OpenAI-compatible base (e.g. http://127.0.0.1:11434/v1). */
+  ollamaBaseUrl?: string;
 }
 
 export interface AgenticMode {
@@ -982,6 +1007,7 @@ function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Set
     watchdog: parseWatchdogConfig(raw.watchdog),
     plugins: parsePlugins(raw.plugins),
     memorySearch: parseMemorySearchSettings(raw.memorySearch),
+    llmRouter: parseLlmRouterConfig(raw.llmRouter),
     session: {
       autoRotate: raw.session?.autoRotate ?? false,
       maxMessages: Number.isFinite(raw.session?.maxMessages) ? Number(raw.session.maxMessages) : 50,
@@ -1131,6 +1157,44 @@ function parseBusAgents(raw: unknown): BusAgentSettings[] {
     out.push(parsed);
   }
   return out;
+}
+
+/**
+ * Parse `settings.llmRouter` (#70). Non-secret config only. Tier model lists
+ * default to empty (operator chooses via the llm_models tool); invalid entries
+ * are dropped with a warning rather than throwing. `OPENROUTER_API_KEY` is never
+ * read here — it's an env-only secret consumed by the llm-router plugin.
+ */
+function parseLlmRouterConfig(raw: unknown): LlmRouterConfig {
+  const defaults = DEFAULT_SETTINGS.llmRouter;
+  if (!raw || typeof raw !== "object") return defaults;
+  const r = raw as Record<string, unknown>;
+
+  const parseTier = (key: "fast" | "balanced" | "reasoning"): string[] => {
+    const tiers = r.tiers as Record<string, unknown> | undefined;
+    const list = tiers?.[key];
+    if (!Array.isArray(list)) return [];
+    return list
+      .filter((m): m is string => typeof m === "string" && m.trim().length > 0)
+      .map((m) => m.trim());
+  };
+
+  const baseUrl =
+    typeof r.openRouterBaseUrl === "string" && r.openRouterBaseUrl.trim().length > 0
+      ? r.openRouterBaseUrl.trim()
+      : defaults.openRouterBaseUrl;
+
+  return {
+    tiers: {
+      fast: parseTier("fast"),
+      balanced: parseTier("balanced"),
+      reasoning: parseTier("reasoning"),
+    },
+    openRouterBaseUrl: baseUrl,
+    ...(typeof r.ollamaBaseUrl === "string" && r.ollamaBaseUrl.trim().length > 0
+      ? { ollamaBaseUrl: r.ollamaBaseUrl.trim() }
+      : {}),
+  };
 }
 
 /**

--- a/src/plugins/llm-router/__tests__/catalogue.test.ts
+++ b/src/plugins/llm-router/__tests__/catalogue.test.ts
@@ -1,0 +1,98 @@
+/**
+ * Catalogue search/filter + cache tests (#70).
+ */
+import { describe, it, expect } from "bun:test";
+import { filterModels, ModelCatalogue } from "../catalogue";
+import type { OpenRouterModel } from "../types";
+
+const MODELS: OpenRouterModel[] = [
+  {
+    id: "anthropic/claude-opus",
+    name: "Claude Opus",
+    context_length: 200000,
+    pricing: { prompt: 0.000015, completion: 0.000075 },
+  },
+  {
+    id: "anthropic/claude-haiku",
+    name: "Claude Haiku",
+    context_length: 200000,
+    pricing: { prompt: 0.0000008, completion: 0.000004 },
+  },
+  {
+    id: "groq/llama-3",
+    name: "Llama 3",
+    context_length: 8192,
+    pricing: { prompt: 0.0000001, completion: 0.0000001 },
+  },
+  {
+    id: "deepseek/chat",
+    name: "DeepSeek Chat",
+    context_length: 64000,
+    pricing: { prompt: 0.0000002, completion: 0.0000002 },
+  },
+];
+
+describe("filterModels", () => {
+  it("substring-matches query over id + name (case-insensitive)", () => {
+    const r = filterModels(MODELS, { query: "claude" });
+    expect(r.map((m) => m.id).sort()).toEqual(["anthropic/claude-haiku", "anthropic/claude-opus"]);
+  });
+
+  it("sorts by ascending prompt price (cheapest first)", () => {
+    const r = filterModels(MODELS, {});
+    expect(r[0].id).toBe("groq/llama-3");
+    expect(r[r.length - 1].id).toBe("anthropic/claude-opus");
+  });
+
+  it("applies maxPromptPrice", () => {
+    const r = filterModels(MODELS, { maxPromptPrice: 0.0000005 });
+    expect(r.map((m) => m.id).sort()).toEqual(["deepseek/chat", "groq/llama-3"]);
+  });
+
+  it("applies minContext", () => {
+    const r = filterModels(MODELS, { minContext: 100000 });
+    expect(r.every((m) => m.context_length >= 100000)).toBe(true);
+    expect(r).toHaveLength(2);
+  });
+
+  it("caps to limit", () => {
+    expect(filterModels(MODELS, { limit: 2 })).toHaveLength(2);
+  });
+});
+
+describe("ModelCatalogue cache", () => {
+  it("fetches once and serves subsequent searches from cache within TTL", async () => {
+    let fetchCount = 0;
+    const fetchImpl = (async () =>
+      new Response(
+        JSON.stringify({
+          data: MODELS.map((m) => ({
+            ...m,
+            pricing: { prompt: String(m.pricing.prompt), completion: String(m.pricing.completion) },
+          })),
+        }),
+        {
+          status: 200,
+        },
+      )) as unknown as typeof fetch;
+    const reqCounter = (async (...args: Parameters<typeof fetch>) => {
+      fetchCount++;
+      return fetchImpl(...args);
+    }) as unknown as typeof fetch;
+
+    let clock = 1000;
+    const cat = new ModelCatalogue(
+      { apiKey: "k", baseUrl: "https://x/api/v1", fetchImpl: reqCounter },
+      10_000,
+      () => clock,
+    );
+
+    await cat.search({ query: "claude" });
+    await cat.search({ query: "groq" });
+    expect(fetchCount).toBe(1); // second search hit the cache
+
+    clock += 20_000; // past TTL
+    await cat.search({});
+    expect(fetchCount).toBe(2); // refreshed
+  });
+});

--- a/src/plugins/llm-router/__tests__/openrouter.test.ts
+++ b/src/plugins/llm-router/__tests__/openrouter.test.ts
@@ -1,0 +1,130 @@
+/**
+ * OpenRouter client tests (#70) — mocked fetch, no network.
+ */
+import { describe, it, expect } from "bun:test";
+import { chatCompletion, listModels, type OpenRouterDeps } from "../openrouter";
+import { ProviderError } from "../types";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const deps = (fetchImpl: typeof fetch): OpenRouterDeps => ({
+  apiKey: "test-key",
+  baseUrl: "https://openrouter.test/api/v1",
+  fetchImpl,
+});
+
+describe("chatCompletion", () => {
+  it("posts to /chat/completions and maps the response", async () => {
+    let captured: { url: string; init: RequestInit } | null = null;
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+      captured = { url, init };
+      return jsonResponse({
+        model: "a/b",
+        choices: [{ message: { content: "hello" } }],
+        usage: { prompt_tokens: 5, completion_tokens: 7, total_tokens: 12 },
+      });
+    }) as unknown as typeof fetch;
+
+    const r = await chatCompletion(
+      "a/b",
+      { messages: [{ role: "user", content: "hi" }] },
+      deps(fetchImpl),
+    );
+    expect(r.content).toBe("hello");
+    expect(r.model).toBe("a/b");
+    expect(r.usage).toEqual({ promptTokens: 5, completionTokens: 7, totalTokens: 12 });
+    expect(captured!.url).toBe("https://openrouter.test/api/v1/chat/completions");
+    expect((captured!.init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer test-key",
+    );
+  });
+
+  it("sends response_format when a schema is supplied", async () => {
+    let bodyStr = "";
+    const fetchImpl = (async (_url: string, init: RequestInit) => {
+      bodyStr = init.body as string;
+      return jsonResponse({ model: "a/b", choices: [{ message: { content: "{}" } }] });
+    }) as unknown as typeof fetch;
+    const r = await chatCompletion(
+      "a/b",
+      { messages: [{ role: "user", content: "hi" }], schema: { type: "object" } },
+      deps(fetchImpl),
+    );
+    expect(bodyStr).toContain("response_format");
+    expect(bodyStr).toContain("json_schema");
+    expect(r.schemaApplied).toBe(true);
+  });
+
+  it("throws a retriable ProviderError on 429", async () => {
+    const fetchImpl = (async () =>
+      jsonResponse({ error: "slow down" }, 429)) as unknown as typeof fetch;
+    try {
+      await chatCompletion("a/b", { messages: [{ role: "user", content: "hi" }] }, deps(fetchImpl));
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProviderError);
+      expect((err as ProviderError).status).toBe(429);
+      expect((err as ProviderError).retriable).toBe(true);
+    }
+  });
+
+  it("throws a non-retriable ProviderError on 400", async () => {
+    const fetchImpl = (async () => jsonResponse({ error: "bad" }, 400)) as unknown as typeof fetch;
+    try {
+      await chatCompletion("a/b", { messages: [{ role: "user", content: "hi" }] }, deps(fetchImpl));
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProviderError);
+      expect((err as ProviderError).retriable).toBe(false);
+    }
+  });
+
+  it("maps a network throw to a retriable 503 ProviderError", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    try {
+      await chatCompletion("a/b", { messages: [{ role: "user", content: "hi" }] }, deps(fetchImpl));
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProviderError);
+      expect((err as ProviderError).status).toBe(503);
+      expect((err as ProviderError).retriable).toBe(true);
+    }
+  });
+});
+
+describe("listModels", () => {
+  it("maps string pricing to numbers and skips entries without ids", async () => {
+    const fetchImpl = (async () =>
+      jsonResponse({
+        data: [
+          {
+            id: "a/b",
+            name: "A B",
+            context_length: 8000,
+            pricing: { prompt: "0.0000015", completion: "0.000006" },
+          },
+          { name: "no id — skipped", pricing: { prompt: "0", completion: "0" } },
+        ],
+      })) as unknown as typeof fetch;
+    const models = await listModels(deps(fetchImpl));
+    expect(models).toHaveLength(1);
+    expect(models[0]).toEqual({
+      id: "a/b",
+      name: "A B",
+      context_length: 8000,
+      pricing: { prompt: 0.0000015, completion: 0.000006 },
+    });
+  });
+
+  it("throws ProviderError on a non-2xx catalogue fetch", async () => {
+    const fetchImpl = (async () => jsonResponse({ error: "nope" }, 500)) as unknown as typeof fetch;
+    await expect(listModels(deps(fetchImpl))).rejects.toBeInstanceOf(ProviderError);
+  });
+});

--- a/src/plugins/llm-router/__tests__/openrouter.test.ts
+++ b/src/plugins/llm-router/__tests__/openrouter.test.ts
@@ -76,6 +76,36 @@ describe("chatCompletion", () => {
     expect(body.provider).toEqual({ order: ["groq"] });
   });
 
+  it("degrades when structured output is rejected: retries without schema, reports schemaApplied false (D5)", async () => {
+    const calls: boolean[] = []; // whether each attempt included response_format
+    const fetchImpl = (async (_url: string, init: RequestInit) => {
+      const hadSchema = (init.body as string).includes("response_format");
+      calls.push(hadSchema);
+      if (hadSchema) return jsonResponse({ error: "structured output unsupported" }, 400);
+      return jsonResponse({ model: "a/b", choices: [{ message: { content: "plain" } }] });
+    }) as unknown as typeof fetch;
+    const r = await chatCompletion(
+      "a/b",
+      { messages: [{ role: "user", content: "hi" }], schema: { type: "object" } },
+      deps(fetchImpl),
+    );
+    expect(r.content).toBe("plain");
+    expect(r.schemaApplied).toBe(false);
+    expect(calls).toEqual([true, false]); // tried with schema, then retried without
+  });
+
+  it("does NOT retry a 400 when no schema was requested (genuine bad request)", async () => {
+    let calls = 0;
+    const fetchImpl = (async () => {
+      calls++;
+      return jsonResponse({ error: "bad" }, 400);
+    }) as unknown as typeof fetch;
+    await expect(
+      chatCompletion("a/b", { messages: [{ role: "user", content: "hi" }] }, deps(fetchImpl)),
+    ).rejects.toBeInstanceOf(ProviderError);
+    expect(calls).toBe(1);
+  });
+
   it("throws a retriable ProviderError on 429", async () => {
     const fetchImpl = (async () =>
       jsonResponse({ error: "slow down" }, 429)) as unknown as typeof fetch;

--- a/src/plugins/llm-router/__tests__/openrouter.test.ts
+++ b/src/plugins/llm-router/__tests__/openrouter.test.ts
@@ -60,6 +60,22 @@ describe("chatCompletion", () => {
     expect(r.schemaApplied).toBe(true);
   });
 
+  it("serializes maxTokens and providerHint into the request body", async () => {
+    let bodyStr = "";
+    const fetchImpl = (async (_url: string, init: RequestInit) => {
+      bodyStr = init.body as string;
+      return jsonResponse({ model: "a/b", choices: [{ message: { content: "ok" } }] });
+    }) as unknown as typeof fetch;
+    await chatCompletion(
+      "a/b",
+      { messages: [{ role: "user", content: "hi" }], maxTokens: 256, providerHint: "groq" },
+      deps(fetchImpl),
+    );
+    const body = JSON.parse(bodyStr);
+    expect(body.max_tokens).toBe(256);
+    expect(body.provider).toEqual({ order: ["groq"] });
+  });
+
   it("throws a retriable ProviderError on 429", async () => {
     const fetchImpl = (async () =>
       jsonResponse({ error: "slow down" }, 429)) as unknown as typeof fetch;
@@ -126,5 +142,19 @@ describe("listModels", () => {
   it("throws ProviderError on a non-2xx catalogue fetch", async () => {
     const fetchImpl = (async () => jsonResponse({ error: "nope" }, 500)) as unknown as typeof fetch;
     await expect(listModels(deps(fetchImpl))).rejects.toBeInstanceOf(ProviderError);
+  });
+
+  it("maps a network throw to a retriable 503 ProviderError", async () => {
+    const fetchImpl = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    try {
+      await listModels(deps(fetchImpl));
+      throw new Error("should have thrown");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ProviderError);
+      expect((err as ProviderError).status).toBe(503);
+      expect((err as ProviderError).retriable).toBe(true);
+    }
   });
 });

--- a/src/plugins/llm-router/__tests__/router.test.ts
+++ b/src/plugins/llm-router/__tests__/router.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Tier resolution + fallback tests for the LLM router (#70).
+ */
+import { describe, it, expect } from "bun:test";
+import { callLlm, resolveModels, providerOf, type Dispatch } from "../router";
+import { ProviderError, type LlmRouterRuntimeConfig } from "../types";
+
+const cfg = (over: Partial<LlmRouterRuntimeConfig> = {}): LlmRouterRuntimeConfig => ({
+  tiers: { fast: ["groq/llama"], balanced: ["a/b", "c/d"], reasoning: [] },
+  openRouterBaseUrl: "https://openrouter.ai/api/v1",
+  ...over,
+});
+
+const okResp = (model: string) => ({
+  content: "hi",
+  model,
+  usage: { promptTokens: 1, completionTokens: 2, totalTokens: 3 },
+  schemaApplied: false,
+});
+
+describe("resolveModels", () => {
+  it("returns the explicit model when provided (bypasses tiers)", () => {
+    expect(resolveModels({ model: "x/y", messages: [] }, cfg())).toEqual(["x/y"]);
+  });
+
+  it("returns the tier's ordered list", () => {
+    expect(resolveModels({ tier: "balanced", messages: [] }, cfg())).toEqual(["a/b", "c/d"]);
+  });
+
+  it("throws an actionable error for an empty tier", () => {
+    expect(() => resolveModels({ tier: "reasoning", messages: [] }, cfg())).toThrow(
+      /no models configured/,
+    );
+  });
+
+  it("throws when neither tier nor model is given", () => {
+    expect(() => resolveModels({ messages: [] }, cfg())).toThrow(/requires either/);
+  });
+});
+
+describe("providerOf", () => {
+  it("takes the id prefix before the slash", () => {
+    expect(providerOf("anthropic/claude-opus")).toBe("anthropic");
+    expect(providerOf("bare-model")).toBe("bare-model");
+  });
+});
+
+describe("callLlm fallback", () => {
+  it("returns the first model that succeeds", async () => {
+    const dispatch: Dispatch = async (model) => okResp(model);
+    const r = await callLlm({ tier: "balanced", messages: [] }, cfg(), dispatch);
+    expect(r.model).toBe("a/b");
+    expect(r.provider).toBe("a");
+    expect(r.fallbackFrom).toBeUndefined();
+  });
+
+  it("falls over to the next model on a retriable (429) error and records the trail", async () => {
+    const dispatch: Dispatch = async (model) => {
+      if (model === "a/b") throw new ProviderError("rate limited", 429, model);
+      return okResp(model);
+    };
+    const r = await callLlm({ tier: "balanced", messages: [] }, cfg(), dispatch);
+    expect(r.model).toBe("c/d");
+    expect(r.fallbackFrom).toEqual(["a/b"]);
+  });
+
+  it("aborts immediately on a non-retriable (400) error", async () => {
+    let calls = 0;
+    const dispatch: Dispatch = async (model) => {
+      calls++;
+      throw new ProviderError("bad request", 400, model);
+    };
+    await expect(callLlm({ tier: "balanced", messages: [] }, cfg(), dispatch)).rejects.toThrow(
+      /bad request/,
+    );
+    expect(calls).toBe(1); // did NOT try the second model
+  });
+
+  it("throws an aggregate error when all candidates fail retriably", async () => {
+    const dispatch: Dispatch = async (model) => {
+      throw new ProviderError("server error", 503, model);
+    };
+    await expect(callLlm({ tier: "balanced", messages: [] }, cfg(), dispatch)).rejects.toThrow(
+      /all 2 candidate model\(s\) failed/,
+    );
+  });
+
+  it("propagates schemaApplied only when a schema was requested", async () => {
+    const dispatch: Dispatch = async (model) => ({ ...okResp(model), schemaApplied: true });
+    const withSchema = await callLlm(
+      { model: "x/y", messages: [], schema: { type: "object" } },
+      cfg(),
+      dispatch,
+    );
+    expect(withSchema.schemaApplied).toBe(true);
+    const noSchema = await callLlm({ model: "x/y", messages: [] }, cfg(), dispatch);
+    expect(noSchema.schemaApplied).toBeUndefined();
+  });
+});

--- a/src/plugins/llm-router/__tests__/router.test.ts
+++ b/src/plugins/llm-router/__tests__/router.test.ts
@@ -27,6 +27,10 @@ describe("resolveModels", () => {
     expect(resolveModels({ tier: "balanced", messages: [] }, cfg())).toEqual(["a/b", "c/d"]);
   });
 
+  it("prefers an explicit model over a tier when both are given (D2)", () => {
+    expect(resolveModels({ model: "x/y", tier: "balanced", messages: [] }, cfg())).toEqual(["x/y"]);
+  });
+
   it("throws an actionable error for an empty tier", () => {
     expect(() => resolveModels({ tier: "reasoning", messages: [] }, cfg())).toThrow(
       /no models configured/,
@@ -62,6 +66,20 @@ describe("callLlm fallback", () => {
     const r = await callLlm({ tier: "balanced", messages: [] }, cfg(), dispatch);
     expect(r.model).toBe("c/d");
     expect(r.fallbackFrom).toEqual(["a/b"]);
+  });
+
+  it("accumulates the fallback trail across multiple hops in a 3-model tier", async () => {
+    const dispatch: Dispatch = async (model) => {
+      if (model === "m1" || model === "m2") throw new ProviderError("429", 429, model);
+      return okResp(model);
+    };
+    const r = await callLlm(
+      { tier: "reasoning", messages: [] },
+      cfg({ tiers: { fast: [], balanced: [], reasoning: ["m1", "m2", "m3"] } }),
+      dispatch,
+    );
+    expect(r.model).toBe("m3");
+    expect(r.fallbackFrom).toEqual(["m1", "m2"]);
   });
 
   it("aborts immediately on a non-retriable (400) error", async () => {

--- a/src/plugins/llm-router/__tests__/server.test.ts
+++ b/src/plugins/llm-router/__tests__/server.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Server handler tests (#70) — exercise createLlmRouterHandlers without stdio,
+ * using an injected fetch that routes by URL.
+ */
+import { describe, it, expect } from "bun:test";
+import { buildRuntimeConfig, createLlmRouterHandlers } from "../server";
+import type { LlmRouterRuntimeConfig } from "../types";
+
+const config = (over: Partial<LlmRouterRuntimeConfig> = {}): LlmRouterRuntimeConfig => ({
+  tiers: { fast: ["groq/llama"], balanced: [], reasoning: [] },
+  openRouterBaseUrl: "https://or.test/api/v1",
+  ...over,
+});
+
+function routingFetch(): typeof fetch {
+  return (async (url: string) => {
+    if (url.endsWith("/chat/completions")) {
+      return new Response(
+        JSON.stringify({
+          model: "groq/llama",
+          choices: [{ message: { content: "answer" } }],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200 },
+      );
+    }
+    if (url.endsWith("/models")) {
+      return new Response(
+        JSON.stringify({
+          data: [
+            {
+              id: "groq/llama",
+              name: "Llama",
+              context_length: 8192,
+              pricing: { prompt: "0", completion: "0" },
+            },
+          ],
+        }),
+        { status: 200 },
+      );
+    }
+    return new Response("not found", { status: 404 });
+  }) as unknown as typeof fetch;
+}
+
+describe("buildRuntimeConfig", () => {
+  it("defaults empty tiers + the OpenRouter base when llmRouter is absent", () => {
+    const c = buildRuntimeConfig({});
+    expect(c.tiers).toEqual({ fast: [], balanced: [], reasoning: [] });
+    expect(c.openRouterBaseUrl).toBe("https://openrouter.ai/api/v1");
+  });
+});
+
+describe("createLlmRouterHandlers.llmCall", () => {
+  it("dispatches via tier and audits the call", async () => {
+    const events: string[] = [];
+    const h = createLlmRouterHandlers({
+      config: config(),
+      apiKey: "k",
+      fetchImpl: routingFetch(),
+      audit: (e) => events.push(e),
+    });
+    const r = (await h.llmCall({ tier: "fast", messages: [{ role: "user", content: "hi" }] })) as {
+      content: string;
+      provider: string;
+    };
+    expect(r.content).toBe("answer");
+    expect(r.provider).toBe("groq");
+    expect(events).toContain("llm_call_dispatched");
+  });
+
+  it("errors (and audits failure) for an unconfigured tier", async () => {
+    const events: string[] = [];
+    const h = createLlmRouterHandlers({
+      config: config(),
+      apiKey: "k",
+      fetchImpl: routingFetch(),
+      audit: (e) => events.push(e),
+    });
+    await expect(
+      h.llmCall({ tier: "balanced", messages: [{ role: "user", content: "hi" }] }),
+    ).rejects.toThrow(/no models configured/);
+    expect(events).toContain("llm_call_failed");
+  });
+
+  it("throws when OPENROUTER_API_KEY is missing", async () => {
+    const h = createLlmRouterHandlers({ config: config(), apiKey: "", fetchImpl: routingFetch() });
+    await expect(
+      h.llmCall({ tier: "fast", messages: [{ role: "user", content: "hi" }] }),
+    ).rejects.toThrow(/OPENROUTER_API_KEY/);
+  });
+
+  it("rejects a non-array messages payload", async () => {
+    const h = createLlmRouterHandlers({ config: config(), apiKey: "k", fetchImpl: routingFetch() });
+    await expect(h.llmCall({ tier: "fast", messages: "nope" })).rejects.toThrow(/non-empty array/);
+  });
+});
+
+describe("createLlmRouterHandlers.llmModels", () => {
+  it("searches the catalogue and audits", async () => {
+    const events: string[] = [];
+    const h = createLlmRouterHandlers({
+      config: config(),
+      apiKey: "k",
+      fetchImpl: routingFetch(),
+      audit: (e) => events.push(e),
+    });
+    const r = (await h.llmModels({ query: "llama" })) as { models: Array<{ id: string }> };
+    expect(r.models.map((m) => m.id)).toEqual(["groq/llama"]);
+    expect(events).toContain("llm_models_listed");
+  });
+});

--- a/src/plugins/llm-router/__tests__/server.test.ts
+++ b/src/plugins/llm-router/__tests__/server.test.ts
@@ -94,6 +94,49 @@ describe("createLlmRouterHandlers.llmCall", () => {
     const h = createLlmRouterHandlers({ config: config(), apiKey: "k", fetchImpl: routingFetch() });
     await expect(h.llmCall({ tier: "fast", messages: "nope" })).rejects.toThrow(/non-empty array/);
   });
+
+  it("uses an explicit model and ignores a bogus tier when both are given (D2)", async () => {
+    const h = createLlmRouterHandlers({ config: config(), apiKey: "k", fetchImpl: routingFetch() });
+    const r = (await h.llmCall({
+      model: "groq/llama",
+      tier: "not-a-tier",
+      messages: [{ role: "user", content: "hi" }],
+    })) as { content: string };
+    expect(r.content).toBe("answer");
+  });
+
+  it("emits llm_call_fallback_taken when the first tier model fails retriably", async () => {
+    const events: string[] = [];
+    // First model 429s, second succeeds — keyed off the model in the request body.
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+      if (url.endsWith("/chat/completions")) {
+        const model = JSON.parse(init.body as string).model;
+        if (model === "x/down")
+          return new Response(JSON.stringify({ error: "rate" }), { status: 429 });
+        return new Response(
+          JSON.stringify({
+            model,
+            choices: [{ message: { content: "ok" } }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const h = createLlmRouterHandlers({
+      config: config({ tiers: { fast: ["x/down", "x/up"], balanced: [], reasoning: [] } }),
+      apiKey: "k",
+      fetchImpl,
+      audit: (e) => events.push(e),
+    });
+    const r = (await h.llmCall({ tier: "fast", messages: [{ role: "user", content: "hi" }] })) as {
+      model: string;
+    };
+    expect(r.model).toBe("x/up");
+    expect(events).toContain("llm_call_fallback_taken");
+  });
 });
 
 describe("createLlmRouterHandlers.llmModels", () => {

--- a/src/plugins/llm-router/catalogue.ts
+++ b/src/plugins/llm-router/catalogue.ts
@@ -1,0 +1,70 @@
+/**
+ * OpenRouter model catalogue — cache + search backing the `llm_models` tool (#70,
+ * SPEC-DELTA D3). The catalogue rarely changes, so we cache the full list
+ * in-process and filter locally; searches never hit the network on a warm cache.
+ */
+
+import { listModels, type OpenRouterDeps } from "./openrouter.js";
+import type { LlmModelsParams, OpenRouterModel } from "./types.js";
+
+export const DEFAULT_CATALOGUE_TTL_MS = 60 * 60 * 1000; // 1h
+
+const DEFAULT_LIMIT = 50;
+
+/**
+ * Pure filter + sort over a catalogue snapshot. Exported for unit testing.
+ * Matches `query` (case-insensitive substring over id + name), applies the
+ * optional price/context bounds, sorts by ascending prompt price (cheapest
+ * first — the common "what's a cheap model for this tier" intent), and caps.
+ */
+export function filterModels(
+  models: readonly OpenRouterModel[],
+  params: LlmModelsParams = {},
+): OpenRouterModel[] {
+  const q = params.query?.trim().toLowerCase();
+  const limit = params.limit && params.limit > 0 ? params.limit : DEFAULT_LIMIT;
+
+  const matched = models.filter((m) => {
+    if (q && !`${m.id} ${m.name}`.toLowerCase().includes(q)) return false;
+    if (params.maxPromptPrice !== undefined && m.pricing.prompt > params.maxPromptPrice) {
+      return false;
+    }
+    if (params.minContext !== undefined && m.context_length < params.minContext) {
+      return false;
+    }
+    return true;
+  });
+
+  matched.sort((a, b) => a.pricing.prompt - b.pricing.prompt || a.id.localeCompare(b.id));
+  return matched.slice(0, limit);
+}
+
+/**
+ * Caching catalogue. `now` is injectable so tests control TTL expiry without
+ * touching the wall clock.
+ */
+export class ModelCatalogue {
+  private snapshot: OpenRouterModel[] | null = null;
+  private fetchedAt = 0;
+
+  constructor(
+    private readonly deps: OpenRouterDeps,
+    private readonly ttlMs: number = DEFAULT_CATALOGUE_TTL_MS,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  /** Cached models, refreshing if the snapshot is missing or stale. */
+  async getAll(): Promise<{ models: OpenRouterModel[]; cachedAt: number }> {
+    if (this.snapshot === null || this.now() - this.fetchedAt >= this.ttlMs) {
+      this.snapshot = await listModels(this.deps);
+      this.fetchedAt = this.now();
+    }
+    return { models: this.snapshot, cachedAt: this.fetchedAt };
+  }
+
+  /** Search the (cached) catalogue. */
+  async search(params: LlmModelsParams): Promise<{ models: OpenRouterModel[]; cachedAt: number }> {
+    const { models, cachedAt } = await this.getAll();
+    return { models: filterModels(models, params), cachedAt };
+  }
+}

--- a/src/plugins/llm-router/openrouter.ts
+++ b/src/plugins/llm-router/openrouter.ts
@@ -1,0 +1,162 @@
+/**
+ * OpenRouter HTTP client — the breadth layer for the LLM router (#70).
+ *
+ * OpenRouter is OpenAI-compatible:
+ *   - POST {base}/chat/completions  → chat completion
+ *   - GET  {base}/models            → full model catalogue
+ *
+ * `fetch` is injectable so tests run without network. The API key is passed in
+ * by the caller (sourced from `OPENROUTER_API_KEY` in the env), never read here.
+ */
+
+import { type ChatMessage, type OpenRouterModel, ProviderError } from "./types.js";
+
+export const DEFAULT_OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1";
+
+export interface OpenRouterDeps {
+  apiKey: string;
+  baseUrl: string;
+  /** Injectable for tests. Defaults to global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+export interface ChatCompletionOptions {
+  messages: ChatMessage[];
+  schema?: Record<string, unknown>;
+  maxTokens?: number;
+  providerHint?: string;
+}
+
+export interface ChatCompletionResponse {
+  content: string;
+  model: string;
+  usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+  /** Whether a requested `response_format` was sent (D5). */
+  schemaApplied: boolean;
+}
+
+/**
+ * One chat completion against a specific model. Throws `ProviderError` (carrying
+ * the HTTP status) on a non-2xx response so the router can decide to fall over.
+ */
+export async function chatCompletion(
+  model: string,
+  opts: ChatCompletionOptions,
+  deps: OpenRouterDeps,
+): Promise<ChatCompletionResponse> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const schemaApplied = !!opts.schema;
+
+  const body: Record<string, unknown> = { model, messages: opts.messages };
+  if (opts.maxTokens !== undefined) body.max_tokens = opts.maxTokens;
+  if (opts.providerHint) body.provider = { order: [opts.providerHint] };
+  if (opts.schema) {
+    body.response_format = {
+      type: "json_schema",
+      json_schema: { name: "result", schema: opts.schema },
+    };
+  }
+
+  let res: Response;
+  try {
+    res = await fetchImpl(`${deps.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${deps.apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    // Network-level failure (DNS, connection) — treat as retriable (5xx-like).
+    throw new ProviderError(
+      `network error calling ${model}: ${err instanceof Error ? err.message : String(err)}`,
+      503,
+      model,
+    );
+  }
+
+  if (!res.ok) {
+    const detail = await safeText(res);
+    throw new ProviderError(
+      `OpenRouter ${res.status} for ${model}: ${detail.slice(0, 200)}`,
+      res.status,
+      model,
+    );
+  }
+
+  const json = (await res.json()) as {
+    model?: string;
+    choices?: Array<{ message?: { content?: string } }>;
+    usage?: { prompt_tokens?: number; completion_tokens?: number; total_tokens?: number };
+  };
+  const content = json.choices?.[0]?.message?.content ?? "";
+  return {
+    content,
+    model: json.model ?? model,
+    usage: {
+      promptTokens: json.usage?.prompt_tokens ?? 0,
+      completionTokens: json.usage?.completion_tokens ?? 0,
+      totalTokens: json.usage?.total_tokens ?? 0,
+    },
+    schemaApplied,
+  };
+}
+
+/**
+ * Fetch the full model catalogue. Maps OpenRouter's string pricing (USD/token)
+ * to numbers. Throws `ProviderError` on a non-2xx response.
+ */
+export async function listModels(deps: OpenRouterDeps): Promise<OpenRouterModel[]> {
+  const fetchImpl = deps.fetchImpl ?? fetch;
+  const res = await fetchImpl(`${deps.baseUrl}/models`, {
+    headers: { Authorization: `Bearer ${deps.apiKey}` },
+  });
+  if (!res.ok) {
+    const detail = await safeText(res);
+    throw new ProviderError(
+      `OpenRouter ${res.status} listing models: ${detail.slice(0, 200)}`,
+      res.status,
+      "(models)",
+    );
+  }
+  const json = (await res.json()) as {
+    data?: Array<{
+      id?: string;
+      name?: string;
+      context_length?: number;
+      pricing?: { prompt?: string | number; completion?: string | number };
+    }>;
+  };
+  const out: OpenRouterModel[] = [];
+  for (const m of json.data ?? []) {
+    if (!m.id) continue;
+    out.push({
+      id: m.id,
+      name: m.name ?? m.id,
+      context_length: m.context_length ?? 0,
+      pricing: {
+        prompt: toNumber(m.pricing?.prompt),
+        completion: toNumber(m.pricing?.completion),
+      },
+    });
+  }
+  return out;
+}
+
+function toNumber(v: string | number | undefined): number {
+  if (typeof v === "number") return v;
+  if (typeof v === "string") {
+    const n = Number.parseFloat(v);
+    return Number.isFinite(n) ? n : 0;
+  }
+  return 0;
+}
+
+async function safeText(res: Response): Promise<string> {
+  try {
+    return await res.text();
+  } catch {
+    return "";
+  }
+}

--- a/src/plugins/llm-router/openrouter.ts
+++ b/src/plugins/llm-router/openrouter.ts
@@ -45,35 +45,19 @@ export async function chatCompletion(
   deps: OpenRouterDeps,
 ): Promise<ChatCompletionResponse> {
   const fetchImpl = deps.fetchImpl ?? fetch;
-  const schemaApplied = !!opts.schema;
+  const wantSchema = !!opts.schema;
 
-  const body: Record<string, unknown> = { model, messages: opts.messages };
-  if (opts.maxTokens !== undefined) body.max_tokens = opts.maxTokens;
-  if (opts.providerHint) body.provider = { order: [opts.providerHint] };
-  if (opts.schema) {
-    body.response_format = {
-      type: "json_schema",
-      json_schema: { name: "result", schema: opts.schema },
-    };
-  }
+  let res = await postChat(model, opts, wantSchema, deps, fetchImpl);
+  let schemaApplied = wantSchema;
 
-  let res: Response;
-  try {
-    res = await fetchImpl(`${deps.baseUrl}/chat/completions`, {
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${deps.apiKey}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify(body),
-    });
-  } catch (err) {
-    // Network-level failure (DNS, connection) — treat as retriable (5xx-like).
-    throw new ProviderError(
-      `network error calling ${model}: ${err instanceof Error ? err.message : String(err)}`,
-      503,
-      model,
-    );
+  // Best-effort structured output (SPEC-DELTA D5). If a schema'd request is
+  // rejected (400/422 — the model/provider doesn't support response_format),
+  // retry ONCE without the schema and report schemaApplied:false, rather than
+  // failing the whole call. A non-schema 400/422 (genuinely bad request) is not
+  // retried here and surfaces below.
+  if (wantSchema && !res.ok && (res.status === 400 || res.status === 422)) {
+    res = await postChat(model, opts, false, deps, fetchImpl);
+    schemaApplied = false;
   }
 
   if (!res.ok) {
@@ -101,6 +85,41 @@ export async function chatCompletion(
     },
     schemaApplied,
   };
+}
+
+/** POST one chat-completion request. `includeSchema` controls whether the
+ *  `response_format` block is sent. Network failures become a retriable 503
+ *  ProviderError; HTTP-status handling is left to the caller. */
+async function postChat(
+  model: string,
+  opts: ChatCompletionOptions,
+  includeSchema: boolean,
+  deps: OpenRouterDeps,
+  fetchImpl: typeof fetch,
+): Promise<Response> {
+  const body: Record<string, unknown> = { model, messages: opts.messages };
+  if (opts.maxTokens !== undefined) body.max_tokens = opts.maxTokens;
+  if (opts.providerHint) body.provider = { order: [opts.providerHint] };
+  if (includeSchema && opts.schema) {
+    body.response_format = {
+      type: "json_schema",
+      json_schema: { name: "result", schema: opts.schema },
+    };
+  }
+  try {
+    return await fetchImpl(`${deps.baseUrl}/chat/completions`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${deps.apiKey}`, "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    // Network-level failure (DNS, connection) — treat as retriable (5xx-like).
+    throw new ProviderError(
+      `network error calling ${model}: ${err instanceof Error ? err.message : String(err)}`,
+      503,
+      model,
+    );
+  }
 }
 
 /**

--- a/src/plugins/llm-router/openrouter.ts
+++ b/src/plugins/llm-router/openrouter.ts
@@ -109,9 +109,20 @@ export async function chatCompletion(
  */
 export async function listModels(deps: OpenRouterDeps): Promise<OpenRouterModel[]> {
   const fetchImpl = deps.fetchImpl ?? fetch;
-  const res = await fetchImpl(`${deps.baseUrl}/models`, {
-    headers: { Authorization: `Bearer ${deps.apiKey}` },
-  });
+  let res: Response;
+  try {
+    res = await fetchImpl(`${deps.baseUrl}/models`, {
+      headers: { Authorization: `Bearer ${deps.apiKey}` },
+    });
+  } catch (err) {
+    // Mirror chatCompletion: surface a network failure as a retriable ProviderError
+    // rather than a raw TypeError, so callers can handle it uniformly.
+    throw new ProviderError(
+      `network error listing models: ${err instanceof Error ? err.message : String(err)}`,
+      503,
+      "(models)",
+    );
+  }
   if (!res.ok) {
     const detail = await safeText(res);
     throw new ProviderError(

--- a/src/plugins/llm-router/router.ts
+++ b/src/plugins/llm-router/router.ts
@@ -1,0 +1,99 @@
+/**
+ * Tier resolution + ordered fallback core for the LLM router (#70).
+ *
+ * Kept dispatch-agnostic: `callLlm` takes a `dispatch` function so the routing /
+ * fallback logic is unit-tested without network. `server.ts` wires the real
+ * OpenRouter dispatch + audit around it.
+ */
+
+import {
+  type LlmCallParams,
+  type LlmCallResult,
+  type LlmRouterRuntimeConfig,
+  ProviderError,
+} from "./types.js";
+import type { ChatCompletionResponse } from "./openrouter.js";
+
+/** A bound chat-completion call for one model. */
+export type Dispatch = (
+  model: string,
+  opts: {
+    messages: LlmCallParams["messages"];
+    schema?: Record<string, unknown>;
+    maxTokens?: number;
+    providerHint?: string;
+  },
+) => Promise<ChatCompletionResponse>;
+
+/**
+ * Resolve the ordered list of candidate models for a call.
+ *   - explicit `model` → just that model (bypasses tiers, SPEC-DELTA D2)
+ *   - `tier` → the operator's configured list (errors if empty, D1)
+ *   - neither → error
+ */
+export function resolveModels(params: LlmCallParams, config: LlmRouterRuntimeConfig): string[] {
+  if (params.model) return [params.model];
+  if (params.tier) {
+    const models = config.tiers[params.tier] ?? [];
+    if (models.length === 0) {
+      throw new Error(
+        `tier "${params.tier}" has no models configured — search with the llm_models tool ` +
+          `and add ids to settings.llmRouter.tiers.${params.tier}, or pass an explicit "model".`,
+      );
+    }
+    return models;
+  }
+  throw new Error('llm_call requires either "tier" or "model".');
+}
+
+/** Provider slug = the part of an OpenRouter id before the first "/". */
+export function providerOf(model: string): string {
+  const slash = model.indexOf("/");
+  return slash > 0 ? model.slice(0, slash) : model;
+}
+
+/**
+ * Dispatch a call, falling over to the next candidate model on a retriable
+ * provider error (429 / 5xx / network). A non-retriable error (e.g. 400) aborts
+ * immediately — retrying a malformed request against another model is pointless.
+ */
+export async function callLlm(
+  params: LlmCallParams,
+  config: LlmRouterRuntimeConfig,
+  dispatch: Dispatch,
+): Promise<LlmCallResult> {
+  const candidates = resolveModels(params, config);
+  const opts = {
+    messages: params.messages,
+    schema: params.schema,
+    maxTokens: params.maxTokens,
+    providerHint: params.providerHint,
+  };
+
+  const fallbackFrom: string[] = [];
+  let lastErr: unknown;
+
+  for (const model of candidates) {
+    try {
+      const res = await dispatch(model, opts);
+      return {
+        content: res.content,
+        model: res.model,
+        provider: providerOf(res.model),
+        usage: res.usage,
+        ...(fallbackFrom.length > 0 ? { fallbackFrom } : {}),
+        ...(params.schema ? { schemaApplied: res.schemaApplied } : {}),
+      };
+    } catch (err) {
+      lastErr = err;
+      if (err instanceof ProviderError && !err.retriable) throw err;
+      // Retriable (or unknown) — record and try the next candidate.
+      fallbackFrom.push(model);
+    }
+  }
+
+  const detail = lastErr instanceof Error ? lastErr.message : String(lastErr);
+  throw new Error(
+    `all ${candidates.length} candidate model(s) failed (tried: ${fallbackFrom.join(", ")}). Last error: ${detail}`,
+  );
+}

--- a/src/plugins/llm-router/server.ts
+++ b/src/plugins/llm-router/server.ts
@@ -1,0 +1,227 @@
+/**
+ * LLM router MCP stdio server (#70).
+ *
+ * Hosted as a multiplexer shared server (register "llm-router" in
+ * settings.mcp.shared + an mcp-proxy.json entry). Exposes two tools:
+ *   - llm_call({ tier|model, messages, schema?, providerHint?, maxTokens? })
+ *   - llm_models({ query?, maxPromptPrice?, minContext?, limit? })
+ *
+ * Run standalone:  bun run src/plugins/llm-router/server.ts
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import { getMcpBridge } from "../mcp-bridge.js";
+import { loadSettings } from "../../config.js";
+import { chatCompletion, DEFAULT_OPENROUTER_BASE_URL, type OpenRouterDeps } from "./openrouter.js";
+import { ModelCatalogue } from "./catalogue.js";
+import { callLlm, type Dispatch } from "./router.js";
+import {
+  TIERS,
+  type LlmCallParams,
+  type LlmModelsParams,
+  type LlmRouterRuntimeConfig,
+} from "./types.js";
+
+const LLM_CALL_TOOL = {
+  name: "llm_call",
+  description:
+    "Dispatch a chat completion across providers via OpenRouter. Route by cost tier " +
+    "(fast|balanced|reasoning, mapped to models in settings.llmRouter) or pass an explicit " +
+    "OpenRouter `model` id to bypass tiers. Non-streaming. Falls over to the next model in the " +
+    "tier on 429/5xx.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      tier: { type: "string", enum: ["fast", "balanced", "reasoning"] },
+      model: { type: "string", description: "Explicit OpenRouter model id; bypasses tier." },
+      messages: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            role: { type: "string", enum: ["system", "user", "assistant", "tool"] },
+            content: { type: "string" },
+          },
+          required: ["role", "content"],
+        },
+      },
+      schema: { type: "object", description: "JSON schema for structured output (best-effort)." },
+      providerHint: { type: "string" },
+      maxTokens: { type: "number" },
+    },
+    required: ["messages"],
+  },
+} as const;
+
+const LLM_MODELS_TOOL = {
+  name: "llm_models",
+  description:
+    "Search the OpenRouter model catalogue (cached). Returns matching models with context " +
+    "length and per-token pricing so you can pick ids for settings.llmRouter tiers or a per-call model.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: { type: "string", description: "Case-insensitive substring over id + name." },
+      maxPromptPrice: { type: "number", description: "Max prompt price (USD/token)." },
+      minContext: { type: "number", description: "Min context window (tokens)." },
+      limit: { type: "number", description: "Max results (default 50)." },
+    },
+  },
+} as const;
+
+export function buildRuntimeConfig(settings: {
+  llmRouter?: Partial<LlmRouterRuntimeConfig>;
+}): LlmRouterRuntimeConfig {
+  const cfg = settings.llmRouter ?? {};
+  const tiers = cfg.tiers ?? { fast: [], balanced: [], reasoning: [] };
+  return {
+    tiers: {
+      fast: tiers.fast ?? [],
+      balanced: tiers.balanced ?? [],
+      reasoning: tiers.reasoning ?? [],
+    },
+    openRouterBaseUrl: cfg.openRouterBaseUrl ?? DEFAULT_OPENROUTER_BASE_URL,
+    ...(cfg.ollamaBaseUrl ? { ollamaBaseUrl: cfg.ollamaBaseUrl } : {}),
+  };
+}
+
+export interface LlmRouterHandlerDeps {
+  config: LlmRouterRuntimeConfig;
+  apiKey: string;
+  fetchImpl?: typeof fetch;
+  /** Catalogue override for tests. */
+  catalogue?: ModelCatalogue;
+  audit?: (event: string, payload: Record<string, unknown>) => void;
+}
+
+/**
+ * The tool logic, decoupled from the stdio transport so it's unit-testable.
+ * Returns the raw result object (the transport layer JSON-stringifies it).
+ */
+export function createLlmRouterHandlers(deps: LlmRouterHandlerDeps) {
+  const orDeps: OpenRouterDeps = {
+    apiKey: deps.apiKey,
+    baseUrl: deps.config.openRouterBaseUrl,
+    ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+  };
+  const catalogue = deps.catalogue ?? new ModelCatalogue(orDeps);
+  const audit = deps.audit ?? (() => {});
+  const dispatch: Dispatch = (model, opts) => chatCompletion(model, opts, orDeps);
+
+  async function llmCall(rawArgs: Record<string, unknown>) {
+    if (!deps.apiKey) throw new Error("OPENROUTER_API_KEY is not set in the daemon environment.");
+    const params = parseLlmCallArgs(rawArgs);
+    const startedAt = Date.now();
+    try {
+      const result = await callLlm(params, deps.config, dispatch);
+      audit("llm_call_dispatched", {
+        tier: params.tier ?? null,
+        model: result.model,
+        provider: result.provider,
+        latencyMs: Date.now() - startedAt,
+        usage: result.usage,
+      });
+      if (result.fallbackFrom?.length) {
+        audit("llm_call_fallback_taken", { from: result.fallbackFrom, to: result.model });
+      }
+      return result;
+    } catch (err) {
+      audit("llm_call_failed", {
+        tier: params.tier ?? null,
+        model: params.model ?? null,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    }
+  }
+
+  async function llmModels(rawArgs: Record<string, unknown>) {
+    if (!deps.apiKey) throw new Error("OPENROUTER_API_KEY is not set in the daemon environment.");
+    const params = parseLlmModelsArgs(rawArgs);
+    const { models, cachedAt } = await catalogue.search(params);
+    audit("llm_models_listed", { query: params.query ?? null, returned: models.length });
+    return { models, cachedAt };
+  }
+
+  return { llmCall, llmModels };
+}
+
+function parseLlmCallArgs(raw: Record<string, unknown>): LlmCallParams {
+  const messages = raw.messages;
+  if (!Array.isArray(messages) || messages.length === 0) {
+    throw new Error("llm_call: `messages` must be a non-empty array.");
+  }
+  const tier = raw.tier;
+  if (tier !== undefined && !TIERS.includes(tier as (typeof TIERS)[number])) {
+    throw new Error(`llm_call: invalid tier "${String(tier)}" (expected fast|balanced|reasoning).`);
+  }
+  return {
+    ...(typeof tier === "string" ? { tier: tier as LlmCallParams["tier"] } : {}),
+    ...(typeof raw.model === "string" ? { model: raw.model } : {}),
+    messages: messages as LlmCallParams["messages"],
+    ...(raw.schema && typeof raw.schema === "object"
+      ? { schema: raw.schema as Record<string, unknown> }
+      : {}),
+    ...(typeof raw.providerHint === "string" ? { providerHint: raw.providerHint } : {}),
+    ...(typeof raw.maxTokens === "number" ? { maxTokens: raw.maxTokens } : {}),
+  };
+}
+
+function parseLlmModelsArgs(raw: Record<string, unknown>): LlmModelsParams {
+  return {
+    ...(typeof raw.query === "string" ? { query: raw.query } : {}),
+    ...(typeof raw.maxPromptPrice === "number" ? { maxPromptPrice: raw.maxPromptPrice } : {}),
+    ...(typeof raw.minContext === "number" ? { minContext: raw.minContext } : {}),
+    ...(typeof raw.limit === "number" ? { limit: raw.limit } : {}),
+  };
+}
+
+export async function startLlmRouterServer(): Promise<void> {
+  const settings = await loadSettings();
+  const config = buildRuntimeConfig(settings as { llmRouter?: Partial<LlmRouterRuntimeConfig> });
+  const bridge = getMcpBridge();
+  const handlers = createLlmRouterHandlers({
+    config,
+    apiKey: process.env.OPENROUTER_API_KEY ?? "",
+    audit: (event, payload) => bridge.audit(event, payload),
+  });
+
+  const server = new Server(
+    { name: "llm-router", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [LLM_CALL_TOOL, LLM_MODELS_TOOL],
+  }));
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    try {
+      const result =
+        name === "llm_call"
+          ? await handlers.llmCall(args ?? {})
+          : name === "llm_models"
+            ? await handlers.llmModels(args ?? {})
+            : (() => {
+                throw new Error(`unknown tool: ${name}`);
+              })();
+      return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: "text", text: `Error: ${message}` }], isError: true };
+    }
+  });
+
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+if (import.meta.main) {
+  startLlmRouterServer().catch((err) => {
+    console.error("[llm-router] Fatal:", err);
+    process.exit(1);
+  });
+}

--- a/src/plugins/llm-router/server.ts
+++ b/src/plugins/llm-router/server.ts
@@ -153,13 +153,19 @@ function parseLlmCallArgs(raw: Record<string, unknown>): LlmCallParams {
   if (!Array.isArray(messages) || messages.length === 0) {
     throw new Error("llm_call: `messages` must be a non-empty array.");
   }
+  // An explicit `model` wins over `tier` (resolveModels checks model first), so
+  // only validate the tier when there's no model to fall back on — otherwise a
+  // bogus tier alongside a valid model would error needlessly.
+  const hasModel = typeof raw.model === "string" && raw.model.trim().length > 0;
   const tier = raw.tier;
-  if (tier !== undefined && !TIERS.includes(tier as (typeof TIERS)[number])) {
+  if (!hasModel && tier !== undefined && !TIERS.includes(tier as (typeof TIERS)[number])) {
     throw new Error(`llm_call: invalid tier "${String(tier)}" (expected fast|balanced|reasoning).`);
   }
   return {
-    ...(typeof tier === "string" ? { tier: tier as LlmCallParams["tier"] } : {}),
-    ...(typeof raw.model === "string" ? { model: raw.model } : {}),
+    ...(typeof tier === "string" && TIERS.includes(tier as (typeof TIERS)[number])
+      ? { tier: tier as LlmCallParams["tier"] }
+      : {}),
+    ...(hasModel ? { model: (raw.model as string).trim() } : {}),
     messages: messages as LlmCallParams["messages"],
     ...(raw.schema && typeof raw.schema === "object"
       ? { schema: raw.schema as Record<string, unknown> }
@@ -182,9 +188,17 @@ export async function startLlmRouterServer(): Promise<void> {
   const settings = await loadSettings();
   const config = buildRuntimeConfig(settings as { llmRouter?: Partial<LlmRouterRuntimeConfig> });
   const bridge = getMcpBridge();
+  const apiKey = process.env.OPENROUTER_API_KEY ?? "";
+  if (!apiKey) {
+    // Surface the misconfiguration at launch instead of only on the first call —
+    // a missing key is a near-certain setup error, not a runtime condition.
+    console.error(
+      "[llm-router] WARNING: OPENROUTER_API_KEY is not set; llm_call/llm_models will fail until it is.",
+    );
+  }
   const handlers = createLlmRouterHandlers({
     config,
-    apiKey: process.env.OPENROUTER_API_KEY ?? "",
+    apiKey,
     audit: (event, payload) => bridge.audit(event, payload),
   });
 

--- a/src/plugins/llm-router/types.ts
+++ b/src/plugins/llm-router/types.ts
@@ -1,0 +1,101 @@
+/**
+ * Shared types for the LLM router MCP plugin (#70).
+ *
+ * The router exposes two tools over MCP:
+ *   - `llm_call`   — dispatch a chat completion by tier (or explicit model)
+ *   - `llm_models` — search the OpenRouter model catalogue
+ *
+ * See `.planning/llm-router/SPEC.md` + `SPEC-DELTA-2026-05-29.md`.
+ */
+
+/** Cost/capability tier. Operator maps each tier to an ordered model list. */
+export type Tier = "fast" | "balanced" | "reasoning";
+
+export const TIERS: readonly Tier[] = ["fast", "balanced", "reasoning"];
+
+/** One chat message in the OpenAI-compatible shape OpenRouter accepts. */
+export interface ChatMessage {
+  role: "system" | "user" | "assistant" | "tool";
+  content: string;
+}
+
+/** Arguments to the `llm_call` tool. `tier` and `model` are mutually exclusive;
+ *  `model` (any OpenRouter id) wins if both are supplied (SPEC-DELTA D2). */
+export interface LlmCallParams {
+  tier?: Tier;
+  /** Explicit OpenRouter model id — bypasses tier resolution. */
+  model?: string;
+  messages: ChatMessage[];
+  /** JSON schema for structured output — best-effort `response_format` (D5). */
+  schema?: Record<string, unknown>;
+  /** Reserved: hint a provider preference for OpenRouter routing. */
+  providerHint?: string;
+  /** Upper bound on output tokens. */
+  maxTokens?: number;
+}
+
+export interface LlmCallResult {
+  content: string;
+  /** The model that actually answered (after any fallback). */
+  model: string;
+  /** Provider slug derived from the model id prefix (e.g. "anthropic"). */
+  provider: string;
+  usage: { promptTokens: number; completionTokens: number; totalTokens: number };
+  /** Models tried before the one that answered (fallback trail), if any. */
+  fallbackFrom?: string[];
+  /** False when `schema` was requested but not applied (D5). */
+  schemaApplied?: boolean;
+}
+
+/** One entry from OpenRouter's `GET /api/v1/models` catalogue (subset we use). */
+export interface OpenRouterModel {
+  id: string;
+  name: string;
+  context_length: number;
+  pricing: { prompt: number; completion: number };
+}
+
+export interface LlmModelsParams {
+  /** Case-insensitive substring match over id + name. */
+  query?: string;
+  /** Keep only models whose prompt price (USD/token) is ≤ this. */
+  maxPromptPrice?: number;
+  /** Keep only models whose context window is ≥ this. */
+  minContext?: number;
+  /** Cap the number of returned models (default 50). */
+  limit?: number;
+}
+
+export interface LlmModelsResult {
+  models: OpenRouterModel[];
+  /** Epoch ms when the catalogue snapshot was fetched. */
+  cachedAt: number;
+}
+
+/** Non-secret router configuration (the secret `OPENROUTER_API_KEY` is env-only). */
+export interface LlmRouterRuntimeConfig {
+  /** Ordered model ids per tier. Empty by default (SPEC-DELTA D1). */
+  tiers: Record<Tier, string[]>;
+  /** OpenRouter API base, default https://openrouter.ai/api/v1. */
+  openRouterBaseUrl: string;
+  /** Optional local Ollama base (e.g. http://127.0.0.1:11434/v1). */
+  ollamaBaseUrl?: string;
+}
+
+/** A provider error carrying the HTTP status so the router can decide to fall
+ *  over (429 / 5xx) vs. abort (4xx that isn't rate-limit). */
+export class ProviderError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly model: string,
+  ) {
+    super(message);
+    this.name = "ProviderError";
+  }
+
+  /** Transient — worth trying the next model in the tier. */
+  get retriable(): boolean {
+    return this.status === 429 || this.status >= 500;
+  }
+}


### PR DESCRIPTION
Phase B of #70 — the LLM router plugin, built against the merged SPEC (#202) + the SPEC-DELTA in this branch.

## What it does
A standalone Bun **stdio MCP server** (`src/plugins/llm-router/`) hosted as a multiplexer shared server. Two tools:

- **`llm_call({ tier | model, messages, schema?, providerHint?, maxTokens? })`** — dispatch a chat completion. Route by cost tier (`fast|balanced|reasoning`, mapped to OpenRouter model ids in `settings.llmRouter`) **or** pass an explicit `model` for any catalogue model. Ordered 429/5xx fallback within the tier; non-retriable 4xx aborts. Returns `{ content, model, provider, usage, fallbackFrom?, schemaApplied? }`.
- **`llm_models({ query?, maxPromptPrice?, minContext?, limit? })`** — search the OpenRouter catalogue (cached ~1h), so model selection is the operator's choice and discoverable.

## Design (SPEC + SPEC-DELTA-2026-05-29)
- **Tiers ship empty** — no opinionated model defaults. An unconfigured tier returns an actionable error pointing at `llm_models`; a per-call `model` works immediately.
- **OpenRouter** as the breadth layer (OpenAI-compatible `/chat/completions` + `/models`); `fetch` injected for tests; **`OPENROUTER_API_KEY` env-only**, never in settings.
- **`schema` → `response_format`** best-effort (D5).
- **Audit** via own-process `mcp-bridge` to the shared JSONL: `llm_call_dispatched` / `_failed` / `_fallback_taken` / `llm_models_listed`. (`caller` attribution deferred — needs multiplexer identity plumbing, pairs with #68.)
- **Zero multiplexer changes** — additive `settings.llmRouter` block + one parse fn.

## How to enable (operator)
1. Add `"llm-router"` to `settings.mcp.shared`.
2. Add an `mcp-proxy.json` entry: `{ "llm-router": { "command": "bun", "args": ["run", ".../src/plugins/llm-router/server.ts"] } }`.
3. Export `OPENROUTER_API_KEY` in the daemon env.
4. Optionally populate `settings.llmRouter.tiers` (or use `llm_models` to pick ids / pass per-call `model`).

`synthesizeBusMcpConfig` then wires it into every PTY automatically.

## Tests (67)
Router resolution/fallback/abort/aggregate/precedence; OpenRouter client (mocked fetch — chat, schema, 429/400/network, models pricing-map, body passthrough); catalogue search/filter + TTL cache; server handlers (dispatch+audit, fallback_taken, empty-tier, missing key, bad payload, model-wins); config parse. No network in tests.

## Review
SPEC + SPEC-DELTA in `.planning/llm-router/`. 6-agent review (security + 5 dimensions): clean bug scan after 2 fixes (listModels network-wrap, tier-validation-with-model), SPEC-conformant, ALIGNED + SIMPLE, no new deps. Security: no CRITICAL/HIGH; one documented LOW (schema size cap, deferred). Reliability: added a startup warning when the key is unset.

## Out of scope
Dashboard model picker (Phase C — will reuse the `llm_models` catalogue proxy); per-caller cost attribution (#68); streaming; provider adapters beyond OpenRouter + Ollama.