### PR TITLE
feat(adapters/telegram): open inbound receipts at message_polled (closes #211)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.133",
+      "version": "2.2.134",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.133",
+  "version": "2.2.134",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -22,6 +22,15 @@ import type {
   SubscriptionHandler,
 } from "../../../bus/core-subscription";
 import type { BusEvent } from "../../../bus/types";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createReceiptStore,
+  hashPrompt,
+  type ReceiptRecord,
+  type ReceiptStore,
+} from "../../../bus/receipt";
 import type {
   TelegramApi,
   TelegramGetUpdatesResult,
@@ -236,6 +245,9 @@ const SILENT_LOGGER = {
 let bus: FakeBus;
 let api: FakeTelegramApi;
 let adapter: TelegramAdapter | null = null;
+let receiptStore: ReceiptStore;
+let receiptDir: string;
+let receiptPath: string;
 
 async function waitFor(predicate: () => boolean, timeoutMs = 1000): Promise<void> {
   const deadline = Date.now() + timeoutMs;
@@ -257,6 +269,7 @@ async function startAdapter(
     api,
     logger: SILENT_LOGGER,
     pollIntervalMs: 5,
+    receiptStore,
     ...opts,
   });
   await a.start();
@@ -266,6 +279,12 @@ async function startAdapter(
 beforeEach(() => {
   bus = new FakeBus();
   api = new FakeTelegramApi();
+  // Isolated receipt store per test — keeps every adapter test (these and
+  // the pre-existing ones that exercise handleMessage) off the real
+  // ~/.claude/claudeclaw/receipts.jsonl.
+  receiptDir = mkdtempSync(join(tmpdir(), "cc-rcpt-"));
+  receiptPath = join(receiptDir, "receipts.jsonl");
+  receiptStore = createReceiptStore({ path: receiptPath });
 });
 
 afterEach(async () => {
@@ -273,6 +292,7 @@ afterEach(async () => {
     await adapter.stop();
     adapter = null;
   }
+  rmSync(receiptDir, { recursive: true, force: true });
 });
 
 /* ────────────────────────────────────────────────────────────────────── */
@@ -1087,5 +1107,113 @@ describe("TelegramAdapter — poll loop recovers from a timed-out getUpdates", (
     expect(bus.prompts[0]?.text).toBe("after recovery");
     // The timeout surfaced in the logs (observability), it wasn't swallowed.
     expect(errors.some((a) => String(a[0]).includes("getUpdates failed"))).toBe(true);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────── */
+/* Inbound receipts (#211)                                                  */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe("TelegramAdapter — inbound receipts (#211)", () => {
+  // Store + cleanup come from the top-level harness (isolated temp store
+  // per test); closedReceipts reads the lines flushed to that store.
+  function closedReceipts(): ReceiptRecord[] {
+    if (!existsSync(receiptPath)) return [];
+    return readFileSync(receiptPath, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as ReceiptRecord);
+  }
+
+  async function feed(text: string, messageId = 50): Promise<number> {
+    const before = bus.prompts.length;
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: messageId,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          text,
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length > before);
+    return bus.prompts.length;
+  }
+
+  it("opens a tg-<update_id> receipt at message_polled with the raw prompt_hash", async () => {
+    adapter = await startAdapter();
+    await feed("hello world"); // first update_id === 1 → tg-1, still open (no reply yet)
+    const open = receiptStore.find("tg-1");
+    expect(open).toBeDefined();
+    expect(open?.record.agent_id).toBe("triage");
+    expect(open?.record.prompt_hash).toBe(hashPrompt("hello world"));
+    expect(open?.record.notes).toMatchObject({ origin: "telegram", origin_id: "100" });
+  });
+
+  it("closes the receipt turn_observed on a final reply", async () => {
+    adapter = await startAdapter();
+    await feed("ping");
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "pong", intent: "final" },
+    });
+    await waitFor(() => closedReceipts().some((r) => r.message_id === "tg-1"));
+    expect(closedReceipts().find((r) => r.message_id === "tg-1")?.final_state).toBe(
+      "turn_observed",
+    );
+  });
+
+  it("auto-closes the receipt as timeout when no reply arrives", async () => {
+    adapter = await startAdapter({ receiptTimeoutMs: 15 });
+    await feed("are you there");
+    await waitFor(() =>
+      closedReceipts().some((r) => r.message_id === "tg-1" && r.final_state === "timeout"),
+    );
+    expect(closedReceipts().find((r) => r.message_id === "tg-1")?.notes?.reason).toBe(
+      "no_final_reply_within_timeout",
+    );
+  });
+
+  it("supersedes a still-open receipt when a new prompt arrives first", async () => {
+    adapter = await startAdapter();
+    await feed("first", 50); // tg-1
+    await feed("second", 51); // tg-2 — supersedes tg-1
+    await waitFor(() => closedReceipts().some((r) => r.message_id === "tg-1"));
+    const r = closedReceipts().find((r) => r.message_id === "tg-1");
+    expect(r?.final_state).toBe("timeout");
+    expect(r?.notes?.superseded).toBe(true);
+  });
+
+  it("drains open receipts as timeout(adapter_stopped) on stop()", async () => {
+    adapter = await startAdapter();
+    await feed("lingering");
+    const a = adapter;
+    await a.stop();
+    await waitFor(() => closedReceipts().some((r) => r.message_id === "tg-1"));
+    const r = closedReceipts().find((r) => r.message_id === "tg-1");
+    expect(r?.final_state).toBe("timeout");
+    expect(r?.notes?.reason).toBe("adapter_stopped");
+    // adapter already stopped; null it so afterEach doesn't re-stop.
+    adapter = null;
+  });
+
+  it("closes turn_observed on a reaction-only final (empty cleanedText)", async () => {
+    adapter = await startAdapter();
+    await feed("react please");
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "[react:\u{1F44D}]", intent: "final" },
+    });
+    await waitFor(() => closedReceipts().some((r) => r.message_id === "tg-1"));
+    expect(closedReceipts().find((r) => r.message_id === "tg-1")?.final_state).toBe(
+      "turn_observed",
+    );
   });
 });

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -7,6 +7,8 @@
  */
 
 import type { BusCore, Subscription } from "../../bus/core";
