### PR TITLE
fix(bus): hold PTY prompts during session (re)init so they are not lost

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.137",
+      "version": "2.2.138",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.137",
+  "version": "2.2.138",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -888,3 +888,98 @@ describe("BusCore IPC", () => {
     client.close();
   });
 });
+
+describe("BusCore delivery gate (session.init / replay_done)", () => {
+  let bus: BusCore;
+  afterEach(async () => {
+    await bus?.stop();
+  });
+
+  const initEvt = (agent: string): BusEvent => ({
+    ts: 1,
+    agent_id: agent,
+    session_id: "s",
+    topic: "session.init",
+    payload: {},
+  });
+  const replayEvt = (agent: string): BusEvent => ({
+    ts: 1,
+    agent_id: agent,
+    session_id: "s",
+    topic: "bus.events.replay_done",
+    payload: {},
+  });
+  const prompt = (agent: string, text: string) =>
+    bus.sendPrompt({ agent_id: agent, origin: "webui", origin_id: "i", user_id: "u", text });
+
+  it("holds a PTY prompt that arrives while the session is (re)initialising", async () => {
+    bus = createBusCore({ eventLogAppend: createMockEventLog().append });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    bus.ingestSessionEvent(initEvt("alpha"));
+    await prompt("alpha", "hello");
+    expect(delivered).toHaveLength(0); // held, not swallowed by a not-yet-ready TUI
+  });
+
+  it("flushes held prompts in FIFO order on replay_done", async () => {
+    bus = createBusCore({ eventLogAppend: createMockEventLog().append });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    bus.ingestSessionEvent(initEvt("alpha"));
+    await prompt("alpha", "one");
+    await prompt("alpha", "two");
+    expect(delivered).toHaveLength(0);
+    bus.ingestSessionEvent(replayEvt("alpha"));
+    expect(delivered).toHaveLength(2);
+    expect(delivered[0]).toContain("one");
+    expect(delivered[1]).toContain("two");
+  });
+
+  it("delivers immediately when the session is not initialising", async () => {
+    bus = createBusCore({ eventLogAppend: createMockEventLog().append });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    await prompt("alpha", "now");
+    expect(delivered).toHaveLength(1);
+    // after a full init->replay cycle, back to immediate delivery
+    bus.ingestSessionEvent(initEvt("alpha"));
+    bus.ingestSessionEvent(replayEvt("alpha"));
+    await prompt("alpha", "again");
+    expect(delivered).toHaveLength(2);
+  });
+
+  it("backstop flushes held prompts if replay_done never arrives (never strands)", async () => {
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      deliveryBackstopMs: 20,
+      onError: () => {},
+    });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    bus.ingestSessionEvent(initEvt("alpha"));
+    await prompt("alpha", "held");
+    expect(delivered).toHaveLength(0);
+    await new Promise((r) => setTimeout(r, 45)); // > backstop
+    expect(delivered).toHaveLength(1); // flushed despite no replay_done
+  });
+
+  it("gates per-agent: one agent initialising doesn't hold another", async () => {
+    bus = createBusCore({ eventLogAppend: createMockEventLog().append });
+    const delivered: Array<[string, string]> = [];
+    bus.setStreamPromptHandler(async (a, text) => {
+      delivered.push([a, text]);
+    });
+    bus.ingestSessionEvent(initEvt("alpha")); // only alpha initialising
+    await prompt("beta", "beta-now");
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0][0]).toBe("beta");
+  });
+});

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -982,4 +982,77 @@ describe("BusCore delivery gate (session.init / replay_done)", () => {
     expect(delivered).toHaveLength(1);
     expect(delivered[0][0]).toBe("beta");
   });
