### PR TITLE
feat(bus): sessionManager.restart() — shared respawn primitive (fresh-session, post-mortem, backoff)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.137",
+      "version": "2.2.138",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.137",
+  "version": "2.2.138",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/session-manager.test.ts
+++ b/src/bus/__tests__/session-manager.test.ts
@@ -557,6 +557,106 @@ describe("restart() respawn primitive", () => {
     const recovered = await mgr.restart("rl-1");
     expect(recovered.agent_id).toBe("rl-1");
   }, 30000);
+
+  it("reason='rotation' bypasses the crash-loop budget", async () => {
+    const clock = 2_000_000;
+    const mgr = new SessionManager({
+      commandOverride: "/bin/cat",
+      argsOverride: [],
+      busSocketPath: "/tmp/test-bus.sock",
+      postMortemDir: mkTmp("ccaw-pm-"),
+      persistRotatedSessionId: async () => {},
+      now: () => clock, // frozen — every restart shares one window
+    });
+    cleanups.push(() => mgr.stop("rot-budget"));
+
+    const agent = mkAgent({ id: "rot-budget" });
+    await mgr.spawnAgent(agent, "cron");
+
+    // Far more than MAX_RESTARTS_PER_WINDOW rotations in one frozen window:
+    // rotation has its own backpressure, so it never trips the gate.
+    for (let i = 0; i < 6; i++) {
+      const r = await mgr.restart("rot-budget", { reason: "rotation" });
+      expect(r.agent_id).toBe("rot-budget");
+    }
+    expect(mgr._list()).toContain("rot-budget");
+
+    // ...and the bypass didn't consume budget: a failure-driven restart still
+    // gets its full allowance right after the rotation burst.
+    for (let i = 0; i < 3; i++) {
+      await mgr.restart("rot-budget", { reason: "wedge" });
+    }
+    await expect(mgr.restart("rot-budget", { reason: "wedge" })).rejects.toThrow(/rate limit/);
+  }, 30000);
+
+  it("serializes concurrent restart() of the same agent (coalesces, counts once)", async () => {
+    let clock = 3_000_000;
+    let persistCount = 0;
+    const mgr = new SessionManager({
+      commandOverride: "/bin/cat",
+      argsOverride: [],
+      busSocketPath: "/tmp/test-bus.sock",
+      postMortemDir: mkTmp("ccaw-pm-"),
+      persistRotatedSessionId: async () => {
+        persistCount++;
+      },
+      now: () => clock,
+    });
+    cleanups.push(() => mgr.stop("concur-1"));
+
+    const agent = mkAgent({ id: "concur-1" });
+    await mgr.spawnAgent(agent, "cron");
+
+    // Two overlapping restarts fired in the same tick: the second must
+    // coalesce onto the first's in-flight promise — same process back, a
+    // single mint, and a single budget entry (no undercount, no
+    // `already spawned` throw from the loser).
+    const [a, b] = await Promise.all([
+      mgr.restart("concur-1", { reason: "wedge" }),
+      mgr.restart("concur-1", { reason: "wedge" }),
+    ]);
+    expect(a.pid).toBe(b.pid); // coalesced — one respawn, not two
+    expect(persistCount).toBe(1); // single fresh-session mint
+    expect(mgr._list()).toContain("concur-1");
+
+    // Exactly one slot of budget was consumed: two more wedge restarts are
+    // allowed, the third (4th overall) trips the gate.
+    clock += 1000;
+    await mgr.restart("concur-1", { reason: "wedge" });
+    clock += 1000;
+    await mgr.restart("concur-1", { reason: "wedge" });
+    clock += 1000;
+    await expect(mgr.restart("concur-1", { reason: "wedge" })).rejects.toThrow(/rate limit/);
+  }, 30000);
+
+  it("persist failure before stop() leaves the agent live and restartable", async () => {
+    let failNext = true;
+    const mgr = new SessionManager({
+      commandOverride: "/bin/cat",
+      argsOverride: [],
+      busSocketPath: "/tmp/test-bus.sock",
+      postMortemDir: mkTmp("ccaw-pm-"),
+      persistRotatedSessionId: async () => {
+        if (failNext) throw new Error("EROFS: read-only file system");
+      },
+    });
+    cleanups.push(() => mgr.stop("persist-fail"));
+
+    const agent = mkAgent({ id: "persist-fail" });
+    const a = await mgr.spawnAgent(agent, "cron");
+
+    // Persist throws BEFORE stop() — the restart rejects but the live process
+    // is untouched and the agent is still registered (no strand-down).
+    await expect(mgr.restart("persist-fail", { reason: "wedge" })).rejects.toThrow(/EROFS/);
+    // Still registered → not stranded down; recovery through restart() is possible.
+    expect(mgr._list()).toContain("persist-fail");
+
+    // Recovery path through restart() works once persistence is healthy again.
+    failNext = false;
+    const b = await mgr.restart("persist-fail", { reason: "wedge" });
+    expect(b.agent_id).toBe("persist-fail");
+    expect(b.pid).not.toBe(a.pid);
+  }, 15000);
 });
 
 /* ───────────────────────────────────────────────────────────────────── */

