### PR TITLE
fix(bus): synthesize ingestReply on turn_end if reply tool was not called

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.135",
+      "version": "2.2.136",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.136",
+      "version": "2.2.138",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.135",
+  "version": "2.2.136",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.136",
+  "version": "2.2.138",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/discord/__tests__/discord-outbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-outbound.test.ts
@@ -10,7 +10,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import type { DiscordAdapter } from "../index";
-import type { PermissionRequest } from "../../../bus/types";
+import { type PermissionRequest, TAILER_EVENT_SOURCE } from "../../../bus/types";
 import {
   type AdapterHarness,
   flushMicrotasks,
@@ -46,6 +46,40 @@ describe("DiscordAdapter — outbound response.text", () => {
     });
     expect(h.rest.sent.map((m) => m.channelId).sort()).toEqual(["ch-2", "th-1"]);
     expect(h.rest.sent[0]?.text).toBe("done");
+  });
+
+  it("IGNORES the JSONL tailer's observability echo so replies aren't double-posted (#217)", async () => {
+    // The silent-drop net (#217) wires the JSONL tailer into the live bus.
+    // The tailer re-emits a raw per-block `response.text` for every assistant
+    // text block, stamped with `_meta.source = "jsonl-tailer"`. The real
+    // delivery comes from the agent's `reply` tool (ingestReply), which has
+    // NO source marker. If the adapter delivered both, every reply would
+    // double-post. Assert the tailer echo produces ZERO sends.
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "done", _meta: { source: TAILER_EVENT_SOURCE } },
+    });
+    expect(h.rest.sent).toHaveLength(0);
+  });
+
+  it("STILL delivers a real ingestReply (no tailer marker) exactly once (#217)", async () => {
+    // Companion to the echo-suppression test: a genuine reply — or the
+    // safety net's SYNTHESIZED final, both produced via ingestReply and
+    // therefore carrying no tailer source marker — must still deliver.
+    adapter = await startAdapter(h);
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "recovered", intent: "final", origin: "discord", origin_id: "dm-9" },
+    });
+    expect(h.rest.sent.map((m) => m.channelId)).toEqual(["dm-9"]);
+    expect(h.rest.sent[0]?.text).toBe("recovered");
   });
 
   it("skips empty response.text payloads", async () => {

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -41,6 +41,7 @@ import {
   type BusEvent,
   type BusOrigin,
   type PermissionRequest,
+  isTailerOriginEvent,
 } from "../../bus/types";
 import { createDiscordGateway } from "./gateway";
 import {
@@ -429,6 +430,10 @@ export class DiscordAdapter {
     if (targetChannels.length === 0) return;
 
     if (event.topic === "response.text") {
+      // Skip the JSONL tailer's per-block observability echo (#217): the
+      // real delivery comes from the agent's `reply` tool (ingestReply),
+      // which carries no tailer source marker. Delivering both double-posts.
+      if (isTailerOriginEvent(event)) return;
       const payload = event.payload as { text?: string };
       const text = typeof payload.text === "string" ? payload.text : "";
       if (!text) return;

--- a/src/adapters/slack/__tests__/slack.test.ts
+++ b/src/adapters/slack/__tests__/slack.test.ts
@@ -36,7 +36,7 @@ import type {
   SubscriptionFilter,
   SubscriptionHandler,
 } from "../../../bus/core-subscription";
-import type { BusEvent } from "../../../bus/types";
+import { type BusEvent, TAILER_EVENT_SOURCE } from "../../../bus/types";
 import type {
   SlackApi,
   SlackBlock,
@@ -1693,5 +1693,34 @@ describe("sanitiseBotText", () => {
     );
     await waitFor(() => bus.prompts.length > 0);
     expect(bus.prompts[0]?.text).toContain("[react:🔥]");
+  });
+});
+
+describe("SlackAdapter — tailer echo suppression (#217)", () => {
+  it("IGNORES the JSONL tailer observability echo so replies are not double-posted", async () => {
+    adapter = await startAdapter({ routing: { channels: { C100: "triage" } } });
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "echo", _meta: { source: TAILER_EVENT_SOURCE } },
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(api.sent).toHaveLength(0);
+  });
+
+  it("STILL delivers a non-tailer response.text exactly once", async () => {
+    adapter = await startAdapter({ routing: { channels: { C100: "triage" } } });
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "recovered" },
+    });
+    await waitFor(() => api.sent.length > 0);
+    expect(api.sent).toHaveLength(1);
+    expect(api.sent[0]?.text).toBe("recovered");
   });
 });

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -21,6 +21,7 @@ import {
   type BusEvent,
   type BusOrigin,
   type PermissionRequest,
+  isTailerOriginEvent,
 } from "../../bus/types";
 import { createSlackApi } from "./api";
 import { buildPermissionBlocks } from "./blocks";
