### PR TITLE
fix(sessions): preserve createdAt across same-session createSession calls

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.132",
+      "version": "2.2.133",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.132",
+  "version": "2.2.133",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/sessions.test.ts
+++ b/src/__tests__/sessions.test.ts
@@ -161,4 +161,46 @@ describe("sessions agent-scoped", () => {
     await Bun.write(sessionPath, JSON.stringify({ sessionId: "", turnCount: 0 }, null, 2));
     expect(await getSession(name)).toBeNull();
   });
+
+  it("createSession preserves createdAt + counters when called again with same sessionId", async () => {
+    const name = uniq("preserve");
+    await mkdir(join(AGENTS_DIR, name), { recursive: true });
+
+    // First create — fresh record with a known createdAt.
+    await createSession("sid-preserve", name);
+    const first = await peekSession(name);
+    expect(first).not.toBeNull();
+    const firstCreatedAt = first!.createdAt;
+
+    // Simulate a bump on the record (a turn happened, a message was counted).
+    await incrementTurn(name);
+
+    // Re-call createSession with the SAME sessionId (the daemon-restart case).
+    // createdAt must be preserved; turnCount/messageCount must NOT be reset.
+    await new Promise((r) => setTimeout(r, 5));
+    await createSession("sid-preserve", name);
+    const second = await peekSession(name);
+    expect(second).not.toBeNull();
+    expect(second!.createdAt).toBe(firstCreatedAt);
+    expect(second!.turnCount).toBe(1);
+  });
+
+  it("createSession resets createdAt + counters when sessionId changes", async () => {
+    const name = uniq("rotate");
+    await mkdir(join(AGENTS_DIR, name), { recursive: true });
+
+    await createSession("sid-old", name);
+    await incrementTurn(name);
+    const before = await peekSession(name);
+    expect(before!.turnCount).toBe(1);
+
+    // Different sessionId — this IS a genuinely new session; counters
+    // should reset, createdAt should advance.
+    await new Promise((r) => setTimeout(r, 5));
+    await createSession("sid-new", name);
+    const after = await peekSession(name);
+    expect(after!.sessionId).toBe("sid-new");
+    expect(after!.createdAt).not.toBe(before!.createdAt);
+    expect(after!.turnCount).toBe(0);
+  });
 });

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -96,14 +96,15 @@ export async function getSession(
 
 /** Save a session ID obtained from Claude Code's output.
  *
- *  Preserves `createdAt` (and `messageCount`) across same-sessionId calls
- *  so that age-based rotation policies (`maxAgeHours`) can actually reach
- *  their threshold. Without this, every daemon restart calls
+ *  Preserves `createdAt`, `turnCount`, `compactWarned`, and `messageCount`
+ *  across same-sessionId calls so that age-based rotation policies
+ *  (`maxAgeHours`) can actually reach their threshold and the bookkeeping
+ *  counters keep accumulating. Without this, every daemon restart calls
  *  `createSession()` again, resetting `createdAt` to "now" — so a daemon
  *  that bounces more often than `maxAgeHours` (e.g. every few hours)
- *  never accumulates enough age to trigger rotation. Fresh `createdAt`
- *  is only written for a genuinely new session (different `sessionId`,
- *  or no prior record). */
+ *  never accumulates enough age to trigger rotation. Fresh values are
+ *  written only for a genuinely new session (different `sessionId`, or
+ *  no prior record). */
 export async function createSession(sessionId: string, agentName?: string): Promise<void> {
   const existing = await loadSession(agentName);
   const now = new Date().toISOString();

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -94,15 +94,28 @@ export async function getSession(
   return null;
 }
 
-/** Save a session ID obtained from Claude Code's output. */
+/** Save a session ID obtained from Claude Code's output.
+ *
+ *  Preserves `createdAt` (and `messageCount`) across same-sessionId calls
+ *  so that age-based rotation policies (`maxAgeHours`) can actually reach
+ *  their threshold. Without this, every daemon restart calls
+ *  `createSession()` again, resetting `createdAt` to "now" — so a daemon
+ *  that bounces more often than `maxAgeHours` (e.g. every few hours)
+ *  never accumulates enough age to trigger rotation. Fresh `createdAt`
+ *  is only written for a genuinely new session (different `sessionId`,
+ *  or no prior record). */
 export async function createSession(sessionId: string, agentName?: string): Promise<void> {
+  const existing = await loadSession(agentName);
+  const now = new Date().toISOString();
+  const isSameSession = existing?.sessionId === sessionId;
   await saveSession(
     {
       sessionId,
-      createdAt: new Date().toISOString(),
-      lastUsedAt: new Date().toISOString(),
-      turnCount: 0,
-      compactWarned: false,
+      createdAt: isSameSession && existing?.createdAt ? existing.createdAt : now,
+      lastUsedAt: now,
+      turnCount: isSameSession ? (existing?.turnCount ?? 0) : 0,
+      compactWarned: isSameSession ? (existing?.compactWarned ?? false) : false,
+      messageCount: isSameSession ? (existing?.messageCount ?? 0) : 0,
     },
     agentName,
   );


### PR DESCRIPTION
## Problem

Refs #213 (the maxAgeHours-doesn't-trigger half).

`createSession()` in `src/sessions.ts` unconditionally writes a fresh `createdAt = new Date().toISOString()` on every call, including the daemon-restart bootstrap path that re-creates the global session with the **same** sessionId. As a result, age-based rotation (`maxAgeHours`) never accumulates past the restart interval — a daemon that bounces more often than `maxAgeHours` (common with a few-hour heartbeat or on-demand restarts) can never trigger an age rotation, even on a session that has been alive for days.

Observed concretely: a session created at `2026-06-01 06:02 UTC` (alive ~20 hours) reported `createdAt` matching whatever the last restart timestamp was, with `messageCount` reset to 0 alongside it.

## Root cause

`createSession()` currently:

```ts
await saveSession({
  sessionId,
  createdAt: new Date().toISOString(),
  lastUsedAt: new Date().toISOString(),
  turnCount: 0,
  compactWarned: false,
}, agentName);
```

No check for an existing record. Every call wipes the historic fields.

## Fix

Read the existing record first; if the prior `sessionId` matches the incoming one (which is the daemon-restart case), preserve `createdAt`, `turnCount`, `compactWarned`, and `messageCount`. Genuinely-new sessions (different sessionId or no prior record) still get fresh values.

```ts
const existing = await loadSession(agentName);
const isSameSession = existing?.sessionId === sessionId;
await saveSession({
  sessionId,
  createdAt: isSameSession && existing?.createdAt ? existing.createdAt : now,
  lastUsedAt: now,
  turnCount: isSameSession ? (existing?.turnCount ?? 0) : 0,
  compactWarned: isSameSession ? (existing?.compactWarned ?? false) : false,
  messageCount: isSameSession ? (existing?.messageCount ?? 0) : 0,
}, agentName);
```

## Test plan

- [x] **T1 build/parse**: `bun build src/index.ts --outdir /tmp/claw-smoke --target bun --no-splitting` → clean
- [x] **T1 lint**: `bun x biome check src/sessions.ts` → clean
- [x] **T1 type check**: `bun x tsc --noEmit` → no new errors
- [x] **T2 unit tests**: `bun test src/__tests__/sessions.test.ts` → 11 pass, 0 fail (9 existing + 2 new)
  - New: `createSession preserves createdAt + counters when called again with same sessionId`
  - New: `createSession resets createdAt + counters when sessionId changes`
- [x] **T2 session-manager tests**: 22 pass, 0 fail (no regression on the bus side)
- [x] **Live test on a real bus-mode daemon**:
  - Pre-restart with patch deployed: `createdAt: 2026-06-01T06:02:25.720Z`, `messageCount: 3`
  - Post-restart: same `createdAt: 2026-06-01T06:02:25.720Z`, `messageCount: 3` — preserved as expected
  - Pre-patch, restart would have reset both fields to "now" / `0`.
  - Daemon resumed normally; no boot regression.

## Scope and follow-ups (not in this PR)

- **Global vs agent-default session divergence** — flagged in #213 "Secondary issue (related)". Separate PR planned.
- **`messageCount` bookkeeping on the bus path** — covered by #214 (also refs #213).

## Version bump

Plugin + marketplace bumped to `2.2.133` per repo policy (`src/` touched).

## Migration notes

None — pure additive correctness fix. Existing records with the historical `createdAt` reset behavior are preserved going forward (no data loss). Genuinely-new session creation path is unchanged.
