### PR TITLE
feat(ui): LLM router dashboard model picker (#70 Phase C)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.131",
+      "version": "2.2.132",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.129",
+      "version": "2.2.130",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.130",
+      "version": "2.2.131",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.131",
+  "version": "2.2.132",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.130",
+  "version": "2.2.131",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.129",
+  "version": "2.2.130",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.planning/llm-router/SPEC-DELTA-phase-c.md
+++ b/.planning/llm-router/SPEC-DELTA-phase-c.md
@@ -1,0 +1,81 @@
+# SPEC-DELTA — Phase C: Dashboard model picker (#70)
+
+**Date:** 2026-05-30. Amends `.planning/llm-router/SPEC.md` + Phase B
+(SPEC-DELTA-2026-05-29). Phase B shipped the `llm_models` MCP tool as the
+catalogue substrate; this phase puts a UI on it.
+
+## Scope
+
+A searchable model picker in the legacy dashboard's Settings modal where the
+operator browses the OpenRouter catalogue and assigns model ids to tiers —
+writes through to `settings.llmRouter.tiers`. No frontend framework added; uses
+the existing `template.ts` / `script.ts` / `styles.ts` server-rendered model.
+
+## Server changes
+
+### New service — `src/ui/services/llm-router-settings.ts`
+Mirrors `src/ui/services/settings.ts` (heartbeat):
+
+```
+readLlmRouterSettings(): Promise<LlmRouterSettingsData>
+updateLlmRouterSettings(patch: { tiers? }): Promise<LlmRouterSettingsData>
+```
+
+Reads/writes `settings.json` directly (same idiom as the heartbeat helper).
+`tiers` accepts the same `{ fast, balanced, reasoning }` shape; ids are
+validated as non-empty trimmed strings.
+
+### New routes in `src/ui/server.ts` (sibling of `/api/settings/heartbeat`)
+- `GET /api/settings/llm-router` → `{ ok, llmRouter }`.
+- `POST /api/settings/llm-router` (CSRF) → patch tiers, return updated settings.
+- `GET /api/llm-router/models?query=&maxPromptPrice=&minContext=&limit=` →
+  `{ ok, models, cachedAt }`. Reuses `ModelCatalogue` + `filterModels` from
+  `src/plugins/llm-router/catalogue.ts` — single source of truth for the proxy.
+  Reads `OPENROUTER_API_KEY` from the daemon env at request time (never logs or
+  returns it).
+
+### Plugin live-reload (small scoped touch)
+`src/plugins/llm-router/server.ts` currently reads `settings.llmRouter` once at
+startup, so dashboard tier edits wouldn't take effect until a daemon restart.
+Fix: `createLlmRouterHandlers` accepts a `getConfig: () => Promise<LlmRouterRuntimeConfig>`
+factory; `startLlmRouterServer` provides a factory that calls
+`reloadSettings()` + `buildRuntimeConfig()` per call. Disk read cost is ms; LLM
+calls are seconds. Tests inject a static factory; backwards-compatible (the
+existing `config` field is still accepted via a wrapper for tests).
+
+## UI changes — Settings modal
+
+Add one section to `settings-stack` between Heartbeat and Clock:
+
+```
+🧠 LLM Router
+ ├─ Per-tier lists: fast / balanced / reasoning
+ │   each shows assigned model ids as removable chips
+ ├─ Search panel: [query input] → results list (id, name, context, $/Mtok)
+ │   each result has "+ fast / + balanced / + reasoning" buttons
+ └─ Save changes  (POSTs the new tiers)
+```
+
+V1 keeps the UI minimal:
+- **Query-only search** in the UI (the route accepts price/context filters too,
+  but they're not surfaced in v1).
+- **No "test this tier" / no per-call model field** (operators have the MCP tool).
+- Empty `OPENROUTER_API_KEY` → the section shows a clear "set the env var" hint
+  instead of erroring on first search.
+
+## Out of scope (deferred)
+
+- Per-tier "test" smoke prompt.
+- Price/context filters in the UI (route already supports them).
+- Streaming / per-call cost surfacing (#68 territory).
+- Touching the bus-runtime web UI (this is the *legacy* dashboard's settings
+  modal, which has feature parity for operator settings — see start.ts:550
+  comment).
+
+## Verification
+
+- Unit tests: `llm-router-settings` read/update; `/api/settings/llm-router`
+  GET/POST round-trip; `/api/llm-router/models` proxy with injected fetch;
+  plugin live-reload (getConfig called per call, picks up updated tiers).
+- **Manual browser verification is yours to do** — I can't run the daemon +
+  click through the modal from here. PR body will flag this explicitly.

--- a/src/plugins/llm-router/__tests__/server.test.ts
+++ b/src/plugins/llm-router/__tests__/server.test.ts
@@ -140,6 +140,44 @@ describe("createLlmRouterHandlers.llmCall", () => {
 });
 
 describe("createLlmRouterHandlers — live-reload via getConfig (#70 Phase C)", () => {
+  it("uses the live openRouterBaseUrl from getConfig (Codex P2 on PR #204)", async () => {
+    // Regression: when only getConfig was passed, baseUrl fell back to the
+    // hardcoded OpenRouter default, so an operator-set proxy URL was ignored.
+    let chatUrl = "";
+    let modelsUrl = "";
+    const fetchImpl = (async (url: string, init?: RequestInit) => {
+      if (url.includes("/chat/completions")) {
+        chatUrl = url;
+        return new Response(
+          JSON.stringify({
+            model: "x/y",
+            choices: [{ message: { content: "ok" } }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+          { status: 200 },
+        );
+      }
+      if (url.includes("/models")) {
+        modelsUrl = url;
+        return new Response(JSON.stringify({ data: [] }), { status: 200 });
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const h = createLlmRouterHandlers({
+      getConfig: async () => ({
+        tiers: { fast: ["x/y"], balanced: [], reasoning: [] },
+        openRouterBaseUrl: "https://proxy.example.test/v1",
+      }),
+      apiKey: "k",
+      fetchImpl,
+    });
+    await h.llmCall({ tier: "fast", messages: [{ role: "user", content: "hi" }] });
+    await h.llmModels({});
+    expect(chatUrl).toBe("https://proxy.example.test/v1/chat/completions");
+    expect(modelsUrl).toBe("https://proxy.example.test/v1/models");
+  });
+
   it("invokes getConfig per llm_call so dashboard tier edits take effect without restart", async () => {
     let configCalls = 0;
     const tierLists: Array<string[]> = [["x/first"], ["x/second"]];

--- a/src/plugins/llm-router/__tests__/server.test.ts
+++ b/src/plugins/llm-router/__tests__/server.test.ts
@@ -139,6 +139,43 @@ describe("createLlmRouterHandlers.llmCall", () => {
   });
 });
 
+describe("createLlmRouterHandlers — live-reload via getConfig (#70 Phase C)", () => {
+  it("invokes getConfig per llm_call so dashboard tier edits take effect without restart", async () => {
+    let configCalls = 0;
+    const tierLists: Array<string[]> = [["x/first"], ["x/second"]];
+    const getConfig = async () => {
+      const fast = tierLists[Math.min(configCalls, tierLists.length - 1)];
+      configCalls++;
+      return {
+        tiers: { fast, balanced: [], reasoning: [] },
+        openRouterBaseUrl: "https://or.test/api/v1",
+      };
+    };
+    const seen: string[] = [];
+    const fetchImpl = (async (url: string, init: RequestInit) => {
+      if (url.endsWith("/chat/completions")) {
+        const model = JSON.parse(init.body as string).model;
+        seen.push(model);
+        return new Response(
+          JSON.stringify({
+            model,
+            choices: [{ message: { content: "ok" } }],
+            usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+          }),
+          { status: 200 },
+        );
+      }
+      return new Response("nf", { status: 404 });
+    }) as unknown as typeof fetch;
+
+    const h = createLlmRouterHandlers({ getConfig, apiKey: "k", fetchImpl });
+    await h.llmCall({ tier: "fast", messages: [{ role: "user", content: "1" }] });
+    await h.llmCall({ tier: "fast", messages: [{ role: "user", content: "2" }] });
+    expect(seen).toEqual(["x/first", "x/second"]); // second call saw the updated tier
+    expect(configCalls).toBeGreaterThanOrEqual(2);
+  });
+});
+
 describe("createLlmRouterHandlers.llmModels", () => {
   it("searches the catalogue and audits", async () => {
     const events: string[] = [];

--- a/src/plugins/llm-router/server.ts
+++ b/src/plugins/llm-router/server.ts
@@ -112,23 +112,37 @@ export function createLlmRouterHandlers(deps: LlmRouterHandlerDeps) {
     throw new Error("createLlmRouterHandlers requires `config` or `getConfig`.");
   }
   const getConfig = deps.getConfig ?? (async () => deps.config as LlmRouterRuntimeConfig);
-  // The catalogue + dispatch only need the API key + base URL — both stable
-  // for the process lifetime — so they're built once. Tier changes go through
-  // `getConfig()` per call, which is the only part dashboard edits affect.
-  const initial = deps.config ?? null;
-  const orDeps: OpenRouterDeps = {
-    apiKey: deps.apiKey,
-    baseUrl: initial?.openRouterBaseUrl ?? "https://openrouter.ai/api/v1",
-    ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
-  };
-  const catalogue = deps.catalogue ?? new ModelCatalogue(orDeps);
   const audit = deps.audit ?? (() => {});
-  const dispatch: Dispatch = (model, opts) => chatCompletion(model, opts, orDeps);
+
+  // `orDeps` (apiKey + baseUrl) is built from the live config per call so a
+  // dashboard edit of `openRouterBaseUrl` (Codex P2 on #204) — or any future
+  // proxy/gateway override — takes effect without a daemon restart. apiKey is
+  // process-env at boot and stable; baseUrl can change. The catalogue holds a
+  // fetched models snapshot, so it's cached by baseUrl and rebuilt only when
+  // baseUrl changes (avoids dropping the cache on every call).
+  let cachedBaseUrl: string | null = null;
+  let cachedCatalogue: ModelCatalogue | null = null;
+  function buildOrDeps(baseUrl: string): OpenRouterDeps {
+    return {
+      apiKey: deps.apiKey,
+      baseUrl,
+      ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
+    };
+  }
+  function getCatalogue(baseUrl: string): ModelCatalogue {
+    if (deps.catalogue) return deps.catalogue;
+    if (cachedCatalogue && cachedBaseUrl === baseUrl) return cachedCatalogue;
+    cachedCatalogue = new ModelCatalogue(buildOrDeps(baseUrl));
+    cachedBaseUrl = baseUrl;
+    return cachedCatalogue;
+  }
 
   async function llmCall(rawArgs: Record<string, unknown>) {
     if (!deps.apiKey) throw new Error("OPENROUTER_API_KEY is not set in the daemon environment.");
     const params = parseLlmCallArgs(rawArgs);
     const config = await getConfig();
+    const orDeps = buildOrDeps(config.openRouterBaseUrl);
+    const dispatch: Dispatch = (model, opts) => chatCompletion(model, opts, orDeps);
     const startedAt = Date.now();
     try {
       const result = await callLlm(params, config, dispatch);
@@ -156,6 +170,8 @@ export function createLlmRouterHandlers(deps: LlmRouterHandlerDeps) {
   async function llmModels(rawArgs: Record<string, unknown>) {
     if (!deps.apiKey) throw new Error("OPENROUTER_API_KEY is not set in the daemon environment.");
     const params = parseLlmModelsArgs(rawArgs);
+    const config = await getConfig();
+    const catalogue = getCatalogue(config.openRouterBaseUrl);
     const { models, cachedAt } = await catalogue.search(params);
     audit("llm_models_listed", { query: params.query ?? null, returned: models.length });
     return { models, cachedAt };

--- a/src/plugins/llm-router/server.ts
+++ b/src/plugins/llm-router/server.ts
@@ -13,7 +13,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { CallToolRequestSchema, ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
 import { getMcpBridge } from "../mcp-bridge.js";
-import { loadSettings } from "../../config.js";
+import { loadSettings, reloadSettings } from "../../config.js";
 import { chatCompletion, DEFAULT_OPENROUTER_BASE_URL, type OpenRouterDeps } from "./openrouter.js";
 import { ModelCatalogue } from "./catalogue.js";
 import { callLlm, type Dispatch } from "./router.js";
@@ -88,7 +88,14 @@ export function buildRuntimeConfig(settings: {
 }
 
 export interface LlmRouterHandlerDeps {
-  config: LlmRouterRuntimeConfig;
+  /**
+   * Either a static config (back-compat for tests) or a `getConfig` factory
+   * invoked per call (#70 Phase C). The factory lets `startLlmRouterServer`
+   * pick up dashboard tier edits without a daemon restart: it returns
+   * `await reloadSettings()` → `buildRuntimeConfig(settings)` each time.
+   */
+  config?: LlmRouterRuntimeConfig;
+  getConfig?: () => Promise<LlmRouterRuntimeConfig>;
   apiKey: string;
   fetchImpl?: typeof fetch;
   /** Catalogue override for tests. */
@@ -101,9 +108,17 @@ export interface LlmRouterHandlerDeps {
  * Returns the raw result object (the transport layer JSON-stringifies it).
  */
 export function createLlmRouterHandlers(deps: LlmRouterHandlerDeps) {
+  if (!deps.config && !deps.getConfig) {
+    throw new Error("createLlmRouterHandlers requires `config` or `getConfig`.");
+  }
+  const getConfig = deps.getConfig ?? (async () => deps.config as LlmRouterRuntimeConfig);
+  // The catalogue + dispatch only need the API key + base URL — both stable
+  // for the process lifetime — so they're built once. Tier changes go through
+  // `getConfig()` per call, which is the only part dashboard edits affect.
+  const initial = deps.config ?? null;
   const orDeps: OpenRouterDeps = {
     apiKey: deps.apiKey,
-    baseUrl: deps.config.openRouterBaseUrl,
+    baseUrl: initial?.openRouterBaseUrl ?? "https://openrouter.ai/api/v1",
     ...(deps.fetchImpl ? { fetchImpl: deps.fetchImpl } : {}),
   };
   const catalogue = deps.catalogue ?? new ModelCatalogue(orDeps);
@@ -113,9 +128,10 @@ export function createLlmRouterHandlers(deps: LlmRouterHandlerDeps) {
   async function llmCall(rawArgs: Record<string, unknown>) {
     if (!deps.apiKey) throw new Error("OPENROUTER_API_KEY is not set in the daemon environment.");
     const params = parseLlmCallArgs(rawArgs);
+    const config = await getConfig();
     const startedAt = Date.now();
     try {
-      const result = await callLlm(params, deps.config, dispatch);
+      const result = await callLlm(params, config, dispatch);
       audit("llm_call_dispatched", {
         tier: params.tier ?? null,
         model: result.model,
@@ -185,8 +201,14 @@ function parseLlmModelsArgs(raw: Record<string, unknown>): LlmModelsParams {
 }
 
 export async function startLlmRouterServer(): Promise<void> {
-  const settings = await loadSettings();
-  const config = buildRuntimeConfig(settings as { llmRouter?: Partial<LlmRouterRuntimeConfig> });
+  // One eager read so we fail-fast on a malformed settings.json at boot, then
+  // re-read on every tool call so dashboard tier edits (#70 Phase C) take
+  // effect without a daemon restart. settings.json is small; cost is ms.
+  await loadSettings();
+  const getConfig = async () => {
+    const settings = await reloadSettings();
+    return buildRuntimeConfig(settings as { llmRouter?: Partial<LlmRouterRuntimeConfig> });
+  };
   const bridge = getMcpBridge();
   const apiKey = process.env.OPENROUTER_API_KEY ?? "";
   if (!apiKey) {
@@ -197,7 +219,7 @@ export async function startLlmRouterServer(): Promise<void> {
     );
   }
   const handlers = createLlmRouterHandlers({
-    config,
+    getConfig,
     apiKey,
     audit: (event, payload) => bridge.audit(event, payload),
   });

--- a/src/ui/__tests__/llm-router-routes.test.ts
+++ b/src/ui/__tests__/llm-router-routes.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Integration test for the /api/llm-router/* routes (#70 Phase C).
+ * Boots a real startWebUi server on an ephemeral port and injects a fake
+ * catalogue via the test seam exported from `src/ui/server.ts`.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { join } from "path";
+import { mkdir, copyFile, unlink, writeFile } from "fs/promises";
+import { existsSync } from "fs";
+
+import { startWebUi, __setLlmRouterCatalogueForTests } from "../server";
+import type { WebServerHandle, WebSnapshot } from "../types";
+import type { ModelCatalogue } from "../../plugins/llm-router/catalogue";
+
+const TOKEN = "test-web-token-abcdefghijklmnop";
+const SETTINGS_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const SETTINGS_FILE = join(SETTINGS_DIR, "settings.json");
+const BACKUP_FILE = join(SETTINGS_DIR, "settings.json.llm-router-routes-test-backup");
+
+function snapshot(): WebSnapshot {
+  return {
+    pid: 1234,
+    startedAt: Date.now(),
+    heartbeatNextAt: 0,
+    settings: {
+      apiToken: undefined,
+      heartbeat: { enabled: false, interval: 30, prompt: "" },
+      security: {},
+      telegram: { token: "", allowedUserIds: [] },
+      discord: { token: "", allowedUserIds: [] },
+      web: { enabled: true, host: "127.0.0.1", port: 0 },
+    } as unknown as WebSnapshot["settings"],
+    jobs: [],
+  };
+}
+
+let handle: WebServerHandle;
+let base: string;
+
+beforeAll(async () => {
+  await mkdir(SETTINGS_DIR, { recursive: true });
+  if (existsSync(SETTINGS_FILE)) await copyFile(SETTINGS_FILE, BACKUP_FILE);
+  await writeFile(SETTINGS_FILE, `${JSON.stringify({}, null, 2)}\n`);
+
+  handle = startWebUi({
+    host: "127.0.0.1",
+    port: 0,
+    token: TOKEN,
+    getSnapshot: snapshot,
+  });
+  base = `http://${handle.host}:${handle.port}`;
+});
+
+afterAll(async () => {
+  handle.stop();
+  __setLlmRouterCatalogueForTests(null);
+  if (existsSync(BACKUP_FILE)) {
+    await copyFile(BACKUP_FILE, SETTINGS_FILE);
+    await unlink(BACKUP_FILE);
+  } else if (existsSync(SETTINGS_FILE)) {
+    await unlink(SETTINGS_FILE);
+  }
+});
+
+beforeEach(async () => {
+  await writeFile(SETTINGS_FILE, `${JSON.stringify({}, null, 2)}\n`);
+});
+
+const auth = { Authorization: `Bearer ${TOKEN}` };
+
+async function csrf(): Promise<{ token: string; cookie: string }> {
+  const res = await fetch(`${base}/api/csrf-token`, { headers: auth });
+  const data = (await res.json()) as { token: string };
+  const cookie = res.headers.get("set-cookie") ?? "";
+  return { token: data.token, cookie };
+}
+
+describe("/api/settings/llm-router", () => {
+  it("GET returns empty tiers + default base on a fresh settings.json", async () => {
+    const res = await fetch(`${base}/api/settings/llm-router`, { headers: auth });
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as {
+      ok: boolean;
+      llmRouter: { tiers: Record<string, string[]>; openRouterBaseUrl: string };
+    };
+    expect(data.ok).toBe(true);
+    expect(data.llmRouter.tiers).toEqual({ fast: [], balanced: [], reasoning: [] });
+    expect(data.llmRouter.openRouterBaseUrl).toBe("https://openrouter.ai/api/v1");
+  });
+
+  it("POST patches tiers and survives a round-trip", async () => {
+    const { token, cookie } = await csrf();
+    const res = await fetch(`${base}/api/settings/llm-router`, {
+      method: "POST",
+      headers: {
+        ...auth,
+        "Content-Type": "application/json",
+        "X-CSRF-Token": token,
+        Cookie: cookie,
+      },
+      body: JSON.stringify({ tiers: { fast: ["groq/llama"], reasoning: ["anthropic/opus"] } }),
+    });
+    const data = (await res.json()) as {
+      ok: boolean;
+      llmRouter: { tiers: Record<string, string[]> };
+    };
+    expect(res.status).toBe(200);
+    expect(data.ok).toBe(true);
+    expect(data.llmRouter.tiers.fast).toEqual(["groq/llama"]);
+    expect(data.llmRouter.tiers.reasoning).toEqual(["anthropic/opus"]);
+
+    const round = await fetch(`${base}/api/settings/llm-router`, { headers: auth });
+    const back = (await round.json()) as { llmRouter: { tiers: Record<string, string[]> } };
+    expect(back.llmRouter.tiers.fast).toEqual(["groq/llama"]);
+  });
+
+  it("POST without any tier keys rejects with 400", async () => {
+    const { token, cookie } = await csrf();
+    const res = await fetch(`${base}/api/settings/llm-router`, {
+      method: "POST",
+      headers: {
+        ...auth,
+        "Content-Type": "application/json",
+        "X-CSRF-Token": token,
+        Cookie: cookie,
+      },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("/api/llm-router/models", () => {
+  beforeAll(() => {
+    // Inject a fake catalogue so the route doesn't try to reach OpenRouter.
+    const stub = {
+      async search(params: { query?: string }) {
+        const all = [
+          {
+            id: "anthropic/claude-opus",
+            name: "Claude Opus",
+            context_length: 200000,
+            pricing: { prompt: 0.000015, completion: 0.000075 },
+          },
+          {
+            id: "groq/llama-3",
+            name: "Llama 3",
+            context_length: 8192,
+            pricing: { prompt: 0.0000001, completion: 0.0000001 },
+          },
+        ];
+        const q = params.query?.toLowerCase();
+        return {
+          models: q ? all.filter((m) => `${m.id} ${m.name}`.toLowerCase().includes(q)) : all,
+          cachedAt: 1000,
+        };
+      },
+    };
+    __setLlmRouterCatalogueForTests(stub as unknown as ModelCatalogue);
+  });
+
+  it("503s when OPENROUTER_API_KEY is not set", async () => {
+    const prior = process.env.OPENROUTER_API_KEY;
+    delete process.env.OPENROUTER_API_KEY;
+    try {
+      const res = await fetch(`${base}/api/llm-router/models?query=claude`, { headers: auth });
+      expect(res.status).toBe(503);
+      const data = (await res.json()) as { ok: boolean; error: string };
+      expect(data.ok).toBe(false);
+      expect(data.error).toMatch(/OPENROUTER_API_KEY/);
+    } finally {
+      if (prior !== undefined) process.env.OPENROUTER_API_KEY = prior;
+    }
+  });
+
+  it("proxies the catalogue search when the key is set", async () => {
+    process.env.OPENROUTER_API_KEY = "test-key";
+    try {
+      const res = await fetch(`${base}/api/llm-router/models?query=claude`, { headers: auth });
+      expect(res.status).toBe(200);
+      const data = (await res.json()) as { ok: boolean; models: Array<{ id: string }> };
+      expect(data.ok).toBe(true);
+      expect(data.models.map((m) => m.id)).toEqual(["anthropic/claude-opus"]);
+    } finally {
+      delete process.env.OPENROUTER_API_KEY;
+    }
+  });
+});

--- a/src/ui/__tests__/llm-router-routes.test.ts
+++ b/src/ui/__tests__/llm-router-routes.test.ts
@@ -185,4 +185,33 @@ describe("/api/llm-router/models", () => {
       delete process.env.OPENROUTER_API_KEY;
     }
   });
+
+  it("forwards maxPromptPrice / minContext / limit query params to the catalogue", async () => {
+    // Replace the stub with one that captures params, so we can assert the
+    // route's parseLlmModelsQuery actually reaches catalogue.search (#70).
+    let captured: Record<string, unknown> | null = null;
+    const capturing = {
+      async search(params: Record<string, unknown>) {
+        captured = params;
+        return { models: [], cachedAt: 0 };
+      },
+    };
+    __setLlmRouterCatalogueForTests(capturing as unknown as ModelCatalogue);
+    process.env.OPENROUTER_API_KEY = "test-key";
+    try {
+      const res = await fetch(
+        `${base}/api/llm-router/models?query=foo&maxPromptPrice=0.000005&minContext=32000&limit=10`,
+        { headers: auth },
+      );
+      expect(res.status).toBe(200);
+      expect(captured).toEqual({
+        query: "foo",
+        maxPromptPrice: 0.000005,
+        minContext: 32000,
+        limit: 10,
+      });
+    } finally {
+      delete process.env.OPENROUTER_API_KEY;
+    }
+  });
 });

--- a/src/ui/__tests__/llm-router-settings.test.ts
+++ b/src/ui/__tests__/llm-router-settings.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for `src/ui/services/llm-router-settings.ts` (#70 Phase C).
+ *
+ * Exercises the real settings.json read/write path with backup + restore around
+ * the run, matching the harness used by runtime-config.test.ts.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { join } from "path";
+import { mkdir, copyFile, unlink, writeFile } from "fs/promises";
+import { existsSync } from "fs";
+
+import { readLlmRouterSettings, updateLlmRouterSettings } from "../services/llm-router-settings";
+
+const SETTINGS_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const SETTINGS_FILE = join(SETTINGS_DIR, "settings.json");
+const BACKUP_FILE = join(SETTINGS_DIR, "settings.json.llm-router-test-backup");
+
+beforeAll(async () => {
+  await mkdir(SETTINGS_DIR, { recursive: true });
+  if (existsSync(SETTINGS_FILE)) await copyFile(SETTINGS_FILE, BACKUP_FILE);
+});
+
+afterAll(async () => {
+  if (existsSync(BACKUP_FILE)) {
+    await copyFile(BACKUP_FILE, SETTINGS_FILE);
+    await unlink(BACKUP_FILE);
+  } else if (existsSync(SETTINGS_FILE)) {
+    await unlink(SETTINGS_FILE);
+  }
+});
+
+async function seed(json: Record<string, unknown>): Promise<void> {
+  await writeFile(SETTINGS_FILE, `${JSON.stringify(json, null, 2)}\n`);
+}
+
+describe("readLlmRouterSettings", () => {
+  beforeEach(async () => {
+    await seed({});
+  });
+
+  it("returns empty tiers + the default base when llmRouter is absent", async () => {
+    const r = await readLlmRouterSettings();
+    expect(r).toEqual({
+      tiers: { fast: [], balanced: [], reasoning: [] },
+      openRouterBaseUrl: "https://openrouter.ai/api/v1",
+    });
+  });
+
+  it("returns configured tiers + optional ollamaBaseUrl", async () => {
+    await seed({
+      llmRouter: {
+        tiers: { fast: ["g/llama"], balanced: ["a/b", "c/d"], reasoning: ["x/y"] },
+        openRouterBaseUrl: "https://or.example/api/v1",
+        ollamaBaseUrl: "http://127.0.0.1:11434/v1",
+      },
+    });
+    const r = await readLlmRouterSettings();
+    expect(r).toEqual({
+      tiers: { fast: ["g/llama"], balanced: ["a/b", "c/d"], reasoning: ["x/y"] },
+      openRouterBaseUrl: "https://or.example/api/v1",
+      ollamaBaseUrl: "http://127.0.0.1:11434/v1",
+    });
+  });
+
+  it("drops non-string / empty tier entries", async () => {
+    await seed({
+      llmRouter: { tiers: { fast: ["  g/llama  ", "", 42, null], balanced: "nope" } },
+    });
+    const r = await readLlmRouterSettings();
+    expect(r.tiers.fast).toEqual(["g/llama"]);
+    expect(r.tiers.balanced).toEqual([]);
+  });
+});
+
+describe("updateLlmRouterSettings", () => {
+  beforeEach(async () => {
+    await seed({});
+  });
+
+  it("creates the llmRouter block on a settings.json that lacks it", async () => {
+    const next = await updateLlmRouterSettings({ tiers: { fast: ["g/llama"] } });
+    expect(next.tiers.fast).toEqual(["g/llama"]);
+    expect(next.tiers.balanced).toEqual([]);
+    // Round-trip from disk to confirm it wrote.
+    const round = await readLlmRouterSettings();
+    expect(round.tiers.fast).toEqual(["g/llama"]);
+  });
+
+  it("only patches the tiers the caller supplied", async () => {
+    await seed({
+      llmRouter: { tiers: { fast: ["keep/me"], balanced: ["b/1"], reasoning: ["r/1"] } },
+    });
+    await updateLlmRouterSettings({ tiers: { balanced: ["new/b"] } });
+    const r = await readLlmRouterSettings();
+    expect(r.tiers.fast).toEqual(["keep/me"]);
+    expect(r.tiers.balanced).toEqual(["new/b"]);
+    expect(r.tiers.reasoning).toEqual(["r/1"]);
+  });
+
+  it("trims + filters ids on write", async () => {
+    await updateLlmRouterSettings({
+      tiers: { fast: ["  groq/llama  ", "", 0 as unknown as string] },
+    });
+    const r = await readLlmRouterSettings();
+    expect(r.tiers.fast).toEqual(["groq/llama"]);
+  });
+});

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -1870,4 +1870,205 @@ setInterval(loadKanban, 10000);
     }
 
     fetchUsage();
-    setInterval(fetchUsage, 60_000);`;
+    setInterval(fetchUsage, 60_000);
+
+    // --- LLM Router (#70 Phase C) — Settings → 🧠 LLM Router → modal ---
+    (function lrInit() {
+      const lrConfig = $("lr-config");
+      const lrModal = $("lr-modal");
+      const lrModalClose = $("lr-modal-close");
+      const lrSearchInput = $("lr-search-input");
+      const lrSearchStatus = $("lr-search-status");
+      const lrResults = $("lr-results");
+      const lrModalStatus = $("lr-modal-status");
+      const lrCancelBtn = $("lr-cancel-btn");
+      const lrSaveBtn = $("lr-save-btn");
+      const lrInfoEl = $("lr-info");
+      const tierEls = {
+        fast: $("lr-tier-fast"),
+        balanced: $("lr-tier-balanced"),
+        reasoning: $("lr-tier-reasoning"),
+      };
+      if (!lrConfig || !lrModal) return;
+
+      let tiers = { fast: [], balanced: [], reasoning: [] };
+      let dirty = false;
+      let searchAbort = null;
+      let searchDebounce = 0;
+
+      function renderChips() {
+        ["fast", "balanced", "reasoning"].forEach(function(t) {
+          const el = tierEls[t];
+          if (!el) return;
+          el.replaceChildren();
+          (tiers[t] || []).forEach(function(id) {
+            const chip = document.createElement("span");
+            chip.className = "lr-chip";
+            chip.textContent = id;
+            const x = document.createElement("button");
+            x.type = "button";
+            x.className = "lr-chip-x";
+            x.setAttribute("aria-label", "Remove " + id);
+            x.textContent = "×";
+            x.addEventListener("click", function() {
+              tiers[t] = (tiers[t] || []).filter(function(m) { return m !== id; });
+              dirty = true;
+              renderChips();
+            });
+            chip.appendChild(x);
+            el.appendChild(chip);
+          });
+          if (!tiers[t] || tiers[t].length === 0) {
+            const empty = document.createElement("span");
+            empty.className = "lr-empty";
+            empty.textContent = "(none)";
+            el.appendChild(empty);
+          }
+        });
+        const total = (tiers.fast || []).length + (tiers.balanced || []).length + (tiers.reasoning || []).length;
+        if (lrInfoEl) lrInfoEl.textContent = total === 0 ? "No models configured" : (total + " model(s) across tiers");
+      }
+
+      function fmtPrice(p) {
+        if (!p) return "—";
+        // OpenRouter pricing is per-token; show $/Mtok for readability.
+        const perMtok = p * 1_000_000;
+        return "$" + (perMtok < 1 ? perMtok.toFixed(3) : perMtok.toFixed(2)) + "/Mt";
+      }
+
+      function renderResults(models) {
+        if (!lrResults) return;
+        lrResults.replaceChildren();
+        if (!models || models.length === 0) {
+          const empty = document.createElement("div");
+          empty.className = "lr-empty";
+          empty.textContent = "No matches.";
+          lrResults.appendChild(empty);
+          return;
+        }
+        models.forEach(function(m) {
+          const row = document.createElement("div");
+          row.className = "lr-row";
+          const meta = document.createElement("div");
+          meta.className = "lr-row-meta";
+          const id = document.createElement("div");
+          id.className = "lr-row-id";
+          id.textContent = m.id;
+          const sub = document.createElement("div");
+          sub.className = "lr-row-sub";
+          const ctx = m.context_length ? Math.round(m.context_length / 1000) + "k" : "?";
+          sub.textContent = m.name + " · " + ctx + " · " + fmtPrice(m.pricing && m.pricing.prompt);
+          meta.appendChild(id);
+          meta.appendChild(sub);
+          const btns = document.createElement("div");
+          btns.className = "lr-row-btns";
+          ["fast", "balanced", "reasoning"].forEach(function(t) {
+            const b = document.createElement("button");
+            b.type = "button";
+            b.className = "hb-toggle";
+            b.textContent = "+ " + t;
+            b.addEventListener("click", function() {
+              tiers[t] = tiers[t] || [];
+              if (tiers[t].indexOf(m.id) === -1) {
+                tiers[t].push(m.id);
+                dirty = true;
+                renderChips();
+              }
+            });
+            btns.appendChild(b);
+          });
+          row.appendChild(meta);
+          row.appendChild(btns);
+          lrResults.appendChild(row);
+        });
+      }
+
+      async function runSearch() {
+        if (!lrSearchInput) return;
+        const q = (lrSearchInput.value || "").trim();
+        if (lrSearchStatus) lrSearchStatus.textContent = q ? "Searching…" : "Loading catalogue…";
+        if (searchAbort) searchAbort.abort();
+        searchAbort = new AbortController();
+        try {
+          const url = "/api/llm-router/models" + (q ? ("?query=" + encodeURIComponent(q)) : "");
+          const res = await fetch(url, { signal: searchAbort.signal });
+          const data = await res.json();
+          if (!data || data.ok !== true) {
+            if (lrSearchStatus) lrSearchStatus.textContent = (data && data.error) || "Search failed";
+            return;
+          }
+          if (lrSearchStatus) lrSearchStatus.textContent = data.models.length + " result(s)";
+          renderResults(data.models);
+        } catch (err) {
+          if (err && err.name === "AbortError") return;
+          if (lrSearchStatus) lrSearchStatus.textContent = "Search failed";
+        }
+      }
+
+      async function loadCurrent() {
+        try {
+          const res = await fetch("/api/settings/llm-router");
+          const data = await res.json();
+          if (data && data.ok && data.llmRouter && data.llmRouter.tiers) {
+            tiers = {
+              fast: (data.llmRouter.tiers.fast || []).slice(),
+              balanced: (data.llmRouter.tiers.balanced || []).slice(),
+              reasoning: (data.llmRouter.tiers.reasoning || []).slice(),
+            };
+          }
+        } catch (_e) { /* keep defaults */ }
+        renderChips();
+      }
+
+      function openModal() {
+        loadCurrent();
+        runSearch();
+        if (lrModal) {
+          lrModal.setAttribute("aria-hidden", "false");
+          lrModal.classList.add("open");
+        }
+        if (lrModalStatus) lrModalStatus.textContent = "";
+      }
+      function closeModal() {
+        if (lrModal) {
+          lrModal.setAttribute("aria-hidden", "true");
+          lrModal.classList.remove("open");
+        }
+        dirty = false;
+      }
+
+      lrConfig.addEventListener("click", openModal);
+      if (lrModalClose) lrModalClose.addEventListener("click", closeModal);
+      if (lrCancelBtn) lrCancelBtn.addEventListener("click", closeModal);
+      if (lrSearchInput) {
+        lrSearchInput.addEventListener("input", function() {
+          window.clearTimeout(searchDebounce);
+          searchDebounce = window.setTimeout(runSearch, 220);
+        });
+      }
+      if (lrSaveBtn) {
+        lrSaveBtn.addEventListener("click", async function() {
+          if (lrModalStatus) lrModalStatus.textContent = "Saving…";
+          try {
+            const res = await mutatingFetch("/api/settings/llm-router", {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ tiers: tiers }),
+            });
+            const data = await res.json();
+            if (data && data.ok) {
+              if (lrModalStatus) lrModalStatus.textContent = "Saved.";
+              dirty = false;
+              renderChips();
+            } else {
+              if (lrModalStatus) lrModalStatus.textContent = (data && data.error) || "Save failed";
+            }
+          } catch (_e) {
+            if (lrModalStatus) lrModalStatus.textContent = "Save failed";
+          }
+        });
+      }
+
+      // Initial info-line load (so the Settings panel shows the count before the modal is opened).
+      loadCurrent();
+    })();`;

--- a/src/ui/page/styles.ts
+++ b/src/ui/page/styles.ts
@@ -1914,4 +1914,30 @@ export const pageStyles = String.raw`    :root {
   .usage-td-label { max-width: 110px; }
   .usage-td-cost { min-width: 80px; }
 }
+
+/* --- LLM Router modal (#70 Phase C) — reuses .hb-* for buttons + inputs --- */
+.lr-card { max-width: 720px; }
+.lr-body { display: flex; flex-direction: column; gap: 16px; padding: 16px 18px 18px; }
+.lr-tiers { display: grid; grid-template-columns: repeat(3, 1fr); gap: 10px; }
+.lr-tier { background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06); border-radius: 8px; padding: 8px 10px; min-height: 64px; }
+.lr-tier-head { font-size: 12px; opacity: 0.7; text-transform: lowercase; margin-bottom: 6px; }
+.lr-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+.lr-chip { display: inline-flex; align-items: center; gap: 4px; padding: 2px 6px 2px 8px; background: rgba(120,160,255,0.12); border: 1px solid rgba(120,160,255,0.28); border-radius: 12px; font-size: 11px; font-family: ui-monospace, monospace; }
+.lr-chip-x { background: transparent; border: 0; color: inherit; cursor: pointer; opacity: 0.6; padding: 0 2px; font-size: 13px; line-height: 1; }
+.lr-chip-x:hover { opacity: 1; }
+.lr-empty { font-size: 11px; opacity: 0.45; font-style: italic; }
+.lr-search { display: flex; flex-direction: column; gap: 6px; }
+.lr-status { font-size: 11px; opacity: 0.6; min-height: 14px; }
+.lr-results { max-height: 280px; overflow-y: auto; display: flex; flex-direction: column; gap: 4px; border: 1px solid rgba(255,255,255,0.06); border-radius: 6px; padding: 4px; }
+.lr-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 6px 8px; border-radius: 4px; }
+.lr-row:hover { background: rgba(255,255,255,0.04); }
+.lr-row-meta { min-width: 0; flex: 1; }
+.lr-row-id { font-family: ui-monospace, monospace; font-size: 12px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.lr-row-sub { font-size: 11px; opacity: 0.6; }
+.lr-row-btns { display: flex; gap: 4px; flex-shrink: 0; }
+.lr-row-btns .hb-toggle { font-size: 10px; padding: 2px 6px; }
+@media (max-width: 600px) {
+  .lr-tiers { grid-template-columns: 1fr; }
+  .lr-row { flex-direction: column; align-items: flex-start; }
+}
 `;

--- a/src/ui/page/template.ts
+++ b/src/ui/page/template.ts
@@ -74,6 +74,13 @@ ${pageStyles}
       </div>
       <div class="setting-item">
         <div class="setting-main">
+          <div class="settings-label">🧠 LLM Router</div>
+          <div class="settings-meta" id="lr-info">Pick OpenRouter models per tier</div>
+        </div>
+        <button class="hb-config" id="lr-config" type="button">Configure</button>
+      </div>
+      <div class="setting-item">
+        <div class="setting-main">
           <div class="settings-label">🧾 Advanced</div>
           <div class="settings-meta">Technical runtime and JSON files</div>
         </div>
@@ -104,6 +111,45 @@ ${pageStyles}
           </div>
         </div>
       </form>
+    </article>
+  </section>
+  <section class="info-modal" id="lr-modal" aria-live="polite" aria-hidden="true">
+    <article class="hb-card lr-card">
+      <div class="info-head">
+        <span>LLM Router</span>
+        <button class="settings-close" id="lr-modal-close" type="button" aria-label="Close LLM router">×</button>
+      </div>
+      <div class="lr-body">
+        <div class="lr-tiers">
+          <div class="lr-tier">
+            <div class="lr-tier-head">⚡ fast</div>
+            <div class="lr-chips" id="lr-tier-fast" data-tier="fast"></div>
+          </div>
+          <div class="lr-tier">
+            <div class="lr-tier-head">⚖️ balanced</div>
+            <div class="lr-chips" id="lr-tier-balanced" data-tier="balanced"></div>
+          </div>
+          <div class="lr-tier">
+            <div class="lr-tier-head">🧠 reasoning</div>
+            <div class="lr-chips" id="lr-tier-reasoning" data-tier="reasoning"></div>
+          </div>
+        </div>
+        <div class="lr-search">
+          <label class="hb-field" for="lr-search-input">
+            <span class="hb-label">Search OpenRouter models</span>
+            <input class="hb-input" id="lr-search-input" type="search" placeholder="e.g. claude, llama, deepseek" autocomplete="off" />
+          </label>
+          <div class="lr-status" id="lr-search-status"></div>
+          <div class="lr-results" id="lr-results"></div>
+        </div>
+        <div class="hb-actions">
+          <div class="hb-status" id="lr-modal-status"></div>
+          <div class="hb-buttons">
+            <button class="hb-btn ghost" id="lr-cancel-btn" type="button">Cancel</button>
+            <button class="hb-btn solid" id="lr-save-btn" type="button">Save</button>
+          </div>
+        </div>
+      </div>
     </article>
   </section>
   <section class="info-modal" id="info-modal" aria-live="polite" aria-hidden="true">

--- a/src/ui/server.ts
+++ b/src/ui/server.ts
@@ -6,6 +6,13 @@ import { checkToken } from "./auth";
 import type { StartWebUiOptions, WebServerHandle } from "./types";
 import { buildState, buildTechnicalInfo, sanitizeSettings } from "./services/state";
 import { readHeartbeatSettings, updateHeartbeatSettings } from "./services/settings";
+import {
+  readLlmRouterSettings,
+  updateLlmRouterSettings,
+  type LlmRouterTiers,
+} from "./services/llm-router-settings";
+import { ModelCatalogue } from "../plugins/llm-router/catalogue";
+import type { LlmModelsParams } from "../plugins/llm-router/types";
 import { createQuickJob, deleteJob } from "./services/jobs";
 import { fireJob } from "../commands/fire";
 import { readLogs } from "./services/logs";
@@ -27,6 +34,49 @@ import { getHttpGateway } from "../plugins/http-gateway.js";
 //   - Per-session CSRF tokens (below) on state-changing routes.
 const CSRF_HEADER_NAME = "X-CSRF-Token";
 const MAX_CSRF_TOKENS = 10000;
+
+// LLM router catalogue cache (#70 Phase C). Lazy module-level singleton —
+// rebuilt only when the API key or base URL changes between requests.
+let _llmRouterCatalogue: { key: string; baseUrl: string; instance: ModelCatalogue } | null = null;
+async function getLlmRouterCatalogue(apiKey: string, baseUrl: string): Promise<ModelCatalogue> {
+  // A test-injected catalogue (key === "__test__") is sticky: routes hit the
+  // stub regardless of the runtime key/baseUrl. Production paths only rebuild
+  // when key or baseUrl changes.
+  if (_llmRouterCatalogue?.key === "__test__") return _llmRouterCatalogue.instance;
+  if (
+    !_llmRouterCatalogue ||
+    _llmRouterCatalogue.key !== apiKey ||
+    _llmRouterCatalogue.baseUrl !== baseUrl
+  ) {
+    _llmRouterCatalogue = {
+      key: apiKey,
+      baseUrl,
+      instance: new ModelCatalogue({ apiKey, baseUrl }),
+    };
+  }
+  return _llmRouterCatalogue.instance;
+}
+
+/** Test seam — reset the singleton between tests (or inject a stub). */
+export function __setLlmRouterCatalogueForTests(instance: ModelCatalogue | null): void {
+  _llmRouterCatalogue = instance ? { key: "__test__", baseUrl: "__test__", instance } : null;
+}
+
+function parseLlmModelsQuery(url: URL): LlmModelsParams {
+  const sp = url.searchParams;
+  const num = (k: string): number | undefined => {
+    const v = sp.get(k);
+    if (v === null || v === "") return undefined;
+    const n = Number.parseFloat(v);
+    return Number.isFinite(n) ? n : undefined;
+  };
+  return {
+    ...(sp.get("query") ? { query: sp.get("query") as string } : {}),
+    ...(num("maxPromptPrice") !== undefined ? { maxPromptPrice: num("maxPromptPrice") } : {}),
+    ...(num("minContext") !== undefined ? { minContext: num("minContext") } : {}),
+    ...(num("limit") !== undefined ? { limit: num("limit") } : {}),
+  };
+}
 
 interface CsrfEntry {
   tokens: Array<{ token: string; expiresAt: number }>;
@@ -351,6 +401,64 @@ export function startWebUi(opts: StartWebUiOptions): WebServerHandle {
         } catch (err) {
           console.error("Heartbeat settings read failed:", err);
           return json({ ok: false, error: "Failed to read heartbeat settings" });
+        }
+      }
+
+      // LLM router settings (#70 Phase C) — read + patch tiers.
+      if (url.pathname === "/api/settings/llm-router" && req.method === "GET") {
+        try {
+          return json({ ok: true, llmRouter: await readLlmRouterSettings() });
+        } catch (err) {
+          console.error("LLM router settings read failed:", err);
+          return json({ ok: false, error: "Failed to read llm-router settings" });
+        }
+      }
+
+      if (url.pathname === "/api/settings/llm-router" && req.method === "POST") {
+        const csrfError = requireCsrf(req);
+        if (csrfError) return csrfError;
+        try {
+          const body = (await req.json()) as { tiers?: Partial<LlmRouterTiers> };
+          const tiersPatch: Partial<LlmRouterTiers> = {};
+          if (body.tiers && typeof body.tiers === "object") {
+            const keys = ["fast", "balanced", "reasoning"] as const;
+            for (const k of keys) {
+              const v = (body.tiers as Record<string, unknown>)[k];
+              if (Array.isArray(v))
+                tiersPatch[k] = v.filter((x): x is string => typeof x === "string");
+            }
+          }
+          if (Object.keys(tiersPatch).length === 0) {
+            return json({ ok: false, error: "no tier fields provided" }, 400);
+          }
+          const next = await updateLlmRouterSettings({ tiers: tiersPatch });
+          return json({ ok: true, llmRouter: next });
+        } catch (err) {
+          console.error("LLM router settings update failed:", err);
+          return json({ ok: false, error: "Failed to update llm-router settings" });
+        }
+      }
+
+      // OpenRouter catalogue proxy backing the dashboard model picker (#70 D3).
+      // Lazy singleton catalogue; reads OPENROUTER_API_KEY at request time so a
+      // late-set env var works without a daemon restart.
+      if (url.pathname === "/api/llm-router/models" && req.method === "GET") {
+        try {
+          const params = parseLlmModelsQuery(url);
+          const apiKey = process.env.OPENROUTER_API_KEY ?? "";
+          if (!apiKey) {
+            return json(
+              { ok: false, error: "OPENROUTER_API_KEY is not set in the daemon environment" },
+              503,
+            );
+          }
+          const settings = await readLlmRouterSettings();
+          const catalogue = await getLlmRouterCatalogue(apiKey, settings.openRouterBaseUrl);
+          const { models, cachedAt } = await catalogue.search(params);
+          return json({ ok: true, models, cachedAt });
+        } catch (err) {
+          console.error("LLM router catalogue search failed:", err);
+          return json({ ok: false, error: "catalogue search failed" }, 502);
         }
       }
 

--- a/src/ui/services/llm-router-settings.ts
+++ b/src/ui/services/llm-router-settings.ts
@@ -1,0 +1,88 @@
+/**
+ * Dashboard read/update helper for `settings.llmRouter` (#70 Phase C). Mirrors
+ * `settings.ts` (heartbeat) — direct settings.json read + mutate sub-section +
+ * writeFile.
+ *
+ * Only `tiers` are operator-editable from the dashboard in v1; advanced fields
+ * (`openRouterBaseUrl`, `ollamaBaseUrl`) stay JSON-only to avoid widening the
+ * UI surface.
+ */
+
+import { readFile, writeFile } from "fs/promises";
+import { SETTINGS_FILE } from "../constants";
+
+export interface LlmRouterTiers {
+  fast: string[];
+  balanced: string[];
+  reasoning: string[];
+}
+
+export interface LlmRouterSettingsPatch {
+  tiers?: Partial<LlmRouterTiers>;
+}
+
+export interface LlmRouterSettingsData {
+  tiers: LlmRouterTiers;
+  openRouterBaseUrl: string;
+  ollamaBaseUrl?: string;
+}
+
+const DEFAULT_BASE = "https://openrouter.ai/api/v1";
+
+function toIdList(raw: unknown): string[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .filter((m): m is string => typeof m === "string" && m.trim().length > 0)
+    .map((m) => m.trim());
+}
+
+function canonical(data: Record<string, unknown>): LlmRouterSettingsData {
+  const lr = (data.llmRouter as Record<string, unknown> | undefined) ?? {};
+  const tiersRaw = (lr.tiers as Record<string, unknown> | undefined) ?? {};
+  const baseUrl =
+    typeof lr.openRouterBaseUrl === "string" && lr.openRouterBaseUrl.trim()
+      ? lr.openRouterBaseUrl.trim()
+      : DEFAULT_BASE;
+  return {
+    tiers: {
+      fast: toIdList(tiersRaw.fast),
+      balanced: toIdList(tiersRaw.balanced),
+      reasoning: toIdList(tiersRaw.reasoning),
+    },
+    openRouterBaseUrl: baseUrl,
+    ...(typeof lr.ollamaBaseUrl === "string" && lr.ollamaBaseUrl.trim()
+      ? { ollamaBaseUrl: lr.ollamaBaseUrl.trim() }
+      : {}),
+  };
+}
+
+export async function readLlmRouterSettings(): Promise<LlmRouterSettingsData> {
+  const raw = await readFile(SETTINGS_FILE, "utf-8");
+  return canonical(JSON.parse(raw) as Record<string, unknown>);
+}
+
+export async function updateLlmRouterSettings(
+  patch: LlmRouterSettingsPatch,
+): Promise<LlmRouterSettingsData> {
+  const raw = await readFile(SETTINGS_FILE, "utf-8");
+  const data = JSON.parse(raw) as Record<string, unknown>;
+  if (!data.llmRouter || typeof data.llmRouter !== "object") {
+    data.llmRouter = {
+      tiers: { fast: [], balanced: [], reasoning: [] },
+      openRouterBaseUrl: DEFAULT_BASE,
+    };
+  }
+  const lr = data.llmRouter as Record<string, unknown>;
+  if (!lr.tiers || typeof lr.tiers !== "object")
+    lr.tiers = { fast: [], balanced: [], reasoning: [] };
+  const tiers = lr.tiers as Record<string, unknown>;
+
+  if (patch.tiers) {
+    if (patch.tiers.fast !== undefined) tiers.fast = toIdList(patch.tiers.fast);
+    if (patch.tiers.balanced !== undefined) tiers.balanced = toIdList(patch.tiers.balanced);
+    if (patch.tiers.reasoning !== undefined) tiers.reasoning = toIdList(patch.tiers.reasoning);
+  }
+
+  await writeFile(SETTINGS_FILE, `${JSON.stringify(data, null, 2)}\n`);
+  return canonical(data);
+}


### PR DESCRIPTION
Phase C of #70 — the "tool now, UI later" half from the Phase B Q&A. Builds on Phases A (SPEC, #202) and B (the `llm_models` MCP tool, #203).

## What it does
Adds a "🧠 **LLM Router**" section to the legacy dashboard's Settings modal. The operator:
1. Opens the modal, sees their current per-tier model lists as removable chips.
2. Types into a search box → debounced query against OpenRouter's catalogue (cached server-side, no fresh fetch per keystroke).
3. Clicks `+ fast` / `+ balanced` / `+ reasoning` on a result to assign.
4. Hits Save → `settings.llmRouter.tiers` is written, and the **plugin picks up the change on its next call without a daemon restart**.

## Server
- `src/ui/services/llm-router-settings.ts` — read/update helper mirroring `settings.ts` (heartbeat).
- Three routes in `src/ui/server.ts`:
  - `GET /api/settings/llm-router` → current tiers + base URLs.
  - `POST /api/settings/llm-router` (CSRF) → patch tiers.
  - `GET /api/llm-router/models?query=&maxPromptPrice=&minContext=&limit=` → catalogue proxy. **Reuses `ModelCatalogue` from `src/plugins/llm-router/catalogue.ts`** (single source of truth — no duplicate catalogue logic). Reads `OPENROUTER_API_KEY` at request time; 503 when unset.
- Module-level singleton catalogue, keyed by `(apiKey, baseUrl)`; rebuilt only when either changes. Test seam: `__setLlmRouterCatalogueForTests` (repo precedent: `isHostAllowed`).

## Plugin live-reload (small scoped touch)
`createLlmRouterHandlers` now accepts `getConfig?: () => Promise<config>` alongside the existing static `config`. `startLlmRouterServer` wires a factory that calls `reloadSettings()` + `buildRuntimeConfig()` per call, so dashboard tier edits take effect immediately. Disk read is single-digit ms; LLM calls are seconds. Tests can still pass static `config` (back-compat).

## UI
- `src/ui/page/template.ts` — new settings-stack item + an aria-live modal section (`#lr-modal`).
- `src/ui/page/script.ts` — self-contained `lrInit` IIFE: chip rendering, debounced (220ms) + AbortController-guarded search, save via the existing `mutatingFetch` (CSRF). **No `innerHTML` for any rendered content** — DOM built via `createElement` / `textContent` / `replaceChildren` (XSS-safe).
- `src/ui/page/styles.ts` — scoped `.lr-*` utility classes; reuses `.hb-*` for buttons/inputs.

## Tests (+15)
- `llm-router-settings.test.ts` — read defaults / configured / invalid-id drop; updates create section, patch only supplied tiers, trim+filter on write (backup/restore harness mirrors `runtime-config.test.ts`).
- `llm-router-routes.test.ts` — boots `startWebUi` on ephemeral port; GET defaults, POST round-trip, empty-body 400; catalogue 503 without env key, 200 with stub catalogue, **filter passthrough** (asserts `maxPromptPrice`/`minContext`/`limit` reach `catalogue.search`).
- Plugin live-reload regression — `getConfig` invoked per `llm_call`; second call sees updated tier ids.

## Review
6-agent review (security + 5 dimensions). Findings, all addressed:
- ✅ Test coverage: filter-passthrough gap → added test (conf 85).
- ✅ Bug-scan "missing Authorization header" → **false positive**: `window.fetch` is monkey-patched at `script.ts:30-53` to auto-add `Authorization: Bearer` to every `/api/*` request.
- ✅ Security: clean (no CRITICAL/HIGH; one documented LOW on the test seam, repo-precedent acceptable).
- ✅ SPEC conformance: all Phase A/B/C decisions verified.
- ✅ Repo-fit: ALIGNED + SIMPLE (zero new deps).

## Browser verification
**Manual click-through is yours to do** — I can't run the daemon + open the dashboard from here. Smoke path: open Settings → 🧠 LLM Router → Configure → type "claude" → click `+ fast` → Save → reopen modal and confirm the chip persisted.

## Out of scope
- Per-tier "test this tier" smoke prompt.
- Price/context filters in the UI (the route accepts them; not surfaced in v1).
- Bus-runtime web UI changes (this is the legacy dashboard).