### PR TITLE
fix(bus): track messageCount and trigger rotation on bus path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.132",
+      "version": "2.2.133",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.132",
+  "version": "2.2.133",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/webui-bridge.ts
+++ b/src/bus/webui-bridge.ts
@@ -18,6 +18,9 @@
 
 import type { BusCore } from "./core";
 import type { BusOrigin } from "./types";
+import { incrementMessageCount, peekSession } from "../sessions";
+import { needsRotation, rotateSession } from "../rotation";
+import { getSettings } from "../config";
 
 /**
  * Per-agent mutex tail used to serialize `streamBusPrompt` calls. Codex
@@ -107,7 +110,36 @@ export async function streamBusPrompt(
     }
   }
   try {
-    return await runPrompt(bus, agentId, message, opts);
+    const result = await runPrompt(bus, agentId, message, opts);
+    if (result.ok) {
+      // Mirror runner.ts bookkeeping (`incrementMessageCount` + rotation
+      // check on the legacy path): the bus path was missing this, so
+      // `session.messageCount` stayed frozen forever and `needsRotation()`
+      // never triggered on bus-mode deployments. Best-effort: a tracking
+      // failure here must never break the prompt flow the caller awaits.
+      try {
+        await incrementMessageCount();
+        // `getSettings()` throws when called before `loadSettings()` —
+        // happens in early boot and in unit tests. Skip rotation in that
+        // case; the increment alone is still useful, and the next call
+        // after settings are loaded will pick it up.
+        let sessionConfig: ReturnType<typeof getSettings>["session"] | null = null;
+        try {
+          sessionConfig = getSettings().session;
+        } catch {
+          /* settings not loaded yet — skip rotation, keep increment */
+        }
+        if (sessionConfig?.autoRotate) {
+          const peeked = await peekSession();
+          if (peeked && needsRotation(peeked, sessionConfig)) {
+            await rotateSession(sessionConfig);
+          }
+        }
+      } catch (e) {
+        console.error(`[${new Date().toLocaleTimeString()}] bus rotation tracking failed:`, e);
+      }
+    }
+    return result;
   } finally {
     // Only clear the tail slot if no other call has chained onto us;
     // chained callers will overwrite the map entry themselves.


### PR DESCRIPTION
## Problem

Refs #213.

The webui bridge routes (`/api/inject`, `/api/chat`, `/api/jobs/fire`) never call `incrementMessageCount()` or `needsRotation()`/`rotateSession()`. On bus-mode deployments — which is the default for any daemon driving `streamBusPrompt` — the `messageCount` field in `.claude/claudeclaw/session.json` stays frozen at its bootstrap value and `needsRotation()` returns `false` regardless of volume. Sessions grow unbounded; subsequent bootstraps reload a `summaries/*.md` snapshot that may be weeks stale; per-prompt latency creeps up; monitoring scripts with short timeouts (e.g. 25 s) start reporting the daemon as "wedged" when it is actually just slow.

## Root cause

`src/runner.ts:2157` and `:2604` perform the bookkeeping on the legacy path:

```ts
if (!agentName && !threadId) await incrementMessageCount();
```

`src/bus/webui-bridge.ts streamBusPrompt()` resolves on `payload.intent === "final"` but performs no equivalent. The bus path replaces the legacy path for the three webui routes named above (see PR #136), so the counter has been dead on bus-mode deployments since that migration.

## Fix

Mirror the legacy bookkeeping at the bus seam: after `runPrompt` returns a successful result, increment the global session counter and check whether rotation should fire. The block is wrapped in `try/catch` so a bookkeeping failure cannot break the prompt flow the caller is awaiting.

`getSettings()` throws when called before `loadSettings()` (early boot, unit tests), so we skip rotation in that specific case but keep the increment. The next call after settings are loaded will pick it up.

This matches the legacy `runner.ts:1583-1589` pattern and uses the same `session` config (not a new key).

## Why option B (and not A/C from #213)

In the issue I proposed three options. This PR is **option B (agent-aware bookkeeping at the bus seam)** without the agent-vs-global session unification piece — that is a separate concern that affects what `rotateSession()` actually summarizes, and deserves its own discussion. **Option A** (single-line `incrementMessageCount`) would not have addressed the rotation trigger. **Option C** (moving the rotation check entirely out of `runner.ts`) is a bigger architectural change that I'd rather see decided in #213 discussion before opening another PR.

## Test plan

- [x] **T1 — Build / parse**: `bun build src/index.ts --outdir /tmp/claw-smoke --target bun --no-splitting` → clean
- [x] **T1 — Lint**: `bun x biome check src/bus/webui-bridge.ts` → clean
- [x] **T1 — Type check**: `bun x tsc --noEmit` → no new errors in `src/bus/webui-bridge.ts`
- [x] **T2 — Unit tests**: `bun test src/bus/__tests__/webui-bridge.test.ts` → 10 pass, 0 fail, no new noise (the `getSettings` early-skip prevents the test-env log spam)
- [x] **Live test on a real bus-mode daemon**:
  - Pre-restart: `session.json.messageCount = 1`, probe latency 25 s+ timeout, daemon flagged "wedged" 3× in 24 h.
  - Post-patch + restart: probe latency **3 s** OK, `messageCount` increments correctly on each successful `/api/inject` (1 → 2 → 3 verified).

## Scope and follow-ups (not in this PR)

- **Global vs agent-default session divergence** — `createSession()` at bootstrap creates a global session with a different `sessionId` than the agent the bus actually drives. `rotateSession()` will summarize the global (small bootstrap session) rather than the agent (the actually large one). Flagged in #213 "Secondary issue (related)"; happy to file a separate issue or take direction in this PR's review.
- **`createdAt` reset on every bootstrap** — makes `maxAgeHours`-based rotation ineffective for daemons that restart more than once per `maxAgeHours` window. Also flagged in #213.

## Version bump

Plugin + marketplace bumped to `2.2.133` per repo policy (`src/` touched).

## Migration notes

None — pure additive fix. Legacy `runner.ts` path is untouched; bus path now mirrors its bookkeeping.
