### PR TITLE
chore(deps): bump bun-pty 0.4.8 -> 0.4.9 (fixes deaf-agent wedge #235)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "dependencies": {
         "@anthropic-ai/sdk": "^0.40.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "bun-pty": "0.4.8",
+        "bun-pty": "0.4.9",
         "commander": "^14.0.3",
         "js-yaml": "^4.1.0",
         "ogg-opus-decoder": "^1.7.3",
@@ -84,7 +84,7 @@
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 
-    "bun-pty": ["bun-pty@0.4.8", "", {}, "sha512-rO70Mrbr13+jxHHHu2YBkk2pNqrJE5cJn29WE++PUr+GFA0hq/VgtQPZANJ8dJo6d7XImvBk37Innt8GM7O28w=="],
+    "bun-pty": ["bun-pty@0.4.9", "", {}, "sha512-IUF/B3FANo8vIQ775Zt7Er7lphMpYMhLkes45am2WE8FaVI7KRYtj1rQwliZ18b6GpNzBNWcl7sz9QT5wDFBeQ=="],
 
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@anthropic-ai/sdk": "^0.40.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "bun-pty": "0.4.8",
+    "bun-pty": "0.4.9",
     "commander": "^14.0.3",
     "js-yaml": "^4.1.0",
     "ogg-opus-decoder": "^1.7.3",


### PR DESCRIPTION
## What

Bumps `bun-pty` `0.4.8 → 0.4.9`. **Closes #235.**

## Why

#235 traced the recurring bus-mode deaf-agent wedge to a bun-pty input-delivery bug: the reader thread treated a transient read error (`EINTR`/`EWOULDBLOCK`) as EOF and flipped the PTY into an `exited` state. After that, `bun_pty_write` short-circuited and **silently dropped every subsequent keystroke while the child `claude` was still alive** — input dead, output still flowing = "deaf agent." It surfaced as model-hang-looking stalls that a restart "fixed" (because the respawn got a fresh PTY).

That bug is fixed upstream and **released in bun-pty v0.4.9** (sursaone/bun-pty#42, fixes sursaone/bun-pty#41) — reader **and** writer threads now retry transient I/O errors instead of terminating.

## Change

`package.json` + `bun.lock` only — no source changes. The version-guard treats this as a non-shipped change (no `marketplace.json` bump required).

## Verification

- `bun install` resolves `bun-pty@0.4.9` (integrity updated in `bun.lock`).
- Ran the bun-pty-touching suites (`pty-process`, `runner`, `src/bus`) on **both** 0.4.8 and 0.4.9 — identical results, **no regressions**. (The two pre-existing `PtyProcess — runTurn sentinel max-wait fallback` timeout failures reproduce on 0.4.8 as well, so they're independent of this bump.)

After this lands, deployments carrying a local vendored `librust_pty.so` patch for the EINTR fix can drop it and rely on the released version.