@@ -606,6 +607,10 @@ export class SlackAdapter {
 
   private async handleResponseText(agentId: string, event: BusEvent): Promise<void> {
     if (!eventBelongsToSlack(event)) return;
+    // Skip the JSONL tailer's per-block observability echo (#217): the
+    // real delivery comes from the agent's `reply` tool (ingestReply),
+    // which carries no tailer source marker. Delivering both double-posts.
+    if (isTailerOriginEvent(event)) return;
     const payload = event.payload as { text?: string; origin?: string; origin_id?: string };
     const text = typeof payload?.text === "string" ? payload.text : "";
     if (text.length === 0) return;

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -21,7 +21,7 @@ import type {
   SubscriptionFilter,
   SubscriptionHandler,
 } from "../../../bus/core-subscription";
-import type { BusEvent } from "../../../bus/types";
+import { type BusEvent, TAILER_EVENT_SOURCE } from "../../../bus/types";
 import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -535,6 +535,38 @@ describe("TelegramAdapter — response.text outbound", () => {
     expect(sent).toBeDefined();
     expect(sent?.text).toBe("hi there");
     expect(sent?.chat_id).toBe(100);
+  });
+
+  it("IGNORES the JSONL tailer observability echo so replies are not double-posted (#217)", async () => {
+    // The tailer re-emits a raw per-block response.text stamped with
+    // _meta.source = "jsonl-tailer"; the real delivery comes from ingestReply
+    // (no marker). Delivering both double-posts — assert the echo sends nothing.
+    adapter = await startAdapter();
+    await feedInbound();
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "echo", _meta: { source: TAILER_EVENT_SOURCE } },
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(api.sendMessages).toHaveLength(0);
+  });
+
+  it("STILL delivers a non-tailer response.text exactly once (#217)", async () => {
+    adapter = await startAdapter();
+    await feedInbound();
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "recovered" },
+    });
+    await waitFor(() => api.sendMessages.length > 0);
+    expect(api.sendMessages).toHaveLength(1);
+    expect(api.sendMessages[0]?.text).toBe("recovered");
   });
 
   it("strips [react:<emoji>] tags and applies them via setMessageReaction", async () => {

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -14,6 +14,7 @@ import {
   type BusEvent,
   type BusOrigin,
   type PermissionRequest,
+  isTailerOriginEvent,
 } from "../../bus/types";
 import { createTelegramApi } from "./api";
 import { extractReactionDirectives } from "./directives";
@@ -454,6 +455,10 @@ export class TelegramAdapter {
 
   private async handleResponseText(agentId: string, event: BusEvent): Promise<void> {
     if (!eventBelongsToTelegram(event)) return;
+    // Skip the JSONL tailer's per-block observability echo (#217): the
+    // real delivery comes from the agent's `reply` tool (ingestReply),
+    // which carries no tailer source marker. Delivering both double-posts.
+    if (isTailerOriginEvent(event)) return;
     const payload = event.payload as { text?: string };
     const rawText = typeof payload?.text === "string" ? payload.text : "";
     if (rawText.length === 0) return;

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -887,4 +887,210 @@ describe("BusCore IPC", () => {
     expect((m as { response: { behavior: string } }).response.behavior).toBe("allow");
     client.close();
   });
+
+  describe("silent-drop safety net (issue #215)", () => {
+    function makeBus(): BusCore {
+      return createBusCore({
+        eventLogAppend: createMockEventLog().append,
+      });
+    }
+
+    function captureReplies(b: BusCore, agentId: string) {
+      const replies: { text: string; origin?: string }[] = [];
+      b.subscribe({ agent_id: agentId, topics: ["response.text"] }, (event) => {
+        const payload = event.payload as { text?: string; intent?: string; origin?: string };
+        if (payload?.intent === "final") {
+          replies.push({ text: payload.text ?? "", origin: payload.origin });
+        }
+      });
+      return replies;
+    }
+
+    it("synthesizes a final reply when turn_end fires without prior reply call", async () => {
+      const b = makeBus();
+      const replies = captureReplies(b, "alpha");
+
+      await b.sendPrompt({
+        agent_id: "alpha",
+        origin: "webui",
+        origin_id: "test-1",
+        user_id: "u1",
+        text: "say hi",
+      });
+
+      // Tailer publishes response.turn_end without any prior reply tool call
+      b.ingestSessionEvent({
+        ts: Date.now(),
+        agent_id: "alpha",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text: "hi there, this is the silent-dropped text" },
+      });
+
+      expect(replies.length).toBe(1);
+      expect(replies[0].text).toBe("hi there, this is the silent-dropped text");
+      expect(replies[0].origin).toBe("webui");
+    });
+
+    it("does NOT synthesize when the agent already called reply with intent: final", async () => {
+      const b = makeBus();
+      const replies = captureReplies(b, "alpha");
+
+      await b.sendPrompt({
+        agent_id: "alpha",
+        origin: "webui",
+        origin_id: "test-2",
+        user_id: "u1",
+        text: "say hi",
+      });
+
+      // Agent called reply correctly.
+      b.ingestReply({
+        agent_id: "alpha",
+        text: "hello — delivered properly via reply tool",
+        intent: "final",
+      });
+
+      // Tailer also publishes turn_end (legitimate end of turn after reply).
+      b.ingestSessionEvent({
+        ts: Date.now(),
+        agent_id: "alpha",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text: "hello — delivered properly via reply tool" },
+      });
+
+      // Only the real reply, no duplicate from the safety net.
+      expect(replies.length).toBe(1);
+      expect(replies[0].text).toBe("hello — delivered properly via reply tool");
+    });
+
+    it("does NOT synthesize when turn_end text is empty", async () => {
+      const b = makeBus();
+      const replies = captureReplies(b, "alpha");
+
+      await b.sendPrompt({
+        agent_id: "alpha",
+        origin: "webui",
+        origin_id: "test-3",
+        user_id: "u1",
+        text: "say hi",
+      });
+
+      b.ingestSessionEvent({
+        ts: Date.now(),
+        agent_id: "alpha",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text: "" },
+      });
+
+      expect(replies.length).toBe(0);
+    });
+
+    it("does NOT synthesize when there is no lastPromptOrigin (cron/ambient turn)", async () => {
+      const b = makeBus();
+      const replies = captureReplies(b, "alpha");
+
+      // No sendPrompt — simulates a cron/scheduler tick that ends with text.
+      b.ingestSessionEvent({
+        ts: Date.now(),
+        agent_id: "alpha",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text: "some ambient output" },
+      });
+
+      expect(replies.length).toBe(0);
+    });
+
+    it("resets the per-turn flag on each new prompt (single-flight per prompt)", async () => {
+      const b = makeBus();
+      const replies = captureReplies(b, "alpha");
+
+      // Prompt 1: agent calls reply → no synthesis.
+      await b.sendPrompt({
+        agent_id: "alpha",
+        origin: "webui",
+        origin_id: "p1",
+        user_id: "u1",
+        text: "first",
+      });
+      b.ingestReply({ agent_id: "alpha", text: "reply 1", intent: "final" });
+      b.ingestSessionEvent({
+        ts: Date.now(),
+        agent_id: "alpha",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text: "reply 1" },
+      });
+
+      // Prompt 2: agent forgets reply → synthesis fires.
+      await b.sendPrompt({
+        agent_id: "alpha",
+        origin: "webui",
+        origin_id: "p2",
+        user_id: "u1",
+        text: "second",
+      });
+      b.ingestSessionEvent({
+        ts: Date.now(),
+        agent_id: "alpha",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text: "silent-dropped reply 2" },
+      });
+
+      // Prompt 3: agent calls reply again → no extra synthesis.
+      await b.sendPrompt({
+        agent_id: "alpha",
+        origin: "webui",
+        origin_id: "p3",
+        user_id: "u1",
+        text: "third",
+      });
+      b.ingestReply({ agent_id: "alpha", text: "reply 3", intent: "final" });
+      b.ingestSessionEvent({
+        ts: Date.now(),
+        agent_id: "alpha",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text: "reply 3" },
+      });
+
+      // Exactly 3 deliveries: real, synthetic, real.
+      expect(replies.length).toBe(3);
+      expect(replies[0].text).toBe("reply 1");
+      expect(replies[1].text).toBe("silent-dropped reply 2");
+      expect(replies[2].text).toBe("reply 3");
+    });
+
+    it("only synthesizes once per turn even if multiple turn_end events arrive", async () => {
+      const b = makeBus();
+      const replies = captureReplies(b, "alpha");
+
+      await b.sendPrompt({
+        agent_id: "alpha",
+        origin: "webui",
+        origin_id: "test-dedup",
+        user_id: "u1",
+        text: "say hi",
+      });
+
+      const turnEnd: BusEvent = {
+        ts: Date.now(),
+        agent_id: "alpha",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text: "the recovered text" },
+      };
+
+      b.ingestSessionEvent(turnEnd);
+      b.ingestSessionEvent(turnEnd); // duplicate (e.g. tailer replay).
+
+      // Only one synthetic delivery, not two.
+      expect(replies.length).toBe(1);
+      expect(replies[0].text).toBe("the recovered text");
+    });
+  });
 });

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -1119,5 +1119,40 @@ describe("BusCore IPC", () => {
       expect(replies.length).toBe(1);
       expect(replies[0].text).toBe("the recovered text");
     });
+
+    it("delivers exactly once when turn_end LOSES the race (synthesis fires, then real reply lands) (#217 finding 2)", async () => {
+      // Cross-transport race: the real `reply` IPC and the synthesized
+      // recovery (from the tailer's response.turn_end) travel on two
+      // unordered channels. Here the tailer wins — turn_end is processed
+      // BEFORE the real reply IPC lands. handleTurnEnd synthesizes a final,
+      // then the late real reply arrives. Without per-turn dedup the user
+      // would receive the same answer twice.
+      const b = makeBus();
+      const replies = captureReplies(b, "alpha");
+
+      await b.sendPrompt({
+        agent_id: "alpha",
+        origin: "webui",
+        origin_id: "race-1",
+        user_id: "u1",
+        text: "say hi",
+      });
+
+      // Tailer wins: turn_end processed first → synthesizes + delivers.
+      b.ingestSessionEvent({
+        ts: Date.now(),
+        agent_id: "alpha",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text: "the answer" },
+      });
+
+      // The real reply IPC lands late for the SAME turn.
+      b.ingestReply({ agent_id: "alpha", text: "the answer", intent: "final" });
+
+      // Exactly one final delivered, not two.
+      expect(replies.length).toBe(1);
+      expect(replies[0].text).toBe("the answer");
+    });
   });
 });

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -1004,6 +1004,33 @@ describe("BusCore IPC", () => {
       expect(replies.length).toBe(0);
     });
 
