### PR TITLE
fix(bus): require real output to confirm turn-start (idle-REPL wedge) — follow-up to #248

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.145",
+      "version": "2.2.146",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.146",
+      "version": "2.2.147",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.145",
+  "version": "2.2.146",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.146",
+  "version": "2.2.147",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -9,20 +9,6 @@
 import { describe, expect, it } from "bun:test";
 import { PtyAgentProcess, type PtyHandle } from "../session-agent-process";
 
-function fakePty(): { handle: PtyHandle; writes: string[] } {
-  const writes: string[] = [];
-  const handle: PtyHandle = {
-    pid: 1234,
-    onData: () => ({ dispose() {} }),
-    onExit: () => ({ dispose() {} }),
-    write: (data: string) => {
-      writes.push(data);
-    },
-    kill: () => {},
-  };
-  return { handle, writes };
-}
-
 describe("PtyAgentProcess.send_prompt_stream", () => {
   it("serialises concurrent prompts so their bytes don't interleave", async () => {
     const { handle, writes, emit } = bootPty();
@@ -175,6 +161,10 @@ describe("PtyAgentProcess.send_prompt_stream delivery-confirm (#wedge)", () => {
     clearInterval(iv);
     // Only the initial submit CR -- no idle footer was ever seen, so no nudge.
     expect(writes.filter((w) => w === "\r").length).toBe(1);
+    // The turn never started, so the typed line is still stranded in the input
+    // box; a stuck compaction must clear it too (else it concatenates onto the
+    // next prompt) -- not only the unconfirmed-idle outcome.
+    expect(writes).toContain("\x15"); // Ctrl-U cleared the stranded line
   });
 
   it("does NOT mistake the bare word 'Compacting' in streamed output for a compaction (no stall)", async () => {
@@ -211,6 +201,34 @@ describe("PtyAgentProcess.send_prompt_stream delivery-confirm (#wedge)", () => {
       await p;
       clearInterval(iv);
       expect(writes).toContain("\x15"); // Ctrl-U cleared the un-submitted prompt
+      expect(warnings.some((w) => w.includes("not confirmed"))).toBe(true);
+    } finally {
+      console.warn = realWarn;
+    }
+  });
+
+  it("treats a WHITESPACE-only confirm window as inconclusive (not a started turn) — the .trim() guard", async () => {
+    // A confirm window that contains only whitespace/newlines must NOT be read
+    // as a started turn: `recentOut.trim().length > 0` is false on "   \n", so
+    // the window stays inconclusive, spends a nudge, and (budget gone) gives up
+    // honestly with a line-clear + warn — same as a truly-empty window. Guards
+    // the `.trim()` half of the gate that a non-whitespace test would miss.
+    const { handle, writes, emit } = bootPty();
+    const realWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...a: unknown[]) => {
+      warnings.push(a.map(String).join(" "));
+    };
+    try {
+      const proc = new PtyAgentProcess("z", handle, { submitConfirmMs: 20, maxSubmitNudges: 2 });
+      const p = proc.send_prompt_stream("hello");
+      // Only whitespace flows during the confirm windows — never a footer,
+      // never streaming text.
+      const iv = setInterval(() => emit("   \n  \n"), 6);
+      await p;
+      clearInterval(iv);
+      expect(writes.filter((w) => w === "\r").length).toBe(3); // submit + 2 nudges
+      expect(writes).toContain("\x15"); // Ctrl-U cleared the un-submitted line
       expect(warnings.some((w) => w.includes("not confirmed"))).toBe(true);
     } finally {
       console.warn = realWarn;

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -25,8 +25,14 @@ function fakePty(): { handle: PtyHandle; writes: string[] } {
 
 describe("PtyAgentProcess.send_prompt_stream", () => {
   it("serialises concurrent prompts so their bytes don't interleave", async () => {
-    const { handle, writes } = fakePty();
+    const { handle, writes, emit } = bootPty();
     const proc = new PtyAgentProcess("alpha", handle, { submitConfirmMs: 5 });
+
+    // A real REPL redraws after each CR: streaming output replaces the footer,
+    // so each turn confirms started after the first window -> exactly one CR per
+    // prompt. (A silent fake never confirms and now nudges to budget — covered
+    // by the idle-REPL test below — which would mask the interleave check here.)
+    const iv = setInterval(() => emit("assistant is streaming a response chunk"), 2);
 
     // Fire two prompts without awaiting the first — without serialisation the
     // second `write(line)` would land inside the first's 200ms settle window,
@@ -34,6 +40,7 @@ describe("PtyAgentProcess.send_prompt_stream", () => {
     const a = proc.send_prompt_stream("first");
     const b = proc.send_prompt_stream("second");
     await Promise.all([a, b]);
+    clearInterval(iv);
 
     // Each prompt's text is immediately followed by its own CR.
     expect(writes).toEqual(["first", "\r", "second", "\r"]);
@@ -204,6 +211,32 @@ describe("PtyAgentProcess.send_prompt_stream delivery-confirm (#wedge)", () => {
       await p;
       clearInterval(iv);
       expect(writes).toContain("\x15"); // Ctrl-U cleared the un-submitted prompt
+      expect(warnings.some((w) => w.includes("not confirmed"))).toBe(true);
+    } finally {
+      console.warn = realWarn;
+    }
+  });
+
+  it("does NOT mistake a silent idle REPL (zero output) for a started turn — keeps nudging then gives up honestly (idle-REPL wedge, dossier 20260612T080557)", async () => {
+    const { handle, writes } = bootPty();
+    const realWarn = console.warn;
+    const warnings: string[] = [];
+    console.warn = (...a: unknown[]) => {
+      warnings.push(a.map(String).join(" "));
+    };
+    try {
+      const proc = new PtyAgentProcess("z", handle, { submitConfirmMs: 20, maxSubmitNudges: 2 });
+      // A long-idle REPL whose swallowed CR triggers no redraw emits NOTHING
+      // during the confirm windows (never call emit). The empty buffer must not
+      // be read as a started turn: `!includes("to cycle")` is true on "" too.
+      // The loop must spend its full nudge budget and then give up honestly,
+      // not claim a phantom turn-started and let the prompt rot to the 5-min
+      // receipt timeout (the residual wedge this guards).
+      await proc.send_prompt_stream("hello");
+      // initial submit CR + 2 nudges = 3 (an empty window is inconclusive, not
+      // a turn-start, so every window spends a nudge until the budget is gone).
+      expect(writes.filter((w) => w === "\r").length).toBe(3);
+      expect(writes).toContain("\x15"); // Ctrl-U cleared the un-submitted line
       expect(warnings.some((w) => w.includes("not confirmed"))).toBe(true);
     } finally {
       console.warn = realWarn;

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -286,16 +286,23 @@ export class PtyAgentProcess implements AgentProcess {
         // spends a nudge instead of claiming a phantom success.
         if (this.recentOut.trim().length > 0 && !this.recentOut.includes("to cycle")) {
           outcome = "turn-started";
+          // A turn confirmed → re-arm the one-shot wedge warning, so a LATER
+          // genuine wedge on this long-lived process still surfaces a diagnostic
+          // instead of being silenced for the rest of the process lifetime.
+          this.warnedUnconfirmedDelivery = false;
           break;
         }
         this.pty.write("\r"); // footer still idle (or silent) -> CR did not submit -> nudge
         nudge++;
       }
-      if (outcome === "unconfirmed-idle") {
+      if (outcome !== "turn-started") {
         // The prompt is still sitting un-submitted in the REPL input box; left
-        // there it would concatenate onto the next prompt. The REPL never began
-        // streaming (footer present, or silent the whole time), so clearing the
-        // line is safe.
+        // there it would concatenate onto the next prompt. This holds for BOTH
+        // give-up outcomes: "unconfirmed-idle" (footer present or silent the
+        // whole time) AND "stuck-compaction" (a compaction never finished within
+        // maxCompactionWaitMs, so the typed line never submitted). A Ctrl-U at a
+        // REPL whose turn never started is a no-op on an empty/legit line, so
+        // clearing on any non-turn-started outcome is safe and symmetric.
         this.pty.write("\x15"); // Ctrl-U: kill the input line
       }
       if (outcome !== "turn-started" && !this.warnedUnconfirmedDelivery) {

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -274,17 +274,28 @@ export class PtyAgentProcess implements AgentProcess {
           }
           continue; // compaction in progress -> wait, do not spend a nudge
         }
-        if (!this.recentOut.includes("to cycle")) {
+        // A turn-start is POSITIVE evidence -- the streaming view replaced the
+        // footer. An EMPTY confirm window is NOT that: a long-idle, quiet REPL
+        // emits nothing, so `!includes("to cycle")` on an empty buffer falsely
+        // reads as turn-started, stops the nudging, and leaves the prompt
+        // un-submitted until the 5-min receipt timeout. This is the residual
+        // idle-REPL wedge (dossier 20260612T080557: idle 7h, stdin written,
+        // turn_started_at absent, socket=no -- with the full delivery+compaction
+        // fix stack already active). Require real output before trusting the
+        // footer's absence; an empty/whitespace window stays inconclusive and
+        // spends a nudge instead of claiming a phantom success.
+        if (this.recentOut.trim().length > 0 && !this.recentOut.includes("to cycle")) {
           outcome = "turn-started";
           break;
         }
-        this.pty.write("\r"); // footer still idle -> CR did not submit -> nudge
+        this.pty.write("\r"); // footer still idle (or silent) -> CR did not submit -> nudge
         nudge++;
       }
       if (outcome === "unconfirmed-idle") {
         // The prompt is still sitting un-submitted in the REPL input box; left
-        // there it would concatenate onto the next prompt. The REPL is idle here
-        // (footer present every window), so clearing the line is safe.
+        // there it would concatenate onto the next prompt. The REPL never began
+        // streaming (footer present, or silent the whole time), so clearing the
+        // line is safe.
         this.pty.write("\x15"); // Ctrl-U: kill the input line
       }
       if (outcome !== "turn-started" && !this.warnedUnconfirmedDelivery) {


### PR DESCRIPTION
## Follow-up to #248 — closes the last residual `socket=no` wedge

#248 made PTY submit reliable for the two wedge classes we had reproduced (CR lost to a paste/redraw race, and a turn eaten by auto-compaction). A third, rarer variant slipped through and reproduced **after** #248 was deployed (forensic dossier `20260612T080557`: agent idle ~7h, stdin written, `turn_started_at` absent, `socket=no`, recovered only by the watchdog at the 5-min receipt timeout).

### Root cause
The delivery-confirm loop treated **absence** of the idle footer (`"to cycle"`) as proof a turn had started. On a long-idle, quiet REPL the confirm window can be **completely empty** (no redraw at all), and `!"".includes("to cycle")` is `true` — so an empty buffer was read as *turn-started*, the loop stopped nudging, and the prompt sat un-submitted until the receipt timed out.

This is a silent failure mode: the message is accepted, no error is raised, and the prompt is simply never processed — the worst shape for any audited/operator-facing pipeline.

### Fix
Turn-start now requires **positive evidence** — real output **and** no footer. An empty/whitespace window is treated as inconclusive: it spends a nudge (better recovery odds if a CR was transiently swallowed) and then gives up **honestly** (`Ctrl-U` to clear the stranded input + a one-shot `warn`) rather than reporting a phantom success on a dead/idle process.

### Validation
- `src/bus/__tests__/session-agent-process.test.ts`: **17/17 pass**, including a new regression that drives a silent idle REPL (zero output) and asserts the loop keeps nudging then gives up honestly instead of false-confirming.
- The pre-existing `serialise` test relied on the same false-positive (its fake PTY never emits) — corrected to emit realistic streaming.
- `biome check` clean on the changed file; no new `tsc` errors.

### Scope
One self-contained commit on `src/bus/session-agent-process.ts` (+49/−5) plus the version bump. No behaviour change on the happy path — only the empty/idle window, which previously false-confirmed, now resolves correctly.
