### PR TITLE
fix(bus): reliable PTY submit — confirm turn started + hold through auto-compaction

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.143",
+      "version": "2.2.144",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.144",
+      "version": "2.2.145",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.143",
+  "version": "2.2.144",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.144",
+  "version": "2.2.145",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -123,6 +123,52 @@ describe("PtyAgentProcess.send_prompt_stream delivery-confirm (#wedge)", () => {
     clearInterval(iv);
     expect(writes.filter((w) => w === "\r").length).toBe(1); // only the submit
   });
+
+  it("waits out an auto-compaction and re-submits when the REPL returns (socket=yes wedge)", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 30,
+      maxSubmitNudges: 2,
+      maxCompactionWaitMs: 5000,
+    });
+    const p = proc.send_prompt_stream("hello");
+    // An auto-compaction seizes the REPL for ~150ms and swallows the submit CR
+    // (no turn). The footer then returns to its idle "to cycle" hint.
+    let compacting = true;
+    const iv = setInterval(
+      () =>
+        emit(
+          compacting
+            ? "\nCompacting conversation… (esc to interrupt)"
+            : "\n⏵ accept edits on (shift+tab to cycle)",
+        ),
+      8,
+    );
+    const stop = setTimeout(() => {
+      compacting = false;
+    }, 150);
+    await p;
+    clearInterval(iv);
+    clearTimeout(stop);
+    // The submit was re-sent AFTER compaction finished: initial CR + >=1 nudge.
+    // (Compaction-wait iterations must not have burned the nudge budget.)
+    expect(writes.filter((w) => w === "\r").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("gives up on a stuck compaction at maxCompactionWaitMs without hanging or spurious submits", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 20,
+      maxSubmitNudges: 2,
+      maxCompactionWaitMs: 80,
+    });
+    const p = proc.send_prompt_stream("hello");
+    const iv = setInterval(() => emit("\nCompacting conversation…"), 8); // never ends
+    await p; // must resolve (bounded), not hang
+    clearInterval(iv);
+    // Only the initial submit CR -- no idle footer was ever seen, so no nudge.
+    expect(writes.filter((w) => w === "\r").length).toBe(1);
+  });
 });
 
 describe("PtyAgentProcess boot-dialog watcher (structural / ANSI-resilient)", () => {

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -169,6 +169,69 @@ describe("PtyAgentProcess.send_prompt_stream delivery-confirm (#wedge)", () => {
     // Only the initial submit CR -- no idle footer was ever seen, so no nudge.
     expect(writes.filter((w) => w === "\r").length).toBe(1);
   });
+
+  it("does NOT mistake the bare word 'Compacting' in streamed output for a compaction (no stall)", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, {
+      submitConfirmMs: 30,
+      maxSubmitNudges: 2,
+      maxCompactionWaitMs: 5000,
+    });
+    const p = proc.send_prompt_stream("hello");
+    // A real turn is streaming and its text contains the bare word "Compacting"
+    // (e.g. the agent discussing log/db compaction). No status line, no footer.
+    // The anchored probe must read this as turn-started, not wait out a phantom
+    // compaction (which would also block the serialised writeChain).
+    const iv = setInterval(() => emit("the daemon was Compacting the old logs when it ran"), 8);
+    const t0 = Date.now();
+    await p;
+    clearInterval(iv);
+    expect(writes.filter((w) => w === "\r").length).toBe(1); // only the submit
+    expect(Date.now() - t0).toBeLessThan(2500); // resolved fast, not the 5s deadline
+  });
+
+  it("clears the stranded input line and warns once when a submit is never confirmed", async () => {
+    const { handle, writes, emit } = bootPty();
+    const realWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...a: unknown[]) => {
+      warnings.push(a.map(String).join(" "));
+    };
+    try {
+      const proc = new PtyAgentProcess("z", handle, { submitConfirmMs: 20, maxSubmitNudges: 2 });
+      const p = proc.send_prompt_stream("hello");
+      const iv = setInterval(() => emit("\n⏵ accept edits on (shift+tab to cycle)"), 6); // idle forever
+      await p;
+      clearInterval(iv);
+      expect(writes).toContain("\x15"); // Ctrl-U cleared the un-submitted prompt
+      expect(warnings.some((w) => w.includes("not confirmed"))).toBe(true);
+    } finally {
+      console.warn = realWarn;
+    }
+  });
+
+  it("rejects (not resolves) if the agent exits during the confirm wait", async () => {
+    const writes: string[] = [];
+    let exitCb: ((e: { exitCode: number }) => void) | null = null;
+    const handle: PtyHandle = {
+      pid: 99,
+      onData: () => ({ dispose() {} }),
+      onExit: (cb) => {
+        exitCb = cb as typeof exitCb;
+        return { dispose() {} };
+      },
+      write: (d: string) => {
+        writes.push(d);
+      },
+      kill: () => {},
+    };
+    const proc = new PtyAgentProcess("z", handle, { submitConfirmMs: 50, maxSubmitNudges: 2 });
+    const p = proc.send_prompt_stream("hello");
+    setTimeout(() => exitCb?.({ exitCode: 1 }), 230); // die after the CR, mid-confirm
+    // The other _exited checks in send_prompt_stream throw; the in-loop check
+    // must too, so the caller/receipt layer learns delivery failed.
+    await expect(p).rejects.toThrow("has exited");
+  });
 });
 
 describe("PtyAgentProcess boot-dialog watcher (structural / ANSI-resilient)", () => {

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -26,7 +26,7 @@ function fakePty(): { handle: PtyHandle; writes: string[] } {
 describe("PtyAgentProcess.send_prompt_stream", () => {
   it("serialises concurrent prompts so their bytes don't interleave", async () => {
     const { handle, writes } = fakePty();
-    const proc = new PtyAgentProcess("alpha", handle);
+    const proc = new PtyAgentProcess("alpha", handle, { submitConfirmMs: 5 });
 
     // Fire two prompts without awaiting the first — without serialisation the
     // second `write(line)` would land inside the first's 200ms settle window,
@@ -54,7 +54,7 @@ describe("PtyAgentProcess.send_prompt_stream", () => {
       },
       kill: () => {},
     };
-    const proc = new PtyAgentProcess("alpha", handle);
+    const proc = new PtyAgentProcess("alpha", handle, { submitConfirmMs: 5 });
 
     // An early prompt is dispatched BEFORE the boot dialog renders (slow
     // fresh-install boot). The old code disengaged the watcher here, leaving
@@ -98,6 +98,32 @@ function bootPty(): { handle: PtyHandle; writes: string[]; emit: (d: string) => 
   };
   return { handle, writes, emit: (d) => dataCb?.(d) };
 }
+
+describe("PtyAgentProcess.send_prompt_stream delivery-confirm (#wedge)", () => {
+  it("re-sends the submit keystroke when the idle REPL footer is still rendering (turn never started)", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, { submitConfirmMs: 60, maxSubmitNudges: 2 });
+    const p = proc.send_prompt_stream("hello");
+    // Simulate a prompt that was typed but NOT submitted: the idle prompt keeps
+    // re-rendering its footer ("to cycle") instead of a streaming turn.
+    const iv = setInterval(() => emit("\n⏵ accept edits on (shift+tab to cycle)"), 8);
+    await p;
+    clearInterval(iv);
+    // 1 initial submit + 2 re-nudges (footer present at every confirm window).
+    expect(writes.filter((w) => w === "\r").length).toBe(3);
+  });
+
+  it("does NOT re-nudge when a turn started (streaming output, footer gone)", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, { submitConfirmMs: 60, maxSubmitNudges: 2 });
+    const p = proc.send_prompt_stream("hello");
+    // Simulate a real turn: streaming output with NO idle footer.
+    const iv = setInterval(() => emit("assistant is streaming a response chunk here"), 8);
+    await p;
+    clearInterval(iv);
+    expect(writes.filter((w) => w === "\r").length).toBe(1); // only the submit
+  });
+});
 
 describe("PtyAgentProcess boot-dialog watcher (structural / ANSI-resilient)", () => {
   it("answers a confirm dialog whose title is split by a cursor-move escape (the 2.1.x regression)", () => {

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -116,6 +116,9 @@ export class PtyAgentProcess implements AgentProcess {
    *  Enter per distinct dialog instead of on every render chunk. */
   private lastConfirmSig: string | null = null;
   private warnedUnhandledDialog = false;
+  /** One-shot guard so an unconfirmed delivery is surfaced once per process
+   *  (see the delivery-confirm loop) instead of spamming the log. */
+  private warnedUnconfirmedDelivery = false;
   /** Hard cap on the boot-dialog watch window (issue #193 / Codex P2). If no
    *  REPL-ready marker is observed within this window (e.g. a future CLI
    *  changes the footer text), the watcher disengages anyway so it never
@@ -241,18 +244,56 @@ export class PtyAgentProcess implements AgentProcess {
       // it finishes the footer returns to "to cycle" and the idle-footer branch
       // re-submits the still-typed prompt. Bounded by maxCompactionWaitMs so a
       // stuck compaction degrades to the watchdog instead of looping forever.
+      // Outcomes: "turn-started" (delivered) | "stuck-compaction" |
+      // "unconfirmed-idle" (gave up). A give-up degrades to the watchdog, but
+      // NEVER silently -- the stranded input line is cleared and a diagnostic is
+      // surfaced, since a silently-dropped prompt is the failure this loop fixes.
       const compactionDeadline = Date.now() + this.maxCompactionWaitMs;
+      let outcome: "turn-started" | "stuck-compaction" | "unconfirmed-idle" = "unconfirmed-idle";
       for (let nudge = 0; nudge < this.maxSubmitNudges; ) {
         this.recentOut = "";
         await new Promise((r) => setTimeout(r, this.submitConfirmMs));
-        if (this._exited) return;
-        if (this.recentOut.includes("Compacting")) {
-          if (Date.now() > compactionDeadline) break;
+        // Exit mid-confirm must REJECT, in parity with the two pre-CR checks
+        // above: the CR is not proof of delivery (the whole point of this loop),
+        // so resolving here would report a phantom success for a prompt whose
+        // target just died -- suppressing re-queue and masking the wedge.
+        if (this._exited) throw new Error(`agent ${this.agent_id} has exited`);
+        // Anchor the compaction probe to the CLI status line ("Compacting
+        // conversation" / "Compacting at auto window") rather than the bare word
+        // "Compacting", which also occurs in ordinary model output: a live turn
+        // streaming that word would otherwise be mistaken for a compaction and
+        // stall this loop -- and the serialised writeChain behind it -- up to the
+        // deadline.
+        if (
+          this.recentOut.includes("Compacting conversation") ||
+          this.recentOut.includes("Compacting at auto")
+        ) {
+          if (Date.now() > compactionDeadline) {
+            outcome = "stuck-compaction";
+            break;
+          }
           continue; // compaction in progress -> wait, do not spend a nudge
         }
-        if (!this.recentOut.includes("to cycle")) break; // turn started
+        if (!this.recentOut.includes("to cycle")) {
+          outcome = "turn-started";
+          break;
+        }
         this.pty.write("\r"); // footer still idle -> CR did not submit -> nudge
         nudge++;
+      }
+      if (outcome === "unconfirmed-idle") {
+        // The prompt is still sitting un-submitted in the REPL input box; left
+        // there it would concatenate onto the next prompt. The REPL is idle here
+        // (footer present every window), so clearing the line is safe.
+        this.pty.write("\x15"); // Ctrl-U: kill the input line
+      }
+      if (outcome !== "turn-started" && !this.warnedUnconfirmedDelivery) {
+        this.warnedUnconfirmedDelivery = true;
+        console.warn(
+          `[delivery-confirm] agent=${this.agent_id}: submit not confirmed ` +
+            `(${outcome}); degraded to the watchdog. Recurring occurrences may mean ` +
+            `the REPL footer marker changed in the CLI.`,
+        );
       }
     });
     // Keep the chain alive past a rejected write so later prompts still run.

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -99,6 +99,7 @@ export class PtyAgentProcess implements AgentProcess {
   private recentOut = "";
   private readonly submitConfirmMs: number;
   private readonly maxSubmitNudges: number;
+  private readonly maxCompactionWaitMs: number;
   /** Boot-dialog watcher state (issue #193). Claude shows interactive
    *  confirmation dialogs at startup (the dev-channels prompt, and the newer
    *  "Bypass Permissions mode" prompt). We answer them by inspecting early PTY
@@ -130,6 +131,9 @@ export class PtyAgentProcess implements AgentProcess {
       submitConfirmMs?: number;
       /** Max times to re-send the submit keystroke when no turn is observed. */
       maxSubmitNudges?: number;
+      /** Upper bound to wait out an in-progress auto-compaction before the
+       *  submit is abandoned to the watchdog (compaction can run ~100s). */
+      maxCompactionWaitMs?: number;
     } = {},
   ) {
     this.agent_id = agent_id;
@@ -137,6 +141,7 @@ export class PtyAgentProcess implements AgentProcess {
     this.pid = pty.pid;
     this.submitConfirmMs = opts.submitConfirmMs ?? 1500;
     this.maxSubmitNudges = opts.maxSubmitNudges ?? 2;
+    this.maxCompactionWaitMs = opts.maxCompactionWaitMs ?? 240_000;
     this.bootDialogTimer = setTimeout(
       () => this.endBootDialogPhase(),
       PtyAgentProcess.BOOT_DIALOG_MAX_MS,
@@ -218,17 +223,36 @@ export class PtyAgentProcess implements AgentProcess {
       // start a turn when the CR lands during a transient REPL render (paste /
       // redraw race) -- the prompt sits un-submitted, no turn, no API socket,
       // and the receipt only times out 5 min later. Confirm a turn started: the
-      // idle REPL footer ("to cycle", the version-stable mode-cycler hint) is
+      // idle REPL footer ("to cycle", the version-stable core of the mode-cycler
+      // hint -- "shift+tab to cycle" in older CLIs, "to cycle permission modes"
+      // in 2.1.168+, so the bare "to cycle" is what survives the rename) is
       // replaced by the streaming view the instant a turn begins; if it is still
       // being rendered after a grace window, re-send the submit keystroke (the
       // text is already in the input box). Bounded; a stray CR at an idle REPL
       // is a no-op, and a genuinely stuck REPL still degrades to the watchdog.
-      for (let nudge = 0; nudge < this.maxSubmitNudges; nudge++) {
+      // NB: handleBootDialog uses the stricter "tab to cycle" to avoid
+      // disengaging on boot prose (#195); here the REPL is already up, so boot
+      // prose is not a concern and the bare core is the safer live-footer match.
+      // A second wedge class (socket=yes): an auto-compaction can seize the
+      // REPL the instant the prompt arrives and swallow the submit CR -- the
+      // turn never starts and the receipt only times out 5 min later. While
+      // "Compacting" is on screen, wait it out; this does NOT spend a submit
+      // nudge (compaction runs ~100s, far longer than the nudge cadence). When
+      // it finishes the footer returns to "to cycle" and the idle-footer branch
+      // re-submits the still-typed prompt. Bounded by maxCompactionWaitMs so a
+      // stuck compaction degrades to the watchdog instead of looping forever.
+      const compactionDeadline = Date.now() + this.maxCompactionWaitMs;
+      for (let nudge = 0; nudge < this.maxSubmitNudges; ) {
         this.recentOut = "";
         await new Promise((r) => setTimeout(r, this.submitConfirmMs));
         if (this._exited) return;
+        if (this.recentOut.includes("Compacting")) {
+          if (Date.now() > compactionDeadline) break;
+          continue; // compaction in progress -> wait, do not spend a nudge
+        }
         if (!this.recentOut.includes("to cycle")) break; // turn started
         this.pty.write("\r"); // footer still idle -> CR did not submit -> nudge
+        nudge++;
       }
     });
     // Keep the chain alive past a rejected write so later prompts still run.

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -94,6 +94,11 @@ export class PtyAgentProcess implements AgentProcess {
   /** Serializes the write/settle/CR sequence so concurrent prompts can't
    *  interleave in the PTY input buffer (review #141 P1). */
   private writeChain: Promise<void> = Promise.resolve();
+  /** ANSI-stripped tail of PTY output, reset after each submit so the
+   *  delivery-confirm check only inspects post-submit frames (#wedge). */
+  private recentOut = "";
+  private readonly submitConfirmMs: number;
+  private readonly maxSubmitNudges: number;
   /** Boot-dialog watcher state (issue #193). Claude shows interactive
    *  confirmation dialogs at startup (the dev-channels prompt, and the newer
    *  "Bypass Permissions mode" prompt). We answer them by inspecting early PTY
@@ -117,16 +122,31 @@ export class PtyAgentProcess implements AgentProcess {
   private static readonly BOOT_DIALOG_MAX_MS = 15_000;
   private bootDialogTimer: ReturnType<typeof setTimeout> | undefined;
 
-  constructor(agent_id: string, pty: PtyHandle) {
+  constructor(
+    agent_id: string,
+    pty: PtyHandle,
+    opts: {
+      /** Grace window to confirm a submit started a turn before re-nudging. */
+      submitConfirmMs?: number;
+      /** Max times to re-send the submit keystroke when no turn is observed. */
+      maxSubmitNudges?: number;
+    } = {},
+  ) {
     this.agent_id = agent_id;
     this.pty = pty;
     this.pid = pty.pid;
+    this.submitConfirmMs = opts.submitConfirmMs ?? 1500;
+    this.maxSubmitNudges = opts.maxSubmitNudges ?? 2;
     this.bootDialogTimer = setTimeout(
       () => this.endBootDialogPhase(),
       PtyAgentProcess.BOOT_DIALOG_MAX_MS,
     );
     pty.onData((chunk) => {
       if (this.bootDialogActive) this.handleBootDialog(chunk);
+      // Keep a small ANSI-stripped tail so send_prompt_stream can tell whether a
+      // submit actually started a turn (the idle REPL footer disappears on turn
+      // start) -- see the delivery-confirm loop. Observation only.
+      this.recentOut = (this.recentOut + stripAnsiEscapes(chunk)).slice(-2000);
       // Crash-signal observation ONLY (spec §5.3). Never parsed as model output.
       for (const h of this.dataHandlers) {
         try {
@@ -192,7 +212,24 @@ export class PtyAgentProcess implements AgentProcess {
       if (this._exited) throw new Error(`agent ${this.agent_id} has exited`);
       this.pty.write(text);
       await new Promise((r) => setTimeout(r, 200));
+      if (this._exited) throw new Error(`agent ${this.agent_id} has exited`);
       this.pty.write("\r");
+      // #wedge fix (prompt-delivery-confirm): the typed text + CR can fail to
+      // start a turn when the CR lands during a transient REPL render (paste /
+      // redraw race) -- the prompt sits un-submitted, no turn, no API socket,
+      // and the receipt only times out 5 min later. Confirm a turn started: the
+      // idle REPL footer ("to cycle", the version-stable mode-cycler hint) is
+      // replaced by the streaming view the instant a turn begins; if it is still
+      // being rendered after a grace window, re-send the submit keystroke (the
+      // text is already in the input box). Bounded; a stray CR at an idle REPL
+      // is a no-op, and a genuinely stuck REPL still degrades to the watchdog.
+      for (let nudge = 0; nudge < this.maxSubmitNudges; nudge++) {
+        this.recentOut = "";
+        await new Promise((r) => setTimeout(r, this.submitConfirmMs));
+        if (this._exited) return;
+        if (!this.recentOut.includes("to cycle")) break; // turn started
+        this.pty.write("\r"); // footer still idle -> CR did not submit -> nudge
+      }
     });
     // Keep the chain alive past a rejected write so later prompts still run.
     this.writeChain = run.catch(() => {});


### PR DESCRIPTION
## Problem

A headless, daemon-spawned PTY agent delivers inbound prompts by typing them into claude's REPL and sending a submitting CR. Two related failure modes let a prompt be **accepted but never turned into a turn** — the agent goes silent and the only signal is a receipt that times out ~5 minutes later:

1. **Delivery race.** When the CR lands during a transient REPL render (bracketed-paste / redraw), the typed text sits in the input box **un-submitted**. No turn starts, no API socket opens. A reproducible wedge dossier showed `stdin_written` but **zero `ESTABLISHED :443`**.

2. **Auto-compaction collision.** When an auto-compaction seizes the REPL the instant a prompt arrives, it **swallows the submit CR**. A captured incident: `/compact` at T, "Compacted" ~100s later, **zero `end_turn`**, the API connection idle (keepalive only) the whole time. The receipt surfaces it as `no_final_reply` only at the 5-minute timeout.

Both are intermittent (~1/day) and, before this change, indistinguishable from a hung model — they were only ever recovered by a watchdog restart.

## Fix

A single, additive **delivery-confirm loop** after the submit CR, entirely at the PTY layer where the signal is real-time. It uses only version-stable TUI invariants:

- **Confirm a turn started.** The idle REPL footer (`"to cycle"`) is replaced by the streaming view the instant a turn begins. If the footer is still idle after a grace window, the submit CR did not land → re-send it (the text is already in the box). Bounded (2 nudges); a stray CR at an idle REPL is a no-op; a genuinely stuck REPL still degrades to the watchdog.

- **Hold through a compaction.** While `"Compacting"` is on screen the submit CR was swallowed, so wait it out — **without spending a nudge** (compaction runs ~100s, far longer than the nudge cadence). When it finishes the footer returns to `"to cycle"` and the idle-footer branch re-submits the still-typed prompt. Bounded by `maxCompactionWaitMs` (default 240s) so a stuck compaction degrades to the watchdog instead of looping.

Re-submit is **CR-only — it never re-types**, so there is no doubling risk if the input box survived compaction. All timings are injectable for tests.

## Why this shape

- **No new event plumbing.** The runner's `auto-compact-*` events only fire on the `claude -p` path, not the PTY/bus path; the `compact_boundary` → `session.compact` tailer event only fires *after* compaction. The live `"Compacting"` frame in the PTY tail is the only real-time start signal, and it's already captured for the boot-dialog watcher.
- **Version-resilience.** The marker is the bare `"to cycle"` core, which survives the CLI rename from `"shift+tab to cycle"` (older) to `"to cycle permission modes"` (2.1.168+). `handleBootDialog` deliberately uses the stricter `"tab to cycle"` to avoid disengaging on boot prose (#195); here the REPL is already up, so boot prose is not a concern and the bare core is the safer live-footer match. (Heads-up: the boot-dialog `"tab to cycle"` marker does not appear in the 2.1.173 footer string, so it may warrant a follow-up — happy to converge both call-sites on a shared constant.)

## Why it matters (delivery integrity)

An operator instruction that is accepted, acknowledged at the transport layer, and then silently lost is the worst failure mode for an agent that runs unattended: no error, no reply, and the loss only visible 5 minutes later as a timeout. This closes the two paths by which a prompt could be dropped between "typed into the PTY" and "a turn actually ran", and every unrecoverable case still degrades **observably** to the watchdog rather than hanging — no silent truncation of the failure.

## Testing

- New tests: re-nudge when the idle footer persists; do **not** re-nudge once a turn streams; wait out a compaction then re-submit; bounded give-up on a stuck compaction (no hang, no spurious submit).
- Bus suite green (`bun test src/bus/`), Biome clean (pinned 2.4.15), `tsc --noEmit` delta 0 vs base.
- Plugin + marketplace manifests bumped to 2.2.144 (version guards).

Markers confirmed against the live CLI bundle (`"Compacting"`, `"to cycle"` present in 2.1.173).
