### PR TITLE
fix(bus): make the boot-dialog watcher resilient to CLI dialog/render changes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.137",
+      "version": "2.2.138",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.137",
+  "version": "2.2.138",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -149,8 +149,46 @@ describe("PtyAgentProcess boot-dialog watcher (structural / ANSI-resilient)", ()
     } finally {
       console.error = origErr;
     }
-    expect(writes).toEqual([]); // no blind keypress on a destructive default
-    expect(warned).toContain("destructive default");
+    expect(writes).toEqual([]); // no blind keypress on a non-proceed default
+    expect(warned).toContain("non-proceed default");
+  });
+
+  it("fails safe on a destructive default phrased without an exit/cancel keyword (allowlist invert)", () => {
+    // A selected default phrased "Delete everything" matched no proceed verb,
+    // so the watcher must warn-and-wait rather than blind-Enter it — the case
+    // the old destructive-blocklist (exit|cancel|abort|…) would have missed.
+    const { handle, writes, emit } = bootPty();
+    new PtyAgentProcess("zeta", handle);
+    const origErr = console.error;
+    let warned = "";
+    console.error = (...a: unknown[]) => {
+      warned = a.map(String).join(" ");
+    };
+    try {
+      emit(" ❯ 1. Delete everything\r\n   2. Keep files\r\n Enter to confirm");
+    } finally {
+      console.error = origErr;
+    }
+    expect(writes).toEqual([]); // not a recognised proceed action -> no Enter
+    expect(warned).toContain("non-proceed default");
+  });
+
+  it("does NOT fire a second Enter when the bypass dialog re-renders after Down+Enter (Codex F3)", async () => {
+    // The bypass-permissions dialog is answered by the gated Down+Enter branch.
+    // On the redraw chunk the SAME dialog text is still on screen with "❯" now
+    // on the accept row — it must NOT fall through to the generic confirm
+    // branch and fire a second, blind Enter racing the deferred one.
+    const { handle, writes, emit } = bootPty();
+    new PtyAgentProcess("eta", handle);
+    emit(
+      "WARNING: Bypass Permissions mode\r\n ❯ 1. No, exit\r\n   2. Yes, I accept\r\n Enter to confirm",
+    );
+    // redraw after Down: selection moved to the accept row, dialog still up.
+    emit(
+      "WARNING: Bypass Permissions mode\r\n   1. No, exit\r\n ❯ 2. Yes, I accept\r\n Enter to confirm",
+    );
+    await new Promise((r) => setTimeout(r, 250)); // let the deferred Enter land
+    expect(writes).toEqual(["\x1b[B", "\r"]); // exactly Down then one Enter
   });
 
   it("disengages on the REPL footer and ignores later dialog-looking text", async () => {

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -80,3 +80,86 @@ describe("PtyAgentProcess.send_prompt_stream", () => {
     expect(writes).toEqual([]);
   });
 });
