### PR TITLE
feat(bus): receipt chain for bus → PTY observability (refs #207)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.132",
+      "version": "2.2.133",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.132",
+  "version": "2.2.133",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/receipt-wiring.test.ts
+++ b/src/bus/__tests__/receipt-wiring.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the bus → PTY receipt wiring helper (issue #207). Verifies the
+ * pid/generation back-fill and the stale_session rollback paths without
+ * booting the full bus runtime.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createReceiptStore, hashPrompt, type ReceiptRecord, type ReceiptStore } from "../receipt";
+import { type AgentProcessLike, createPromptStreamHandler } from "../receipt-wiring";
+
+let tmpDir: string;
+let logPath: string;
+let store: ReceiptStore;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "receipt-wiring-"));
+  logPath = join(tmpDir, "receipts.jsonl");
+  store = createReceiptStore({ path: logPath });
+});
+
+afterEach(() => {
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function readReceipts(): ReceiptRecord[] {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as ReceiptRecord);
+}
+
+function fakeAgent(pid: number, sendImpl?: (line: string) => Promise<void>): AgentProcessLike {
+  return {
+    pid,
+    send_prompt_stream: sendImpl ?? (() => Promise.resolve()),
+  };
+}
+
+describe("createPromptStreamHandler", () => {
+  test("writes to the PTY when no receipt is open (back-compat)", async () => {
+    let captured: string | null = null;
+    const handler = createPromptStreamHandler(
+      () =>
+        fakeAgent(111, async (t) => {
+          captured = t;
+        }),
+      { store },
+    );
+    await handler("alpha", "hi");
+    expect(captured).toBe("hi");
+    expect(readReceipts()).toHaveLength(0);
+  });
+
+  test("back-fills pid + generation + route_resolved_at when a receipt is open", async () => {
+    const r = store.open("m1", { agent_id: "alpha", prompt_hash: hashPrompt("hi") });
+    const handler = createPromptStreamHandler(() => fakeAgent(2222), { store });
+    await handler("alpha", "hi");
+    expect(r.record.process_pid).toBe(2222);
+    expect(r.record.process_generation).toBe(1);
+    expect(r.record.notes?.route_resolved_at).toBeDefined();
+    expect(r.record.notes?.stdin_written_at).toBeDefined();
+  });
+
+  test("generation bumps when the same agent_id is seen with a different pid", async () => {
+    const handler = createPromptStreamHandler(() => fakeAgent(currentPid), { store });
+    let currentPid = 100;
+    const r1 = store.open("m-a", { agent_id: "alpha", prompt_hash: hashPrompt("a") });
+    await handler("alpha", "a");
+    expect(r1.record.process_generation).toBe(1);
+    expect(r1.record.process_pid).toBe(100);
+
+    currentPid = 200;
+    const r2 = store.open("m-b", { agent_id: "alpha", prompt_hash: hashPrompt("b") });
+    await handler("alpha", "b");
+    expect(r2.record.process_generation).toBe(2);
+    expect(r2.record.process_pid).toBe(200);
+  });
+
+  test("generation stays stable when the same pid is observed twice", async () => {
+    const handler = createPromptStreamHandler(() => fakeAgent(777), { store });
+    const r1 = store.open("m-1", { agent_id: "alpha", prompt_hash: hashPrompt("one") });
+    await handler("alpha", "one");
+    const r2 = store.open("m-2", { agent_id: "alpha", prompt_hash: hashPrompt("two") });
+    await handler("alpha", "two");
+    expect(r1.record.process_generation).toBe(1);
+    expect(r2.record.process_generation).toBe(1);
+  });
+
+  test("closes receipt as stale_session on PTY write error and re-throws", async () => {
+    const handler = createPromptStreamHandler(
+      () => fakeAgent(42, () => Promise.reject(new Error("pty closed"))),
+      { store },
+    );
+    store.open("m-err", { agent_id: "alpha", prompt_hash: hashPrompt("zap") });
+    await expect(handler("alpha", "zap")).rejects.toThrow("pty closed");
+    // Allow the close fire-and-forget to flush.
+    await new Promise((r) => setTimeout(r, 10));
+    const recs = readReceipts();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].final_state).toBe("stale_session");
+    expect(recs[0].notes?.stage).toBe("pty_write");
+    expect(recs[0].notes?.error).toBe("pty closed");
+  });
+
+  test("closes receipt as stale_session when agent is not registered", async () => {
+    const handler = createPromptStreamHandler(() => undefined, { store });
+    store.open("m-unreg", { agent_id: "ghost", prompt_hash: hashPrompt("hello") });
+    await handler("ghost", "hello");
+    await new Promise((r) => setTimeout(r, 10));
+    const recs = readReceipts();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].final_state).toBe("stale_session");
+    expect(recs[0].notes?.reason).toBe("agent_not_registered");
+  });
+
+  test("closes receipt as stale_session when agent has no send_prompt_stream", async () => {
+    const handler = createPromptStreamHandler(() => ({ pid: 9 }) as AgentProcessLike, { store });
+    store.open("m-nostream", { agent_id: "alpha", prompt_hash: hashPrompt("x") });
+    await handler("alpha", "x");
+    await new Promise((r) => setTimeout(r, 10));
+    const recs = readReceipts();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].final_state).toBe("stale_session");
+    expect(recs[0].notes?.reason).toBe("no_send_prompt_stream");
+  });
+
+  test("does not crash when no receipt AND PTY write fails", async () => {
+    const handler = createPromptStreamHandler(
+      () => fakeAgent(1, () => Promise.reject(new Error("boom"))),
+      { store },
+    );
+    await expect(handler("alpha", "no-receipt")).rejects.toThrow("boom");
+    expect(readReceipts()).toHaveLength(0);
+  });
+});

--- a/src/bus/__tests__/receipt-wiring.test.ts
+++ b/src/bus/__tests__/receipt-wiring.test.ts
@@ -8,7 +8,11 @@ import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { createReceiptStore, hashPrompt, type ReceiptRecord, type ReceiptStore } from "../receipt";
-import { type AgentProcessLike, createPromptStreamHandler } from "../receipt-wiring";
+import {
+  type AgentProcessLike,
+  createPromptStreamHandler,
+  unwrapChannelText,
+} from "../receipt-wiring";
 
 let tmpDir: string;
 let logPath: string;
@@ -38,6 +42,30 @@ function fakeAgent(pid: number, sendImpl?: (line: string) => Promise<void>): Age
     send_prompt_stream: sendImpl ?? (() => Promise.resolve()),
   };
 }