+
+  // Real producer order for a fresh/restart/rotation session: the tailer's
+  // start() emits `replay_done` BEFORE the model writes the first line that
+  // triggers `session.init`. The gate must stay order-independent — a prompt
+  // arriving after this real order must deliver IMMEDIATELY (not wait for the
+  // backstop), since the session is already live by `replay_done`.
+  it("delivers immediately on the real producer order (replay_done then session.init)", async () => {
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      deliveryBackstopMs: 1000, // long: a backstop-driven flush would be a bug here
+    });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    // Fresh/empty file: tailer emits replay_done first, then a late session.init.
+    bus.ingestSessionEvent(replayEvt("alpha"));
+    bus.ingestSessionEvent(initEvt("alpha"));
+    await prompt("alpha", "fresh");
+    expect(delivered).toHaveLength(1); // not held until the backstop
+    expect(delivered[0]).toContain("fresh");
+  });
+
+  // A late session.init for an already-live generation is a no-op: a prompt
+  // that arrives between replay_done and the late init must still flow.
+  it("a late session.init for the live generation does not re-arm the hold", async () => {
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      deliveryBackstopMs: 1000,
+    });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    bus.ingestSessionEvent(replayEvt("alpha")); // session live (generation "s")
+    await prompt("alpha", "p1");
+    expect(delivered).toHaveLength(1);
+    bus.ingestSessionEvent(initEvt("alpha")); // late init for SAME generation "s"
+    await prompt("alpha", "p2");
+    expect(delivered).toHaveLength(2); // p2 not held
+  });
+
+  // A genuinely new generation arriving init-first (existing/non-empty file at
+  // start of the new tailer) must still arm the hold even though a PRIOR
+  // generation was already live.
+  it("a new generation's session.init (init before replay) still arms the hold", async () => {
+    bus = createBusCore({ eventLogAppend: createMockEventLog().append });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    // Generation "s" goes live, then a new generation "s2" reinitialises with
+    // an existing file → init("s2") arrives BEFORE replay_done("s2").
+    bus.ingestSessionEvent(replayEvt("alpha")); // gen "s" live
+    bus.ingestSessionEvent({
+      ts: 1,
+      agent_id: "alpha",
+      session_id: "s2",
+      topic: "session.init",
+      payload: {},
+    });
+    await prompt("alpha", "held");
+    expect(delivered).toHaveLength(0); // held: new gen is (re)initialising
+    bus.ingestSessionEvent({
+      ts: 1,
+      agent_id: "alpha",
+      session_id: "s2",
+      topic: "bus.events.replay_done",
+      payload: {},
+    });
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0]).toContain("held");
+  });
 });

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -524,6 +524,57 @@ describe("BusCore IPC", () => {
     client.close();
   });
 