+
+function bootPty(): { handle: PtyHandle; writes: string[]; emit: (d: string) => void } {
+  const writes: string[] = [];
+  let dataCb: ((d: string) => void) | null = null;
+  const handle: PtyHandle = {
+    pid: 4321,
+    onData: (cb) => {
+      dataCb = cb;
+      return { dispose() {} };
+    },
+    onExit: () => ({ dispose() {} }),
+    write: (data: string) => {
+      writes.push(data);
+    },
+    kill: () => {},
+  };
+  return { handle, writes, emit: (d) => dataCb?.(d) };
+}
+
+describe("PtyAgentProcess boot-dialog watcher (structural / ANSI-resilient)", () => {
+  it("answers a confirm dialog whose title is split by a cursor-move escape (the 2.1.x regression)", () => {
+    const { handle, writes, emit } = bootPty();
+    new PtyAgentProcess("alpha", handle);
+    // Raw PTY: ESC[32G is interleaved INSIDE the title, so a literal
+    // "development channels" match on the raw buffer fails — exactly the bug
+    // that wedged boots after a CLI auto-update. The structural match (selected
+    // option + "Enter to confirm") must still confirm the proceed default.
+    emit(
+      "WARNING: Loading development\x1b[32Gchannels\r\n" +
+        " ❯ 1. I am using this for local development\r\n" +
+        "   2. Exit\r\n Enter to confirm · Esc to cancel",
+    );
+    expect(writes).toEqual(["\r"]);
+  });
+
+  it("answers the new trust-folder dialog with Enter (default = trust)", () => {
+    const { handle, writes, emit } = bootPty();
+    new PtyAgentProcess("beta", handle);
+    emit(
+      "Quick safety check: Is this a project you trust?\r\n" +
+        " ❯ 1. Yes, I trust this folder\r\n   2. No, exit\r\n Enter to confirm · Esc to cancel",
+    );
+    expect(writes).toEqual(["\r"]);
+  });
+
+  it("sends one Enter per distinct dialog, not per render chunk", () => {
+    const { handle, writes, emit } = bootPty();
+    new PtyAgentProcess("gamma", handle);
+    const trust = " ❯ 1. Yes, I trust this folder\r\n   2. No, exit\r\n Enter to confirm";
+    emit(trust);
+    emit(trust); // same dialog re-rendered across chunks -> no second Enter
+    expect(writes).toEqual(["\r"]);
+    emit(" ❯ 1. I am using this for local development\r\n   2. Exit\r\n Enter to confirm"); // distinct dialog
+    expect(writes).toEqual(["\r", "\r"]);
+  });
+
+  it("does NOT auto-answer an unknown dialog whose default is destructive; warns once", () => {
+    const { handle, writes, emit } = bootPty();
+    new PtyAgentProcess("delta", handle);
+    const origErr = console.error;
+    let warned = "";
+    console.error = (...a: unknown[]) => {
+      warned = a.map(String).join(" ");
+    };
+    try {
+      emit(" ❯ 2. No, exit\r\n   1. Delete everything\r\n Enter to confirm");
+    } finally {
+      console.error = origErr;
+    }
+    expect(writes).toEqual([]); // no blind keypress on a destructive default
+    expect(warned).toContain("destructive default");
+  });
+
+  it("disengages on the REPL footer and ignores later dialog-looking text", async () => {
+    const { handle, writes, emit } = bootPty();
+    new PtyAgentProcess("epsilon", handle);
+    emit("⏵⏵ bypass permissions on (shift+tab to cycle) · ← for agents");
+    writes.length = 0;
+    emit(" ❯ 1. I am using this for local development\r\n Enter to confirm");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(writes).toEqual([]); // disengaged -> no key into a live REPL
+  });
+});

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -236,18 +236,24 @@ export class PtyAgentProcess implements AgentProcess {
 
     // REPL is up — disengage FIRST so we never inject a key into a live REPL.
     // Every REPL mode footer carries the mode-cycler hint ("shift+tab to
-    // cycle" / "to cycle permission modes"); "to cycle" is its version-stable
-    // core and appears in no dialog.
-    if (buf.includes("to cycle")) {
+    // cycle" / a future "tab to cycle permission modes"); "tab to cycle" is its
+    // version-stable core and — unlike the bare "to cycle" — cannot trip on
+    // arbitrary boot prose, which would disengage early and re-expose #195.
+    if (buf.includes("tab to cycle")) {
       this.endBootDialogPhase();
       return;
     }
 
     // Bypass-permissions dialog — DEFAULT is "No, exit"; a blind Enter selects
     // exit and kills the agent, so move the selection to the accept row first.
-    if (!this.answeredBypassPrompt && buf.includes("Yes, I accept")) {
-      this.answeredBypassPrompt = true;
-      this.sendBootKeys("\x1b[B", "\r"); // Down, then Enter
+    if (buf.includes("Yes, I accept")) {
+      if (!this.answeredBypassPrompt) {
+        this.answeredBypassPrompt = true;
+        this.sendBootKeys("\x1b[B", "\r"); // Down, then Enter
+      }
+      // The bypass dialog is still on screen (re-rendered after the Down): do
+      // NOT fall through to the generic confirm branch, which would fire a
+      // second, blind Enter racing the deferred one above (Codex F3 / #195).
       return;
     }
 
@@ -274,17 +280,25 @@ export class PtyAgentProcess implements AgentProcess {
       .trim()
       .toLowerCase();
     if (selected === this.lastConfirmSig) return; // same dialog still rendering
-    const destructiveDefault = /\b(exit|cancel|abort|quit|decline|reject)\b/.test(selected);
-    if (!destructiveDefault) {
+    // Fail-safe ALLOWLIST: only auto-press Enter when the selected ("❯") option
+    // affirmatively reads as a proceed/accept action. This subsumes the old
+    // destructive-blocklist (which both blind-Entered destructive defaults
+    // phrased delete/discard/… and false-wedged on benign labels that merely
+    // mentioned "exit"): an unrecognised default now degrades to "stuck + a
+    // one-time warning" rather than "blindly pressed the wrong button".
+    const label = selected.replace(/^❯\s*\d*[.):]?\s*/, ""); // strip "❯ N." prefix
+    const proceedDefault =
+      /\b(yes|accept|trust|continue|proceed|allow|enable|confirm|ok|i am using this)\b/.test(label);
+    if (proceedDefault) {
       this.lastConfirmSig = selected;
-      this.sendBootKeys("\r"); // default is the proceed option
+      this.sendBootKeys("\r"); // default is a recognised proceed option
     } else if (!this.warnedUnhandledDialog) {
-      // Unknown dialog with a destructive default — don't guess which key is
+      // Default does not read as a proceed action — don't guess which key is
       // safe. Surface it so the drift is visible (the watchdog / a follow-up
-      // can react) instead of silently wedging.
+      // can react) instead of silently pressing the wrong button.
       this.warnedUnhandledDialog = true;
       console.error(
-        `[boot-dialog] agent=${this.agent_id}: confirm dialog with destructive default ` +
+        `[boot-dialog] agent=${this.agent_id}: confirm dialog with non-proceed default ` +
           `not auto-answered (selected="${selected.trim().slice(0, 60)}"). REPL may stall.`,
       );
     }

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -24,6 +24,24 @@ import type { ChildProcess } from "node:child_process";
 import { sanitizePtyPromptText } from "../runner/pty-prompt-sanitizer";
 import type { SupervisionMode } from "./types";
 
+/** Strip ANSI OSC/CSI escape sequences so dialog matching survives the
+ *  cursor-positioning escapes the CLI interleaves into rendered text. Without
+ *  this, a raw substring like "development channels" silently stops matching
+ *  after a CLI build renders it as "development\x1b[32Gchannels". Mirrors the
+ *  stripper in `runner/pty-process.ts` (kept local to avoid importing the PTY
+ *  runner into the bus module). */
+function stripAnsiEscapes(text: string): string {
+  return (
+    text
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: OSC escape sequences require control bytes.
+      .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI CSI escape stripper.
+      .replace(/\x1b\[[?0-9;]*[ -/]*[@-~]/g, "")
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: catch-all ESC byte stripper.
+      .replace(/\x1b/g, "")
+  );
+}
+
 export type ExitHandler = (code: number) => void;
 export type DataHandler = (chunk: string) => void;
 
@@ -88,7 +106,10 @@ export class PtyAgentProcess implements AgentProcess {
   private bootDialogActive = true;
   private bootDialogBuffer = "";
   private answeredBypassPrompt = false;
-  private answeredDevChannelsPrompt = false;
+  /** Signature of the last generic confirm-dialog we answered, so we send one
+   *  Enter per distinct dialog instead of on every render chunk. */
+  private lastConfirmSig: string | null = null;
+  private warnedUnhandledDialog = false;
   /** Hard cap on the boot-dialog watch window (issue #193 / Codex P2). If no
    *  REPL-ready marker is observed within this window (e.g. a future CLI
    *  changes the footer text), the watcher disengages anyway so it never
@@ -191,52 +212,101 @@ export class PtyAgentProcess implements AgentProcess {
   }
 
   /** Answer claude's interactive startup confirmation dialogs by inspecting
-   *  early PTY output (issue #193). Sends the *correct* key per dialog: Enter
-   *  for the dev-channels confirmation (whose default IS the accept option),
-   *  and Down+Enter for the "Bypass Permissions mode" dialog (whose default is
-   *  "No, exit" — a blind Enter would select exit and kill the agent). Matches
-   *  on text unique to each dialog so the REPL footer (which contains the
-   *  "shift+tab to cycle" hint) cannot false-trigger. */
+   *  early PTY output (issue #193), then disengage once the REPL is up.
+   *
+   *  Resilient to CLI rendering changes (the reason this used to wedge after a
+   *  CLI auto-update): the raw PTY stream interleaves cursor-positioning
+   *  escapes *inside* dialog text — e.g. a build renders the title
+   *  "development<ESC>[32Gchannels" — so a literal substring match on the raw
+   *  buffer silently stops matching, leaving the dialog unanswered and the
+   *  agent stuck before the REPL. We therefore (1) strip ANSI before matching,
+   *  and (2) drive the dialog by its *structure* — the selected ("❯") option +
+   *  the "Enter to confirm" affordance — rather than per-title strings.
+   *
+   *  Default-key safety: a dialog whose selected option is a proceed action
+   *  (trust-folder, dev-channels) is confirmed with Enter. The only known
+   *  dialog whose default is destructive is the bypass-permissions prompt
+   *  ("No, exit" preselected) — handled specifically with Down+Enter. An
+   *  unrecognised dialog whose default looks destructive is NOT auto-answered
+   *  (we log once instead), so a future CLI change degrades to "stuck + a
+   *  warning" rather than "blindly pressed the wrong button". */
   private handleBootDialog(chunk: string): void {
     this.bootDialogBuffer = (this.bootDialogBuffer + chunk).slice(-4000);
-    const buf = this.bootDialogBuffer;
+    const buf = stripAnsiEscapes(this.bootDialogBuffer);
+
+    // REPL is up — disengage FIRST so we never inject a key into a live REPL.
+    // Every REPL mode footer carries the mode-cycler hint ("shift+tab to
+    // cycle" / "to cycle permission modes"); "to cycle" is its version-stable
+    // core and appears in no dialog.
+    if (buf.includes("to cycle")) {
+      this.endBootDialogPhase();
+      return;
+    }
+
+    // Bypass-permissions dialog — DEFAULT is "No, exit"; a blind Enter selects
+    // exit and kills the agent, so move the selection to the accept row first.
     if (!this.answeredBypassPrompt && buf.includes("Yes, I accept")) {
       this.answeredBypassPrompt = true;
-      try {
-        this.pty.write("\x1b[B"); // move selection to "2. Yes, I accept"
+      this.sendBootKeys("\x1b[B", "\r"); // Down, then Enter
+      return;
+    }
+
+    // Generic confirm dialog. Identify the selected option (the "❯" row) just
+    // above the "Enter to confirm" affordance and only press Enter when that
+    // default is a proceed action. Dedup on the option region so we send one
+    // Enter per distinct dialog (trust-folder → dev-channels → REPL), not one
+    // per render chunk.
+    // Use the LAST affordance: the buffer accumulates across dialogs, so an
+    // earlier (already-answered) dialog's text may still be present above the
+    // current one.
+    const ec = buf.lastIndexOf("Enter to confirm");
+    if (ec === -1) return;
+    const region = buf.slice(0, ec);
+    const arrow = region.lastIndexOf("❯");
+    if (arrow === -1) return;
+    const eol = region.indexOf("\n", arrow);
+    // The selected ("❯") option line identifies the dialog stably regardless of
+    // how much earlier output has accumulated in the buffer — use it both as
+    // the proceed/destructive discriminator AND the per-dialog dedup key (one
+    // Enter per distinct dialog, not per render chunk).
+    const selected = region
+      .slice(arrow, eol === -1 ? region.length : eol)
+      .trim()
+      .toLowerCase();
+    if (selected === this.lastConfirmSig) return; // same dialog still rendering
+    const destructiveDefault = /\b(exit|cancel|abort|quit|decline|reject)\b/.test(selected);
+    if (!destructiveDefault) {
+      this.lastConfirmSig = selected;
+      this.sendBootKeys("\r"); // default is the proceed option
+    } else if (!this.warnedUnhandledDialog) {
+      // Unknown dialog with a destructive default — don't guess which key is
+      // safe. Surface it so the drift is visible (the watchdog / a follow-up
+      // can react) instead of silently wedging.
+      this.warnedUnhandledDialog = true;
+      console.error(
+        `[boot-dialog] agent=${this.agent_id}: confirm dialog with destructive default ` +
+          `not auto-answered (selected="${selected.trim().slice(0, 60)}"). REPL may stall.`,
+      );
+    }
+  }
+
+  /** Write one or two keystrokes to the PTY, the second after a short settle so
+   *  a bracketed-paste terminal treats them as distinct keys. Swallows write
+   *  errors (the PTY can exit mid-boot). */
+  private sendBootKeys(first: string, second?: string): void {
+    try {
+      this.pty.write(first);
+      if (second !== undefined) {
         setTimeout(() => {
           try {
-            this.pty.write("\r");
+            this.pty.write(second);
           } catch {
             /* pty may have exited — non-fatal */
           }
         }, 200);
-      } catch {
-        /* pty may have exited — non-fatal */
       }
-      return;
-    }
-    if (!this.answeredDevChannelsPrompt && buf.includes("development channels")) {
-      this.answeredDevChannelsPrompt = true;
-      try {
-        this.pty.write("\r");
-      } catch {
-        /* pty may have exited — non-fatal */
-      }
-      return;
-    }
-    // REPL-ready marker (issue #193 / Codex P2 ×2). Every REPL mode footer
-    // ends with the "shift+tab to cycle" mode-cycler hint, regardless of the
-    // agent's permission_mode ("bypass permissions on", "plan mode on",
-    // "accept edits on", etc.). Matching the generic hint — rather than the
-    // bypass-specific footer — means the watcher disengages promptly in ALL
-    // modes, not only bypass. (The bypass-only marker left non-bypass agents
-    // watching until the 15s timeout, during which a stray "Yes, I accept"
-    // model echo could inject Down/Enter into a live REPL.) No dialog contains
-    // this hint, so it cannot false-trigger. Disengaging stops buffering +
-    // cancels the timeout; writes nothing.
-    if (buf.includes("shift+tab to cycle")) {
-      this.endBootDialogPhase();
+    } catch {
+      /* pty may have exited — non-fatal */
     }
   }
 


### PR DESCRIPTION
## Problem

A daemon-spawned, headless `claude` can silently wedge at startup: the agent process stays alive and keeps reading its PTY, but it never reaches the REPL — so inbound prompts are read yet never produce a turn (no model call, no reply). It "recovers" only on a restart that happens to skip the dialog and re-wedges otherwise, which presents as an intermittent "the agent went deaf".

## Root cause

The boot-dialog watcher (`PtyAgentProcess.handleBootDialog`) dismisses `claude`'s interactive startup confirmation dialogs by matching **hardcoded raw substrings** against the PTY stream and pressing the right key. Two CLI rendering changes broke that:

1. **Cursor escapes interleaved in dialog text.** The dev-channels dialog title now renders with a cursor-move escape *inside* the text — the raw stream is `development\x1b[32Gchannels`, not `development channels`. So `buf.includes("development channels")` never matches and the dialog is never confirmed. (A terminal resolves the escape and shows clean text, which is why it looks fine to a human but not to a substring match on the raw bytes.)
2. **A new gate dialog.** A trust-folder prompt ("Is this a project you … trust?") now precedes the others and had no handler at all.

Either path leaves the dialog unanswered → the CLI never reaches the REPL → prompts are read but never turned into a turn.

## Fix

Drive the startup dialogs by **structure** instead of fragile per-title strings:

- **Strip ANSI before matching**, so interleaved cursor escapes can't silently break a match.
- Identify the dialog by its selected option (the `❯` row) plus the `Enter to confirm` affordance. When the default is a *proceed* action (trust-folder, dev-channels) → send Enter. The bypass-permissions dialog keeps its specific Down+Enter handler because its default is destructive ("No, exit").
- An unrecognised dialog whose default *looks* destructive is **left alone with a one-shot warning** rather than a blind keypress — so a future CLI change degrades to "stuck + a logged warning" instead of "pressed the wrong button".
- Dedup on the selected-option line → one Enter per distinct dialog, not one per render chunk.
- REPL-readiness is checked first (the `to cycle` footer hint) so a keystroke is never injected into a live REPL.

The only remaining version-specific assumption is the selector glyph; everything else tolerates dialog-text and render changes across CLI builds.

## Test plan

- New unit tests in `session-agent-process.test.ts`, including the regression itself: a dialog whose title is split by a cursor-move escape is still confirmed; the new trust-folder dialog is answered; a destructive-default dialog is **not** auto-answered (and warns once); dedup sends one Enter per distinct dialog; the watcher disengages on the REPL footer and then ignores dialog-looking text.
- Full `src/bus` suite: no regressions (pre-existing failures unchanged).
- Smoke build + Biome lint clean; plugin/marketplace versions bumped.
- Verified live against a daemon-spawned headless agent on a recent CLI build: pre-fix the startup dialog was never dismissed and prompts timed out before a turn; post-fix the agent reaches the REPL and inbound turns complete normally.