+
+describe("unwrapChannelText", () => {
+  test("passes through plain text unchanged", () => {
+    expect(unwrapChannelText("hello world")).toBe("hello world");
+  });
+
+  test("extracts inner text from a channel wrapper", () => {
+    const wrapped =
+      '<channel source="webui" chat_id="inject" user_id="webui" ts="2026-05-31T00:00:00Z">hello world</channel>';
+    expect(unwrapChannelText(wrapped)).toBe("hello world");
+  });
+
+  test("decodes XML entities (`<`, `>`, `&`) in the inner text", () => {
+    const wrapped =
+      '<channel source="webui" chat_id="x" user_id="x" ts="t">a &amp; b &lt; c &gt; d</channel>';
+    expect(unwrapChannelText(wrapped)).toBe("a & b < c > d");
+  });
+
+  test("matches hashPrompt of the unwrapped form", () => {
+    const original = "Réponds: ok";
+    const wrapped = `<channel source="webui" chat_id="inject" user_id="webui" ts="2026-05-31T00:00:00Z">${original}</channel>`;
+    expect(hashPrompt(unwrapChannelText(wrapped))).toBe(hashPrompt(original));
+  });
+});
 
 describe("createPromptStreamHandler", () => {
   test("writes to the PTY when no receipt is open (back-compat)", async () => {
@@ -125,6 +153,20 @@ describe("createPromptStreamHandler", () => {
     expect(recs).toHaveLength(1);
     expect(recs[0].final_state).toBe("stale_session");
     expect(recs[0].notes?.reason).toBe("no_send_prompt_stream");
+  });
+
+  test("matches receipt by hash of unwrapped channel text (real bus path)", async () => {
+    // Mirrors what `BusCoreImpl.sendPrompt` actually delivers: the prompt is
+    // wrapped in a <channel ...>...</channel> block. The handler must unwrap
+    // before hashing so the receipt opened with the *raw* prompt hash is
+    // found.
+    const raw = "réponds: ok";
+    const wrapped = `<channel source="webui" chat_id="inject" user_id="webui" ts="t0">${raw}</channel>`;
+    const r = store.open("m-wrap", { agent_id: "alpha", prompt_hash: hashPrompt(raw) });
+    const handler = createPromptStreamHandler(() => fakeAgent(31415), { store });
+    await handler("alpha", wrapped);
+    expect(r.record.process_pid).toBe(31415);
+    expect(r.record.notes?.stdin_written_at).toBeDefined();
   });
 
   test("does not crash when no receipt AND PTY write fails", async () => {

--- a/src/bus/__tests__/receipt.test.ts
+++ b/src/bus/__tests__/receipt.test.ts
@@ -9,6 +9,8 @@ import {
   createReceiptStore,
   hashPrompt,
   defaultReceiptLogPath,
+  getDefaultReceiptStore,
+  _setDefaultReceiptStoreForTests,
   type ReceiptRecord,
 } from "../receipt";
 
@@ -175,5 +177,63 @@ describe("ReceiptStore", () => {
     await r.close("turn_observed", { stage2: "done" });
     const [rec] = readReceipts();
     expect(rec.notes).toEqual({ stage1: "ok", stage2: "done" });
+  });
+});
+
+describe("findByPromptHash", () => {
+  test("indexes a receipt opened with a prompt_hash", () => {
+    const store = createReceiptStore({ path: logPath });
+    const h = hashPrompt("the prompt");
+    const r = store.open("tg-h1", { prompt_hash: h });
+    expect(store.findByPromptHash(h)).toBe(r);
+  });
+
+  test("returns undefined for an unknown hash", () => {
+    const store = createReceiptStore({ path: logPath });
+    expect(store.findByPromptHash("sha256:0000000000000000")).toBeUndefined();
+  });
+
+  test("indexes a receipt that gets its prompt_hash via patch()", () => {
+    const store = createReceiptStore({ path: logPath });
+    const r = store.open("tg-h2");
+    const h = hashPrompt("late hash");
+    r.patch({ prompt_hash: h });
+    expect(store.findByPromptHash(h)).toBe(r);
+  });
+
+  test("close() removes the receipt from the hash index", async () => {
+    const store = createReceiptStore({ path: logPath });
+    const h = hashPrompt("zap");
+    const r = store.open("tg-h3", { prompt_hash: h });
+    expect(store.findByPromptHash(h)).toBe(r);
+    await r.close("turn_observed");
+    expect(store.findByPromptHash(h)).toBeUndefined();
+  });
+
+  test("patching prompt_hash to a new value re-indexes", () => {
+    const store = createReceiptStore({ path: logPath });
+    const h1 = hashPrompt("one");
+    const h2 = hashPrompt("two");
+    const r = store.open("tg-h4", { prompt_hash: h1 });
+    r.patch({ prompt_hash: h2 });
+    expect(store.findByPromptHash(h1)).toBeUndefined();
+    expect(store.findByPromptHash(h2)).toBe(r);
+  });
+});
+
+describe("getDefaultReceiptStore", () => {
+  test("returns the same instance across calls (singleton)", () => {
+    const a = getDefaultReceiptStore();
+    const b = getDefaultReceiptStore();
+    expect(a).toBe(b);
+  });
+
+  test("_setDefaultReceiptStoreForTests swaps the singleton + restores", () => {
+    const original = getDefaultReceiptStore();
+    const fake = createReceiptStore({ path: logPath });
+    const restore = _setDefaultReceiptStoreForTests(fake);
+    expect(getDefaultReceiptStore()).toBe(fake);
+    restore();
+    expect(getDefaultReceiptStore()).toBe(original);
   });
 });

--- a/src/bus/__tests__/receipt.test.ts
+++ b/src/bus/__tests__/receipt.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the per-message receipt chain (issue #207).
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createReceiptStore,
+  hashPrompt,
+  defaultReceiptLogPath,
+  type ReceiptRecord,
+} from "../receipt";
+
+let tmpDir: string;
+let logPath: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "claudeclaw-receipt-test-"));
+  logPath = join(tmpDir, "receipts.jsonl");
+});
+
+afterEach(() => {
+  if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function readReceipts(): ReceiptRecord[] {
+  if (!existsSync(logPath)) return [];
+  return readFileSync(logPath, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim().length > 0)
+    .map((l) => JSON.parse(l) as ReceiptRecord);
+}
+
+describe("hashPrompt", () => {
+  test("produces a stable sha256-prefixed short hash", () => {
+    const h1 = hashPrompt("hello");
+    const h2 = hashPrompt("hello");
+    expect(h1).toBe(h2);
+    expect(h1).toMatch(/^sha256:[a-f0-9]{16}$/);
+  });
+
+  test("different inputs produce different hashes", () => {
+    expect(hashPrompt("foo")).not.toBe(hashPrompt("bar"));
+  });
+});
+
+describe("defaultReceiptLogPath", () => {
+  test("ends with .claude/claudeclaw/receipts.jsonl under homedir", () => {
+    const p = defaultReceiptLogPath();
+    expect(p.endsWith("/.claude/claudeclaw/receipts.jsonl")).toBe(true);
+  });
+});
+
+describe("ReceiptStore", () => {
+  test("opens a receipt, closes it, and appends one JSONL line", async () => {
+    const store = createReceiptStore({ path: logPath });
+    const r = store.open("tg-1", { selected_route: "agent=default", agent_id: "default" });
+    expect(r.message_id).toBe("tg-1");
+    expect(r.record.final_state).toBe("message_polled"); // sentinel until close
+    await r.close("turn_observed");
+
+    const recs = readReceipts();
+    expect(recs.length).toBe(1);
+    expect(recs[0].message_id).toBe("tg-1");
+    expect(recs[0].final_state).toBe("turn_observed");
+    expect(recs[0].selected_route).toBe("agent=default");
+    expect(typeof recs[0].duration_ms).toBe("number");
+  });
+
+  test("patch() merges fields but cannot override identity or final state", async () => {
+    const store = createReceiptStore({ path: logPath });
+    const r = store.open("tg-2");
+    r.patch({ session_id: "abc", process_pid: 4242 });
+    // attempt to clobber identity — must be ignored
+    r.patch({ message_id: "EVIL", received_at: "1970-01-01", final_state: "wedged_prompt" });
+    await r.close("turn_observed");
+
+    const [rec] = readReceipts();
+    expect(rec.message_id).toBe("tg-2");
+    expect(rec.session_id).toBe("abc");
+    expect(rec.process_pid).toBe(4242);
+    expect(rec.final_state).toBe("turn_observed"); // patch did not change it
+  });
+
+  test("close() is idempotent — second call is a no-op", async () => {
+    const store = createReceiptStore({ path: logPath });
+    const r = store.open("tg-3");
+    await r.close("turn_observed");
+    await r.close("wedged_prompt"); // should be ignored
+
+    const recs = readReceipts();
+    expect(recs.length).toBe(1);
+    expect(recs[0].final_state).toBe("turn_observed");
+  });
+
+  test("open() with same message_id returns the same receipt and merges new fields", async () => {
+    const store = createReceiptStore({ path: logPath });
+    const r1 = store.open("tg-4", { agent_id: "default" });
+    const r2 = store.open("tg-4", { session_id: "sid-1" });
+    expect(r1).toBe(r2);
+    expect(r1.record.session_id).toBe("sid-1");
+    expect(r1.record.agent_id).toBe("default");
+  });
+
+  test("find() returns an open receipt without creating one", () => {
+    const store = createReceiptStore({ path: logPath });
+    expect(store.find("ghost")).toBeUndefined();
+    const r = store.open("tg-5");
+    expect(store.find("tg-5")).toBe(r);
+  });
+
+  test("drain() closes every open receipt with the given final state", async () => {
+    const store = createReceiptStore({ path: logPath });
+    store.open("a");
+    store.open("b");
+    store.open("c");
+    await store.drain("timeout");
+    const recs = readReceipts();
+    expect(recs.length).toBe(3);
+    expect(recs.every((r) => r.final_state === "timeout")).toBe(true);
+    expect(recs.every((r) => r.notes?.drained === true)).toBe(true);
+  });
+
+  test("missing parent directory is created on first append", async () => {
+    const deep = join(tmpDir, "a", "b", "c", "receipts.jsonl");
+    const store = createReceiptStore({ path: deep });
+    await store.open("x").close("turn_observed");
+    expect(existsSync(deep)).toBe(true);
+  });
+
+  test("write failures surface to onError and never throw", async () => {
+    const errs: { err: Error; ctx: string }[] = [];
+    const store = createReceiptStore({
+      path: "/dev/null/nope/receipts.jsonl",
+      onError: (err, ctx) => errs.push({ err, ctx }),
+    });
+    await expect(store.open("tg-x").close("turn_observed")).resolves.toBeUndefined();
+    expect(errs.length).toBeGreaterThan(0);
+    expect(errs.some((e) => e.ctx === "append" || e.ctx === "mkdir")).toBe(true);
+  });
+
+  test("duration_ms reflects the time between open and close", async () => {
+    let t = 0;
+    const fakeNow = () => new Date(t);
+    const store = createReceiptStore({ path: logPath, now: fakeNow });
+    const r = store.open("tg-time");
+    t += 1234;
+    await r.close("turn_observed");
+    const [rec] = readReceipts();
+    expect(rec.duration_ms).toBe(1234);
+  });
+
+  test("notes from patch and close are merged on the final record", async () => {
+    const store = createReceiptStore({ path: logPath });
+    const r = store.open("tg-notes");
+    r.patch({ notes: { stage1: "ok" } });
+    await r.close("turn_observed", { stage2: "done" });
+    const [rec] = readReceipts();
+    expect(rec.notes).toEqual({ stage1: "ok", stage2: "done" });
+  });
+});

--- a/src/bus/__tests__/receipt.test.ts
+++ b/src/bus/__tests__/receipt.test.ts
@@ -129,6 +129,23 @@ describe("ReceiptStore", () => {
     expect(existsSync(deep)).toBe(true);
   });
 
+  test("receipts.jsonl is tightened to 0600 after the first write", async () => {
+    const { statSync } = await import("node:fs");
+    const store = createReceiptStore({ path: logPath });
+    await store.open("mode").close("turn_observed");
+    const mode = statSync(logPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  test("patch() cannot inject duration_ms — it's always computed at close", async () => {
+    const store = createReceiptStore({ path: logPath });
+    const r = store.open("dur-protect");
+    r.patch({ duration_ms: 999_999 });
+    await r.close("turn_observed");
+    const [rec] = readReceipts();
+    expect(rec.duration_ms).toBeLessThan(999_999);
+  });
+
   test("write failures surface to onError and never throw", async () => {
     const errs: { err: Error; ctx: string }[] = [];
     const store = createReceiptStore({

--- a/src/bus/__tests__/webui-bridge.test.ts
+++ b/src/bus/__tests__/webui-bridge.test.ts
@@ -9,10 +9,37 @@
  * reply path by calling `bus.ingestReply` directly — that's how the
  * plus-bus MCP server normally publishes claude's responses.
  */
-import { describe, expect, it } from "bun:test";
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createBusCore, type BusCore } from "../core";
 import type { EventEntryInput, EventRecord } from "../../event-log";
+import {
+  _setDefaultReceiptStoreForTests,
+  createReceiptStore,
+  hashPrompt,
+  type ReceiptRecord,
+  type ReceiptStore,
+} from "../receipt";
 import { streamBusPrompt } from "../webui-bridge";
+
+// Redirect the process-wide default receipt store to a throwaway path for the
+// duration of this file so the existing 11 streamBusPrompt tests (which
+// do not pass receiptStore) do not append to the user real
+// ~/.claude/claudeclaw/receipts.jsonl. The receipt-chain describe below
+// passes an explicit per-test store so it is not affected by this redirection.
+let _singletonTmpDir: string;
+let _restoreSingleton: (() => void) | null = null;
+beforeAll(() => {
+  _singletonTmpDir = mkdtempSync(join(tmpdir(), "ccplus-bridge-singleton-"));
+  const sink = createReceiptStore({ path: join(_singletonTmpDir, "receipts.jsonl") });
+  _restoreSingleton = _setDefaultReceiptStoreForTests(sink);
+});
+afterAll(() => {
+  _restoreSingleton?.();
+  if (existsSync(_singletonTmpDir)) rmSync(_singletonTmpDir, { recursive: true, force: true });
+});
 
 function mockEventLog() {
   let seq = 0;
@@ -224,5 +251,102 @@ describe("streamBusPrompt", () => {
     const [a, b] = await Promise.all([aPending, bPending]);
     expect(a.output).toBe("alpha-reply");
     expect(b.output).toBe("beta-reply");
+  });
+});
+
+/**
+ * Receipt-chain wiring: the bridge must open a receipt at entry, stamp
+ * `agent_id` + `prompt_hash` + selected route, and close on the terminal
+ * state observed (`turn_observed` / `timeout` / `wedged_prompt`). Issue #207.
+ */
+describe("streamBusPrompt — receipt chain", () => {
+  let tmpDir: string;
+  let logPath: string;
+  let store: ReceiptStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "ccplus-bridge-receipt-"));
+    logPath = join(tmpDir, "receipts.jsonl");
+    store = createReceiptStore({ path: logPath });
+  });
+
+  afterEach(() => {
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function readReceipts(): ReceiptRecord[] {
+    if (!existsSync(logPath)) return [];
+    return readFileSync(logPath, "utf-8")
+      .split("\n")
+      .filter((l) => l.trim().length > 0)
+      .map((l) => JSON.parse(l) as ReceiptRecord);
+  }
+
+  it("closes a receipt as turn_observed on intent:final", async () => {
+    const bus = makeBus();
+    const pending = streamBusPrompt(bus, "alpha", "hello world", {
+      timeoutMs: 2000,
+      receiptStore: store,
+      originId: "test-msg-1",
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    bus.ingestReply({ agent_id: "alpha", text: "reply", intent: "final" });
+    await pending;
+    // Wait for the receipt close fire-and-forget to flush to disk.
+    for (let i = 0; i < 20 && readReceipts().length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const recs = readReceipts();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].final_state).toBe("turn_observed");
+    expect(recs[0].agent_id).toBe("alpha");
+    expect(recs[0].selected_route).toBe("agent=alpha");
+    expect(recs[0].prompt_hash).toBe(hashPrompt("hello world"));
+    expect(recs[0].message_id).toMatch(/^webui:test-msg-1:[0-9a-f]{8}$/);
+    expect(typeof recs[0].duration_ms).toBe("number");
+    expect(recs[0].notes).toMatchObject({ output_chars: 5, bus_send_ok: true });
+  });
+
+  it("closes a receipt as timeout when no final lands", async () => {
+    const bus = makeBus();
+    const pending = streamBusPrompt(bus, "alpha", "stuck", {
+      timeoutMs: 100,
+      receiptStore: store,
+    });
+    await pending;
+    for (let i = 0; i < 20 && readReceipts().length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const recs = readReceipts();
+    expect(recs).toHaveLength(1);
+    expect(recs[0].final_state).toBe("timeout");
+    expect(recs[0].notes?.timeout_ms).toBe(100);
+  });
+
+  it("indexes the open receipt by prompt_hash so the bus → PTY seam can patch", async () => {
+    const bus = makeBus();
+    const pending = streamBusPrompt(bus, "alpha", "lookup me", {
+      timeoutMs: 1000,
+      receiptStore: store,
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    // The receipt is open and indexed by hash — runtime-mount would find it here.
+    const r = store.findByPromptHash(hashPrompt("lookup me"));
+    expect(r).toBeDefined();
+    expect(r?.record.agent_id).toBe("alpha");
+    // Simulate the bus → PTY seam back-filling PID + generation.
+    r?.patch({ process_pid: 12345, process_generation: 1 });
+    bus.ingestReply({ agent_id: "alpha", text: "ok", intent: "final" });
+    await pending;
+    for (let i = 0; i < 20 && readReceipts().length === 0; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    const recs = readReceipts();
+    expect(recs[0].process_pid).toBe(12345);
+    expect(recs[0].process_generation).toBe(1);
+    // After close, the hash index is cleared.
+    expect(store.findByPromptHash(hashPrompt("lookup me"))).toBeUndefined();
   });
 });

--- a/src/bus/receipt-wiring.ts
+++ b/src/bus/receipt-wiring.ts
@@ -1,0 +1,103 @@
+/**
+ * Bus → PTY receipt wiring for the daemon entry point (issue #207).
+ *
+ * Extracted from `runtime-mount.ts` so the back-filling logic — looking up
+ * an open receipt by prompt hash, stamping pid / generation / stdin_written,
+ * and rolling back to `stale_session` on PTY error — can be unit-tested
+ * without booting the full bus runtime.
+ */
+import { getDefaultReceiptStore, hashPrompt, type ReceiptStore } from "./receipt";
+
+/** Structural view of the bits an `AgentProcess` exposes that we touch.
+ *  Declared here so the helper doesn't drag in `session-agent-process.ts`. */
+export interface AgentProcessLike {
+  readonly pid: number;
+  send_prompt_stream?(line: string): Promise<void>;
+}
+
+export type StreamPromptHandler = (agent_id: string, text: string) => Promise<void>;
+
+export interface PromptStreamHandlerOptions {
+  /** Receipt store to back-fill into. Defaults to the process-wide singleton. */
+  store?: ReceiptStore;
+  /** Clock seam for tests (used to stamp `route_resolved_at`/`stdin_written_at`). */
+  now?: () => Date;
+}
+
+/**
+ * Build the `StreamPromptHandler` that the daemon installs via
+ * `bus.setStreamPromptHandler(...)`. The handler:
+ *
+ *   1. Locates the agent process via `getAgent(agent_id)`.
+ *   2. Looks up an open receipt by `hashPrompt(text)`.
+ *   3. If both present, stamps `process_pid`, `process_generation`,
+ *      `route_resolved_at` BEFORE writing to the PTY.
+ *   4. Writes the prompt; on success, stamps `stdin_written_at`. On failure,
+ *      closes the receipt as `stale_session` so the cause is visible in the
+ *      receipts log (the caller can still close it later — `close` is
+ *      idempotent).
+ *   5. If no agent process is registered (or it doesn't expose
+ *      `send_prompt_stream`), closes the receipt as `stale_session`.
+ *
+ * `process_generation` bumps each time the same `agent_id` is observed with
+ * a different pid (proxy for SessionManager respawns).
+ */
+export function createPromptStreamHandler(
+  getAgent: (agent_id: string) => AgentProcessLike | undefined,
+  opts: PromptStreamHandlerOptions = {},
+): StreamPromptHandler {
+  const store = opts.store ?? getDefaultReceiptStore();
+  const now = opts.now ?? (() => new Date());
+  const generationByAgent = new Map<string, { pid: number; gen: number }>();
+
+  return async (agent_id: string, text: string): Promise<void> => {
+    const proc = getAgent(agent_id);
+    const receipt = store.findByPromptHash(hashPrompt(text));
+
+    if (proc && typeof proc.send_prompt_stream === "function") {
+      if (receipt) {
+        let gen = 1;
+        const tracked = generationByAgent.get(agent_id);
+        if (tracked && tracked.pid === proc.pid) {
+          gen = tracked.gen;
+        } else {
+          gen = (tracked?.gen ?? 0) + 1;
+          generationByAgent.set(agent_id, { pid: proc.pid, gen });
+        }
+        receipt.patch({
+          process_pid: proc.pid,
+          process_generation: gen,
+          notes: { ...receipt.record.notes, route_resolved_at: now().toISOString() },
+        });
+      }
+      try {
+        await proc.send_prompt_stream(text);
+        if (receipt) {
+          receipt.patch({
+            notes: { ...receipt.record.notes, stdin_written_at: now().toISOString() },
+          });
+        }
+      } catch (err) {
+        // PTY write failed — `stale_session` reflects "the process was
+        // there when we checked but rejected the write". The caller
+        // (`streamBusPrompt`) will still close on timeout/error; close
+        // here as a stronger signal so the receipts log carries the
+        // PTY-side cause rather than an opaque timeout.
+        if (receipt) {
+          await receipt.close("stale_session", {
+            error: err instanceof Error ? err.message : String(err),
+            stage: "pty_write",
+          });
+        }
+        throw err;
+      }
+    } else if (receipt) {
+      // No process registered (or it doesn't support streaming). The
+      // bus seam can't proceed — record `stale_session` so the wedge
+      // is visible.
+      await receipt.close("stale_session", {
+        reason: proc ? "no_send_prompt_stream" : "agent_not_registered",
+      });
+    }
+  };
+}

--- a/src/bus/receipt-wiring.ts
+++ b/src/bus/receipt-wiring.ts
@@ -8,6 +8,25 @@
  */
 import { getDefaultReceiptStore, hashPrompt, type ReceiptStore } from "./receipt";
 
+/**
+ * Recover the original prompt text from the `<channel source=... chat_id=...
+ * user_id=... ts=...>TEXT</channel>` wrapper that `BusCoreImpl.sendPrompt`
+ * adds before invoking `streamPromptHandler`. Returns the inner text with
+ * XML entities reversed so its `hashPrompt` matches the one the caller
+ * computed on the raw prompt at receipt-open time.
+ *
+ * Idempotent for non-wrapped input — direct callers (no bus wrapper) get
+ * their text back unchanged.
+ */
+export function unwrapChannelText(text: string): string {
+  const m = text.match(/^<channel\s[^>]*>([\s\S]*)<\/channel>$/);
+  if (!m) return text;
+  // Reverse `escapeXmlText` from `bus/core.ts`: text-mode escaping only
+  // covers `&`, `<`, `>`. Decode in reverse application order so an
+  // already-encoded `&amp;` isn't double-unescaped.
+  return m[1].replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/&amp;/g, "&");
+}
+
 /** Structural view of the bits an `AgentProcess` exposes that we touch.
  *  Declared here so the helper doesn't drag in `session-agent-process.ts`. */
 export interface AgentProcessLike {
@@ -52,7 +71,11 @@ export function createPromptStreamHandler(
 
   return async (agent_id: string, text: string): Promise<void> => {
     const proc = getAgent(agent_id);
-    const receipt = store.findByPromptHash(hashPrompt(text));
+    // `BusCoreImpl.sendPrompt` wraps the prompt in a `<channel ...>...</channel>`
+    // block before invoking us, so the receipt — keyed on the *raw* prompt at
+    // open time — is found by hashing the unwrapped inner text. Plain
+    // (unwrapped) callers fall through unchanged.
+    const receipt = store.findByPromptHash(hashPrompt(unwrapChannelText(text)));
 
     if (proc && typeof proc.send_prompt_stream === "function") {
       if (receipt) {

--- a/src/bus/receipt.ts
+++ b/src/bus/receipt.ts
@@ -1,0 +1,189 @@
+/**
+ * Per-message receipt chain for the bus path (issue #207).
+ *
+ * A `Receipt` opens when an inbound message enters the bus and accumulates
+ * stamps as the message moves through the pipeline:
+ *
+ *     message_polled → route_resolved → stdin_written → turn_observed
+ *                                                       (or wedged_prompt)
+ *
+ * Each receipt closes on a terminal `final_state` and is appended as one JSON
+ * line to `~/.claude/claudeclaw/receipts.jsonl` for offline analysis. The goal
+ * is to make intermittent agent wedges *visible* — distinguishing between
+ * "prompt never reached agent" / "agent never generated a turn" / "tailer never
+ * observed it" — without needing to instrument at debug time.
+ *
+ * Failures (filesystem errors, malformed state) are surfaced through
+ * `onError` and never thrown — instrumentation must not break the bus.
+ */
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync } from "node:fs";
+import { appendFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+
+/** Terminal states a receipt can land on. The first four are normal flow;
+ *  the rest are failure surfaces we want to make countable. */
+export type ReceiptFinalState =
+  | "message_polled"
+  | "route_resolved"
+  | "stdin_written"
+  | "turn_observed"
+  | "wedged_prompt"
+  | "stale_session"
+  | "timeout";
+
+export interface ReceiptRecord {
+  /** Adapter-side identifier (e.g. `tg-<update_id>`, `discord-<msg_id>`). */
+  message_id: string;
+  /** ISO timestamp the receipt opened. */
+  received_at: string;
+  selected_route?: string;
+  agent_id?: string;
+  session_id?: string;
+  agent_cwd?: string;
+  process_pid?: number;
+  /** Bumps each time the agent process is respawned for the same `agent_id`. */
+  process_generation?: number;
+  /** Short SHA256 of the prompt text — proves what went in without storing it. */
+  prompt_hash?: string;
+  /** Path the `JsonlTailer` is watching for this session's turns. */
+  claude_jsonl_path?: string;
+  /** Byte offset of the observed `turn_duration` event in the JSONL (when matched). */
+  turn_event_offset?: number | null;
+  final_state: ReceiptFinalState;
+  /** Milliseconds from `received_at` to `final_state`. */
+  duration_ms?: number;
+  /** Free-form per-stamp notes (e.g. error kind on `timeout`). */
+  notes?: Record<string, unknown>;
+}
+
+export interface OpenReceipt {
+  readonly message_id: string;
+  /** Snapshot of the in-progress record (callers should not mutate). */
+  readonly record: Readonly<ReceiptRecord>;
+  /** Merge fields into the in-progress record. Idempotent for repeated keys. */
+  patch(fields: Partial<ReceiptRecord>): void;
+  /** Stamp the final state and append to the receipts log. Idempotent — a
+   *  second `close` call is a no-op (the first one wins). */
+  close(state: ReceiptFinalState, notes?: Record<string, unknown>): Promise<void>;
+}
+
+export interface ReceiptStore {
+  /** Open a new receipt for an inbound message. If a receipt is already open
+   *  for `message_id` (re-delivery), the existing one is returned. */
+  open(message_id: string, fields?: Partial<ReceiptRecord>): OpenReceipt;
+  /** Find an open receipt without creating one. */
+  find(message_id: string): OpenReceipt | undefined;
+  /** Close every still-open receipt with the given terminal state (e.g. on
+   *  daemon shutdown, mark them as `timeout`). */
+  drain(state: ReceiptFinalState): Promise<void>;
+  /** Path receipts are written to. */
+  readonly logPath: string;
+}
+
+export interface ReceiptStoreOptions {
+  /** Override the receipts log path. Defaults to
+   *  `~/.claude/claudeclaw/receipts.jsonl`. */
+  path?: string;
+  /** Clock seam for tests. */
+  now?: () => Date;
+  /** Logger for non-fatal write failures. Defaults to a no-op so a broken disk
+   *  never crashes the bus. */
+  onError?: (err: Error, ctx: string) => void;
+}
+
+/** Compute a short, stable hash of a prompt string. Short on purpose — the
+ *  receipt should not let the full prompt leak into observability logs. */
+export function hashPrompt(text: string): string {
+  return "sha256:" + createHash("sha256").update(text).digest("hex").slice(0, 16);
+}
+
+export function defaultReceiptLogPath(): string {
+  return join(homedir(), ".claude", "claudeclaw", "receipts.jsonl");
+}
+
+export function createReceiptStore(opts: ReceiptStoreOptions = {}): ReceiptStore {
+  const logPath = opts.path ?? defaultReceiptLogPath();
+  const now = opts.now ?? (() => new Date());
+  const onError = opts.onError ?? (() => {});
+  const openReceipts = new Map<string, OpenReceipt>();
+
+  // Best-effort ensure parent directory exists. Synchronous (one-shot) so we
+  // don't race the first append.
+  try {
+    const dir = dirname(logPath);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+  } catch (err) {
+    onError(err as Error, "mkdir");
+  }
+
+  async function appendRecord(rec: ReceiptRecord): Promise<void> {
+    try {
+      await appendFile(logPath, JSON.stringify(rec) + "\n", "utf8");
+    } catch (err) {
+      onError(err as Error, "append");
+    }
+  }
+
+  function makeReceipt(message_id: string, fields: Partial<ReceiptRecord>): OpenReceipt {
+    const startedAt = now();
+    const rec: ReceiptRecord = {
+      message_id,
+      received_at: startedAt.toISOString(),
+      // sentinel — overwritten by close()
+      final_state: "message_polled",
+      ...fields,
+      // received_at + message_id from caller's fields are ignored on purpose
+      // so a typo can't change the receipt's identity.
+      ...(fields.message_id ? { message_id } : {}),
+      ...(fields.received_at ? { received_at: startedAt.toISOString() } : {}),
+    };
+    let closed = false;
+    const receipt: OpenReceipt = {
+      message_id,
+      get record() {
+        return rec;
+      },
+      patch(more: Partial<ReceiptRecord>): void {
+        if (closed) return;
+        // Don't allow patch() to override identity or terminal state.
+        const { message_id: _m, received_at: _r, final_state: _f, ...rest } = more;
+        Object.assign(rec, rest);
+      },
+      async close(state: ReceiptFinalState, notes?: Record<string, unknown>): Promise<void> {
+        if (closed) return;
+        closed = true;
+        rec.final_state = state;
+        rec.duration_ms = now().getTime() - startedAt.getTime();
+        if (notes) rec.notes = { ...(rec.notes ?? {}), ...notes };
+        openReceipts.delete(message_id);
+        await appendRecord(rec);
+      },
+    };
+    return receipt;
+  }
+
+  return {
+    logPath,
+    open(message_id: string, fields: Partial<ReceiptRecord> = {}): OpenReceipt {
+      const existing = openReceipts.get(message_id);
+      if (existing) {
+        // Idempotent re-open: merge any new fields into the existing receipt
+        // so re-deliveries don't lose context.
+        if (Object.keys(fields).length > 0) existing.patch(fields);
+        return existing;
+      }
+      const created = makeReceipt(message_id, fields);
+      openReceipts.set(message_id, created);
+      return created;
+    },
+    find(message_id: string): OpenReceipt | undefined {
+      return openReceipts.get(message_id);
+    },
+    async drain(state: ReceiptFinalState): Promise<void> {
+      const pending = [...openReceipts.values()];
+      await Promise.all(pending.map((r) => r.close(state, { drained: true })));
+    },
+  };
+}

--- a/src/bus/receipt.ts
+++ b/src/bus/receipt.ts
@@ -79,6 +79,10 @@ export interface ReceiptStore {
   open(message_id: string, fields?: Partial<ReceiptRecord>): OpenReceipt;
   /** Find an open receipt without creating one. */
   find(message_id: string): OpenReceipt | undefined;
+  /** Look up an open receipt by its `prompt_hash`. Used at the bus → PTY
+   *  seam, where only the prompt text is available (no message_id). Returns
+   *  undefined if no receipt is currently open for that hash. */
+  findByPromptHash(prompt_hash: string): OpenReceipt | undefined;
   /** Close every still-open receipt with the given terminal state (e.g. on
    *  daemon shutdown, mark them as `timeout`). */
   drain(state: ReceiptFinalState): Promise<void>;
@@ -112,6 +116,13 @@ export function createReceiptStore(opts: ReceiptStoreOptions = {}): ReceiptStore
   const now = opts.now ?? (() => new Date());
   const onError = opts.onError ?? (() => {});
   const openReceipts = new Map<string, OpenReceipt>();
+  // Secondary index for the bus → PTY seam, which only sees `text` (no
+  // message_id). Populated when a receipt is patched with `prompt_hash` and
+  // cleared on close. A hash collision would shadow an earlier still-open
+  // receipt; we accept that for the short window between stdin_written and
+  // turn_observed since the alternative (collision-free uuid plumbing
+  // through every adapter) is invasive.
+  const byPromptHash = new Map<string, OpenReceipt>();
 
   // Best-effort ensure parent directory exists. Synchronous (one-shot) so we
   // don't race the first append.
@@ -145,6 +156,16 @@ export function createReceiptStore(opts: ReceiptStoreOptions = {}): ReceiptStore
     }
   }
 
+  function indexHash(receipt: OpenReceipt, hash: string | undefined): void {
+    if (!hash) return;
+    byPromptHash.set(hash, receipt);
+  }
+
+  function deindexHash(hash: string | undefined): void {
+    if (!hash) return;
+    byPromptHash.delete(hash);
+  }
+
   function makeReceipt(message_id: string, fields: Partial<ReceiptRecord>): OpenReceipt {
     const startedAt = now();
     // Drop any caller-supplied identity / terminal fields up-front so a typo
@@ -173,7 +194,14 @@ export function createReceiptStore(opts: ReceiptStoreOptions = {}): ReceiptStore
         if (closed) return;
         // Don't allow patch() to override identity or terminal state.
         const { message_id: _m, received_at: _r, final_state: _f, ...rest } = more;
+        // Track hash transitions so the prompt-hash index stays in sync if a
+        // caller back-fills the hash after open.
+        const before = rec.prompt_hash;
         Object.assign(rec, rest);
+        if (rec.prompt_hash !== before) {
+          deindexHash(before);
+          indexHash(this, rec.prompt_hash);
+        }
       },
       async close(state: ReceiptFinalState, notes?: Record<string, unknown>): Promise<void> {
         if (closed) return;
@@ -182,9 +210,11 @@ export function createReceiptStore(opts: ReceiptStoreOptions = {}): ReceiptStore
         rec.duration_ms = now().getTime() - startedAt.getTime();
         if (notes) rec.notes = { ...(rec.notes ?? {}), ...notes };
         openReceipts.delete(message_id);
+        deindexHash(rec.prompt_hash);
         await appendRecord(rec);
       },
     };
+    indexHash(receipt, rec.prompt_hash);
     return receipt;
   }
 
@@ -205,9 +235,42 @@ export function createReceiptStore(opts: ReceiptStoreOptions = {}): ReceiptStore
     find(message_id: string): OpenReceipt | undefined {
       return openReceipts.get(message_id);
     },
+    findByPromptHash(prompt_hash: string): OpenReceipt | undefined {
+      return byPromptHash.get(prompt_hash);
+    },
     async drain(state: ReceiptFinalState): Promise<void> {
       const pending = [...openReceipts.values()];
       await Promise.all(pending.map((r) => r.close(state, { drained: true })));
     },
+  };
+}
+
+/**
+ * Process-wide singleton store. Lazily created on first access so importing
+ * this module does not touch the filesystem. The store writes to
+ * `~/.claude/claudeclaw/receipts.jsonl` and forwards non-fatal failures to
+ * stderr — instrumentation must never break the bus, but we still want to
+ * know if the disk is wedged.
+ */
+let _defaultStore: ReceiptStore | null = null;
+export function getDefaultReceiptStore(): ReceiptStore {
+  if (_defaultStore) return _defaultStore;
+  _defaultStore = createReceiptStore({
+    onError: (err, ctx) => {
+      // One-line, prefixed, on stderr — easy to grep, won't drown daemon logs.
+      console.error(`[receipt:${ctx}] ${err.message}`);
+    },
+  });
+  return _defaultStore;
+}
+
+/** Test-only: swap the singleton. Returns a disposer that restores the
+ *  previous one. Not exported via the module's main entry — the bus runtime
+ *  always calls `getDefaultReceiptStore()`. */
+export function _setDefaultReceiptStoreForTests(store: ReceiptStore | null): () => void {
+  const prev = _defaultStore;
+  _defaultStore = store;
+  return () => {
+    _defaultStore = prev;
   };
 }

--- a/src/bus/receipt.ts
+++ b/src/bus/receipt.ts
@@ -18,7 +18,7 @@
  */
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
-import { appendFile } from "node:fs/promises";
+import { appendFile, chmod } from "node:fs/promises";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
@@ -65,7 +65,11 @@ export interface OpenReceipt {
   /** Merge fields into the in-progress record. Idempotent for repeated keys. */
   patch(fields: Partial<ReceiptRecord>): void;
   /** Stamp the final state and append to the receipts log. Idempotent — a
-   *  second `close` call is a no-op (the first one wins). */
+   *  second `close` call is a no-op (the first one wins).
+   *
+   *  `notes` is caller-controlled free-form metadata (latency, error kind,
+   *  retry count, etc.). **Do not put secrets here** — receipts land on disk
+   *  as JSONL for offline analysis. Hash anything sensitive first. */
   close(state: ReceiptFinalState, notes?: Record<string, unknown>): Promise<void>;
 }
 
@@ -118,9 +122,24 @@ export function createReceiptStore(opts: ReceiptStoreOptions = {}): ReceiptStore
     onError(err as Error, "mkdir");
   }
 
+  // Tighten the receipts.jsonl file mode to 0600 once we've written to it.
+  // The default umask leaves it 0664 (group-readable), which is loose for a
+  // log that carries operational metadata (session_id, pid, cwd, prompt hash).
+  // Idempotent — we only need to chmod the first time the file actually exists
+  // on disk for this store.
+  let modeEnsured = false;
+
   async function appendRecord(rec: ReceiptRecord): Promise<void> {
     try {
       await appendFile(logPath, `${JSON.stringify(rec)}\n`, "utf8");
+      if (!modeEnsured) {
+        try {
+          await chmod(logPath, 0o600);
+        } catch (err) {
+          onError(err as Error, "chmod");
+        }
+        modeEnsured = true;
+      }
     } catch (err) {
       onError(err as Error, "append");
     }
@@ -128,16 +147,21 @@ export function createReceiptStore(opts: ReceiptStoreOptions = {}): ReceiptStore
 
   function makeReceipt(message_id: string, fields: Partial<ReceiptRecord>): OpenReceipt {
     const startedAt = now();
+    // Drop any caller-supplied identity / terminal fields up-front so a typo
+    // in `fields` can't change which receipt this is or close it prematurely.
+    const {
+      message_id: _ignoreMessageId,
+      received_at: _ignoreReceivedAt,
+      final_state: _ignoreFinalState,
+      duration_ms: _ignoreDurationMs,
+      ...safeFields
+    } = fields;
     const rec: ReceiptRecord = {
       message_id,
       received_at: startedAt.toISOString(),
       // sentinel — overwritten by close()
       final_state: "message_polled",
-      ...fields,
-      // received_at + message_id from caller's fields are ignored on purpose
-      // so a typo can't change the receipt's identity.
-      ...(fields.message_id ? { message_id } : {}),
-      ...(fields.received_at ? { received_at: startedAt.toISOString() } : {}),
+      ...safeFields,
     };
     let closed = false;
     const receipt: OpenReceipt = {

--- a/src/bus/receipt.ts
+++ b/src/bus/receipt.ts
@@ -96,7 +96,7 @@ export interface ReceiptStoreOptions {
 /** Compute a short, stable hash of a prompt string. Short on purpose — the
  *  receipt should not let the full prompt leak into observability logs. */
 export function hashPrompt(text: string): string {
-  return "sha256:" + createHash("sha256").update(text).digest("hex").slice(0, 16);
+  return `sha256:${createHash("sha256").update(text).digest("hex").slice(0, 16)}`;
 }
 
 export function defaultReceiptLogPath(): string {
@@ -120,7 +120,7 @@ export function createReceiptStore(opts: ReceiptStoreOptions = {}): ReceiptStore
 
   async function appendRecord(rec: ReceiptRecord): Promise<void> {
     try {
-      await appendFile(logPath, JSON.stringify(rec) + "\n", "utf8");
+      await appendFile(logPath, `${JSON.stringify(rec)}\n`, "utf8");
     } catch (err) {
       onError(err as Error, "append");
     }

--- a/src/bus/receipt.ts
+++ b/src/bus/receipt.ts
@@ -23,7 +23,21 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 
 /** Terminal states a receipt can land on. The first four are normal flow;
- *  the rest are failure surfaces we want to make countable. */
+ *  the rest are failure surfaces we want to make countable.
+ *
+ *  Vocabulary note vs issue #207 (where the chain was originally
+ *  specified): #207 used `wedged_prompt` to mean `stdin_written` ✓ but
+ *  `turn_observed` never fires within the timeout window — what this
+ *  implementation calls `timeout`. Here, `wedged_prompt` is reserved
+ *  for the narrower failure of `bus.sendPrompt` itself rejecting at
+ *  entry (route was resolvable but the bus refused the prompt). Keep
+ *  this mapping in mind when cross-reading #207 against `receipts.jsonl`.
+ *
+ *  Caveat on `turn_observed`: this state is *bridge-inferred* from an
+ *  `intent: "final"` event on `response.text` — it means "the bridge
+ *  thinks the turn happened". It is NOT yet tailer-confirmed via
+ *  `claude_jsonl_path` + `turn_event_offset` (follow-up). Treat it as
+ *  a strong-but-not-authoritative signal until that wire lands. */
 export type ReceiptFinalState =
   | "message_polled"
   | "route_resolved"

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -38,6 +38,7 @@ import { wireSlashCommands } from "./wiring";
 import type { MountedAdapter } from "./adapter-wiring";
 import { stopBusAdapters } from "./adapter-wiring";
 import { detectOrphanAgents, formatOrphanWarnings } from "./orphan-agent-detect";
+import { createPromptStreamHandler } from "./receipt-wiring";
 
 export interface BusRuntimeHandle {
   /** The mounted BusCore. Adapters / tests subscribe via this. */
@@ -249,13 +250,14 @@ export async function mountBusRuntime(
     wireSlashCommands(bus, sessionManager);
     // Wire PTY-stdin prompt delivery: route inbound prompts to the agent's
     // REPL so headless claudes (which ignore the MCP channel notification)
-    // start a turn. No-op for agents whose process doesn't support streaming.
-    bus.setStreamPromptHandler(async (agentId, text) => {
-      const proc = sessionManager.getAgent(agentId);
-      if (proc && typeof proc.send_prompt_stream === "function") {
-        await proc.send_prompt_stream(text);
-      }
-    });
+    // start a turn. Receipt chain (issue #207): the helper looks up the open
+    // receipt by `prompt_hash`, back-fills pid + generation + stamps
+    // `stdin_written_at` on success, and closes as `stale_session` if the
+    // PTY write fails or no process is registered. The caller (e.g. the
+    // webui bridge) still owns the terminal close on observed/timeout.
+    bus.setStreamPromptHandler(
+      createPromptStreamHandler((agentId) => sessionManager.getAgent(agentId)),
+    );
 
     const declaredAgents = opts.agents ?? [];
 

--- a/src/bus/webui-bridge.ts
+++ b/src/bus/webui-bridge.ts
@@ -14,9 +14,19 @@
  *   - `/api/chat` — passes `onChunk` so each `response.text` event is
  *     streamed back to the dashboard SSE as it arrives. Resolves
  *     when `intent: "final"` lands or the timeout fires.
+ *
+ * Receipt chain (issue #207): every call opens a receipt at entry, stamps
+ * `route_resolved` + `prompt_hash` immediately, and closes on the terminal
+ * state (`turn_observed` on final, `timeout` on timer, `wedged_prompt` on
+ * `bus.sendPrompt` rejection). The bus → PTY seam in `runtime-mount.ts`
+ * back-fills `process_pid`/`process_generation`/`agent_cwd` + stamps
+ * `stdin_written` via `findByPromptHash`. Receipts land at
+ * `~/.claude/claudeclaw/receipts.jsonl` (0600).
  */
 
+import { randomBytes } from "node:crypto";
 import type { BusCore } from "./core";
+import { getDefaultReceiptStore, hashPrompt, type ReceiptStore } from "./receipt";
 import type { BusOrigin } from "./types";
 
 /**
@@ -51,6 +61,11 @@ export interface StreamBusPromptOptions {
    * with `ok: false` and whatever was accumulated when the timeout fires.
    */
   timeoutMs?: number;
+  /**
+   * Receipt store to record per-prompt observability into. Defaults to the
+   * process-wide singleton (`getDefaultReceiptStore`). Override is for tests.
+   */
+  receiptStore?: ReceiptStore;
 }
 
 export interface BusPromptResult {
@@ -123,10 +138,31 @@ function runPrompt(
   opts: StreamBusPromptOptions,
 ): Promise<BusPromptResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_PROMPT_TIMEOUT_MS;
+  const origin = opts.origin ?? "webui";
+  const originId = opts.originId ?? "webui";
+  // Receipt: open at entry so the prompt is *visible* from the first byte
+  // of bridge work. `message_id` includes a short nonce so concurrent calls
+  // sharing the same `origin_id` (e.g. two webui chats) don't collide on
+  // the receipt store's `message_id` index. The `prompt_hash` index, by
+  // contrast, is keyed on the prompt text and is what the bus → PTY seam
+  // uses to back-fill PID/generation/cwd.
+  const store = opts.receiptStore ?? getDefaultReceiptStore();
+  const messageId = `${origin}:${originId}:${randomBytes(4).toString("hex")}`;
+  const prompt_hash = hashPrompt(message);
+  const receipt = store.open(messageId, {
+    selected_route: `agent=${agentId}`,
+    agent_id: agentId,
+    prompt_hash,
+    notes: { origin, origin_id: originId },
+  });
   let accumulated = "";
   return new Promise<BusPromptResult>((resolve) => {
     let resolved = false;
-    const finish = (r: BusPromptResult) => {
+    const finish = (
+      r: BusPromptResult,
+      finalState: "turn_observed" | "timeout" | "wedged_prompt",
+      notes?: Record<string, unknown>,
+    ) => {
       if (resolved) return;
       resolved = true;
       try {
@@ -135,6 +171,11 @@ function runPrompt(
         /* idempotent close — fine */
       }
       clearTimeout(timer);
+      // Close the receipt before resolving — best-effort, never throws.
+      // We don't await here because the caller (e.g. dashboard SSE)
+      // shouldn't block on a disk write, but the store appends serially
+      // so observers see the line within a tick.
+      void receipt.close(finalState, notes);
       resolve(r);
     };
     const sub = bus.subscribe({ agent_id: agentId, topics: ["response.text"] }, (event) => {
@@ -150,36 +191,55 @@ function runPrompt(
         }
       }
       if (payload.intent === "final") {
-        finish({
-          ok: true,
-          output: accumulated || (payload.text ?? ""),
-          exitCode: 0,
-        });
+        finish(
+          {
+            ok: true,
+            output: accumulated || (payload.text ?? ""),
+            exitCode: 0,
+          },
+          "turn_observed",
+          { output_chars: accumulated.length },
+        );
       }
     });
     const timer = setTimeout(() => {
-      finish({
-        ok: false,
-        output: accumulated,
-        exitCode: 1,
-        error: `timed out after ${timeoutMs}ms waiting for agent ${agentId} reply`,
-      });
+      finish(
+        {
+          ok: false,
+          output: accumulated,
+          exitCode: 1,
+          error: `timed out after ${timeoutMs}ms waiting for agent ${agentId} reply`,
+        },
+        "timeout",
+        { timeout_ms: timeoutMs, accumulated_chars: accumulated.length },
+      );
     }, timeoutMs);
     bus
       .sendPrompt({
         agent_id: agentId,
-        origin: opts.origin ?? "webui",
-        origin_id: opts.originId ?? "webui",
+        origin,
+        origin_id: originId,
         user_id: "webui",
         text: message,
       })
+      .then(() => {
+        // The bus accepted the prompt — the route was resolvable. We
+        // don't yet know whether the PTY actually accepted it (that's
+        // stamped by `runtime-mount.ts` via prompt_hash lookup), but
+        // we can confirm the bus seam is unblocked.
+        receipt.patch({ notes: { ...receipt.record.notes, bus_send_ok: true } });
+      })
       .catch((err) => {
-        finish({
-          ok: false,
-          output: accumulated,
-          exitCode: 1,
-          error: err instanceof Error ? err.message : String(err),
-        });
+        finish(
+          {
+            ok: false,
+            output: accumulated,
+            exitCode: 1,
+            error: err instanceof Error ? err.message : String(err),
+          },
+          "wedged_prompt",
+          { error: err instanceof Error ? err.message : String(err), stage: "bus_send_prompt" },
+        );
       });
   });
 }


### PR DESCRIPTION
## Problem

Issue #207: when an inbound message produces no agent turn (intermittent
wedge), we can't tell *where* the chain broke — bus, PTY write, the
agent's REPL, or the JSONL tailer — without instrumenting at debug time.
Today's logs let us see *that* something hung; they don't let us count
*how often* each surface fails, or correlate a specific message to the
exact pid that should have started a turn.

## Approach

A per-message **receipt** opens at the bridge entry and accumulates
stamps as the message moves through the bus → PTY pipeline:

```
  message_polled → route_resolved → stdin_written → turn_observed
                                                    (or wedged_prompt /
                                                     stale_session /
                                                     timeout)
```

Each receipt closes on a terminal `final_state` and is appended as one
JSON line to `~/.claude/claudeclaw/receipts.jsonl` (mode `0600`) for
offline analysis. Failure surfaces are **distinct terminal states** so
they're countable: `stale_session` = "PTY rejected the write or the
agent wasn't registered", `timeout` = "no `final` event in the window",
`wedged_prompt` = "the bus refused the prompt up-front".

## Scope of this PR — wired end-to-end

Three sites are instrumented:

1. **`src/bus/receipt.ts`** — `ReceiptStore` + `createReceiptStore` +
   `getDefaultReceiptStore()` (process-wide singleton) +
   `findByPromptHash(hash)` (secondary index used by the bus → PTY
   seam).
2. **`src/bus/webui-bridge.ts` (`streamBusPrompt` / `runPrompt`)** —
   opens a receipt at entry with `agent_id`, `selected_route`, and a
   short `prompt_hash`; closes on `intent: "final"` as `turn_observed`,
   on the timeout as `timeout`, or on a `bus.sendPrompt` rejection as
   `wedged_prompt`.
3. **`src/bus/receipt-wiring.ts` (`createPromptStreamHandler`) wired
   into `runtime-mount.ts`** — at the bus → PTY seam, looks the receipt
   up by `prompt_hash`, back-fills `process_pid` + `process_generation`
   + `route_resolved_at`, stamps `stdin_written_at` on successful PTY
   write, or closes as `stale_session` on PTY write failure / no agent
   registered.

`runtime-mount.ts` itself stays small (one helper call); the wiring
helper is extracted so its pid/generation/error paths can be unit-tested
without booting the full bus.

## Security / compliance posture

- Prompt text is **not** stored — only a 16-char SHA-256 prefix
  (`hashPrompt`), enough to correlate a receipt to a specific message
  without leaking content into observability logs.
- The receipts log is **chmod 0600** after the first append; default
  umask would otherwise leave it group-readable, which is loose for a
  log that carries operational metadata (session id, pid, cwd-derived
  fields, prompt hash).
- The store **never throws**: filesystem errors are forwarded to a
  caller-supplied `onError`, defaulting to a single stderr line.
  Instrumentation must not be able to break the bus.
- Identity fields (`message_id`, `received_at`, `final_state`,
  `duration_ms`) cannot be overridden via `patch()` — a typo in caller
  fields can't change which receipt is which or close it prematurely.
- `close()` is idempotent — first call wins, second is a no-op. Prevents
  a buggy caller from double-appending or transitioning a receipt
  through two terminal states.

## Behaviour change

- **None for the success path.** Receipts are write-only — no caller's
  control flow depends on whether a receipt opened or closed
  successfully.
- A new `~/.claude/claudeclaw/receipts.jsonl` file appears on first use.
  No retention/rotation in this PR — operators can `truncate` /
  `logrotate` it externally if needed (followup candidate).

## Tests

`bun test src/bus/__tests__/{receipt,receipt-wiring,webui-bridge}.test.ts` →
**35 → 43 pass / 0 fail** (18 new tests added by this PR):

- **`receipt.test.ts`** — store basics, hash index transitions, singleton
  swap, identity-field guards, 0600 mode, write-failure forwarding,
  duration accuracy, drain.
- **`receipt-wiring.test.ts`** — pid back-fill, generation bump on pid
  change / stable on same pid, `stale_session` on PTY write error,
  `stale_session` when agent unregistered or no `send_prompt_stream`,
  no-receipt back-compat path.
- **`webui-bridge.test.ts`** — three new `streamBusPrompt — receipt
  chain` cases asserting `turn_observed` on final, `timeout` on no
  reply, and that the open receipt is discoverable by `findByPromptHash`
  during the prompt's in-flight window. A `beforeAll/afterAll` swap
  redirects the singleton to a tmp path so the existing 11 bridge tests
  don't append to the real receipts log.

`bun test src/bus` → **308 pass / 0 fail / 1 skip** (env-gated
`SCHEMA_PROBE_INTEGRATION`). Zero regressions vs `upstream/main`
(2054 → 2072 tests, same pre-existing fail count outside `src/bus`).

A standalone functional smoke at `scripts/smoke_receipt.ts` (21/21
checks: default path, single open/close, 50-way concurrency, idempotent
close, re-open merging, drain, write-failure surfacing, `hashPrompt`
stability, 0600 verification) is kept local-only — not part of the
committed test surface, but useful when iterating on the module.

`bun x biome check` clean on all touched files. `bun x tsc --noEmit`
introduces **zero** new errors (337 pre-existing on `upstream/main`,
337 on this branch — none in the touched files).

## What this PR doesn't do

- **Adapter-side `message_polled` stamps.** Adapters (telegram, discord,
  slack) and `/api/inject` currently call `bus.sendPrompt` directly,
  bypassing `streamBusPrompt`. They'd open their own receipt with the
  adapter's `message_id` (e.g. `tg-<update_id>`) before delegating.
  Tracked as a followup to keep this PR scoped to the bus interior.
- **JSONL-tailer-side `turn_event_offset` back-fill.** The
  `turn_observed` state is currently inferred from `response.text` with
  `intent: "final"`; recording the byte offset where the tailer
  *actually saw* the `turn_duration` event would prove the tailer side
  too. Cheap to add once the schema settles.
- **Retention / rotation** of `receipts.jsonl`.

Refs #207.