+  it("drops held prompts and cancels the backstop on IPC disconnect (#243 review)", async () => {
+    // A prompt held during (re)init must NOT be flushed into a restart that
+    // reuses the same agent_id: when the subprocess IPC socket drops, onClose
+    // tears down the gate timer + queue so the backstop can never inject a
+    // stale keystroke into the new process.
+    const sockPath = join(tempDir, "bus.sock");
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      socketPath: sockPath,
+      deliveryBackstopMs: 100,
+      onError: () => {},
+    });
+    await bus.start();
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+
+    const client = await connectIpcClient(sockPath);
+    client.send({
+      type: "hello",
+      agent_id: "alpha",
+      capabilities: ["claude/channel", "claude/channel/permission"],
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    expect(bus.state().connectedAgents).toContain("alpha");
+
+    // Arm the gate and queue a held prompt, then drop the socket BEFORE replay_done.
+    bus.ingestSessionEvent({
+      ts: 1,
+      agent_id: "alpha",
+      session_id: "s",
+      topic: "session.init",
+      payload: {},
+    });
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "webui",
+      origin_id: "i",
+      user_id: "u",
+      text: "held",
+    });
+    expect(delivered).toHaveLength(0);
+    client.close();
+
+    // Past the backstop: without the onClose teardown the held prompt would
+    // flush here; with it, nothing is delivered.
+    await new Promise((r) => setTimeout(r, 160));
+    expect(delivered).toHaveLength(0);
+  });
+
   it("sendPrompt forwards an IpcPrompt to the right MCP connection", async () => {
     const sockPath = join(tempDir, "bus.sock");
     bus = createBusCore({

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -359,7 +359,9 @@ export class BusCoreImpl implements BusCore {
     if (this.agentInitializing.has(agent_id)) return;
     const timer = setTimeout(() => {
       this.onError(
-        new Error(`replay_done not seen within backstop; flushing held prompts for agent_id=${agent_id}`),
+        new Error(
+          `replay_done not seen within backstop; flushing held prompts for agent_id=${agent_id}`,
+        ),
         { ctx: "deliveryBackstop", agent_id },
       );
       this.markAgentReady(agent_id);

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -191,9 +191,30 @@ export class BusCoreImpl implements BusCore {
    * missed `replay_done` can never strand a prompt (worst case = the previous
    * deliver-immediately behaviour). `agentInitializing` maps an agent to its
    * backstop timer; `deliveryQueue` holds the wrapped prompts awaiting flush.
+   *
+   * The gate is ORDER-INDEPENDENT. The JSONL tailer emits `replay_done` for
+   * every session generation, but `session.init` only when the model writes
+   * the first line of a previously-empty file. For a fresh / restart /
+   * `/clear`-rotated session the file is empty at `start()`, so the tailer
+   * emits `replay_done` FIRST and `session.init` LATER (once the model
+   * writes). Treating `session.init` as an unconditional "arm" would then hold
+   * an already-live session until the backstop fires — penalising exactly the
+   * (re)init path this gate is meant to protect. So `replay_done`
+   * unconditionally marks the agent READY for its session generation
+   * (`agentLiveSession`) and flushes; a `session.init` for an already-live
+   * generation is a no-op. `session.init` only arms a hold when the agent is
+   * NOT already past `replay_done` for the current generation (the real
+   * init→replay order, i.e. an existing/non-empty file at `start()`).
    */
   private readonly agentInitializing = new Map<string, ReturnType<typeof setTimeout>>();
   private readonly deliveryQueue = new Map<string, string[]>();
+  /**
+   * Per-agent session generation (the `replay_done` `session_id`) that has
+   * already reached `replay_done` and is therefore live. Makes the gate
+   * order-independent: a late `session.init` carrying this same generation
+   * must not re-arm a hold on a session that is already running.
+   */
+  private readonly agentLiveSession = new Map<string, string>();
   private readonly deliveryBackstopMs: number;
 
   constructor(opts: BusCoreOptions = {}) {
@@ -244,6 +265,7 @@ export class BusCoreImpl implements BusCore {
     for (const timer of this.agentInitializing.values()) clearTimeout(timer);
     this.agentInitializing.clear();
     this.deliveryQueue.clear();
+    this.agentLiveSession.clear();
   }
 
   /* ─────────────────────────────── prompts ─────────────────────────────── */
@@ -348,10 +370,18 @@ export class BusCoreImpl implements BusCore {
     );
   }
 
-  /** `session.init` → start holding PTY-stdin prompts for this agent. The
-   *  backstop force-flushes if `replay_done` never arrives, so a held prompt is
-   *  never stranded; it's re-armed on each `session.init`. */
-  private markAgentInitializing(agent_id: string): void {
+  /** `session.init` → start holding PTY-stdin prompts for this agent, UNLESS
+   *  the agent is already past `replay_done` for this session generation (the
+   *  fresh/restart/rotation path emits `replay_done` BEFORE `session.init`, so
+   *  the session is already live and must not be re-held). The backstop
+   *  force-flushes if `replay_done` never arrives, so a held prompt is never
+   *  stranded; the hold is re-armed on each fresh-generation `session.init`. */
+  private markAgentInitializing(agent_id: string, session_id?: string): void {
+    // Order-independence: if `replay_done` for this generation was already
+    // observed, the session is live — a (late) `session.init` for it must not
+    // arm a fresh hold. A missing/unknown session_id falls through to arming,
+    // bounded by the backstop, so worst case = the previous behaviour.
+    if (session_id && this.agentLiveSession.get(agent_id) === session_id) return;
     // Keep the EARLIEST deadline: don't re-arm if already holding. Otherwise a
     // rapid `session.init` churn (< backstop interval, e.g. an IPC-reconnect
     // storm) would keep pushing the deadline out and strand held prompts. The
@@ -369,8 +399,12 @@ export class BusCoreImpl implements BusCore {
     this.agentInitializing.set(agent_id, timer);
   }
 
-  /** `replay_done` (or backstop) → session ready: flush held prompts in order. */
-  private markAgentReady(agent_id: string): void {
+  /** `replay_done` (or backstop) → session ready: record the live generation
+   *  (so a late `session.init` for it can't re-arm a hold), clear any pending
+   *  hold, and flush held prompts in order. Called unconditionally on
+   *  `replay_done`, which the tailer emits for every session generation. */
+  private markAgentReady(agent_id: string, session_id?: string): void {
+    if (session_id) this.agentLiveSession.set(agent_id, session_id);
     const timer = this.agentInitializing.get(agent_id);
     if (timer) clearTimeout(timer);
     this.agentInitializing.delete(agent_id);
@@ -482,8 +516,8 @@ export class BusCoreImpl implements BusCore {
     // (re)initialising so a keystroke isn't swallowed by a not-yet-ready TUI,
     // and release them once it's live.
     if (e.agent_id) {
-      if (e.topic === "session.init") this.markAgentInitializing(e.agent_id);
-      else if (e.topic === "bus.events.replay_done") this.markAgentReady(e.agent_id);
+      if (e.topic === "session.init") this.markAgentInitializing(e.agent_id, e.session_id);
+      else if (e.topic === "bus.events.replay_done") this.markAgentReady(e.agent_id, e.session_id);
     }
     this.publish(e);
   }

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -286,6 +286,17 @@ export class BusCoreImpl implements BusCore {
           this.lastPromptOrigin.delete(agentId);
           this.currentTurnReplied.delete(agentId);
           this.currentTurnFinalPublished.delete(agentId);
+          // The subprocess is gone -- tear down this agent's delivery-gate
+          // state too, so a held prompt plus an armed backstop timer can never
+          // flush a stale keystroke into a restart that reuses this agent_id.
+          // NOT agentLiveSession: clearing it would let a late session.init
+          // arm a hold on the resumed (already-live) session -- the very
+          // anti-pattern the order-independent gate avoids -- and the new
+          // tailer re-emits replay_done which sets it again anyway.
+          const heldInitTimer = this.agentInitializing.get(agentId);
+          if (heldInitTimer) clearTimeout(heldInitTimer);
+          this.agentInitializing.delete(agentId);
+          this.deliveryQueue.delete(agentId);
         }
       },
       onError: (err, agentId) => this.onError(err, { ctx: "ipc", agentId }),

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -121,6 +121,10 @@ export interface BusCoreOptions {
   eventLogAppend?: EventLogAppendFn;
   /** Ringbuffer cap per subscriber. */
   ringbufferCapacity?: number;
+  /** Backstop (ms) for the delivery gate: max time a prompt is held while the
+   *  agent's session (re)initialises before it's flushed even without a
+   *  `replay_done`. Defaults to 4000. Lowered in tests. */
+  deliveryBackstopMs?: number;
   /** Slash-command delegate (Agent C wires this). */
   slashCommandHandler?: SlashCommandHandler;
   /** REPL prompt delegate for PTY-stdin agents. Wired by the Session Manager. */
@@ -178,9 +182,24 @@ export class BusCoreImpl implements BusCore {
    */
   private readonly lastPromptOrigin = new Map<string, { origin: BusOrigin; origin_id: string }>();
 
+  /**
+   * Delivery gate. A prompt typed into a PTY-resident agent while its session
+   * is (re)initialising — `session.init` seen but `bus.events.replay_done` not
+   * yet — is swallowed by the not-yet-ready TUI and never starts a turn
+   * (observed as an intermittent "prompt delivered, no reply"). Such prompts
+   * are held and flushed on `replay_done`, or after a backstop timeout so a
+   * missed `replay_done` can never strand a prompt (worst case = the previous
+   * deliver-immediately behaviour). `agentInitializing` maps an agent to its
+   * backstop timer; `deliveryQueue` holds the wrapped prompts awaiting flush.
+   */
+  private readonly agentInitializing = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly deliveryQueue = new Map<string, string[]>();
+  private readonly deliveryBackstopMs: number;
+
   constructor(opts: BusCoreOptions = {}) {
     this.socketPath = opts.socketPath ?? null;
     this.ringbufferCapacity = opts.ringbufferCapacity ?? DEFAULT_RINGBUFFER_CAPACITY;
+    this.deliveryBackstopMs = opts.deliveryBackstopMs ?? 4000;
     this.eventLogAppend = opts.eventLogAppend ?? eventLogAppend;
     this.slashCommandHandler = opts.slashCommandHandler ?? null;
     this.streamPromptHandler = opts.streamPromptHandler ?? null;
@@ -222,6 +241,9 @@ export class BusCoreImpl implements BusCore {
     }
     this.subscribers.clear();
     this.connectedAgents.clear();
+    for (const timer of this.agentInitializing.values()) clearTimeout(timer);
+    this.agentInitializing.clear();
+    this.deliveryQueue.clear();
   }
 
   /* ─────────────────────────────── prompts ─────────────────────────────── */
@@ -300,11 +322,60 @@ export class BusCoreImpl implements BusCore {
         }
       }
       const wrapped = `<channel ${attrs.join(" ")}>${escapeXmlText(req.text)}</channel>`;
-      void this.streamPromptHandler(req.agent_id, wrapped).catch((err) =>
-        this.onError(err, { ctx: "streamPromptHandler", agent_id: req.agent_id }),
-      );
+      this.deliverOrQueuePrompt(req.agent_id, wrapped);
     }
     return { promise_id };
+  }
+
+  /** Deliver a PTY-stdin prompt, or hold it if the agent's session is
+   *  (re)initialising (the not-yet-ready TUI would swallow the keystroke).
+   *  Held prompts flush on `replay_done` (`markAgentReady`) or the backstop. */
+  private deliverOrQueuePrompt(agent_id: string, wrapped: string): void {
+    if (!this.streamPromptHandler) return;
+    if (this.agentInitializing.has(agent_id)) {
+      const q = this.deliveryQueue.get(agent_id) ?? [];
+      q.push(wrapped);
+      this.deliveryQueue.set(agent_id, q);
+      return;
+    }
+    this.streamDeliver(agent_id, wrapped);
+  }
+
+  private streamDeliver(agent_id: string, wrapped: string): void {
+    if (!this.streamPromptHandler) return;
+    void this.streamPromptHandler(agent_id, wrapped).catch((err) =>
+      this.onError(err, { ctx: "streamPromptHandler", agent_id }),
+    );
+  }
+
+  /** `session.init` → start holding PTY-stdin prompts for this agent. The
+   *  backstop force-flushes if `replay_done` never arrives, so a held prompt is
+   *  never stranded; it's re-armed on each `session.init`. */
+  private markAgentInitializing(agent_id: string): void {
+    // Keep the EARLIEST deadline: don't re-arm if already holding. Otherwise a
+    // rapid `session.init` churn (< backstop interval, e.g. an IPC-reconnect
+    // storm) would keep pushing the deadline out and strand held prompts. The
+    // backstop must fire within `deliveryBackstopMs` of the FIRST init.
+    if (this.agentInitializing.has(agent_id)) return;
+    const timer = setTimeout(() => {
+      this.onError(
+        new Error(`replay_done not seen within backstop; flushing held prompts for agent_id=${agent_id}`),
+        { ctx: "deliveryBackstop", agent_id },
+      );
+      this.markAgentReady(agent_id);
+    }, this.deliveryBackstopMs);
+    this.agentInitializing.set(agent_id, timer);
+  }
+
+  /** `replay_done` (or backstop) → session ready: flush held prompts in order. */
+  private markAgentReady(agent_id: string): void {
+    const timer = this.agentInitializing.get(agent_id);
+    if (timer) clearTimeout(timer);
+    this.agentInitializing.delete(agent_id);
+    const q = this.deliveryQueue.get(agent_id);
+    if (!q || q.length === 0) return;
+    this.deliveryQueue.delete(agent_id);
+    for (const wrapped of q) this.streamDeliver(agent_id, wrapped);
   }
 
   async invokeSlashCommand(agent_id: string, cmd: string): Promise<void> {
@@ -405,6 +476,13 @@ export class BusCoreImpl implements BusCore {
   }
 
   ingestSessionEvent(e: BusEvent): void {
+    // Delivery gate: hold PTY-stdin prompts while the agent's session is
+    // (re)initialising so a keystroke isn't swallowed by a not-yet-ready TUI,
+    // and release them once it's live.
+    if (e.agent_id) {
+      if (e.topic === "session.init") this.markAgentInitializing(e.agent_id);
+      else if (e.topic === "bus.events.replay_done") this.markAgentReady(e.agent_id);
+    }
     this.publish(e);
   }
 


### PR DESCRIPTION
## Problem

A prompt sent to a PTY-resident agent can be silently lost: while the agent's session is (re)initialising, the keystroke is written to the PTY but the not-yet-ready TUI swallows it and no turn ever runs. The receipt shows the prompt was written (`stdin_written`) yet no turn starts and no reply comes back. It presents as an intermittent "delivered, no reply", and hits fixed-cadence callers (e.g. a heartbeat) far more than human-spaced, retried ones.

## Root cause

`BusCore.sendPrompt` types the prompt into the PTY via `streamPromptHandler` immediately, with no check that the agent is at a ready prompt. When `sendPrompt` runs during the window between `session.init` and `bus.events.replay_done` (the JSONL tailer's session-(re)init lifecycle), the TUI isn't accepting input yet and the keystroke is dropped.

## Fix

Gate PTY-stdin delivery at the single choke point (`sendPrompt` → `streamPromptHandler`):

- Track per-agent init state from `ingestSessionEvent`: `session.init` → holding, `bus.events.replay_done` → ready (flush).
- While holding, queue prompts (FIFO) instead of typing them into a not-ready TUI; flush them in order on `replay_done`.
- A per-agent backstop (default 4s, anchored to the EARLIEST `session.init` so a reconnect storm can't keep pushing the deadline out) flushes held prompts anyway if `replay_done` is missed — so a held prompt is never stranded (worst case = the previous deliver-immediately behaviour).
- Per-agent and additive: the IPC path is untouched, and delivery is immediate whenever the agent isn't initialising. The backstop interval is injectable for tests.

## Test plan

- New unit tests: prompt held during init; FIFO flush on `replay_done`; immediate delivery when ready; backstop flush when `replay_done` never arrives (never strands); per-agent isolation.
- Full `src/bus` suite green — no regressions. Smoke build + Biome lint clean; plugin/marketplace versions bumped.
- Deployed to a live daemon-spawned agent: boots clean, normal turns unaffected.
