### PR TITLE
feat(bus): observability + process-level MCP reconciliation (#222)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.137",
+      "version": "2.2.138",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.137",
+  "version": "2.2.138",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/mcp-reconciler.test.ts
+++ b/src/bus/__tests__/mcp-reconciler.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from "bun:test";
+import { createMcpReconciler, type McpReconcilerDeps } from "../mcp-reconciler";
+
+/**
+ * Deterministic harness: manual timer queue + mutable clock so confirm-delay,
+ * cooldown, and the attempt cap can be exercised without real time.
+ */
+function harness(over: Partial<McpReconcilerDeps> = {}) {
+  const timers: Array<{ fn: () => void; ms: number }> = [];
+  const logs: Array<{ msg: string; fields: Record<string, unknown> }> = [];
+  let clock = 1_000_000;
+  const restartCalls: string[] = [];
+
+  const deps: McpReconcilerDeps = {
+    isConnected: () => false,
+    isProcessAlive: () => true,
+    restart: async (id) => {
+      restartCalls.push(id);
+    },
+    log: (msg, fields) => logs.push({ msg, fields }),
+    setTimer: (fn, ms) => {
+      timers.push({ fn, ms });
+      return timers.length - 1;
+    },
+    now: () => clock,
+    ...over,
+  };
+
+  return {
+    deps,
+    logs,
+    restartCalls,
+    timers,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+    // Fire all currently-queued timers (simulating their delay elapsing) and
+    // let the restart promise's .then run.
+    flush: async () => {
+      const due = timers.splice(0, timers.length);
+      for (const t of due) t.fn();
+      await Promise.resolve();
+      await Promise.resolve();
+    },
+  };
+}
+
+describe("createMcpReconciler (#222)", () => {
+  it("does not restart on the bare signal — arms a confirm timer first", () => {
+    const h = harness();
+    const onFail = createMcpReconciler(h.deps);
+    onFail("default", { reason: "test" });
+    expect(h.restartCalls).toEqual([]);
+    expect(h.timers.length).toBe(1);
+    expect(h.logs.some((l) => l.msg === "reconcile-armed")).toBe(true);
+  });
+
+  it("restarts when still disconnected + alive after the confirm window", async () => {
+    const h = harness();
+    const onFail = createMcpReconciler(h.deps);
+    onFail("default", { reason: "test" });
+    await h.flush();
+    expect(h.restartCalls).toEqual(["default"]);
+  });
+
+  it("does NOT restart if the agent reconnected during the confirm window", async () => {
+    let connected = false;
+    const h = harness({ isConnected: () => connected });
+    const onFail = createMcpReconciler(h.deps);
+    onFail("default", { reason: "test" });
+    connected = true; // mcp-server re-handshaked on its own
+    await h.flush();
+    expect(h.restartCalls).toEqual([]);
+    expect(h.logs.some((l) => l.msg === "reconcile-recovered")).toBe(true);
+  });
+
+  it("does NOT restart if the process is not alive (supervisor owns respawn)", async () => {
+    const h = harness({ isProcessAlive: () => false });
+    const onFail = createMcpReconciler(h.deps);
+    onFail("default", { reason: "test" });
+    await h.flush();
+    expect(h.restartCalls).toEqual([]);
+    expect(h.logs.some((l) => l.msg === "reconcile-skip")).toBe(true);
+  });
+
+  it("coalesces a burst of signals into a single restart", async () => {
+    const h = harness();
+    const onFail = createMcpReconciler(h.deps);
+    onFail("default", { reason: "a" });
+    onFail("default", { reason: "b" });
+    onFail("default", { reason: "c" });
+    expect(h.timers.length).toBe(1); // only one confirm armed
+    await h.flush();
+    expect(h.restartCalls).toEqual(["default"]);
+  });
+
+  it("honours the cooldown between restarts", async () => {
+    const h = harness();
+    const onFail = createMcpReconciler(h.deps, { cooldownMs: 60_000 });
+    onFail("default", { reason: "1" });
+    await h.flush();
+    expect(h.restartCalls.length).toBe(1);
+
+    h.advance(10_000); // < cooldown
+    onFail("default", { reason: "2" });
+    await h.flush();
+    expect(h.restartCalls.length).toBe(1); // suppressed
+    expect(h.logs.some((l) => l.msg === "reconcile-skip" && l.fields.reason === "cooldown")).toBe(
+      true,
+    );
+
+    h.advance(60_000); // now past cooldown
+    onFail("default", { reason: "3" });
+    await h.flush();
+    expect(h.restartCalls.length).toBe(2);
+  });
+
+  it("backs off after the attempt cap within the window", async () => {
+    const h = harness();
+    const onFail = createMcpReconciler(h.deps, {
+      cooldownMs: 1_000,
+      maxAttempts: 2,
+      windowMs: 60 * 60_000,
+    });
+    for (let i = 0; i < 4; i++) {
+      onFail("default", { reason: `r${i}` });
+      await h.flush();
+      h.advance(2_000); // clear cooldown each round
+    }
+    expect(h.restartCalls.length).toBe(2); // capped
+    expect(h.logs.some((l) => l.msg === "reconcile-giveup")).toBe(true);
+  });
+
+  it("tracks agents independently", async () => {
+    const h = harness();
+    const onFail = createMcpReconciler(h.deps);
+    onFail("alpha", { reason: "x" });
+    onFail("beta", { reason: "y" });
+    expect(h.timers.length).toBe(2);
+    await h.flush();
+    expect(h.restartCalls.sort()).toEqual(["alpha", "beta"]);
+  });
+});

--- a/src/bus/__tests__/mcp-reconciler.test.ts
+++ b/src/bus/__tests__/mcp-reconciler.test.ts
@@ -131,6 +131,34 @@ describe("createMcpReconciler (#222)", () => {
     expect(h.logs.some((l) => l.msg === "reconcile-giveup")).toBe(true);
   });
 
+  it("rate-limits and gives up even when restart() REJECTS (no storm)", async () => {
+    // restart() that always rejects — e.g. the Session Manager throwing on its
+    // OWN crash-loop rate-limit ("restart rate limit exceeded"). The cooldown
+    // and attempt-cap must still engage: the reconciler counts ATTEMPTS, not
+    // successes. Without that, restartHistory stays empty and the reconciler
+    // storms restart() every confirm window forever, and reconcile-giveup
+    // never fires.
+    const calls: string[] = [];
+    const h = harness({
+      restart: async (id) => {
+        calls.push(id);
+        throw new Error("restart rate limit exceeded");
+      },
+    });
+    const onFail = createMcpReconciler(h.deps, {
+      cooldownMs: 1_000,
+      maxAttempts: 2,
+      windowMs: 60 * 60_000,
+    });
+    for (let i = 0; i < 6; i++) {
+      onFail("default", { reason: `r${i}` });
+      await h.flush();
+      h.advance(2_000); // clear cooldown each round
+    }
+    expect(calls.length).toBe(2); // capped despite every restart rejecting
+    expect(h.logs.some((l) => l.msg === "reconcile-giveup")).toBe(true);
+  });
+
   it("tracks agents independently", async () => {
     const h = harness();
     const onFail = createMcpReconciler(h.deps);

--- a/src/bus/__tests__/runtime-mount.test.ts
+++ b/src/bus/__tests__/runtime-mount.test.ts
@@ -82,6 +82,12 @@ function createFakeBus(opts: FakeBusOptions = {}): FakeBus {
     // care about ordering observe via the `events` buffer in
     // setSlashCommandHandler.
     setStreamPromptHandler() {},
+    // #222 reconciliation contract — runtime-mount installs the reconciler
+    // signal handler on start. No-op fake.
+    setMcpSendFailedHandler() {},
+    isAgentConnected() {
+      return false;
+    },
     setSlashCommandHandler(h) {
       if (h === null) {
         detachCalls += 1;

--- a/src/bus/__tests__/runtime-mount.test.ts
+++ b/src/bus/__tests__/runtime-mount.test.ts
@@ -59,6 +59,7 @@ function createFakeBus(opts: FakeBusOptions = {}): FakeBus {
   let detachCalls = 0;
   let installed = false;
   let detached = false;
+  let mcpDetached = false;
   const events: string[] = [];
   return {
     async sendPrompt() {
@@ -84,7 +85,9 @@ function createFakeBus(opts: FakeBusOptions = {}): FakeBus {
     setStreamPromptHandler() {},
     // #222 reconciliation contract — runtime-mount installs the reconciler
     // signal handler on start. No-op fake.
-    setMcpSendFailedHandler() {},
+    setMcpSendFailedHandler(h) {
+      if (h === null) mcpDetached = true;
+    },
     isAgentConnected() {
       return false;
     },
@@ -125,6 +128,9 @@ function createFakeBus(opts: FakeBusOptions = {}): FakeBus {
     },
     slashHandlerDetached() {
       return detached;
+    },
+    mcpHandlerDetached() {
+      return mcpDetached;
     },
     startCalls() {
       return starts;
@@ -187,6 +193,8 @@ describe("mountBusRuntime — happy path (injected fakes)", () => {
     expect(detachIdx).toBeGreaterThanOrEqual(0);
     expect(stopIdx).toBeGreaterThanOrEqual(0);
     expect(detachIdx).toBeLessThan(stopIdx);
+    // #237: the reconciler signal handler is detached too (symmetry).
+    expect(bus.mcpHandlerDetached()).toBe(true);
   });
 
   it("stop() swallows errors from bus.stop() and bus.setSlashCommandHandler", async () => {

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -127,6 +127,15 @@ export interface BusCoreOptions {
   streamPromptHandler?: StreamPromptHandler;
   /** Logger; defaults to console.error. */
   onError?: (err: unknown, ctx?: Record<string, unknown>) => void;
+  /**
+   * Reconciliation signal (issue #222). Fired when an IPC `send` to an agent
+   * fails because Bus core has no live MCP connection for it. The daemon
+   * wires this to a debounced reconciler that checks process liveness via
+   * the Session Manager and respawns the agent if it's alive-but-deaf
+   * (process up, MCP/IPC registration gone). Default no-op so the bus is
+   * usable without the wiring (and in tests).
+   */
+  onMcpSendFailed?: (agentId: string, ctx: { reason: string }) => void;
 }
 
 /* ───────────────────────────────────────────────────────────────────── */
@@ -145,6 +154,16 @@ export interface BusCore {
    */
   setSlashCommandHandler(handler: SlashCommandHandler | null): void;
   setStreamPromptHandler(handler: StreamPromptHandler | null): void;
+  /**
+   * Install or replace the #222 reconciliation signal handler. Wired by the
+   * bus runtime once the Session Manager is available. Pass `null` to detach
+   * (resets to a no-op).
+   */
+  setMcpSendFailedHandler(
+    handler: ((agentId: string, ctx: { reason: string }) => void) | null,
+  ): void;
+  /** True if Bus core currently holds a live MCP/IPC connection for the agent (#222). */
+  isAgentConnected(agentId: string): boolean;
   ingestReply(req: IngestReplyRequest): void;
   ingestSessionEvent(e: BusEvent): void;
   ingestPermissionDecision(req: IngestPermissionDecisionRequest): void;
@@ -167,6 +186,9 @@ export class BusCoreImpl implements BusCore {
   private slashCommandHandler: SlashCommandHandler | null;
   private streamPromptHandler: StreamPromptHandler | null;
   private readonly onError: (err: unknown, ctx?: Record<string, unknown>) => void;
+  // Settable post-hoc (like streamPromptHandler): the bus is constructed
+  // before the SessionManager exists, so the reconciler is wired afterwards.
+  private onMcpSendFailed: (agentId: string, ctx: { reason: string }) => void = () => {};
   /**
    * Tracks the origin (surface + channel id) of the most recent prompt
    * per agent. Adapters use this on outbound `response.text` events to
@@ -185,6 +207,18 @@ export class BusCoreImpl implements BusCore {
     this.slashCommandHandler = opts.slashCommandHandler ?? null;
     this.streamPromptHandler = opts.streamPromptHandler ?? null;
     this.onError = opts.onError ?? ((err, ctx) => console.error("[bus]", err, ctx));
+    if (opts.onMcpSendFailed) this.onMcpSendFailed = opts.onMcpSendFailed;
+  }
+
+  /**
+   * Structured observability for the MCP registration seam (#222). Lands on
+   * stderr → captured in the daemon log, grep-able as `[bus-ipc]`. Until this
+   * existed, the bus logged the *symptom* ("No MCP connection") loudly but
+   * nothing about *why* there was no connection — no hello/close/restart
+   * trace — so a recurring deaf-agent wedge was undiagnosable from logs.
+   */
+  private logIpc(msg: string, fields: Record<string, unknown>): void {
+    console.error(`[bus-ipc] ${msg}`, { ts: new Date().toISOString(), ...fields });
   }
 
   /* ─────────────────────────────── lifecycle ─────────────────────────────── */
@@ -194,6 +228,12 @@ export class BusCoreImpl implements BusCore {
     this.ipcServer = await bindUdsServer(this.socketPath, {
       onHello: (agentId, _caps) => {
         this.connectedAgents.add(agentId);
+        this.logIpc("hello", {
+          agent: agentId,
+          caps: _caps.length,
+          connections: this.ipcServer?.connectionCount() ?? 0,
+          registered: this.connectedAgents.size,
+        });
       },
       onMessage: (agentId, msg) => this.handleIpcMessage(agentId, msg),
       onClose: (agentId) => {
@@ -206,6 +246,13 @@ export class BusCoreImpl implements BusCore {
           // agent (after a reconnect) would inherit the dead session's
           // origin and misroute (5-agent review on PR #138, A1 finding).
           this.lastPromptOrigin.delete(agentId);
+          this.logIpc("close", {
+            agent: agentId,
+            connections: this.ipcServer?.connectionCount() ?? 0,
+            registered: this.connectedAgents.size,
+          });
+        } else {
+          this.logIpc("close", { agent: null, note: "pre-handshake socket closed" });
         }
       },
       onError: (err, agentId) => this.onError(err, { ctx: "ipc", agentId }),
@@ -279,6 +326,23 @@ export class BusCoreImpl implements BusCore {
         this.onError(new Error(`No MCP connection for agent_id=${req.agent_id}`), {
           ctx: "sendPrompt",
         });
+        // #222 observability: was the agent ever registered, or did it just
+        // drop? `registeredKnown=false` means we never saw a hello (a fresh
+        // mcp-server never reached the bus); `=true` + no connection means the
+        // socket dropped after handshake. Distinguishes "never connected"
+        // from "connected then lost" at a glance.
+        this.logIpc("send-failed", {
+          agent: req.agent_id,
+          ctx: "sendPrompt",
+          registeredKnown: this.connectedAgents.has(req.agent_id),
+          connections: this.ipcServer.connectionCount(),
+        });
+        // The inbound prompt still falls through to PTY-stdin below, but the
+        // agent's outbound `reply` path rides this same dead IPC with no
+        // fallback → it goes deaf. Signal the daemon to reconcile (respawn if
+        // the process is alive-but-deaf). Debounce/cooldown live in the wired
+        // reconciler, not here.
+        this.onMcpSendFailed(req.agent_id, { reason: "sendPrompt:no-mcp-connection" });
       }
     }
 
@@ -322,6 +386,16 @@ export class BusCoreImpl implements BusCore {
 
   setStreamPromptHandler(handler: StreamPromptHandler | null): void {
     this.streamPromptHandler = handler;
+  }
+
+  setMcpSendFailedHandler(
+    handler: ((agentId: string, ctx: { reason: string }) => void) | null,
+  ): void {
+    this.onMcpSendFailed = handler ?? (() => {});
+  }
+
+  isAgentConnected(agentId: string): boolean {
+    return this.connectedAgents.has(agentId);
   }
 
   /* ─────────────────────────────── subscriptions ─────────────────────────────── */

--- a/src/bus/mcp-reconciler.ts
+++ b/src/bus/mcp-reconciler.ts
@@ -1,0 +1,157 @@
+/**
+ * MCP/IPC reconciliation (issue #222).
+ *
+ * Root-cause class addressed: an agent's `claude` process stays alive but its
+ * MCP/IPC registration with Bus core is gone (segfault-respawn of the bus MCP
+ * subprocess, peer reset, a fresh mcp-server that never re-handshakes). Bus
+ * core's `connectionsByAgent` then has no socket for the agent, so every
+ * `sendPrompt` returns false ("No MCP connection") AND the agent's outbound
+ * `reply` rides the same dead IPC with no fallback — the agent goes deaf.
+ *
+ * The pre-existing mcp-server reconnect logic only recovers an in-process
+ * socket drop. It does NOT recover the case where the whole mcp-server PROCESS
+ * dies and is relaunched (observed live 2026-06-07: a 1-min-old mcp-server
+ * under a 6h-old agent, send failing 15×+). This reconciler closes that gap at
+ * the process level: on the send-fail signal, confirm the agent is still
+ * disconnected after a short window (so we don't kill an agent mid-spawn whose
+ * mcp-server simply hasn't handshaked yet), then respawn it via the Session
+ * Manager's existing `restart()` primitive.
+ *
+ * Safety rails:
+ *   - confirm-delay: ignore the first signal for `confirmMs`; re-check before
+ *     acting. A normal spawn's connect window self-heals and is never touched.
+ *   - cooldown: at most one restart per agent per `cooldownMs`.
+ *   - attempt cap: `maxAttempts` restarts within `windowMs`, then back off and
+ *     log loudly (the out-of-process watchdog / a human takes over) — no storm.
+ */
+
+export interface McpReconcilerDeps {
+  /** True iff Bus core currently holds a live MCP connection for the agent. */
+  isConnected(agentId: string): boolean;
+  /** True iff the agent's process is alive (not exited) per the Session Manager. */
+  isProcessAlive(agentId: string): boolean;
+  /** Respawn the agent (Session Manager `restart()` — same session_id, resumes). */
+  restart(agentId: string): Promise<unknown>;
+  /** Structured logger. Lands in the daemon log, grep-able. */
+  log(msg: string, fields: Record<string, unknown>): void;
+  /** Schedule a callback. Injectable for tests. Returns a handle to cancel. */
+  setTimer?: (fn: () => void, ms: number) => unknown;
+  /** Clock. Injectable for tests. */
+  now?: () => number;
+}
+
+export interface McpReconcilerOptions {
+  /** Wait this long after a signal, then re-check before acting (default 5s). */
+  confirmMs?: number;
+  /** Minimum interval between restarts per agent (default 60s). */
+  cooldownMs?: number;
+  /** Max restarts within `windowMs` before backing off (default 3). */
+  maxAttempts?: number;
+  /** Rolling window for the attempt cap (default 15min). */
+  windowMs?: number;
+}
+
+export type McpSendFailedHandler = (agentId: string, ctx: { reason: string }) => void;
+
+interface AgentState {
+  /** A confirm-check is already scheduled — coalesce further signals. */
+  pendingConfirm: boolean;
+  /** A restart is in flight — don't pile on. */
+  inFlight: boolean;
+  /** Timestamps of recent restarts (within `windowMs`). */
+  restartHistory: number[];
+}
+
+export function createMcpReconciler(
+  deps: McpReconcilerDeps,
+  opts: McpReconcilerOptions = {},
+): McpSendFailedHandler {
+  const confirmMs = opts.confirmMs ?? 5_000;
+  const cooldownMs = opts.cooldownMs ?? 60_000;
+  const maxAttempts = opts.maxAttempts ?? 3;
+  const windowMs = opts.windowMs ?? 15 * 60_000;
+  const now = deps.now ?? (() => Date.now());
+  const setTimer =
+    deps.setTimer ??
+    ((fn: () => void, ms: number) => {
+      const t = setTimeout(fn, ms);
+      // Don't keep the daemon alive solely for a reconcile timer.
+      (t as { unref?: () => void }).unref?.();
+      return t;
+    });
+
+  const states = new Map<string, AgentState>();
+  const stateFor = (id: string): AgentState => {
+    let s = states.get(id);
+    if (!s) {
+      s = { pendingConfirm: false, inFlight: false, restartHistory: [] };
+      states.set(id, s);
+    }
+    return s;
+  };
+
+  function attempt(agentId: string, reason: string): void {
+    const s = stateFor(agentId);
+    s.pendingConfirm = false;
+
+    // Self-healed during the confirm window (mcp-server (re)connected) — done.
+    if (deps.isConnected(agentId)) {
+      deps.log("reconcile-recovered", {
+        agent: agentId,
+        note: "reconnected during confirm window",
+      });
+      return;
+    }
+    // Process is gone (or never spawned): the Session Manager's own onExit /
+    // supervisor owns respawn. The reconciler only handles alive-but-deaf.
+    if (!deps.isProcessAlive(agentId)) {
+      deps.log("reconcile-skip", { agent: agentId, reason: "process-not-alive" });
+      return;
+    }
+    if (s.inFlight) return;
+
+    const t = now();
+    s.restartHistory = s.restartHistory.filter((ts) => t - ts < windowMs);
+    const last = s.restartHistory[s.restartHistory.length - 1] ?? 0;
+    if (last && t - last < cooldownMs) {
+      deps.log("reconcile-skip", {
+        agent: agentId,
+        reason: "cooldown",
+        sinceLastMs: t - last,
+      });
+      return;
+    }
+    if (s.restartHistory.length >= maxAttempts) {
+      deps.log("reconcile-giveup", {
+        agent: agentId,
+        attempts: s.restartHistory.length,
+        windowMs,
+        note: "attempt cap hit — backing off, watchdog/human takes over",
+      });
+      return;
+    }
+
+    s.inFlight = true;
+    const attemptNo = s.restartHistory.length + 1;
+    deps.log("reconcile-restart", { agent: agentId, attempt: attemptNo, reason });
+    Promise.resolve(deps.restart(agentId))
+      .then(() => {
+        s.restartHistory.push(now());
+        deps.log("reconcile-restart-ok", { agent: agentId, attempt: attemptNo });
+      })
+      .catch((err) => {
+        deps.log("reconcile-restart-failed", { agent: agentId, err: String(err) });
+      })
+      .finally(() => {
+        s.inFlight = false;
+      });
+  }
+
+  return function onMcpSendFailed(agentId: string, ctx: { reason: string }): void {
+    const s = stateFor(agentId);
+    if (s.pendingConfirm || s.inFlight) return; // coalesce
+    s.pendingConfirm = true;
+    deps.log("reconcile-armed", { agent: agentId, reason: ctx.reason, confirmMs });
+    setTimer(() => attempt(agentId, ctx.reason), confirmMs);
+  };
+}

--- a/src/bus/mcp-reconciler.ts
+++ b/src/bus/mcp-reconciler.ts
@@ -132,11 +132,16 @@ export function createMcpReconciler(
     }
 
     s.inFlight = true;
-    const attemptNo = s.restartHistory.length + 1;
+    // Count the ATTEMPT, not the success: record the timestamp at dispatch so
+    // the cooldown and attempt-cap apply even when restart() REJECTS (e.g. the
+    // Session Manager throwing on its own crash-loop rate-limit). Otherwise a
+    // perpetually-failing restart() leaves restartHistory empty and storms
+    // restart() every confirmMs with no backoff, and reconcile-giveup never fires.
+    s.restartHistory.push(now());
+    const attemptNo = s.restartHistory.length;
     deps.log("reconcile-restart", { agent: agentId, attempt: attemptNo, reason });
     Promise.resolve(deps.restart(agentId))
       .then(() => {
-        s.restartHistory.push(now());
         deps.log("reconcile-restart-ok", { agent: agentId, attempt: attemptNo });
       })
       .catch((err) => {
@@ -148,6 +153,22 @@ export function createMcpReconciler(
   }
 
   return function onMcpSendFailed(agentId: string, ctx: { reason: string }): void {
+    // Opportunistic prune so `states` does not grow one stale entry per
+    // ever-signalled agent_id for the daemon lifetime: drop fully-idle agents
+    // whose restart history has aged out of the window. A pruned agent that
+    // signals again just gets fresh state — an aged-out empty history carries
+    // no live cooldown/cap meaning (attempt() window-filters it anyway).
+    const tprune = now();
+    for (const [id, st] of states) {
+      if (
+        id !== agentId &&
+        !st.pendingConfirm &&
+        !st.inFlight &&
+        !st.restartHistory.some((ts) => tprune - ts < windowMs)
+      ) {
+        states.delete(id);
+      }
+    }
     const s = stateFor(agentId);
     if (s.pendingConfirm || s.inFlight) return; // coalesce
     s.pendingConfirm = true;

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -35,6 +35,7 @@ import type { AgentConfig, BusOrigin } from "./types";
 import { BusCoreImpl, type BusCore } from "./core";
 import { SessionManager } from "./session-manager";
 import { wireSlashCommands } from "./wiring";
+import { createMcpReconciler } from "./mcp-reconciler";
 import type { MountedAdapter } from "./adapter-wiring";
 import { stopBusAdapters } from "./adapter-wiring";
 import { detectOrphanAgents, formatOrphanWarnings } from "./orphan-agent-detect";
@@ -257,6 +258,20 @@ export async function mountBusRuntime(
     // webui bridge) still owns the terminal close on observed/timeout.
     bus.setStreamPromptHandler(
       createPromptStreamHandler((agentId) => sessionManager.getAgent(agentId)),
+    );
+
+    // #222 reconciliation: when an IPC send fails because the agent's MCP
+    // registration is gone but its process is still alive (the recurring
+    // deaf-agent wedge), respawn it via the Session Manager. Confirm-delay +
+    // cooldown + attempt cap live in the reconciler so this never storms or
+    // kills an agent that's merely mid-spawn.
+    bus.setMcpSendFailedHandler(
+      createMcpReconciler({
+        isConnected: (agentId) => bus.isAgentConnected(agentId),
+        isProcessAlive: (agentId) => sessionManager.health()[agentId]?.alive ?? false,
+        restart: (agentId) => sessionManager.restart(agentId),
+        log: (msg, fields) => logger.error("[mcp-reconcile]", msg, fields),
+      }),
     );
 
     const declaredAgents = opts.agents ?? [];

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -422,6 +422,7 @@ export async function mountBusRuntime(
         try {
           bus.setSlashCommandHandler(null);
           bus.setStreamPromptHandler(null);
+          bus.setMcpSendFailedHandler(null);
         } catch (err) {
           logger.error("[bus-runtime] setSlashCommandHandler(null) failed", err);
         }
@@ -452,6 +453,7 @@ export async function mountBusRuntime(
       try {
         bus.setSlashCommandHandler(null);
         bus.setStreamPromptHandler(null);
+        bus.setMcpSendFailedHandler(null);
       } catch {
         /* ignore — surfacing the original error matters more. */
       }


### PR DESCRIPTION
## What

Closes the **control-plane** half of the recurring deaf-agent wedge tracked in #222. Complements #217 (the data-plane / silent-drop net) — different failure surface, no overlap.

## The failure

An agent's `claude` process stays alive but its **MCP/IPC registration** with Bus core is gone — the bus MCP subprocess segfault-respawned, the peer reset, or (the common one) the whole `mcp-server` **process** died and was relaunched and never re-handshaked. `connectionsByAgent` then has no socket for the agent, so:

- inbound `sendPrompt` → `ipcServer.send()` returns `false` → `No MCP connection` (logged, then falls through to the PTY-stdin path), **and**
- the agent's outbound `reply` rides that **same dead IPC with no fallback** → it goes silent.

The existing mcp-server reconnect recovers an *in-process socket drop*. It does **not** recover a whole-process respawn — the new process must do a fresh connect + hello, and nothing retries that at the process level. Observed live: a 1-min-old `mcp-server` under a 6h-old agent, `send` failing 15×+.

## Why it kept being undiagnosable

The registration seam was **silent**. The bus logged the *symptom* loudly but never *why* there was no connection — `onHello`/`onClose` were no-ops, no record of a handshake, drop, or process restart. So every recurrence came down to guessing.

## What this adds

**1. Observability** (`core.ts`): `[bus-ipc]` structured logs on `hello` / `close`, and a `send-failed` line whose `registeredKnown` flag distinguishes *never-registered* (a fresh mcp-server that never reached the bus) from *connected-then-dropped*. The seam is now greppable in one pass.

**2. Reconciliation** (`mcp-reconciler.ts`, wired in `runtime-mount`): `BusCore` emits an `onMcpSendFailed` signal (settable post-hoc, mirroring `streamPromptHandler`) and exposes `isAgentConnected`. The reconciler, on send-fail:

- **confirm-delay** (5 s) then re-checks — does **not** restart an agent that's merely mid-spawn. (`claude --resume` spawns its MCP server *lazily on the first turn*, so the first prompt after **any** restart legitimately races send-fail → hello; the delay absorbs it.)
- restarts via the existing **`sessionManager.restart()`** primitive only if the agent is **alive-but-deaf** (process up, no MCP connection).
- **cooldown** (60 s) + **attempt cap** (3 / 15 min) → no restart storms; past the cap it backs off and logs loudly for an out-of-process watchdog / human to take over.

This is the same shared `restart()` mechanism #226 builds on — this PR only needs the base signature already on `main`.

## Validation (deployed live before this PR)

The exact designed chain was observed in production:

```
[bus-ipc] send-failed   { registeredKnown: false }
[mcp-reconcile] reconcile-armed  { confirmMs: 5000 }
[bus-ipc] hello         { caps: 2, connections: 1 }   ← +409ms
[mcp-reconcile] reconcile-recovered  ← agent reconnected in-window → NO restart
```

Agent processed the prompt and produced output; the reconciler correctly stood down instead of needlessly restarting a healthy mid-spawn agent.

## Tests / safety

- New `mcp-reconciler` unit suite: confirm-delay, recovered-during-window, process-not-alive skip, signal coalescing, cooldown, attempt cap, per-agent isolation.
- Fake-bus contract updated for the two new `BusCore` methods.
- Full bus suite green, biome clean, `tsc` clean on touched files. No regressions.
- Version bumped (plugin + marketplace) per the Version Guard.

Default is a no-op, so the bus stays usable without the wiring (and in tests).