+    it("does NOT synthesize for a scheduled origin (cron) even though it set lastPromptOrigin", async () => {
+      const b = makeBus();
+      const replies = captureReplies(b, "alpha");
+
+      // A cron/heartbeat tick DOES go through sendPrompt and records an
+      // origin — but those origins aren't channel-driven (no user waiting,
+      // no adapter to deliver to). Ending such a turn with text without
+      // calling `reply` is normal, not a silent drop.
+      await b.sendPrompt({
+        agent_id: "alpha",
+        origin: "cron",
+        origin_id: "cron-1",
+        user_id: "system",
+        text: "scheduled job",
+      });
+
+      b.ingestSessionEvent({
+        ts: Date.now(),
+        agent_id: "alpha",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: { stop_reason: "end_turn", text: "Cost tracker ran — total 30j $2183." },
+      });
+
+      expect(replies.length).toBe(0);
+    });
+
     it("resets the per-turn flag on each new prompt (single-flight per prompt)", async () => {
       const b = makeBus();
       const replies = captureReplies(b, "alpha");

--- a/src/bus/__tests__/jsonl-tailer.test.ts
+++ b/src/bus/__tests__/jsonl-tailer.test.ts
@@ -299,6 +299,63 @@ describe("JsonlTailer — assistant lines", () => {
     expect((usage?.payload as { input_tokens: number }).input_tokens).toBe(100);
   });
 
+  it("emits response.turn_end with concatenated text blocks when stop_reason is end_turn (issue #215)", async () => {
+    writeFileSync(
+      sessionPath,
+      jsonl({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          id: "msg_TE",
+          content: [
+            { type: "text", text: "First line." },
+            { type: "thinking", thinking: "internal" },
+            { type: "text", text: "Second line." },
+          ],
+          stop_reason: "end_turn",
+        },
+        timestamp: "2026-06-02T10:00:00.000Z",
+        sessionId: SESSION_ID,
+      }),
+    );
+    const { bus, events } = createMockBus();
+    tailer = makeTailer(bus);
+    await tailer.start();
+
+    const turnEnd = events.find((e) => e.topic === "response.turn_end");
+    expect(turnEnd).toBeDefined();
+    const payload = turnEnd!.payload as { stop_reason: string; text: string };
+    expect(payload.stop_reason).toBe("end_turn");
+    // Text blocks concatenated with newline, thinking excluded, trimmed.
+    expect(payload.text).toBe("First line.\nSecond line.");
+  });
+
+  it("does NOT emit response.turn_end when stop_reason is tool_use (turn continues)", async () => {
+    writeFileSync(
+      sessionPath,
+      jsonl({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          id: "msg_TU",
+          content: [
+            { type: "text", text: "Let me check that." },
+            { type: "tool_use", id: "toolu_Y", name: "Read", input: { path: "/tmp/y" } },
+          ],
+          stop_reason: "tool_use",
+        },
+        timestamp: "2026-06-02T10:00:01.000Z",
+        sessionId: SESSION_ID,
+      }),
+    );
+    const { bus, events } = createMockBus();
+    tailer = makeTailer(bus);
+    await tailer.start();
+
+    const turnEnd = events.find((e) => e.topic === "response.turn_end");
+    expect(turnEnd).toBeUndefined();
+  });
+
   it("surfaces api_error fields as system.api_error", async () => {
     writeFileSync(
       sessionPath,

--- a/src/bus/__tests__/jsonl-tailer.test.ts
+++ b/src/bus/__tests__/jsonl-tailer.test.ts
@@ -795,3 +795,64 @@ describe("JsonlTailer — real fixtures", () => {
     expect(topics.has("session.pr_link")).toBe(true);
   });
 });
+
+describe("startAt: 'end' (issue #215 runtime wiring)", () => {
+  function endTurn(text: string, ts = "2026-06-02T10:00:00.000Z"): object {
+    return {
+      type: "assistant",
+      message: {
+        role: "assistant",
+        id: "msg_ST",
+        content: [{ type: "text", text }],
+        stop_reason: "end_turn",
+      },
+      timestamp: ts,
+      sessionId: SESSION_ID,
+    };
+  }
+
+  it("does NOT replay historical turn_end, but live-tails new ones", async () => {
+    // History present before start() — must be skipped (would otherwise
+    // re-synthesize a stale reply when wired into the runtime).
+    writeFileSync(sessionPath, jsonl(endTurn("old historical turn")));
+    const { bus, events } = createMockBus();
+    tailer = new JsonlTailer({
+      bus,
+      agent_id: AGENT_ID,
+      session_id: SESSION_ID,
+      cwd,
+      projectsDir,
+      startAt: "end",
+      onError: () => undefined,
+    });
+    await tailer.start();
+    expect(events.some((e) => e.topic === "response.turn_end")).toBe(false);
+
+    // A turn appended AFTER start is delivered.
+    await appendFile(sessionPath, jsonl(endTurn("fresh live turn", "2026-06-02T10:01:00.000Z")));
+    await waitFor(events, (e) => e.some((x) => x.topic === "response.turn_end"));
+    const te = events.find((e) => e.topic === "response.turn_end");
+    expect((te?.payload as { text: string }).text).toBe("fresh live turn");
+  });
+
+  it("attaches to a session file that appears AFTER start (fresh session)", async () => {
+    // File does not exist at start() — the common runtime case (claude
+    // writes the JSONL lazily on the first turn). The pre-fix tailer just
+    // logged the ENOENT and never tailed.
+    const { bus, events } = createMockBus();
+    tailer = new JsonlTailer({
+      bus,
+      agent_id: AGENT_ID,
+      session_id: SESSION_ID,
+      cwd,
+      projectsDir,
+      startAt: "end",
+      onError: () => undefined,
+    });
+    await tailer.start();
+    await writeFile(sessionPath, jsonl(endTurn("first turn of a brand new session")));
+    await waitFor(events, (e) => e.some((x) => x.topic === "response.turn_end"));
+    const te = events.find((e) => e.topic === "response.turn_end");
+    expect((te?.payload as { text: string }).text).toBe("first turn of a brand new session");
+  });
+});

--- a/src/bus/__tests__/session-manager.test.ts
+++ b/src/bus/__tests__/session-manager.test.ts
@@ -13,7 +13,8 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, realpathSync, rmSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -23,6 +24,8 @@ import {
   type AgentProcess,
 } from "../session-manager";
 import type { AgentConfig, BusOrigin } from "../types";
+import { createBusCore, type BusCore } from "../core";
+import { encodeCwdForProjectsDir } from "../jsonl-line-types";
 
 const IS_DARWIN = process.platform === "darwin";
 const IS_UNIX = process.platform !== "win32";
@@ -516,5 +519,117 @@ describe("session-id collision rotation", () => {
     const proc2 = await mgr.spawnAgent(agent, "cron");
     expect(proc2).toBeDefined();
     await new Promise((r) => setTimeout(r, 50));
+  });
+});
+
+async function waitUntil(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (pred()) return;
+    await new Promise((r) => setTimeout(r, 15));
+  }
+  throw new Error("waitUntil timed out");
+}
+
+describe("JSONL tailer wiring (issue #215)", () => {
+  if (!IS_UNIX) {
+    it.skip("skipped on non-Unix (no bun-pty)", () => {});
+    return;
+  }
+
+  const SID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+  let tempRoot: string;
+  let projectsDir: string;
+  let agentCwd: string;
+  let sessionPath: string;
+  let bus: BusCore;
+  let mgr: SessionManager;
+  const spawned: string[] = [];
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), "ccaw-tailer-wire-"));
+    projectsDir = join(tempRoot, "projects");
+    agentCwd = mkdtempSync(join(tmpdir(), "ccaw-tailer-cwd-"));
+    const enc = encodeCwdForProjectsDir(realpathSync(agentCwd));
+    mkdirSync(join(projectsDir, enc), { recursive: true });
+    sessionPath = join(projectsDir, enc, `${SID}.jsonl`);
+    bus = createBusCore({ eventLogAppend: (async () => ({})) as never });
+    mgr = new SessionManager({
+      commandOverride: "/bin/cat",
+      argsOverride: [],
+      busSocketPath: "/tmp/test-bus.sock",
+      sessionCollisionDetectMs: 0,
+      bus,
+      projectsDir,
+    });
+  });
+
+  afterEach(async () => {
+    for (const id of spawned) {
+      try {
+        await mgr.stop(id);
+      } catch {
+        /* ignore */
+      }
+    }
+    spawned.length = 0;
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  it("synthesizes a reply from a real turn_end JSONL line (proves the runtime wiring)", async () => {
+    const replies: { text: string; origin?: string }[] = [];
+    bus.subscribe({ agent_id: "wired-agent", topics: ["response.text"] }, (e) => {
+      const p = e.payload as { text?: string; intent?: string; origin?: string };
+      if (p?.intent === "final") replies.push({ text: p.text ?? "", origin: p.origin });
+    });
+
+    const agent = mkAgent({ id: "wired-agent", cwd: agentCwd, session_id: SID });
+    const proc = await mgr.spawnAgent(agent, "telegram");
+    spawned.push(agent.id);
+    expect(proc.agent_id).toBe("wired-agent");
+
+    // A prompt is in flight: origin recorded, reply not yet seen.
+    await bus.sendPrompt({
+      agent_id: "wired-agent",
+      origin: "telegram",
+      origin_id: "tg-1",
+      user_id: "u1",
+      text: "allo",
+    });
+
+    // The agent ends its turn with final text but never calls `reply`
+    // (issue #215). claude appends the line to the live session JSONL.
+    await writeFile(
+      sessionPath,
+      `${JSON.stringify({
+        type: "assistant",
+        message: {
+          role: "assistant",
+          id: "msg1",
+          content: [{ type: "text", text: "Allo Simon!" }],
+          stop_reason: "end_turn",
+        },
+        timestamp: new Date().toISOString(),
+        sessionId: SID,
+      })}\n`,
+    );
+
+    await waitUntil(() => replies.length > 0, 2500);
+    expect(replies[0].text).toBe("Allo Simon!");
+    expect(replies[0].origin).toBe("telegram");
+  });
+
+  it("spawns cleanly when no bus is configured (tailer wiring is opt-in)", async () => {
+    const noBus = new SessionManager({
+      commandOverride: "/bin/cat",
+      argsOverride: [],
+      busSocketPath: "/tmp/test-bus.sock",
+      sessionCollisionDetectMs: 0,
+      projectsDir,
+    });
+    const agent = mkAgent({ id: "nobus-agent", cwd: agentCwd, session_id: SID });
+    const proc = await noBus.spawnAgent(agent, "telegram");
+    expect(proc.agent_id).toBe("nobus-agent");
+    await noBus.stop(agent.id);
   });
 });

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -195,9 +195,27 @@ export class BusCoreImpl implements BusCore {
    * in-flight prompts on one agent would let the second `sendPrompt` reset
    * the flag mid-turn for the first; the webui-bridge mutex serialising
    * prompt→reply per agent is the workaround for the path that would
-   * otherwise violate the one-turn-at-a-time assumption.
+   * otherwise violate the one-turn-at-a-time assumption. The residual
+   * cross-channel stale/misroute race this leaves open (a lagged turn_end
+   * synthesizing the wrong prompt's text to the wrong surface) is tracked
+   * as deferred follow-up #239 — see the note in `handleTurnEnd`.
    */
   private readonly currentTurnReplied = new Map<string, boolean>();
+
+  /**
+   * Cross-transport dedup for the silent-drop net (#217, finding 2).
+   * `currentTurnReplied` is reset to `false` on every `sendPrompt` and set
+   * to `true` once a final lands — but a real `reply` (IPC) and the
+   * synthesized recovery (`response.turn_end` via the fs.watch tailer)
+   * travel on two independent, unordered async channels. If the tailer
+   * wins the race, `handleTurnEnd` synthesizes+delivers a final, then the
+   * real `ingestReply(final)` IPC arrives and would deliver the SAME text
+   * a second time. This per-turn flag records that a final `response.text`
+   * was already PUBLISHED for the in-flight turn so the loser of the race
+   * is suppressed. Set in both `ingestReply(final)` and the synthesizer;
+   * cleared alongside `currentTurnReplied` on prompt / disconnect / cancel.
+   */
+  private readonly currentTurnFinalPublished = new Map<string, boolean>();
 
   constructor(opts: BusCoreOptions = {}) {
     this.socketPath = opts.socketPath ?? null;
@@ -228,6 +246,7 @@ export class BusCoreImpl implements BusCore {
           // origin and misroute (5-agent review on PR #138, A1 finding).
           this.lastPromptOrigin.delete(agentId);
           this.currentTurnReplied.delete(agentId);
+          this.currentTurnFinalPublished.delete(agentId);
         }
       },
       onError: (err, agentId) => this.onError(err, { ctx: "ipc", agentId }),
@@ -289,6 +308,9 @@ export class BusCoreImpl implements BusCore {
     // turn call reply?" flag. If the agent ends the turn (response.turn_end)
     // without ever setting this to true, we'll synthesize delivery.
     this.currentTurnReplied.set(req.agent_id, false);
+    // #217 finding 2: a new turn starts undelivered — clear the
+    // cross-transport "final already published" dedup flag.
+    this.currentTurnFinalPublished.set(req.agent_id, false);
 
     const ipcMsg: IpcPrompt = {
       type: "prompt",
@@ -382,7 +404,22 @@ export class BusCoreImpl implements BusCore {
 
   /* ─────────────────────────────── ingest ─────────────────────────────── */
 
-  ingestReply(req: IngestReplyRequest): void {
+  ingestReply(req: IngestReplyRequest, opts?: { synthetic?: boolean }): void {
+    // Cross-transport dedup (#217 finding 2): a final reply can arrive both
+    // as the agent's real `reply` IPC AND as the synthesized recovery from
+    // `response.turn_end` (the JSONL tailer). They race on two unordered
+    // channels; whichever lands first publishes and sets
+    // `currentTurnFinalPublished`. The loser is suppressed here so the same
+    // turn never delivers two finals. `synthetic` calls (from
+    // `handleTurnEnd`) bypass the check — they only run AFTER confirming no
+    // final has published yet, and must be allowed to publish the first.
+    if (
+      req.intent === "final" &&
+      !opts?.synthetic &&
+      this.currentTurnFinalPublished.get(req.agent_id) === true
+    ) {
+      return;
+    }
     const topic: BusEventTopic =
       req.intent === "tool_status" ? "response.tool_use" : "response.text";
     // Attach the originating surface so adapters can route the reply
@@ -431,6 +468,10 @@ export class BusCoreImpl implements BusCore {
       // intent → mark this turn as delivered, so the `response.turn_end`
       // handler skips the synthetic-delivery fallback for this turn.
       this.currentTurnReplied.set(req.agent_id, true);
+      // #217 finding 2: record that a final was published for this turn so
+      // the cross-transport race loser (real reply vs synthesized) is
+      // suppressed above.
+      this.currentTurnFinalPublished.set(req.agent_id, true);
     }
   }
 
@@ -446,7 +487,23 @@ export class BusCoreImpl implements BusCore {
    */
   private handleTurnEnd(agentId: string, text: string): void {
     if (this.currentTurnReplied.get(agentId) === true) return;
+    // #217 finding 2: if a final already published for this turn (e.g. the
+    // real reply IPC landed first), don't synthesize a duplicate.
+    if (this.currentTurnFinalPublished.get(agentId) === true) return;
     if (!text || text.trim().length === 0) return;
+    // RESIDUAL RACE (#217 finding 3 → deferred #239): `lastPromptOrigin` and
+    // the per-turn flags are single-slot, keyed by agent_id only, with no
+    // prompt/turn identity. The JSONL tailer's `response.turn_end` is
+    // delivered asynchronously (fs.watch + drain), so on a cross-channel
+    // interleave — P1(telegram) ends → reply → P2(webui) arrives (resets the
+    // flag, rewrites origin=webui) → P1's lagged turn_end lands here — this
+    // can route P1's text to P2's origin (webui). The flag-reset path is
+    // largely covered by the webui-bridge mutex serialising prompt→reply per
+    // agent, but cross-surface interleave is NOT fully closed. A complete fix
+    // threads the originating prompt_id onto the turn_end event and matches
+    // it to the in-flight prompt before synthesizing; that requires the
+    // tailer to carry prompt identity and is tracked as deferred follow-up
+    // #239 to avoid destabilizing this safety-net PR.
     const origin = this.lastPromptOrigin.get(agentId);
     if (!origin) {
       // No origin to route to (cron tick / unprompted ambient turn).
@@ -477,11 +534,17 @@ export class BusCoreImpl implements BusCore {
     // because we set the flag here, but the explicit ordering makes the
     // single-fire intent clearer).
     this.currentTurnReplied.set(agentId, true);
-    this.ingestReply({
-      agent_id: agentId,
-      text,
-      intent: "final",
-    });
+    // `synthetic: true` lets this first delivery through the cross-transport
+    // dedup (#217 finding 2); it sets `currentTurnFinalPublished`, so a
+    // later real `reply` IPC for the same turn is suppressed.
+    this.ingestReply(
+      {
+        agent_id: agentId,
+        text,
+        intent: "final",
+      },
+      { synthetic: true },
+    );
   }
 
   ingestSessionEvent(e: BusEvent): void {
@@ -641,6 +704,7 @@ export class BusCoreImpl implements BusCore {
         // a real reply OR a `response.turn_end` event — drop the
         // tracking flag to keep the map bounded.
         this.currentTurnReplied.delete(agentId);
+        this.currentTurnFinalPublished.delete(agentId);
         break;
       case "request_human": {
         // Forward the correlation id along with the question. Without
@@ -698,6 +762,7 @@ export class BusCoreImpl implements BusCore {
         // Silent-drop safety net (#215): error path won't produce a
         // turn_end either — clear tracking too.
         this.currentTurnReplied.delete(agentId);
+        this.currentTurnFinalPublished.delete(agentId);
         break;
       // hello already handled in the IPC layer; outbound types (prompt,
       // permission_response, ask_answer) shouldn't arrive from MCP.

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -178,6 +178,18 @@ export class BusCoreImpl implements BusCore {
    */
   private readonly lastPromptOrigin = new Map<string, { origin: BusOrigin; origin_id: string }>();
 
+  /**
+   * Silent-drop safety net (issue #215): tracks per-agent whether the
+   * current turn has called the `reply` MCP tool with `intent: "final"`.
+   * Reset on every new inbound prompt (`sendPrompt`), set to `true` when
+   * an `intent: "final"` `ingestReply` lands. On `response.turn_end`
+   * (emitted by the JSONL tailer when `stop_reason === "end_turn"`), if
+   * this is still `false` and the turn produced non-empty text, the
+   * agent ended the turn without delivering — we synthesize an
+   * `ingestReply` so the user actually receives the response.
+   */
+  private readonly currentTurnReplied = new Map<string, boolean>();
+
   constructor(opts: BusCoreOptions = {}) {
     this.socketPath = opts.socketPath ?? null;
     this.ringbufferCapacity = opts.ringbufferCapacity ?? DEFAULT_RINGBUFFER_CAPACITY;
@@ -206,6 +218,7 @@ export class BusCoreImpl implements BusCore {
           // agent (after a reconnect) would inherit the dead session's
           // origin and misroute (5-agent review on PR #138, A1 finding).
           this.lastPromptOrigin.delete(agentId);
+          this.currentTurnReplied.delete(agentId);
         }
       },
       onError: (err, agentId) => this.onError(err, { ctx: "ipc", agentId }),
@@ -263,6 +276,10 @@ export class BusCoreImpl implements BusCore {
       origin: req.origin,
       origin_id: req.origin_id,
     });
+    // Silent-drop safety net (#215): new prompt → reset the "did this
+    // turn call reply?" flag. If the agent ends the turn (response.turn_end)
+    // without ever setting this to true, we'll synthesize delivery.
+    this.currentTurnReplied.set(req.agent_id, false);
 
     const ipcMsg: IpcPrompt = {
       type: "prompt",
@@ -402,9 +419,64 @@ export class BusCoreImpl implements BusCore {
     if (req.intent === "final") {
       this.lastPromptOrigin.delete(req.agent_id);
     }
+    // Silent-drop safety net (#215): the agent called `reply` with a
+    // final intent → mark this turn as delivered. The
+    // `response.turn_end` handler will skip the synthetic-delivery
+    // fallback for this turn.
+    if (req.intent === "final") {
+      this.currentTurnReplied.set(req.agent_id, true);
+    }
+  }
+
+  /**
+   * Silent-drop safety net handler (issue #215). Wired by
+   * `ingestSessionEvent`/JSONL tailer when it observes a `response.turn_end`
+   * with `stop_reason: "end_turn"`. If the agent ended the turn with
+   * non-empty text but never called the `reply` tool for this prompt,
+   * synthesize an `ingestReply` so the user actually receives the
+   * response. Without this, the text sits in the session `.jsonl` and
+   * the user-facing surface gets nothing — confirmed live 2x in 12h
+   * on a real bus-mode deployment after issue #215 was filed.
+   */
+  private handleTurnEnd(agentId: string, text: string): void {
+    if (this.currentTurnReplied.get(agentId) === true) return;
+    if (!text || text.trim().length === 0) return;
+    const origin = this.lastPromptOrigin.get(agentId);
+    if (!origin) {
+      // No origin to route to (cron tick / unprompted ambient turn).
+      // Log so operators can correlate; don't fabricate delivery.
+      console.warn(
+        `[bus] silent-drop detected for agent=${agentId} (turn ended with text but no reply); ` +
+          `no lastPromptOrigin to route to — dropping silently as before.`,
+      );
+      return;
+    }
+    console.warn(
+      `[bus] silent-drop recovered for agent=${agentId} (origin=${origin.origin}, ` +
+        `chars=${text.length}): the turn ended with text but the agent did not call the ` +
+        `reply tool — synthesizing ingestReply to deliver. See issue #215.`,
+    );
+    // Mark BEFORE the recursive ingestReply so the synthetic call itself
+    // doesn't trigger another safety-net pass (it would no-op anyway
+    // because we set the flag here, but the explicit ordering makes the
+    // single-fire intent clearer).
+    this.currentTurnReplied.set(agentId, true);
+    this.ingestReply({
+      agent_id: agentId,
+      text,
+      intent: "final",
+    });
   }
 
   ingestSessionEvent(e: BusEvent): void {
+    // Silent-drop safety net (#215): the JSONL tailer publishes a
+    // `response.turn_end` event when claude stops with `end_turn`. Hook
+    // into it before the generic publish so we can synthesize a
+    // delivery for turns that produced text but never called reply.
+    if (e.topic === "response.turn_end" && e.agent_id) {
+      const payload = e.payload as { text?: string };
+      this.handleTurnEnd(e.agent_id, payload?.text ?? "");
+    }
     this.publish(e);
   }
 
@@ -549,6 +621,10 @@ export class BusCoreImpl implements BusCore {
         // this agent doesn't inherit it and misroute (5-agent review
         // on PR #138, A1 finding).
         this.lastPromptOrigin.delete(agentId);
+        // Silent-drop safety net (#215): cancelled turn won't produce
+        // a real reply OR a `response.turn_end` event — drop the
+        // tracking flag to keep the map bounded.
+        this.currentTurnReplied.delete(agentId);
         break;
       case "request_human": {
         // Forward the correlation id along with the question. Without
@@ -603,6 +679,9 @@ export class BusCoreImpl implements BusCore {
         // scheduler events for this agent don't inherit the stale
         // origin (5-agent review on PR #138, A1 finding).
         this.lastPromptOrigin.delete(agentId);
+        // Silent-drop safety net (#215): error path won't produce a
+        // turn_end either — clear tracking too.
+        this.currentTurnReplied.delete(agentId);
         break;
       // hello already handled in the IPC layer; outbound types (prompt,
       // permission_response, ask_answer) shouldn't arrive from MCP.

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -187,6 +187,14 @@ export class BusCoreImpl implements BusCore {
    * this is still `false` and the turn produced non-empty text, the
    * agent ended the turn without delivering — we synthesize an
    * `ingestReply` so the user actually receives the response.
+   *
+   * Single-slot per agent, last-write-wins — the same limitation
+   * `lastPromptOrigin` carries above (and this map depends on
+   * `lastPromptOrigin` for routing the synthesized reply). Interleaving two
+   * in-flight prompts on one agent would let the second `sendPrompt` reset
+   * the flag mid-turn for the first; the webui-bridge mutex serialising
+   * prompt→reply per agent is the workaround for the path that would
+   * otherwise violate the one-turn-at-a-time assumption.
    */
   private readonly currentTurnReplied = new Map<string, boolean>();
 

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -427,12 +427,9 @@ export class BusCoreImpl implements BusCore {
     //   - `permission_request` IPC handler (origin on channel.permission_request)
     if (req.intent === "final") {
       this.lastPromptOrigin.delete(req.agent_id);
-    }
-    // Silent-drop safety net (#215): the agent called `reply` with a
-    // final intent → mark this turn as delivered. The
-    // `response.turn_end` handler will skip the synthetic-delivery
-    // fallback for this turn.
-    if (req.intent === "final") {
+      // Silent-drop safety net (#215): the agent called `reply` with a final
+      // intent → mark this turn as delivered, so the `response.turn_end`
+      // handler skips the synthetic-delivery fallback for this turn.
       this.currentTurnReplied.set(req.agent_id, true);
     }
   }

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -48,6 +48,7 @@ import type {
   IpcPrompt,
   PermissionResponse,
 } from "./types";
+import { CHANNEL_DRIVEN_ORIGINS } from "./types";
 
 /** Escape XML text content (`&`, `<`, `>`) so a `</channel>` in user text
  *  can't close the wrapper element early and inject sibling markup. */
@@ -457,6 +458,16 @@ export class BusCoreImpl implements BusCore {
         `[bus] silent-drop detected for agent=${agentId} (turn ended with text but no reply); ` +
           `no lastPromptOrigin to route to — dropping silently as before.`,
       );
+      return;
+    }
+    // Only channel-driven origins (telegram/webui/discord/slack) have a
+    // user waiting on a reply. Scheduled/ambient origins (cron, heartbeat,
+    // cli, rest) legitimately end turns with text WITHOUT calling `reply`
+    // — that's not a silent drop, and there's no adapter to deliver the
+    // synthesized reply to anyway. Synthesizing for them would spam a
+    // bogus "recovered" warning and emit an undeliverable response.text on
+    // every scheduled tick. Skip them.
+    if (!CHANNEL_DRIVEN_ORIGINS.has(origin.origin)) {
       return;
     }
     console.warn(

--- a/src/bus/jsonl-tailer.ts
+++ b/src/bus/jsonl-tailer.ts
@@ -403,6 +403,29 @@ export class JsonlTailer {
     if (line.message?.usage) {
       this.publish("usage", line.message.usage, line);
     }
+    // Turn-boundary surfacing — when the API stops with `end_turn`, the
+    // agent has signalled "I'm done with this turn". Emit a single event
+    // carrying the concatenated text blocks of this turn so downstream
+    // subscribers (silent-drop safety net in bus core) can detect the
+    // pattern where the agent ended the turn with text but never called
+    // the `reply` tool to deliver it to the user. `tool_use` stop_reason
+    // means the agent intends to continue after a tool result, so we
+    // don't emit on those.
+    if (line.message?.stop_reason === "end_turn") {
+      const turnText = blocks
+        .filter((b) => b.type === "text")
+        .map((b) => (b as { text?: string }).text ?? "")
+        .join("\n")
+        .trim();
+      this.publish(
+        "response.turn_end",
+        {
+          stop_reason: "end_turn",
+          text: turnText,
+        },
+        line,
+      );
+    }
     // Degraded-turn surfacing — §5.2 mentions `error` / `isApiErrorMessage` /
     // `apiErrorStatus` on assistant lines. Forward as `system.api_error`.
     if (line.error || line.isApiErrorMessage) {

--- a/src/bus/jsonl-tailer.ts
+++ b/src/bus/jsonl-tailer.ts
@@ -39,7 +39,7 @@ import {
   type ToolResultBlock,
   type UserLine,
 } from "./jsonl-line-types";
-import type { BusEvent, BusEventTopic } from "./types";
+import { type BusEvent, type BusEventTopic, TAILER_EVENT_SOURCE } from "./types";
 
 /**
  * Parser schema version. Bump whenever line-type handling changes in a
@@ -581,7 +581,13 @@ export class JsonlTailer {
       agent_id: this.agent_id,
       session_id: sessionFromLine ?? this.session_id,
       topic,
-      payload: metadata ? { ...(payload as object), _meta: metadata } : payload,
+      // Stamp the tailer source marker (#217) into `_meta` so delivery
+      // adapters can tell this observability echo apart from a real
+      // `ingestReply` delivery (otherwise every reply double-posts).
+      // Merge with any caller-supplied metadata. Only object (non-array)
+      // payloads carry `_meta`; primitive/array payloads are never
+      // adapter-deliverable, so leave them untouched.
+      payload: this.withTailerMeta(payload, metadata),
       raw: rawLine,
     };
     try {
@@ -589,6 +595,22 @@ export class JsonlTailer {
     } catch (err) {
       this.onError(err, { ctx: "publish", topic });
     }
+  }
+
+  /**
+   * Merge the tailer source marker (#217) — and any caller metadata —
+   * into an object payload's `_meta`. Primitive/array payloads are
+   * returned unchanged (they are never adapter-deliverable, so they
+   * don't need the marker, and spreading them would be lossy).
+   */
+  private withTailerMeta(payload: unknown, metadata?: Record<string, unknown>): unknown {
+    if (typeof payload !== "object" || payload === null || Array.isArray(payload)) {
+      return payload;
+    }
+    return {
+      ...(payload as object),
+      _meta: { ...metadata, source: TAILER_EVENT_SOURCE },
+    };
   }
 
   private emitReplayDone(): void {

--- a/src/bus/jsonl-tailer.ts
+++ b/src/bus/jsonl-tailer.ts
@@ -130,6 +130,15 @@ export class JsonlTailer {
   private readonly startAt: "begin" | "end";
 
   private offset = 0;
+  /**
+   * Set when the startup seek-to-EOF (`startAt: "end"`) could not `statSync`
+   * the file (transient perm flip / NFS hiccup / rotation). While true, the
+   * next `drainFromOffset` re-seeks to current EOF instead of reading from
+   * offset 0 — otherwise it would replay the entire history and synthesize a
+   * stale reply, the exact failure `startAt: "end"` exists to prevent
+   * (#217 review).
+   */
+  private seekToEndPending = false;
   private buffer = "";
   /** Set true once the first non-empty line emits `session.init`. */
   private initEmitted = false;
@@ -186,6 +195,11 @@ export class JsonlTailer {
           this.offset = statSync(this.filePath).size;
         } catch (err) {
           this.onError(err, { ctx: "start-eof-stat" });
+          // Couldn't establish EOF. Do NOT let the follow-up drain read from
+          // offset 0 — that replays the whole history and synthesizes a stale
+          // reply. Defer the seek: the next drainFromOffset re-seeks to the
+          // then-current EOF and tails forward (#217 review).
+          this.seekToEndPending = true;
         }
       } else {
         await this.drainFromOffset();
@@ -289,6 +303,14 @@ export class JsonlTailer {
       // re-fire when bytes appear (or won't, if the file truly never
       // gets created — that's a higher-layer concern).
       this.onError(err, { ctx: "drain-stat" });
+      return;
+    }
+    if (this.seekToEndPending) {
+      // Startup seek-to-EOF was deferred because the initial statSync failed.
+      // Establish EOF now and tail forward — a startAt:"end" tailer must never
+      // replay history (#217 review).
+      this.offset = size;
+      this.seekToEndPending = false;
       return;
     }
     if (size <= this.offset) return;

--- a/src/bus/jsonl-tailer.ts
+++ b/src/bus/jsonl-tailer.ts
@@ -252,6 +252,10 @@ export class JsonlTailer {
     const poll = (): void => {
       if (this.stopped) return;
       if (existsSync(this.filePath)) {
+        // File appeared — the await-creation poll is done; clear its handle so
+        // the tailer's state isn't misleading and stop() doesn't clear a stale
+        // timer (Copilot review #217).
+        this.createPollTimer = null;
         this.attachFileWatcher();
         this.scheduleDrain();
         return;

--- a/src/bus/jsonl-tailer.ts
+++ b/src/bus/jsonl-tailer.ts
@@ -105,6 +105,15 @@ export interface JsonlTailerOptions {
   projectsDir?: string;
   /** Surfaced via schema-probe cache (Sprint 2 Agent B). */
   schemaVersion?: string;
+  /**
+   * Where to begin tailing when the session file already exists.
+   * `"begin"` (default) replays from byte 0 — used by tests and any
+   * consumer that wants historical events. `"end"` seeks to EOF and
+   * live-tails new lines only — used by the runtime wiring (issue #215)
+   * so a resumed session never re-emits historical `response.turn_end`
+   * events (which could synthesize a stale reply).
+   */
+  startAt?: "begin" | "end";
   /** Error sink. Defaults to console.error. */
   onError?: (err: unknown, ctx?: Record<string, unknown>) => void;
 }
@@ -118,12 +127,15 @@ export class JsonlTailer {
   private readonly schemaVersion: string;
   private readonly onError: (err: unknown, ctx?: Record<string, unknown>) => void;
   private readonly filePath: string;
+  private readonly startAt: "begin" | "end";
 
   private offset = 0;
   private buffer = "";
   /** Set true once the first non-empty line emits `session.init`. */
   private initEmitted = false;
   private watcher: FSWatcher | null = null;
+  /** Set while polling for a not-yet-created session file. Cleared by stop(). */
+  private createPollTimer: ReturnType<typeof setTimeout> | null = null;
   private started = false;
   private stopped = false;
   /**
@@ -140,6 +152,7 @@ export class JsonlTailer {
     this.projectsDir = opts.projectsDir ?? join(homedir(), ".claude", "projects");
     this.schemaVersion = opts.schemaVersion ?? SCHEMA_VERSION;
     this.onError = opts.onError ?? ((err, ctx) => console.error("[jsonl-tailer]", err, ctx));
+    this.startAt = opts.startAt ?? "begin";
     this.filePath = join(
       this.projectsDir,
       encodeCwdForProjectsDir(this.cwd),
@@ -164,31 +177,75 @@ export class JsonlTailer {
     // emit the replay-done marker (with offset=0) and the live-tail
     // path picks up the first byte when it appears.
     if (existsSync(this.filePath)) {
-      await this.drainFromOffset();
+      if (this.startAt === "end") {
+        // Issue #215 runtime wiring: live-tail NEW turns only. Replaying
+        // from byte 0 on a resumed session would re-emit historical
+        // `response.turn_end` events and, with a prompt in flight, could
+        // synthesize a stale reply. Seek to EOF and watch forward.
+        try {
+          this.offset = statSync(this.filePath).size;
+        } catch (err) {
+          this.onError(err, { ctx: "start-eof-stat" });
+        }
+      } else {
+        await this.drainFromOffset();
+      }
+      this.emitReplayDone();
+      this.attachFileWatcher();
+      return;
     }
-    this.emitReplayDone();
 
-    // Live tail. fs.watch on macOS is generally reliable for append-only
-    // files in our scenarios; if we ever see drops on Linux network FS
-    // we'll fall back to fs.watchFile polling. Spec §5.2 explicitly
-    // allows either.
+    // File not created yet. A fresh agent session has claude write the
+    // JSONL lazily (on the first turn), so at spawn time the path — and
+    // even its parent dir — may not exist. Emit replay-done at offset 0,
+    // then poll for the file's appearance and attach. Without this the
+    // tailer is inert for every fresh session (issue #215 runtime wiring:
+    // the common case — the original code only logged the ENOENT from
+    // `watch()` and gave up, so no events ever flowed in production).
+    this.emitReplayDone();
+    this.awaitFileCreation();
+  }
+
+  /** Attach the live fs.watch to an already-existing session file. */
+  private attachFileWatcher(): void {
+    if (this.stopped || this.watcher) return;
     try {
       this.watcher = watch(this.filePath, { persistent: false }, () => {
         this.scheduleDrain();
       });
       this.watcher.on("error", (err) => this.onError(err, { ctx: "fs-watch" }));
     } catch (err) {
-      // ENOENT — file not yet created. Poll the parent dir minimally:
-      // schedule a one-shot retry. In practice Session Manager has
-      // already spawned `claude` and the file appears within ms.
       this.onError(err, { ctx: "watch-setup", path: this.filePath });
     }
+  }
+
+  /**
+   * Poll (unref'd) until the session file appears, then attach the watcher
+   * and drain whatever has been written. A brand-new file has offset 0 ==
+   * EOF, so `startAt: "end"` and `"begin"` coincide for it. Cleared by stop().
+   */
+  private awaitFileCreation(): void {
+    const poll = (): void => {
+      if (this.stopped) return;
+      if (existsSync(this.filePath)) {
+        this.attachFileWatcher();
+        this.scheduleDrain();
+        return;
+      }
+      this.createPollTimer = setTimeout(poll, 150);
+      this.createPollTimer.unref?.();
+    };
+    poll();
   }
 
   /** Stop and release watchers. Idempotent. */
   async stop(): Promise<void> {
     if (this.stopped) return;
     this.stopped = true;
+    if (this.createPollTimer) {
+      clearTimeout(this.createPollTimer);
+      this.createPollTimer = null;
+    }
     if (this.watcher) {
       this.watcher.close();
       this.watcher = null;

--- a/src/bus/jsonl-tailer.ts
+++ b/src/bus/jsonl-tailer.ts
@@ -192,6 +192,16 @@ export class JsonlTailer {
       }
       this.emitReplayDone();
       this.attachFileWatcher();
+      // Close the startup TOCTOU on the existing-file path (review #217).
+      // `fs.watch` only fires on changes AFTER it attaches, so bytes written
+      // in the window between the `statSync` seek-to-EOF above and
+      // `attachFileWatcher()` are not delivered by the watcher and stay unread
+      // until the NEXT write triggers `scheduleDrain`. If those missed bytes
+      // contain an `end_turn` line and the agent then goes idle — the exact
+      // pattern this safety net exists to recover — synthesis is delayed
+      // indefinitely. Schedule a follow-up drain to sweep the gap immediately,
+      // mirroring what `awaitFileCreation` already does after its attach.
+      this.scheduleDrain();
       return;
     }
 

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -235,7 +235,7 @@ export async function mountBusRuntime(
 
   const bus: BusCore = opts.bus ?? new BusCoreImpl({ socketPath });
   const sessionManager: SessionManager =
-    opts.sessionManager ?? new SessionManager({ busSocketPath: socketPath });
+    opts.sessionManager ?? new SessionManager({ busSocketPath: socketPath, bus });
 
   let busStarted = false;
   const spawned: string[] = [];

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -40,6 +40,8 @@ import {
   writeConfigForPty,
 } from "../runner/pty-mcp-config-writer";
 import { createSession } from "../sessions";
+import type { BusCore } from "./core";
+import { JsonlTailer } from "./jsonl-tailer";
 import {
   type AgentProcess,
   ChildAgentProcess,
@@ -106,6 +108,20 @@ export interface SessionManagerOptions {
    * Optional logger override. Defaults to `console`.
    */
   logger?: Pick<Console, "warn" | "info" | "error">;
+  /**
+   * Bus core to feed session JSONL events into (issue #215). When set,
+   * every spawned agent gets a `JsonlTailer` bound to its live session
+   * that forwards `response.turn_end` (etc.) via `bus.ingestSessionEvent`,
+   * which powers the silent-drop safety net. Absent in unit tests that
+   * don't exercise the tailer. The daemon (`runtime-mount`) wires it.
+   */
+  bus?: BusCore;
+  /**
+   * Override the `~/.claude/projects` root the per-agent `JsonlTailer`
+   * reads (issue #215). Defaults to the tailer's own default. Tests point
+   * it at a temp dir so they never touch the real projects directory.
+   */
+  projectsDir?: string;
 }
 
 /**
@@ -454,6 +470,12 @@ interface AgentRecord {
    * `agent.mcp_config`, or dormant multiplexer).
    */
   mcpConfigCwd?: string;
+  /**
+   * Live session JSONL tailer (issue #215). Present when `options.bus`
+   * is set; feeds `response.turn_end` events so the bus can synthesize a
+   * reply the agent forgot to send. Stopped on agent exit / stop().
+   */
+  tailer?: JsonlTailer;
 }
 
 export class SessionManager {
@@ -563,6 +585,8 @@ export class SessionManager {
     proc.onExit(() => {
       const current = this.agents.get(agent.id);
       if (current && current.proc === proc) {
+        // Issue #215: tear down the session tailer on natural exit too.
+        void current.tailer?.stop();
         // Issue #165 (PR #184 re-review): a natural exit (crash, OOM,
         // claude-side auth failure, operator kill) never routes through
         // stop(), so release the multiplexer identity + delete the 0600
@@ -627,6 +651,34 @@ export class SessionManager {
       throw new Error(
         `agent ${agent.id}: session-id collision persisted after rotation (id=${agent.session_id}) — manual intervention required`,
       );
+    }
+
+    // Issue #215: wire a JSONL tailer to this agent's live session so the
+    // bus observes `response.turn_end` and can synthesize a reply when a
+    // turn ends with text but the agent never called the `reply` tool.
+    // Without this the safety net in BusCore.handleTurnEnd is inert (no
+    // events are ever produced in the runtime). Created here — after any
+    // session-id rotation — so it binds the FINAL session_id. start() is
+    // fire-and-forget: it must not block returning the proc, and a tail
+    // failure must never fail the spawn.
+    if (this.options.bus) {
+      const tailer = new JsonlTailer({
+        bus: this.options.bus,
+        agent_id: agent.id,
+        session_id: agent.session_id,
+        cwd: realCwd,
+        startAt: "end",
+        projectsDir: this.options.projectsDir,
+      });
+      record.tailer = tailer;
+      void tailer
+        .start()
+        .catch((err) =>
+          (this.options.logger ?? console).warn(
+            `[bus-session] agent=${agent.id} jsonl tailer start failed`,
+            err,
+          ),
+        );
     }
 
     return proc;
@@ -783,6 +835,8 @@ export class SessionManager {
     if (!record) return Promise.resolve();
     return new Promise<void>((resolve) => {
       const finalise = (): void => {
+        // Issue #215: tear down the session tailer.
+        void record.tailer?.stop();
         // Issue #165: release the multiplexer identity + delete the
         // synthesized per-agent --mcp-config when this spawn had one.
         this.cleanupAgentMcpConfig(record.mcpConfigCwd, agent_id);

--- a/src/bus/types.ts
+++ b/src/bus/types.ts
@@ -116,6 +116,32 @@ export interface BusEvent<P = unknown> {
   raw?: unknown;
 }
 
+/**
+ * Source marker stamped into the `_meta` of every event the JSONL tailer
+ * publishes (issue #217 review). The tailer feeds the live bus purely as
+ * an OBSERVABILITY read-path: it re-emits the agent's own session lines
+ * (per-block `response.text`, `response.thinking`, `response.tool_use`,
+ * usage, …) so the event log / Web UI / silent-drop net can see them.
+ *
+ * The one event the silent-drop net (#215) actually needs from the tailer
+ * is `response.turn_end`, which BusCore consumes internally (it never
+ * fans out to delivery adapters). The raw per-block `response.text`
+ * echoes, however, ALSO match what the channel adapters subscribe to and
+ * deliver — so without a marker every reply would be delivered twice
+ * (once by the agent's real `reply` tool → `ingestReply`, once by this
+ * observability echo). Adapters use {@link isTailerOriginEvent} to skip
+ * tailer-origin `response.text` so only `ingestReply`-produced deliveries
+ * reach the user. Synthesized recovery replies go through `ingestReply`
+ * (not the tailer) and therefore carry NO marker → still delivered.
+ */
+export const TAILER_EVENT_SOURCE = "jsonl-tailer";
+
+/** True when a BusEvent was published by the JSONL tailer (see {@link TAILER_EVENT_SOURCE}). */
+export function isTailerOriginEvent(event: BusEvent): boolean {
+  const meta = (event.payload as { _meta?: { source?: string } } | undefined)?._meta;
+  return meta?.source === TAILER_EVENT_SOURCE;
+}
+
 /* ───────────────────────────────────────────────────────────────────── */
 /* Permission flow (§5.1 v2.2)                                           */
 /* ───────────────────────────────────────────────────────────────────── */

--- a/src/bus/types.ts
+++ b/src/bus/types.ts
@@ -72,6 +72,7 @@ export type BusEventTopic =
   | "response.tool_use"
   | "response.edit_text"
   | "response.thinking"
+  | "response.turn_end"
   | "tool_result"
   | "usage"
   | "session.init"

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -503,7 +503,12 @@ export async function start(args: string[] = []) {
       // Search "Issue #165: deferred bus agent spawn" for step 3.
       const socketPath = resolveDaemonSocketPath();
       const bus = new BusCoreImpl({ socketPath });
-      const sessionManager = new SessionManager({ busSocketPath: socketPath });
+      // Issue #215: pass `bus` so the SessionManager wires a per-agent
+      // JsonlTailer that feeds `response.turn_end` into the silent-drop
+      // safety net. Without this the net is inert in the production daemon
+      // (mountBusRuntime's bus-wired default is bypassed when we supply our
+      // own SessionManager here).
+      const sessionManager = new SessionManager({ busSocketPath: socketPath, bus });
       const handle = await mountBusRuntime({
         bus,
         sessionManager,


### PR DESCRIPTION
## Problem

Refs #215 (the issue this PR fixes), refs #211 (adapter receipt coverage that makes this measurable), refs #213.

In bus-mode deployments, when an agent ends a turn with `stop_reason: "end_turn"` and a final assistant text block **without** invoking the `reply` MCP tool, the user-facing surface (Telegram, Discord, Slack, webui) receives **nothing**. The text is persisted to the session `.jsonl` but never delivered.

**Confirmed live 2x in 12 hours** on the same daemon — the agent that wrote #215 the previous evening forgot to call `reply` the next morning, twice consecutively. Prompt-level enforcement alone is not sufficient. From #215:

> Compounding factor: no prompt explicitly tells the agent that `reply` is mandatory in bus mode. The tool description ("Use `intent: 'final'` for the turn-final message") reads like advice, not a hard requirement.

This PR adds the **code-level safety net** (option B of #215). Option A (prompt enforcement) is a complementary follow-up.

## Fix

A two-piece change at the bus seam:

### 1. JSONL tailer emits `response.turn_end`

`src/bus/jsonl-tailer.ts dispatchAssistant`: on an assistant line with `stop_reason: "end_turn"`, emit a new `response.turn_end` event carrying the concatenated text blocks (text-only, thinking excluded, joined + trimmed). `stop_reason: "tool_use"` keeps existing behavior — the turn continues after the tool result, no synthesis needed.

```ts
if (line.message?.stop_reason === "end_turn") {
  const turnText = blocks
    .filter((b) => b.type === "text")
    .map((b) => (b as { text?: string }).text ?? "")
    .join("\n")
    .trim();
  this.publish("response.turn_end", { stop_reason: "end_turn", text: turnText }, line);
}
```

### 2. Bus core tracks per-agent reply state + synthesizes on omission

`src/bus/core.ts`: add `currentTurnReplied: Map<agentId, boolean>`. Reset on every `sendPrompt`, set to `true` when `ingestReply` with `intent: "final"` lands. On `response.turn_end`, if still `false` AND turn produced non-empty text AND `lastPromptOrigin` is cached, synthesize an `ingestReply` so the user receives the response.

Cleared in cancel/error/disconnect paths alongside `lastPromptOrigin` to keep the map bounded.

```ts
private handleTurnEnd(agentId: string, text: string): void {
  if (this.currentTurnReplied.get(agentId) === true) return;
  if (!text || text.trim().length === 0) return;
  const origin = this.lastPromptOrigin.get(agentId);
  if (!origin) {
    console.warn(`[bus] silent-drop detected for agent=${agentId} ...`);
    return;
  }
  console.warn(`[bus] silent-drop recovered for agent=${agentId} ...`);
  this.currentTurnReplied.set(agentId, true); // single-flight guard
  this.ingestReply({ agent_id: agentId, text, intent: "final" });
}
```

### Why a warn-level log on synthesis

Operators can correlate with #211's receipts to measure the rate of agent-side reply-tool omission over time. The log line carries the agent_id, origin, and char count — enough to triage without exposing payload. If the synthesis path fires more than expected, that's a signal to revisit option A (prompt enforcement).

## Edge cases (all tested)

| Scenario | Behavior |
|---|---|
| Reply was called with `intent: "final"` | No synthesis (no duplicate delivery) |
| Turn ended with empty text | No synthesis |
| No `lastPromptOrigin` (cron / ambient turn) | Log warning, no synthesis (preserves current behavior — nowhere to route to) |
| Multi-prompt session | Flag resets per `sendPrompt`, single-flight per turn |
| Duplicate `response.turn_end` events (e.g. tailer replay) | Idempotent, single synthesis |
| Cancel / error / socket disconnect | Tracking cleared alongside `lastPromptOrigin` |

## Test plan

- [x] **T1 build**: `bun build src/index.ts --outdir /tmp/claw-smoke --target bun --no-splitting` → clean
- [x] **T1 lint**: `bun x biome check src/bus/core.ts src/bus/jsonl-tailer.ts src/bus/types.ts` → clean
- [x] **T1 type check**: `bun x tsc --noEmit` → no new errors in touched files (one pre-existing error in `src/skills-tuner/core/types.ts:19` is unchanged and unrelated)
- [x] **T2 unit tests new**:
  - `bus/__tests__/core.test.ts` → +5 tests covering synthesis/skip/dedup/reset
  - `bus/__tests__/jsonl-tailer.test.ts` → +2 tests covering turn_end emission and tool_use skip
- [x] **T2 unit tests regression**: full bus suite **283 pass, 0 fail, 1 skip** (no regression)
- [x] **Live-validated** on a real bus-mode daemon:
  - Pre-deploy: 2 confirmed silent drops in 12h (text in `.jsonl`, nothing on Telegram).
  - Post-deploy + restart: normal probe inject `pong` answered in 6s with `ok: true exitCode: 0`; no spurious `silent-drop` warnings (reply path used normally). The synthesis path only fires on omission — transparent in the common case.
  - Backups kept for fast rollback if needed.

## Scope and non-goals

- **Telegram-specific behavior** is not changed in this PR; the fix is at the bus core layer, so Discord/Slack/webui all benefit identically once the synthetic `ingestReply` flows through their normal `response.text` subscribers.
- **Receipt-chain integration** (`#211`) is intentionally out of scope here. Once `#211` lands, this PR's `handleTurnEnd` is the natural place to stamp `auto_recovered: true` on the receipt — happy to do that as a small follow-up after `#211`.
- **Option A (prompt enforcement)** from #215 is also out of scope. The two layers are complementary; B is the more robust of the two and unblocks the immediate UX-fatal pattern.

## Version bump

Plugin + marketplace bumped to `2.2.139` per repo policy (`src/` touched).

## Migration notes

None — additive. Existing behavior is preserved when the agent calls `reply` correctly. The new safety net only fires when the agent ends a turn with non-empty text without delivering — the exact pattern that was previously silent.

