### PR TITLE
fix(ui/auth): persist webui token in localStorage so it survives tab close (#220 followup-tracked)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.135",
+      "version": "2.2.137",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.135",
+  "version": "2.2.137",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/ui/page/script.ts
+++ b/src/ui/page/script.ts
@@ -1,28 +1,37 @@
 export const pageScript = String.raw`    const $ = (id) => document.getElementById(id);
 
     // --- Web token auth (issue #164 PR B) ---
-    // All /api/* routes now require the 256-bit web token. On first load
-    // we read it from the ?token= query param (how the operator opens the
-    // dashboard), persist it to sessionStorage, then strip it from the URL
+    // All /api/* routes require the 256-bit web token. On first load we
+    // read it from the ?token= query param (how the operator opens the
+    // dashboard), persist it to localStorage, then strip it from the URL
     // so it doesn't linger in history / Referer headers. Every same-origin
     // /api/ fetch then carries it as an Authorization: Bearer header via
     // the wrapper below — covering both raw fetch() and mutatingFetch.
+    //
+    // localStorage (not sessionStorage) because the server-side token at
+    // .claude/claudeclaw/web.token is permanent, so making the operator
+    // re-paste on every tab close was UX-only friction with no security
+    // benefit on a single-user dashboard. XSS exfiltration risk is the
+    // same for both storages; persistence is the only difference.
+    // Issue #220 tracks the stronger fix (httpOnly cookie + Set-Cookie
+    // bootstrap) for when the dashboard becomes multi-user or starts
+    // including third-party JS.
     (function initWebToken() {
       try {
         const u = new URL(window.location.href);
         const t = u.searchParams.get("token");
         if (t) {
-          sessionStorage.setItem("ccaw_web_token", t);
+          localStorage.setItem("ccaw_web_token", t);
           u.searchParams.delete("token");
           window.history.replaceState({}, document.title, u.pathname + u.search + u.hash);
         }
       } catch (e) {
-        /* sessionStorage / URL unavailable — fall through unauthenticated */
+        /* localStorage / URL unavailable — fall through unauthenticated */
       }
     })();
     function getWebToken() {
       try {
-        return sessionStorage.getItem("ccaw_web_token") || "";
+        return localStorage.getItem("ccaw_web_token") || "";
       } catch (e) {
         return "";
       }
@@ -1057,7 +1066,7 @@ export const pageScript = String.raw`    const $ = (id) => document.getElementBy
         const v = input.value.trim();
         if (!v) return;
         try {
-          sessionStorage.setItem("ccaw_web_token", v);
+          localStorage.setItem("ccaw_web_token", v);
         } catch (e) {}
         bar.remove();
         loadSettings();


### PR DESCRIPTION
## Problem

Operators see the **"Web token required. Paste it"** banner on every fresh browser session at `claudeclaw.poview.ai`, despite the server-side `~/.claude/claudeclaw/web.token` being permanent. Re-pasting the same token every day is UX-only friction with no security benefit on a single-user dashboard.

Confirmed live today (2026-06-05 14:10 BST) — banner reappeared after browser restart even though the token file at `.claude/claudeclaw/web.token` is unchanged from when it was first written. Screenshot in the original report.

## Root cause

`src/ui/page/script.ts` persists the token to **`sessionStorage`**, which is per-tab and clears on tab/browser close. Three call sites:

- `initWebToken()` — captures `?token=` query param on first load
- `getWebToken()` — read for the `Authorization: Bearer` wrapper
- Save-button handler in the banner

All three read/write `sessionStorage.{getItem,setItem}("ccaw_web_token", …)`. Browser close ⇒ session cleared ⇒ banner re-appears ⇒ operator pastes the same permanent token again.

## Fix

Swap all three sites to `localStorage`. That's the entire change.

### Why localStorage is the right tier here

| Concern | sessionStorage | localStorage |
|---|---|---|
| XSS exfiltration risk | identical (both JS-readable by same-origin scripts) | identical |
| Persistence | per-tab, cleared on close | persists until user clears site data |
| Cross-tab UX | each tab needs its own paste | shared per-origin |

XSS posture is unchanged — the original sessionStorage choice was defensive against shoulder-surfing on shared/public terminals, which doesn't apply to a single-user dashboard on the operator's own machine.

### Stronger fix tracked elsewhere

Issue **#220** tracks the proper long-term solution (httpOnly cookie + Set-Cookie bootstrap + CSRF re-tightening) for when the dashboard becomes multi-user or starts including third-party JS. That's the right time to also re-evaluate the storage tier. This PR is the immediate UX fix; #220 is the structural fix.

## Test plan

- [x] **Unit tests**: `bun test src/ui/__tests__/auth.test.ts` → 6 pass / 0 fail. Server-side token machinery is unchanged.
- [x] **Lint**: `bun run lint` → exit 0 (no new errors; 961 pre-existing warnings unchanged).
- [x] **Build**: implicit via CI plugin-version-guard + marketplace-version-guard.
- [ ] **Manual smoke after deploy**: close browser → reopen claudeclaw dashboard URL → banner does NOT re-appear (was the failing case in the screenshot).

No new automated tests; the inline dashboard script (`src/ui/page/script.ts`) is not covered by unit tests today. The change is a single-method swap on three lines plus comment refresh.

## Security review

Self-reviewed (Claude opus-4-7) on the rebased sha `6d5ded5` — byte-identical security-relevant code as the prior `21884c6` review on 2026-06-02. Findings:

- **XSS exfiltration**: identical risk to sessionStorage — both are JS-readable from same-origin scripts. No third-party JS is loaded by `page/script.ts`, so the actual exploitation surface is the inline script itself.
- **Cross-tab leakage**: localStorage shares per-origin — UX win, no leak because every tab is the same single user.
- **Token theft via stolen device**: same as before — both storages survive on disk for the duration of the chosen tier; physical access to the operator's machine reads either equally.
- **Server-side rotation**: untouched. The token file at `.claude/claudeclaw/web.token` is permanent and operator-managed via #220 follow-up.

## Migration notes

None. Additive UX fix. Existing tabs that have already pasted the token via the old sessionStorage path will see the banner once after this deploys (sessionStorage doesn't migrate to localStorage automatically). One paste, then it persists forever. Operators with the token still in their URL bar from the original auth flow will be re-prompted, paste once, done.

## Version bump

Plugin + marketplace bumped to `2.2.137` per repo policy.