+import { openInboundReceipt } from "../../bus/receipt-wiring";
+import { getDefaultReceiptStore, type OpenReceipt, type ReceiptStore } from "../../bus/receipt";
 import {
   CHANNEL_DRIVEN_ORIGINS,
   type BusEvent,
@@ -40,6 +42,12 @@ export interface TelegramAdapterOptions {
   };
   /** Poll interval ms between successive `getUpdates` calls. Default 1000. */
   pollIntervalMs?: number;
+  /** Milliseconds before an unanswered turn's receipt (#211) auto-closes as
+   *  `timeout`. Defaults to 5 min (RECEIPT_TIMEOUT_MS). Lowered in tests. */
+  receiptTimeoutMs?: number;
+  /** Receipt store (#211). Defaults to the process-wide singleton; tests
+   *  inject an isolated store so they never touch the real receipts.jsonl. */
+  receiptStore?: ReceiptStore;
   /** Override the API client (tests inject a fake). */
   api?: TelegramApi;
   /** Optional structured logger; defaults to `console`. */
@@ -92,6 +100,8 @@ export class TelegramAdapter {
   private readonly routingChats: Record<string, string>;
   private readonly defaultAgentId: string | undefined;
   private readonly pollIntervalMs: number;
+  private readonly receiptTimeoutMs: number;
+  private readonly receiptStore: ReceiptStore;
   private readonly logger: Pick<Console, "warn" | "info" | "error">;
 
   /** getUpdates offset cursor — bumped past the highest processed update_id. */
@@ -136,6 +146,19 @@ export class TelegramAdapter {
   >();
   /** Agents with a live turn message (placeholder/progress) the next reply edits in place. */
   private readonly turnActive = new Set<string>();
+
+  /** Open per-message receipts (#211) keyed by convKey. Closed on the
+   *  first final reply (`turn_observed`) or by timeout (`timeout`), so an
+   *  unanswered Telegram turn becomes legible in receipts.jsonl instead of
+   *  the opaque silence that motivated #207. */
+  private readonly openReceipts = new Map<
+    string,
+    { receipt: OpenReceipt; timer: ReturnType<typeof setTimeout> }
+  >();
+
+  /** Mirror of webui-bridge's DEFAULT_PROMPT_TIMEOUT_MS — a turn that never
+   *  produces a final reply closes its receipt as `timeout` after this. */
+  private static readonly RECEIPT_TIMEOUT_MS = 5 * 60 * 1000;
   /** request_id → context; callback_query routes back to `ingestPermissionDecision`. */
   private readonly pendingPermissions = new Map<string, { agent_id: string; chat_id: number }>();
   /** chat_id → pending ask. The next plain-text reply resolves it. */
@@ -163,6 +186,8 @@ export class TelegramAdapter {
     this.routingChats = { ...opts.routing.chats };
     this.defaultAgentId = opts.routing.defaultAgentId;
     this.pollIntervalMs = opts.pollIntervalMs ?? 1000;
+    this.receiptTimeoutMs = opts.receiptTimeoutMs ?? TelegramAdapter.RECEIPT_TIMEOUT_MS;
+    this.receiptStore = opts.receiptStore ?? getDefaultReceiptStore();
     this.logger = opts.logger ?? console;
   }
 
@@ -220,6 +245,12 @@ export class TelegramAdapter {
     this.lastBotMessage.clear();
     for (const id of Array.from(this.spinnerState.keys())) this.stopSpinner(id);
     this.turnActive.clear();
+    // Receipt (#211): close any still-open receipts so their watchdog
+    // timers do not leak across a stop->start cycle; the log records the
+    // turn was cut short by adapter shutdown, not a silent hang.
+    for (const key of Array.from(this.openReceipts.keys())) {
+      this.closeTelegramReceipt(key, "timeout", { reason: "adapter_stopped" });
+    }
 
     if (this.loopPromise) {
       try {
@@ -270,14 +301,14 @@ export class TelegramAdapter {
   private async dispatchUpdate(update: TelegramUpdate): Promise<void> {
     const message = update.message ?? update.edited_message;
     if (message) {
-      await this.handleMessage(message);
+      await this.handleMessage(message, update.update_id);
     }
     if (update.callback_query) {
       await this.handleCallbackQuery(update.callback_query);
     }
   }
 
-  private async handleMessage(message: TelegramMessage): Promise<void> {
+  private async handleMessage(message: TelegramMessage, updateId: number): Promise<void> {
     const chatId = message.chat.id;
     const userId = message.from?.id;
 
@@ -343,6 +374,11 @@ export class TelegramAdapter {
     if (text.length === 0 && (!attachments || attachments.length === 0)) {
       return;
     }
+
+    // Receipt (#211): open at the adapter boundary BEFORE delegating to the
+    // bus. hashPrompt runs on the raw `text` (pre-<channel> wrapper) so the
+    // bus -> PTY seam's findByPromptHash still hits the same receipt.
+    this.openTelegramReceipt(agentId, chatId, updateId, text);
 
     await this.bus.sendPrompt({
       agent_id: agentId,
@@ -438,6 +474,15 @@ export class TelegramAdapter {
     const key = this.convKey(agentId, target.chat_id);
     // Every new reply replaces the active animated message — stop any prior spinner.
     this.stopSpinner(key);
+    // Receipt (#211): a non-progress response.text is the turn-final
+    // delivery — close as `turn_observed`. Closed even when cleanedText is
+    // empty (a reaction-only final), since the turn WAS observed; the empty
+    // rawText case already returned above. Idempotent (second final no-op);
+    // progress replies leave it open; unprompted replies (cron/heartbeat)
+    // with no open receipt no-op.
+    if (intent !== "progress") {
+      this.closeTelegramReceipt(key, "turn_observed");
+    }
     if (cleanedText.length === 0) {
       // nothing textual; fall through to reactions.
     } else if (this.turnActive.has(key)) {
@@ -623,6 +668,49 @@ export class TelegramAdapter {
    * chat A's placeholder. Compose with `chat_id` so each conversation tracks
    * its own outbound message.
    */
+  /** Open an inbound receipt for a Telegram turn and arm its timeout. */
+  private openTelegramReceipt(
+    agentId: string,
+    chatId: number,
+    updateId: number,
+    rawText: string,
+  ): void {
+    const key = this.convKey(agentId, chatId);
+    // A new prompt arrived before the previous turn replied — close the
+    // stale receipt as `timeout` (note `superseded`) so it doesn't leak,
+    // distinct from a genuine no-reply timeout.
+    this.closeTelegramReceipt(key, "timeout", { superseded: true });
+    const receipt = openInboundReceipt({
+      store: this.receiptStore,
+      messageId: `tg-${updateId}`,
+      agentId,
+      rawText,
+      origin: "telegram",
+      originId: String(chatId),
+    });
+    const timer = setTimeout(() => {
+      this.closeTelegramReceipt(key, "timeout", {
+        reason: "no_final_reply_within_timeout",
+      });
+    }, this.receiptTimeoutMs);
+    // Never keep the event loop alive solely for this watchdog timer.
+    if (typeof timer.unref === "function") timer.unref();
+    this.openReceipts.set(key, { receipt, timer });
+  }
+
+  /** Close (idempotently) the open receipt for a conversation, if any. */
+  private closeTelegramReceipt(
+    key: string,
+    state: "turn_observed" | "timeout",
+    notes?: Record<string, unknown>,
+  ): void {
+    const entry = this.openReceipts.get(key);
+    if (!entry) return;
+    this.openReceipts.delete(key);
+    clearTimeout(entry.timer);
+    void entry.receipt.close(state, notes);
+  }
+
   private convKey(agentId: string, chatId: number): string {
     return `${agentId}:${chatId}`;
   }

--- a/src/bus/__tests__/receipt-wiring.test.ts
+++ b/src/bus/__tests__/receipt-wiring.test.ts
@@ -11,6 +11,7 @@ import { createReceiptStore, hashPrompt, type ReceiptRecord, type ReceiptStore }
 import {
   type AgentProcessLike,
   createPromptStreamHandler,
+  openInboundReceipt,
   unwrapChannelText,
 } from "../receipt-wiring";
 
@@ -176,5 +177,40 @@ describe("createPromptStreamHandler", () => {
     );
     await expect(handler("alpha", "no-receipt")).rejects.toThrow("boom");
     expect(readReceipts()).toHaveLength(0);
+  });
+});
+
+describe("openInboundReceipt (#211 — adapter boundary open)", () => {
+  test("opens at message_polled with raw prompt_hash + origin notes", () => {
+    const raw = "what's the weather";
+    const receipt = openInboundReceipt({
+      store,
+      messageId: "tg-7",
+      agentId: "triage",
+      rawText: raw,
+      origin: "telegram",
+      originId: "100",
+    });
+    expect(receipt.record.message_id).toBe("tg-7");
+    expect(receipt.record.final_state).toBe("message_polled");
+    expect(receipt.record.agent_id).toBe("triage");
+    expect(receipt.record.selected_route).toBe("agent=triage");
+    // Hash invariant: computed on the RAW text (pre-<channel> wrapper), so the
+    // bus -> PTY seam's findByPromptHash (which unwraps first) hits the same one.
+    expect(receipt.record.prompt_hash).toBe(hashPrompt(raw));
+    expect(receipt.record.notes).toMatchObject({ origin: "telegram", origin_id: "100" });
+  });
+
+  test("findByPromptHash on the raw text resolves the open receipt", () => {
+    const raw = "deploy the thing";
+    openInboundReceipt({
+      store,
+      messageId: "tg-8",
+      agentId: "a1",
+      rawText: raw,
+      origin: "telegram",
+      originId: "1",
+    });
+    expect(store.findByPromptHash(hashPrompt(raw))?.record.message_id).toBe("tg-8");
   });
 });

--- a/src/bus/receipt-wiring.ts
+++ b/src/bus/receipt-wiring.ts
@@ -6,7 +6,8 @@
  * and rolling back to `stale_session` on PTY error — can be unit-tested
  * without booting the full bus runtime.
  */
-import { getDefaultReceiptStore, hashPrompt, type ReceiptStore } from "./receipt";
+import { getDefaultReceiptStore, hashPrompt, type OpenReceipt, type ReceiptStore } from "./receipt";
+import type { BusOrigin } from "./types";
 
 /**
  * Recover the original prompt text from the `<channel source=... chat_id=...
@@ -25,6 +26,39 @@ export function unwrapChannelText(text: string): string {
   // covers `&`, `<`, `>`. Decode in reverse application order so an
   // already-encoded `&amp;` isn't double-unescaped.
   return m[1].replace(/&gt;/g, ">").replace(/&lt;/g, "<").replace(/&amp;/g, "&");
+}
+
+export interface OpenInboundReceiptParams {
+  /** Adapter-side id, e.g. `tg-<update_id>`, `discord-<msg_id>`, `webui:inject:<nonce>`. */
+  messageId: string;
+  agentId: string;
+  /** The RAW prompt text, hashed BEFORE the bus's `<channel ...>` wrapper is
+   *  applied. The bus -> PTY seam unwraps the channel block before hashing
+   *  (see `unwrapChannelText`), so hashing the raw text here keeps
+   *  `findByPromptHash` hitting the same receipt. */
+  rawText: string;
+  origin: BusOrigin;
+  originId: string;
+  store?: ReceiptStore;
+}
+
+/**
+ * Open an inbound receipt at the adapter boundary (the `message_polled`
+ * surface), mirroring the open in `webui-bridge.ts`. Adapters and
+ * `/api/inject` call `bus.sendPrompt` directly, bypassing `streamBusPrompt`,
+ * so without this they never open a receipt and #207's headline symptom
+ * (intermittent Telegram "no reply") stays uninstrumented. The returned
+ * `OpenReceipt` is closed by the caller when it observes the outbound reply
+ * (`turn_observed`) or when its own timeout fires (`timeout`).
+ */
+export function openInboundReceipt(params: OpenInboundReceiptParams): OpenReceipt {
+  const store = params.store ?? getDefaultReceiptStore();
+  return store.open(params.messageId, {
+    selected_route: `agent=${params.agentId}`,
+    agent_id: params.agentId,
+    prompt_hash: hashPrompt(params.rawText),
+    notes: { origin: params.origin, origin_id: params.originId },
+  });
 }
 
 /** Structural view of the bits an `AgentProcess` exposes that we touch.


### PR DESCRIPTION
## Problem

#209 scoped the receipt chain to the bus interior. Adapters call `bus.sendPrompt` directly, bypassing `streamBusPrompt`, so an inbound Telegram message never opens a receipt — and #207's headline symptom (intermittent Telegram "no reply" with the poll loop provably alive, 409 on a manual `getUpdates`) stays uninstrumented. An operator hitting the wedge sees the same opaque silence they had before #209.

## Fix

Open a receipt at the adapter boundary, before delegating to the bus.

- **New helper `openInboundReceipt(...)`** next to `receipt-wiring.ts` — `message_id` shape, `prompt_hash` semantics and origin notes are universal; only `origin`/`originId` differ per surface.
- **Telegram adapter** opens `tg-<update_id>` in `handleMessage` and closes it:
  - `turn_observed` on the first non-progress `response.text` (turn-final, incl. a reaction-only final whose cleaned text is empty),
  - `timeout` after `receiptTimeoutMs` (default 5 min) if no reply ever lands — this is what makes the wedge legible,
  - `timeout{superseded}` when a newer prompt for the same chat opens first,
  - `timeout{adapter_stopped}` drained on `stop()` so watchdog timers never leak.
- **Hash invariant**: `hashPrompt` runs on the RAW text, before the `<channel>` wrapper, so the bus -> PTY seam's `findByPromptHash` (which unwraps first) hits the same receipt.
- `receiptStore` + `receiptTimeoutMs` are constructor seams (ops-configurable; tests inject an isolated store so neither these nor the pre-existing adapter tests ever touch the real `receipts.jsonl`).

## Scope

- **Telegram**: done (this PR).
- **`/api/inject` + `/api/chat`**: already instrumented — they route through `sendPromptAndAwait` -> `streamBusPrompt` -> `runPrompt`, which opens/closes a `webui:inject:<nonce>` receipt. The issue's premise that inject bypasses `streamBusPrompt` is now outdated; no change needed (verified live, see below).
- **Discord/Slack**: same `openInboundReceipt` shape, deferred to a follow-up to keep this reviewable.

## Validation (live on a Plus daemon)

```
tg-<id>            | turn_observed | dur=7943ms    | route_resolved+stdin_written ✓
tg-<id>            | timeout       | dur=300001ms  | route_resolved+stdin_written ✓ (wedged during agent respawn)
webui:inject:<n>   | timeout       | dur=300001ms  | route_resolved+stdin_written ✓ (inject surface)
```

The wedged receipts carry `stdin_written_at` **with no turn** — which finally distinguishes "prompt reached the agent but it never generated a turn" from "prompt never reached the agent", the exact RCA question #207 raised.

## Tests

8 new (helper record shape + raw-hash invariant + `findByPromptHash` round-trip; adapter open-at-`message_polled`, close on final, reaction-only final, auto-close on timeout, supersede, `stop()` drain). The two touched suites are green; the full suite shows no new fail/error vs the branch baseline.

## Notes

- Stacks on #209 (the receipt chain) — the receipt-chain commits below land with #209; rebases to a single-commit diff once #209 merges.
- Out of scope (per issue): `turn_event_offset` back-fill (#212), `receipts.jsonl` retention.

Refs #207, #209.