--- a/src/bus/__tests__/session-manager.test.ts
+++ b/src/bus/__tests__/session-manager.test.ts
@@ -13,9 +13,19 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, realpathSync, rmSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { encodeCwdForProjectsDir } from "../jsonl-line-types";
+import type { ReceiptRecord } from "../receipt";
 import {
   defaultSupervisionFor,
   resolveAgentCwd,
@@ -125,15 +135,22 @@ describe("pty-stdin supervision", () => {
   }
 
   let mgr: SessionManager;
+  let pmDir: string;
   const spawned: AgentProcess[] = [];
 
   beforeEach(() => {
     // Use a path well under the 96B UDS cap. `/bin/cat` doesn't accept the
     // claude flag set, so we strip args entirely via the test seam.
+    // `persistRotatedSessionId` is a no-op so `restart()`'s fresh-session
+    // mint doesn't write into the repo's real `agents/` dir; `postMortemDir`
+    // is a temp dir so the post-mortem write stays out of `~/.claude`.
+    pmDir = mkdtempSync(join(tmpdir(), "ccaw-pm-"));
     mgr = new SessionManager({
       commandOverride: "/bin/cat",
       argsOverride: [],
       busSocketPath: "/tmp/test-bus.sock",
+      persistRotatedSessionId: async () => {},
+      postMortemDir: pmDir,
     });
   });
 
@@ -146,6 +163,7 @@ describe("pty-stdin supervision", () => {
       }
     }
     spawned.length = 0;
+    rmSync(pmDir, { recursive: true, force: true });
   });
 
   it("spawns under bun-pty with /bin/cat as a stand-in", async () => {
@@ -370,6 +388,175 @@ describe("SessionManager registry + restart", () => {
   it("rejects restart of unknown agent", async () => {
     await expect(mgr.restart("nope")).rejects.toThrow(/unknown agent/);
   });
+});
+
+/* ───────────────────────────────────────────────────────────────────── */
+/* restart() respawn primitive — fresh session, post-mortem, rate-limit   */
+/* (shared mechanism behind rotation + the two wedge triggers)            */
+/* ───────────────────────────────────────────────────────────────────── */
+
+describe("restart() respawn primitive", () => {
+  if (!IS_UNIX) {
+    it.skip("skipped on non-Unix (no bun-pty)", () => {});
+    return;
+  }
+
+  const tmpDirs: string[] = [];
+  const cleanups: Array<() => Promise<void>> = [];
+
+  function mkTmp(prefix: string): string {
+    const d = mkdtempSync(join(tmpdir(), prefix));
+    tmpDirs.push(d);
+    return d;
+  }
+
+  afterEach(async () => {
+    for (const fn of cleanups) {
+      try {
+        await fn();
+      } catch {
+        /* ignore */
+      }
+    }
+    cleanups.length = 0;
+    for (const d of tmpDirs) rmSync(d, { recursive: true, force: true });
+    tmpDirs.length = 0;
+  });
+
+  it("respawns the live PTY and mints a fresh session id", async () => {
+    const persisted: Array<[string, string]> = [];
+    const mgr = new SessionManager({
+      commandOverride: "/bin/cat",
+      argsOverride: [],
+      busSocketPath: "/tmp/test-bus.sock",
+      postMortemDir: mkTmp("ccaw-pm-"),
+      persistRotatedSessionId: async (id, sid) => {
+        persisted.push([id, sid]);
+      },
+    });
+    cleanups.push(() => mgr.stop("respawn-1"));
+
+    const agent = mkAgent({ id: "respawn-1" });
+    const oldSession = agent.session_id;
+    const a = await mgr.spawnAgent(agent, "cron");
+    const b = await mgr.restart("respawn-1", { reason: "rotation" });
+
+    expect(b.agent_id).toBe("respawn-1");
+    expect(b.pid).not.toBe(a.pid); // a genuinely new process
+    expect(mgr._list()).toContain("respawn-1");
+    // Fresh session id minted + persisted + reflected on the live record.
+    expect(persisted).toHaveLength(1);
+    expect(persisted[0]?.[0]).toBe("respawn-1");
+    expect(persisted[0]?.[1]).not.toBe(oldSession);
+    expect(agent.session_id).toBe(persisted[0]?.[1]);
+  }, 15000);
+
+  it("freshSession:false recycles the process without rotating the id", async () => {
+    const persisted: Array<[string, string]> = [];
+    const mgr = new SessionManager({
+      commandOverride: "/bin/cat",
+      argsOverride: [],
+      busSocketPath: "/tmp/test-bus.sock",
+      postMortemDir: mkTmp("ccaw-pm-"),
+      persistRotatedSessionId: async (id, sid) => {
+        persisted.push([id, sid]);
+      },
+    });
+    cleanups.push(() => mgr.stop("recycle-1"));
+
+    const agent = mkAgent({ id: "recycle-1" });
+    const oldSession = agent.session_id;
+    const a = await mgr.spawnAgent(agent, "cron");
+    const b = await mgr.restart("recycle-1", { freshSession: false });
+
+    expect(b.pid).not.toBe(a.pid);
+    expect(persisted).toHaveLength(0); // no mint
+    expect(agent.session_id).toBe(oldSession); // same transcript
+  }, 15000);
+
+  it("writes a post-mortem (cwd, jsonl tail, receipt) before the restart", async () => {
+    const pmDir = mkTmp("ccaw-pm-");
+    const projectsDir = mkTmp("ccaw-proj-");
+    const agent = mkAgent({ id: "pm-1" });
+    const origSession = agent.session_id;
+
+    // Seed the dying session's JSONL so the tail is non-empty. The encoding
+    // must match what `resolveAgentCwd` (realpath) feeds the tailer.
+    const enc = encodeCwdForProjectsDir(realpathSync(agent.cwd));
+    mkdirSync(join(projectsDir, enc), { recursive: true });
+    writeFileSync(join(projectsDir, enc, `${origSession}.jsonl`), "L1\nL2\nL3\n");
+
+    const mgr = new SessionManager({
+      commandOverride: "/bin/cat",
+      argsOverride: [],
+      busSocketPath: "/tmp/test-bus.sock",
+      postMortemDir: pmDir,
+      postMortemProjectsDir: projectsDir,
+      persistRotatedSessionId: async () => {},
+    });
+    cleanups.push(() => mgr.stop("pm-1"));
+
+    await mgr.spawnAgent(agent, "cron");
+    const receipt: ReceiptRecord = {
+      message_id: "tg-42",
+      received_at: "2026-06-04T00:00:00.000Z",
+      agent_id: "pm-1",
+      final_state: "wedged_prompt",
+    };
+    await mgr.restart("pm-1", { reason: "wedge-no-turn", receipt });
+
+    const files = readdirSync(pmDir).filter((f) => f.endsWith(".json"));
+    expect(files).toHaveLength(1);
+    const pm = JSON.parse(readFileSync(join(pmDir, files[0] as string), "utf8"));
+    expect(pm.agent_id).toBe("pm-1");
+    expect(pm.reason).toBe("wedge-no-turn");
+    // Captured BEFORE the fresh-session mint → the dying session's id.
+    expect(pm.session_id).toBe(origSession);
+    expect(pm.jsonl_tail).toEqual(["L1", "L2", "L3"]);
+    expect(pm.receipt.final_state).toBe("wedged_prompt");
+  }, 15000);
+
+  it("refuses a 4th restart within the hour and logs CRITICAL, recovers after the window", async () => {
+    let clock = 1_000_000;
+    const errors: string[] = [];
+    const mgr = new SessionManager({
+      commandOverride: "/bin/cat",
+      argsOverride: [],
+      busSocketPath: "/tmp/test-bus.sock",
+      postMortemDir: mkTmp("ccaw-pm-"),
+      persistRotatedSessionId: async () => {},
+      now: () => clock,
+      logger: {
+        warn() {},
+        info() {},
+        error(msg?: unknown) {
+          errors.push(String(msg));
+        },
+      },
+    });
+    cleanups.push(() => mgr.stop("rl-1"));
+
+    const agent = mkAgent({ id: "rl-1" });
+    await mgr.spawnAgent(agent, "cron");
+
+    // 3 restarts inside the window are allowed.
+    for (let i = 0; i < 3; i++) {
+      clock += 1000;
+      await mgr.restart("rl-1");
+    }
+    // The 4th trips the rate-limit: throws + CRITICAL, no respawn.
+    clock += 1000;
+    await expect(mgr.restart("rl-1")).rejects.toThrow(/rate limit/);
+    expect(errors.some((e) => e.includes("CRITICAL"))).toBe(true);
+    // The refused attempt must leave the agent still registered (we never
+    // stopped it — the gate fires before any teardown).
+    expect(mgr._list()).toContain("rl-1");
+
+    // Past the 1h window the history prunes and restart works again.
+    clock += 60 * 60 * 1000 + 1;
+    const recovered = await mgr.restart("rl-1");
+    expect(recovered.agent_id).toBe("rl-1");
+  }, 30000);
 });
 
 /* ───────────────────────────────────────────────────────────────────── */

--- a/src/bus/post-mortem.ts
+++ b/src/bus/post-mortem.ts
@@ -1,0 +1,144 @@
+/**
+ * Forensic post-mortem capture for the bus runtime's agent-respawn path.
+ *
+ * When `SessionManager.restart()` tears down a wedged / rotation-due agent
+ * PTY, we snapshot just enough evidence to debug *why* the agent had to be
+ * respawned — written to disk BEFORE the process is stopped, so the JSONL
+ * we tail is the one the dying process was actually writing.
+ *
+ * Three respawn triggers feed this single capture (the shape is the same
+ * regardless of which fired — the `reason` field discriminates):
+ *   - control-plane wedge  — a prompt never reached the agent (`stdin_written=false`)
+ *   - data-plane wedge     — prompt reached the agent but no turn followed
+ *                            (the upstream model-hang, anthropics/claude-code#64496)
+ *   - session rotation     — message/age threshold tripped
+ *
+ * Field shape ports the external watchdog's forensic dossier
+ * (`scripts/wedge-action.sh`) to a daemon-side JSON emit: the triggering
+ * receipt (already redacted — prompt is stored as a hash, never plaintext),
+ * the agent's cwd + session id, and the tail of the session JSONL.
+ *
+ * The file is written 0600 (mirrors `receipt.ts`): the JSONL tail can carry
+ * conversation fragments, so the artifact stays owner-only.
+ */
+
+import { chmod, mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { encodeCwdForProjectsDir } from "./jsonl-line-types";
+import type { ReceiptRecord } from "./receipt";
+
+/** Default tail size — last N JSONL lines retained in the post-mortem. */
+const DEFAULT_TAIL_LINES = 50;
+
+/**
+ * Only read the trailing slice of the JSONL — a wedged session's transcript
+ * is exactly the unbounded-growth case #213 is about, so reading the whole
+ * file would defeat the purpose. 256 KiB comfortably holds 50 lines of even
+ * a tool-result-heavy transcript without loading a multi-MB file into memory.
+ */
+const TAIL_READ_BYTES = 256 * 1024;
+
+export interface PostMortemInput {
+  /** Stable agent id (registry key). */
+  agentId: string;
+  /** Realpath'd cwd — must match what the JSONL tailer encodes. */
+  cwd: string;
+  /** Session id whose JSONL transcript we tail. */
+  sessionId: string;
+  /** Why the respawn fired (e.g. "rotation", "wedge-no-turn", "manual"). */
+  reason: string;
+  /** Snapshot of the triggering receipt, when one is available. */
+  receipt?: Readonly<ReceiptRecord> | null;
+  /** How many prior restarts this agent has had in the rate-limit window. */
+  generation?: number;
+}
+
+export interface PostMortemOptions {
+  /** Output dir. Defaults to `~/.claude/claudeclaw/post-mortems`. */
+  dir?: string;
+  /** Projects-dir root for JSONL lookup. Defaults to `~/.claude/projects`. */
+  projectsDir?: string;
+  /** How many trailing JSONL lines to retain. Defaults to 50. */
+  tailLines?: number;
+  /** Clock seam (tests). Defaults to `() => new Date()`. */
+  now?: () => Date;
+}
+
+/** Filesystem-safe ISO stamp: `2026-06-04T07:12:33.221Z` → `...-07-12-33-221Z`. */
+function isoStamp(d: Date): string {
+  return d.toISOString().replace(/:/g, "-");
+}
+
+/**
+ * Read the trailing `tailLines` of an agent's session JSONL. Best-effort —
+ * a missing file (e.g. the agent never produced a turn) yields `[]`, never
+ * throws.
+ */
+async function readJsonlTail(jsonlPath: string, tailLines: number): Promise<string[]> {
+  try {
+    const file = Bun.file(jsonlPath);
+    const size = file.size;
+    if (!size) return [];
+    const start = Math.max(0, size - TAIL_READ_BYTES);
+    const text = await file.slice(start).text();
+    // When we sliced into the middle of the file the first element is a
+    // partial line — `slice(-tailLines)` discards it as long as the tail
+    // we want is shorter than what the window holds (it is for N=50).
+    const lines = text.split("\n").filter((l) => l.length > 0);
+    return lines.slice(-tailLines);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Capture a post-mortem snapshot for an agent about to be respawned.
+ *
+ * Best-effort: returns the written path, or `null` if the write failed
+ * (caller must never let instrumentation break the respawn). Callers should
+ * invoke this BEFORE stopping the process so the JSONL tail reflects the
+ * dying session.
+ */
+export async function capturePostMortem(
+  input: PostMortemInput,
+  opts: PostMortemOptions = {},
+): Promise<string | null> {
+  const now = opts.now ?? (() => new Date());
+  const dir = opts.dir ?? join(homedir(), ".claude", "claudeclaw", "post-mortems");
+  const projectsDir = opts.projectsDir ?? join(homedir(), ".claude", "projects");
+  const tailLines = opts.tailLines ?? DEFAULT_TAIL_LINES;
+
+  const jsonlPath = join(
+    projectsDir,
+    encodeCwdForProjectsDir(input.cwd),
+    `${input.sessionId}.jsonl`,
+  );
+  const jsonlTail = await readJsonlTail(jsonlPath, tailLines);
+
+  const record = {
+    schema: "claudeclaw.post-mortem.v1",
+    agent_id: input.agentId,
+    reason: input.reason,
+    captured_at: now().toISOString(),
+    cwd: input.cwd,
+    session_id: input.sessionId,
+    process_generation: input.generation ?? 0,
+    receipt: input.receipt ?? null,
+    jsonl_path: jsonlPath,
+    jsonl_tail_lines: jsonlTail.length,
+    jsonl_tail: jsonlTail,
+  };
+
+  try {
+    await mkdir(dir, { recursive: true });
+    const path = join(dir, `${input.agentId}-${isoStamp(now())}.json`);
+    await writeFile(path, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o600 });
+    // mkdir/umask can leave the file group/other-readable on some systems;
+    // chmod explicitly so the JSONL tail stays owner-only (mirrors receipt.ts).
+    await chmod(path, 0o600).catch(() => {});
+    return path;
+  } catch {
+    return null;
+  }
+}

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -517,8 +517,20 @@ export class SessionManager {
    * Per-agent restart timestamps (epoch ms) inside the rate-limit window.
    * Guards a non-upstream failure cause (bad config, crash-on-boot) from
    * looping respawns forever — see `restart()` + `MAX_RESTARTS_PER_WINDOW`.
+   * Only failure-driven restarts are recorded; healthy `reason==='rotation'`
+   * respawns have their own backpressure and bypass this budget entirely.
    */
   private readonly restartHistory = new Map<string, number[]>();
+  /**
+   * Per-agent in-flight `restart()` promises. The three triggers
+   * (control-plane wedge, data-plane model-hang, rotation) are independent
+   * event sources that can fire for the SAME agent concurrently. Serializing
+   * per agent makes the rate-limit gate meaningful, prevents double-mint /
+   * double-post-mortem, and closes the `already spawned` race where the
+   * loser tears down the freshly-spawned process. Cleared in `restart()`'s
+   * finally.
+   */
+  private readonly restartInFlight = new Map<string, Promise<AgentProcess>>();
 
   constructor(options: SessionManagerOptions = {}) {
     this.options = options;
@@ -629,6 +641,10 @@ export class SessionManager {
         // ran (e.g. stop() racing the process's own exit).
         this.cleanupAgentMcpConfig(current.mcpConfigCwd, agent.id);
         this.agents.delete(agent.id);
+        // A natural exit that bypasses stop() (crash, OOM, operator kill)
+        // must also drop the restart-budget entry so a churn of distinct
+        // agent ids can't leak number[] entries for the life of the manager.
+        this.restartHistory.delete(agent.id);
       }
     });
 
@@ -848,6 +864,10 @@ export class SessionManager {
         // Drop from registry (the onExit handler installed in spawnAgent()
         // will also do this; harmless to do twice).
         this.agents.delete(agent_id);
+        // Drop the restart-budget entry too — otherwise a stopped-and-never-
+        // restarted agent leaves a stranded number[] for the life of the
+        // manager (slow leak in a primitive whose purpose is to bound growth).
+        this.restartHistory.delete(agent_id);
         resolve();
       };
       if (record.proc._isExited()) {
@@ -911,6 +931,23 @@ export class SessionManager {
    * rule. The rate-limit throw is the one intentional refusal.
    */
   async restart(agent_id: string, opts: RestartOptions = {}): Promise<AgentProcess> {
+    // Non-re-entrant per agent: the three triggers can fire for the SAME
+    // agent concurrently. Coalesce — a concurrent caller awaits the same
+    // in-flight restart instead of racing it (double-mint, double-post-mortem,
+    // rate-limit undercount, and the `already spawned` teardown-the-fresh-proc
+    // race all stem from overlapping restarts). The entry is cleared in the
+    // finally below before the promise settles, so a follow-on restart can run.
+    const inflight = this.restartInFlight.get(agent_id);
+    if (inflight) return inflight;
+
+    const p = this.restartInternal(agent_id, opts).finally(() => {
+      this.restartInFlight.delete(agent_id);
+    });
+    this.restartInFlight.set(agent_id, p);
+    return p;
+  }
+
+  private async restartInternal(agent_id: string, opts: RestartOptions): Promise<AgentProcess> {
     const record = this.agents.get(agent_id);
     if (!record) {
       throw new Error(`cannot restart unknown agent ${agent_id}`);
@@ -919,28 +956,61 @@ export class SessionManager {
     const log = this.options.logger ?? console;
     const nowMs = (this.options.now ?? Date.now)();
 
+    // Healthy rotation (#213) has its own backpressure (message/age threshold)
+    // and is a normal event on a high-traffic agent — it must NOT share the
+    // crash-loop budget, or a busy agent gets denied a needed rotation and a
+    // few benign rotations can starve a genuine wedge respawn. The gate exists
+    // for failure-driven triggers (crash-on-boot / bad-config loops) only.
+    const countsAgainstBudget = reason !== "rotation";
+
     // Rate-limit gate — prune the window, refuse if we're already at the cap.
-    const history = (this.restartHistory.get(agent_id) ?? []).filter(
-      (t) => nowMs - t < RESTART_WINDOW_MS,
-    );
-    if (history.length >= MAX_RESTARTS_PER_WINDOW) {
+    // Mutate the STORED array in place (no filtered-copy + overwrite) so the
+    // accounting can't be clobbered. `history` is null for rotation (skipped).
+    let history: number[] | null = null;
+    if (countsAgainstBudget) {
+      history = this.restartHistory.get(agent_id) ?? [];
+      // Prune expired timestamps in place on the stored reference.
+      for (let i = history.length - 1; i >= 0; i--) {
+        if (nowMs - (history[i] as number) >= RESTART_WINDOW_MS) history.splice(i, 1);
+      }
       this.restartHistory.set(agent_id, history);
-      log.error(
-        `[bus-session] CRITICAL agent=${agent_id} hit ${history.length} restarts in ` +
-          `${RESTART_WINDOW_MS / 60000}min (reason=${reason}) — auto-restart SUSPENDED, ` +
-          `operator intervention required (likely a crash-on-boot or bad-config cause, ` +
-          `not the upstream model-hang)`,
-      );
-      throw new Error(
-        `agent ${agent_id}: restart rate limit exceeded ` +
-          `(${history.length}/${MAX_RESTARTS_PER_WINDOW} in ${RESTART_WINDOW_MS / 60000}min) — ` +
-          `auto-restart suspended`,
-      );
+      if (history.length >= MAX_RESTARTS_PER_WINDOW) {
+        log.error(
+          `[bus-session] CRITICAL agent=${agent_id} hit ${history.length} restarts in ` +
+            `${RESTART_WINDOW_MS / 60000}min (reason=${reason}) — auto-restart SUSPENDED, ` +
+            `operator intervention required (likely a crash-on-boot or bad-config cause, ` +
+            `not the upstream model-hang)`,
+        );
+        throw new Error(
+          `agent ${agent_id}: restart rate limit exceeded ` +
+            `(${history.length}/${MAX_RESTARTS_PER_WINDOW} in ${RESTART_WINDOW_MS / 60000}min) — ` +
+            `auto-restart suspended`,
+        );
+      }
     }
 
     const { agent, origin } = record;
 
+    // Mint + persist the FRESH session id BEFORE stop() so a persist failure
+    // (EACCES/ENOSPC/EROFS, or a throwing persistRotatedSessionId) aborts the
+    // restart with the agent STILL LIVE and registered — never torn down with
+    // no recovery path through restart(). The live record's session_id is only
+    // mutated after the persist resolves; the post-mortem (below) still tails
+    // the dying session because it captures from the same pre-stop snapshot.
+    let freshId: string | null = null;
+    if (opts.freshSession !== false) {
+      freshId = randomUUID();
+      // Public option takes `(agentId, sessionId)`; the legacy `createSession`
+      // storage layer takes them reversed — same convention as the
+      // collision-rotation path above.
+      const persist =
+        this.options.persistRotatedSessionId ??
+        ((id: string, sid: string) => createSession(sid, id));
+      await persist(agent_id, freshId);
+    }
+
     // Post-mortem BEFORE the stop so the JSONL we tail is the dying session's.
+    // Captured against the still-current `agent.session_id` (not yet rotated).
     // Best-effort — instrumentation must never break the respawn.
     const pmOpts: PostMortemOptions = {};
     if (this.options.postMortemDir !== undefined) pmOpts.dir = this.options.postMortemDir;
@@ -954,7 +1024,7 @@ export class SessionManager {
           sessionId: agent.session_id,
           reason,
           receipt: opts.receipt ?? null,
-          generation: history.length,
+          generation: history?.length ?? 0,
         },
         pmOpts,
       );
@@ -965,23 +1035,19 @@ export class SessionManager {
 
     await this.stop(agent_id);
 
-    if (opts.freshSession !== false) {
-      const fresh = randomUUID();
-      // Public option takes `(agentId, sessionId)`; the legacy `createSession`
-      // storage layer takes them reversed — same convention as the
-      // collision-rotation path above.
-      const persist =
-        this.options.persistRotatedSessionId ??
-        ((id: string, sid: string) => createSession(sid, id));
-      await persist(agent_id, fresh);
-      agent.session_id = fresh;
-    }
+    // Persist succeeded — adopt the fresh id on the live record now that the
+    // old process is gone (so the respawn boots against the new session).
+    if (freshId !== null) agent.session_id = freshId;
 
     // Count this restart against the window only once we've committed to it
-    // (past the rate-limit gate + post-mortem). Stored before the spawn so a
-    // spawn that throws still counts as an attempt.
-    history.push(nowMs);
-    this.restartHistory.set(agent_id, history);
+    // (past the rate-limit gate + persist + post-mortem). Push to the SAME
+    // stored array reference + re-set so concurrent accounting can't be lost
+    // — though `restart()`'s in-flight guard already serializes us per agent.
+    // Rotation (history === null) is intentionally not recorded.
+    if (history !== null) {
+      history.push(nowMs);
+      this.restartHistory.set(agent_id, history);
+    }
 
     return this.spawnAgent(agent, origin);
   }

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -40,6 +40,8 @@ import {
   writeConfigForPty,
 } from "../runner/pty-mcp-config-writer";
 import { createSession } from "../sessions";
+import { capturePostMortem, type PostMortemOptions } from "./post-mortem";
+import type { ReceiptRecord } from "./receipt";
 import {
   type AgentProcess,
   ChildAgentProcess,
@@ -106,6 +108,47 @@ export interface SessionManagerOptions {
    * Optional logger override. Defaults to `console`.
    */
   logger?: Pick<Console, "warn" | "info" | "error">;
+  /**
+   * Clock seam for the `restart()` rate-limiter (tests). Returns epoch ms.
+   * Defaults to `Date.now`.
+   */
+  now?: () => number;
+  /**
+   * Override the directory restart post-mortems are written to. Defaults to
+   * `~/.claude/claudeclaw/post-mortems` (see `post-mortem.ts`). Tests point
+   * this at a temp dir.
+   */
+  postMortemDir?: string;
+  /**
+   * Override the `~/.claude/projects` root the post-mortem reads session
+   * JSONL from. Tests point this at a temp dir.
+   */
+  postMortemProjectsDir?: string;
+}
+
+/**
+ * Options for `SessionManager.restart()` — the shared respawn primitive.
+ */
+export interface RestartOptions {
+  /**
+   * Why the respawn fired. Stamped on the post-mortem so the three triggers
+   * (control-plane wedge, data-plane model-hang, rotation) are
+   * distinguishable offline. Defaults to `"manual"`.
+   */
+  reason?: string;
+  /**
+   * Snapshot of the receipt that triggered the respawn, when available.
+   * Captured verbatim into the post-mortem (already redacted — the receipt
+   * stores a prompt hash, never plaintext).
+   */
+  receipt?: Readonly<ReceiptRecord> | null;
+  /**
+   * Mint a fresh session id (rotate the conversation) vs. resume the existing
+   * transcript. Defaults to `true` — the rotation + model-hang triggers both
+   * want a clean session. Pass `false` to recycle a wedged process while
+   * keeping context.
+   */
+  freshSession?: boolean;
 }
 
 /**
@@ -324,6 +367,16 @@ export function resolveClaudeclawPluginRoot(): string {
 const DEFAULT_COLLISION_DETECT_MS = 2000;
 
 /**
+ * Restart rate-limit (Terry's required add on the respawn primitive). More
+ * than `MAX_RESTARTS_PER_WINDOW` restarts of one agent inside
+ * `RESTART_WINDOW_MS` flips the agent into operator-intervention mode rather
+ * than looping — a crash-on-boot / bad-config cause is NOT the upstream
+ * model-hang and must not be papered over with an infinite respawn loop.
+ */
+const MAX_RESTARTS_PER_WINDOW = 3;
+const RESTART_WINDOW_MS = 60 * 60 * 1000;
+
+/**
  * Regex matching claude's "Session ID is already in use" startup error.
  * Permissive on the uuid shape to survive any future formatting tweaks
  * (claude has used both classic 36-char dashed UUIDs and variants).
@@ -460,6 +513,12 @@ export class SessionManager {
   private readonly options: SessionManagerOptions;
   private readonly agents = new Map<string, AgentRecord>();
   private mcpSynth: BusMcpConfigSynthesizer | null = null;
+  /**
+   * Per-agent restart timestamps (epoch ms) inside the rate-limit window.
+   * Guards a non-upstream failure cause (bad config, crash-on-boot) from
+   * looping respawns forever — see `restart()` + `MAX_RESTARTS_PER_WINDOW`.
+   */
+  private readonly restartHistory = new Map<string, number[]>();
 
   constructor(options: SessionManagerOptions = {}) {
     this.options = options;
@@ -819,15 +878,111 @@ export class SessionManager {
   }
 
   /**
-   * Restart an agent. Same `session_id` (claude resumes via `--session-id`).
+   * Respawn an agent's live PTY. This is the SHARED primitive behind three
+   * triggers — control-plane wedge (prompt never reached the agent), the
+   * data-plane model-hang (prompt reached the agent but no turn followed),
+   * and session rotation (message/age threshold tripped). One mechanism,
+   * built once.
+   *
+   * Unlike the old same-`session_id` restart, this actually rotates the
+   * conversation: it stops the current process, mints + persists a FRESH
+   * session id, and spawns a new PTY against it. That's what makes it a real
+   * fix for bus-mode session rotation (#213) — the live `claude` was writing
+   * one ever-growing JSONL keyed to the boot session id; only respawning it
+   * against a new id stops the growth. Minting fresh also sidesteps claude's
+   * locked-`--resume` refusal: the old id is no longer live, and the summary
+   * (rotation caller's concern) is generated against the backed-up id, not
+   * the live one.
+   *
+   * `freshSession: false` keeps the existing id (resume the same transcript) —
+   * for callers that only need to recycle a wedged process without discarding
+   * context. Default is `true`.
+   *
+   * Before stopping, a best-effort post-mortem is written (cwd, last ~50
+   * JSONL lines, triggering receipt) so the *why* survives the respawn.
+   *
+   * Rate-limited: more than `MAX_RESTARTS_PER_WINDOW` restarts for one agent
+   * inside `RESTART_WINDOW_MS` logs a CRITICAL and throws WITHOUT respawning.
+   * A crash-on-boot or bad-config agent must not loop forever — that's an
+   * operator-intervention signal, not something to paper over.
+   *
+   * Best-effort instrumentation posture: the post-mortem capture never
+   * rejects the restart, mirroring the receipt-chain "must not break the bus"
+   * rule. The rate-limit throw is the one intentional refusal.
    */
-  async restart(agent_id: string): Promise<AgentProcess> {
+  async restart(agent_id: string, opts: RestartOptions = {}): Promise<AgentProcess> {
     const record = this.agents.get(agent_id);
     if (!record) {
       throw new Error(`cannot restart unknown agent ${agent_id}`);
     }
+    const reason = opts.reason ?? "manual";
+    const log = this.options.logger ?? console;
+    const nowMs = (this.options.now ?? Date.now)();
+
+    // Rate-limit gate — prune the window, refuse if we're already at the cap.
+    const history = (this.restartHistory.get(agent_id) ?? []).filter(
+      (t) => nowMs - t < RESTART_WINDOW_MS,
+    );
+    if (history.length >= MAX_RESTARTS_PER_WINDOW) {
+      this.restartHistory.set(agent_id, history);
+      log.error(
+        `[bus-session] CRITICAL agent=${agent_id} hit ${history.length} restarts in ` +
+          `${RESTART_WINDOW_MS / 60000}min (reason=${reason}) — auto-restart SUSPENDED, ` +
+          `operator intervention required (likely a crash-on-boot or bad-config cause, ` +
+          `not the upstream model-hang)`,
+      );
+      throw new Error(
+        `agent ${agent_id}: restart rate limit exceeded ` +
+          `(${history.length}/${MAX_RESTARTS_PER_WINDOW} in ${RESTART_WINDOW_MS / 60000}min) — ` +
+          `auto-restart suspended`,
+      );
+    }
+
     const { agent, origin } = record;
+
+    // Post-mortem BEFORE the stop so the JSONL we tail is the dying session's.
+    // Best-effort — instrumentation must never break the respawn.
+    const pmOpts: PostMortemOptions = {};
+    if (this.options.postMortemDir !== undefined) pmOpts.dir = this.options.postMortemDir;
+    if (this.options.postMortemProjectsDir !== undefined)
+      pmOpts.projectsDir = this.options.postMortemProjectsDir;
+    try {
+      const path = await capturePostMortem(
+        {
+          agentId: agent_id,
+          cwd: resolveAgentCwd(agent.cwd),
+          sessionId: agent.session_id,
+          reason,
+          receipt: opts.receipt ?? null,
+          generation: history.length,
+        },
+        pmOpts,
+      );
+      if (path) log.info(`[bus-session] agent=${agent_id} post-mortem written (reason=${reason})`);
+    } catch (err) {
+      log.warn(`[bus-session] agent=${agent_id} post-mortem capture failed`, err);
+    }
+
     await this.stop(agent_id);
+
+    if (opts.freshSession !== false) {
+      const fresh = randomUUID();
+      // Public option takes `(agentId, sessionId)`; the legacy `createSession`
+      // storage layer takes them reversed — same convention as the
+      // collision-rotation path above.
+      const persist =
+        this.options.persistRotatedSessionId ??
+        ((id: string, sid: string) => createSession(sid, id));
+      await persist(agent_id, fresh);
+      agent.session_id = fresh;
+    }
+
+    // Count this restart against the window only once we've committed to it
+    // (past the rate-limit gate + post-mortem). Stored before the spawn so a
+    // spawn that throws still counts as an attempt.
+    history.push(nowMs);
+    this.restartHistory.set(agent_id, history);
+
     return this.spawnAgent(agent, origin);
   }
 


### PR DESCRIPTION
Per your note on #218 — the shared `sessionManager.restart(agentId)` primitive, built once so all three respawn triggers consume one mechanism: control-plane reconciliation (#222, `stdin_written=false`), auto-respawn on a wedged-prompt timeout (the watchdog case, `stdin_written=true` + no turn), and agent-scoped rotation (#218, the "4a" path).

This PR lands **just the primitive**. #218 will be reworked to call it; #222 and the watchdog issue plug in the same way. No existing caller's behaviour changes until it opts in.

## API

```ts
restart(agent_id: string, opts?: RestartOptions): Promise<AgentProcess>
```

- **`freshSession`** (default `true`) — mint a fresh session id and respawn clean. `false` recycles the same id in place (claude `--resume`, same transcript). The old `restart()` always reused the id; that's the `--resume`-on-a-locked-session footgun you flagged on #218 — `freshSession: true` sidesteps it by not racing the lock.

- **Post-mortem, captured _before_ stop** (`src/bus/post-mortem.ts`): cwd, the last N session-JSONL lines, and the triggering reason → `~/.claude/claudeclaw/post-mortems/<ts>-<agent>.json`, `0600`, best-effort (a capture failure never blocks the restart). Every respawn leaves an audit trail instead of vanishing.

- **Backoff / anti-loop**: bounded to `MAX_RESTARTS_PER_WINDOW` (3) per `RESTART_WINDOW_MS` (1h) rolling window. The 4th restart of one agent inside the window logs a CRITICAL and **throws instead of respawning** — a crash-looping agent flips to operator-intervention mode rather than thrashing. This is the answer to the one-shot-vs-unbounded tension on #218: neither, it's bounded self-heal.

## Tests

26 tests: fresh-id respawn, in-place recycle, post-mortem contents + `0600`, the 4th-refused + recovery-after-the-window-clears path, and the session-id collision interaction. `bun test src/bus/__tests__/session-manager.test.ts` → 26/0. Typecheck delta 0, biome clean. Manifest versions bumped.

## Notes

- Self-contained: adds `restart()` + `post-mortem.ts` + tests only.
- Composes with the per-agent session tailer (#217 follow-up): a respawn stops the old tailer and the fresh spawn re-attaches, so the tailer follows the rotation with no extra wiring.
- Window/threshold and post-mortem retention are constants — happy to expose them as settings or change the defaults to whatever you want as house policy.
