### PR TITLE
fix(bus): attribute flush-verify per-prompt + compaction-aware re-delivery

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.147",
+      "version": "2.2.148",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.145",
+      "version": "2.2.146",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.148",
+      "version": "2.2.149",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.149",
+      "version": "2.2.150",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.146",
+      "version": "2.2.147",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.147",
+  "version": "2.2.148",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.145",
+  "version": "2.2.146",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.148",
+  "version": "2.2.149",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.146",
+  "version": "2.2.147",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.149",
+  "version": "2.2.150",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -939,6 +939,40 @@ describe("BusCore IPC", () => {
     client.close();
   });
 
+  it("re-delivers an immediately-delivered prompt when the IPC send failed (MCP-blip wedge, #252)", async () => {
+    // dossier 20260614T034258: the MCP/IPC socket blipped right at the prompt
+    // boundary (`send-failed: no-mcp-connection`), the prompt fell through to an
+    // IMMEDIATE PTY delivery (session not initialising, so no backstop), the
+    // keystroke coincided with the reconnect and never started a turn — and the
+    // #222 reconciler disarmed on "reconnected during confirm window" without
+    // verifying a turn. Verify turn-start on this path too and re-deliver once.
+    const sockPath = join(tempDir, "bus.sock");
+    const delivered: string[] = [];
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      socketPath: sockPath,
+      flushVerifyMs: 30,
+      streamPromptHandler: async (_a, text) => {
+        delivered.push(text);
+      },
+      onError: () => {},
+    });
+    await bus.start();
+    // No agent ever connected → ipcServer.send returns false (ipcSendFailed),
+    // and the agent is NOT initialising → the prompt is delivered immediately.
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "telegram",
+      origin_id: "i",
+      user_id: "u",
+      text: "ping",
+    });
+    expect(delivered).toHaveLength(1); // delivered immediately to PTY
+    await new Promise((r) => setTimeout(r, 45)); // > flushVerify, no turn → re-deliver once
+    expect(delivered).toHaveLength(2);
+    expect(delivered[1]).toContain("ping");
+  });
+
   describe("silent-drop safety net (issue #215)", () => {
     function makeBus(): BusCore {
       return createBusCore({

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -1536,9 +1536,18 @@ describe("BusCore delivery gate (session.init / replay_done)", () => {
     await prompt("alpha", "held");
     await new Promise((r) => setTimeout(r, 45)); // > backstop → first (swallowed) flush
     expect(delivered).toHaveLength(1);
-    // A DIFFERENT prompt's turn-start lands — must not satisfy the swallowed one.
+    // A DIFFERENT prompt's turn-start lands — must not satisfy the swallowed one
+    // (attribution), though it does mark the agent's turn active so the verify
+    // defers until that turn ends.
     bus.ingestSessionEvent(turnEvt("alpha", "<channel>some other prompt</channel>"));
-    await new Promise((r) => setTimeout(r, 45)); // > flushVerify → swallowed prompt re-delivered
+    bus.ingestSessionEvent({
+      ts: 1,
+      agent_id: "alpha",
+      session_id: "s",
+      topic: "response.turn_end",
+      payload: { text: "" },
+    }); // the unrelated turn ends → REPL free → "held"'s verify can now fire
+    await new Promise((r) => setTimeout(r, 60)); // > flushVerify + grace → swallowed prompt re-delivered
     expect(delivered).toHaveLength(2);
     expect(delivered[1]).toContain("held");
   });
@@ -1629,5 +1638,60 @@ describe("BusCore delivery gate (session.init / replay_done)", () => {
     // backstop#2 (~140) flushes it → d=2 and must NOT re-arm a third verify.
     await new Promise((r) => setTimeout(r, 200)); // past backstop#2 + any spurious 3rd verify
     expect(delivered).toHaveLength(2); // exactly one re-delivery, never a second
+  });
+
+  // Turn-end event helper for the back-to-back (neighbor-turn) tests.
+  const turnEndEvt = (agent: string): BusEvent => ({
+    ts: 1,
+    agent_id: agent,
+    session_id: "s",
+    topic: "response.turn_end",
+    payload: { text: "" }, // empty → the #215 synthesizer is a no-op
+  });
+
+  it("re-delivers a prompt queued behind a neighbor turn if it never starts its own (bus-level #250 HIGH)", async () => {
+    // A prompt delivered while a neighbor turn is STREAMING is only a queued
+    // keystroke in the REPL box; the PTY confirm-loop can misread the neighbor's
+    // stream as this prompt's turn-start. The bus arms a verify (reliable
+    // tailer attribution), DEFERS it while the neighbor turn is active (the
+    // prompt legitimately waits behind it — re-delivering sooner double-submits),
+    // and re-delivers only if no turn ever starts for it.
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      flushVerifyMs: 40,
+      onError: () => {},
+    });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    bus.ingestSessionEvent(turnEvt("alpha", "<channel>neighbor</channel>")); // neighbor turn active
+    await prompt("alpha", "queued");
+    expect(delivered).toHaveLength(1); // delivered immediately (queued in the box)
+    await new Promise((r) => setTimeout(r, 100)); // > flushVerify, but neighbor still active
+    expect(delivered).toHaveLength(1); // DEFERRED — not re-delivered behind the live turn
+    bus.ingestSessionEvent(turnEndEvt("alpha")); // neighbor turn ends → REPL free
+    await new Promise((r) => setTimeout(r, 100)); // > flushVerify + grace, no turn for "queued"
+    expect(delivered).toHaveLength(2); // now re-delivered exactly once
+    expect(delivered[1]).toContain("queued");
+  });
+
+  it("does NOT re-deliver a queued prompt that starts its own turn after the neighbor ends (#252)", async () => {
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      flushVerifyMs: 40,
+      onError: () => {},
+    });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    bus.ingestSessionEvent(turnEvt("alpha", "<channel>neighbor</channel>")); // neighbor turn active
+    await prompt("alpha", "queued");
+    expect(delivered).toHaveLength(1);
+    bus.ingestSessionEvent(turnEndEvt("alpha")); // neighbor ends
+    bus.ingestSessionEvent(turnEvt("alpha", delivered[0])); // "queued" starts its OWN turn → cancel
+    await new Promise((r) => setTimeout(r, 100)); // > flushVerify + grace
+    expect(delivered).toHaveLength(1); // attributed → not re-delivered
   });
 });

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -1496,6 +1496,35 @@ describe("BusCore delivery gate (session.init / replay_done)", () => {
     expect(delivered[1]).toContain("held");
   });
 
+  it("attributes a MULTI-LINE prompt's turn-start despite PTY newline sanitization (#252 ultra HIGH)", async () => {
+    // The PTY layer runs sanitizePtyPromptText before typing — newlines collapse
+    // to spaces — and the tailer's `prompt` event carries that sanitized form.
+    // The verify must key on the sanitized text, else a multi-line prompt's
+    // healthy turn never matches and the prompt is spuriously re-delivered
+    // (double-submit). This test fails on the raw-key implementation.
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      deliveryBackstopMs: 20,
+      flushVerifyMs: 30,
+      onError: () => {},
+    });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    bus.ingestSessionEvent(initEvt("alpha"));
+    await prompt("alpha", "line one\nline two"); // multi-line user text
+    await new Promise((r) => setTimeout(r, 45)); // > backstop → flush
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0]).toContain("\n"); // raw wrapped still carries the newline
+    // The tailer records what claude received = the PTY-sanitized line (newlines
+    // collapsed to spaces). Emitting THAT must still cancel the verify.
+    const sanitized = delivered[0].replace(/\r\n?|\n/g, " ");
+    bus.ingestSessionEvent(turnEvt("alpha", sanitized));
+    await new Promise((r) => setTimeout(r, 45)); // > flushVerify
+    expect(delivered).toHaveLength(1); // attributed → NOT re-delivered
+  });
+
   it("does NOT re-deliver while a delivery handler is still in-flight (compaction, #252)", async () => {
     // The regression: flushVerify fired at flushVerifyMs (8s) while the delivery
     // handler legitimately held through auto-compaction (up to 240s), so the

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -1378,12 +1378,18 @@ describe("BusCore delivery gate (session.init / replay_done)", () => {
   // A backstop flush fires on a TIMER because replay_done never arrived. During
   // an IPC-reconnect storm the session is still re-initialising, so the flushed
   // keystroke is swallowed and never starts a turn (dossier 20260613T033017).
-  const turnEvt = (agent: string): BusEvent => ({
+  //
+  // Turn-start proof is ATTRIBUTED (#252): the tailer `prompt` event carries the
+  // ingested user line, which is the exact wrapped string the bus delivered. The
+  // verify is cancelled only when the event's `text` matches a pending prompt —
+  // so `turnEvt` must echo the delivered text, and an unrelated prompt's turn
+  // (different text) must NOT cancel.
+  const turnEvt = (agent: string, ingestedText: string): BusEvent => ({
     ts: 1,
     agent_id: agent,
     session_id: "s",
     topic: "prompt", // tailer: claude wrote the ingested user line = turn started
-    payload: { text: "x" },
+    payload: { text: ingestedText },
   });
 
   it("re-delivers ONCE when a backstop-flushed prompt never starts a turn (idle-REPL wedge)", async () => {
@@ -1424,8 +1430,67 @@ describe("BusCore delivery gate (session.init / replay_done)", () => {
     await prompt("alpha", "held");
     await new Promise((r) => setTimeout(r, 45)); // > backstop → flush
     expect(delivered).toHaveLength(1);
-    bus.ingestSessionEvent(turnEvt("alpha")); // turn started → cancel pending re-delivery
+    // tailer `prompt` echoing the delivered (wrapped) line proves THIS prompt
+    // started its turn → cancel its pending re-delivery.
+    bus.ingestSessionEvent(turnEvt("alpha", delivered[0]));
     await new Promise((r) => setTimeout(r, 45)); // > flushVerify
     expect(delivered).toHaveLength(1); // not re-delivered
+  });
+
+  it("re-delivers when only an UNRELATED prompt starts a turn (attribution, #252)", async () => {
+    // The bug: a later unrelated prompt's turn activity cancelled the swallowed
+    // prompt's pending re-delivery, dropping it silently. Attribution by ingested
+    // text fixes it — a non-matching `prompt` event must NOT cancel.
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      deliveryBackstopMs: 20,
+      flushVerifyMs: 30,
+      onError: () => {},
+    });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    bus.ingestSessionEvent(initEvt("alpha"));
+    await prompt("alpha", "held");
+    await new Promise((r) => setTimeout(r, 45)); // > backstop → first (swallowed) flush
+    expect(delivered).toHaveLength(1);
+    // A DIFFERENT prompt's turn-start lands — must not satisfy the swallowed one.
+    bus.ingestSessionEvent(turnEvt("alpha", "<channel>some other prompt</channel>"));
+    await new Promise((r) => setTimeout(r, 45)); // > flushVerify → swallowed prompt re-delivered
+    expect(delivered).toHaveLength(2);
+    expect(delivered[1]).toContain("held");
+  });
+
+  it("does NOT re-deliver while a delivery handler is still in-flight (compaction, #252)", async () => {
+    // The regression: flushVerify fired at flushVerifyMs (8s) while the delivery
+    // handler legitimately held through auto-compaction (up to 240s), so the
+    // prompt got submitted twice once compaction finished. The in-flight guard
+    // defers re-delivery until the handler settles.
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      deliveryBackstopMs: 20,
+      flushVerifyMs: 30,
+      onError: () => {},
+    });
+    const delivered: string[] = [];
+    let release!: () => void;
+    const handlerDone = new Promise<void>((r) => {
+      release = r;
+    });
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+      await handlerDone; // simulate a handler blocked on compaction
+    });
+    bus.ingestSessionEvent(initEvt("alpha"));
+    await prompt("alpha", "held");
+    await new Promise((r) => setTimeout(r, 45)); // > backstop → flush (handler now in-flight)
+    expect(delivered).toHaveLength(1);
+    await new Promise((r) => setTimeout(r, 80)); // well past flushVerify — must NOT double-submit
+    expect(delivered).toHaveLength(1); // deferred while in-flight
+    release(); // compaction finishes, handler settles, turn never started
+    await new Promise((r) => setTimeout(r, 45)); // next verify tick → re-deliver once
+    expect(delivered).toHaveLength(2);
+    expect(delivered[1]).toContain("held");
   });
 });

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -973,6 +973,53 @@ describe("BusCore IPC", () => {
     expect(delivered[1]).toContain("ping");
   });
 
+  it("clears a pending flush-verify when the agent's socket closes (no stale re-delivery, #252)", async () => {
+    // A reconciler restart (#222) kills the claude process → its IPC socket
+    // closes → onClose must tear down any armed verify, so a verify timer can
+    // never re-deliver a keystroke into a restarted session that reused the
+    // agent_id (and the reconciler/verify don't both act on the same prompt).
+    const sockPath = join(tempDir, "bus.sock");
+    const delivered: string[] = [];
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      socketPath: sockPath,
+      deliveryBackstopMs: 20,
+      flushVerifyMs: 80,
+      streamPromptHandler: async (_a, text) => {
+        delivered.push(text);
+      },
+      onError: () => {},
+    });
+    await bus.start();
+    const client = await connectIpcClient(sockPath);
+    const hello: IpcHello = {
+      type: "hello",
+      agent_id: "alpha",
+      capabilities: ["claude/channel", "claude/channel/permission"],
+    };
+    client.send(hello);
+    await new Promise((r) => setTimeout(r, 20)); // let the hello register the connection
+    bus.ingestSessionEvent({
+      ts: 1,
+      agent_id: "alpha",
+      session_id: "s",
+      topic: "session.init",
+      payload: {},
+    });
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "telegram",
+      origin_id: "i",
+      user_id: "u",
+      text: "held",
+    });
+    await new Promise((r) => setTimeout(r, 50)); // > backstop → flush + arm verify
+    expect(delivered).toHaveLength(1);
+    client.close(); // socket close → onClose(alpha) → clearFlushVerify(alpha)
+    await new Promise((r) => setTimeout(r, 120)); // > flushVerify + grace
+    expect(delivered).toHaveLength(1); // verify torn down → NOT re-delivered
+  });
+
   describe("silent-drop safety net (issue #215)", () => {
     function makeBus(): BusCore {
       return createBusCore({
@@ -1555,5 +1602,32 @@ describe("BusCore delivery gate (session.init / replay_done)", () => {
     await new Promise((r) => setTimeout(r, 45)); // next verify tick → re-deliver once
     expect(delivered).toHaveLength(2);
     expect(delivered[1]).toContain("held");
+  });
+
+  it("re-delivers a swallowed prompt AT MOST ONCE across repeated backstop cycles (#252)", async () => {
+    // A re-delivery that is itself held (agent re-initialising) and flushed by a
+    // SECOND backstop must NOT arm a second verify: a prompt gets one
+    // re-delivery for its whole lifetime, the watchdog is the net beyond that.
+    // The verify entry is left in the pending map after re-delivery precisely so
+    // a later armFlushVerify for the same key is a no-op.
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      deliveryBackstopMs: 50,
+      flushVerifyMs: 60,
+      onError: () => {},
+    });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    bus.ingestSessionEvent(initEvt("alpha"));
+    await prompt("alpha", "held");
+    await new Promise((r) => setTimeout(r, 90)); // > backstop → flush#1 (d=1), verify armed
+    expect(delivered).toHaveLength(1);
+    bus.ingestSessionEvent(initEvt("alpha")); // re-init: the imminent re-delivery is held
+    // verify fires (~110) → grace → re-deliver (~125), queued (initialising);
+    // backstop#2 (~140) flushes it → d=2 and must NOT re-arm a third verify.
+    await new Promise((r) => setTimeout(r, 200)); // past backstop#2 + any spurious 3rd verify
+    expect(delivered).toHaveLength(2); // exactly one re-delivery, never a second
   });
 });

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -1374,4 +1374,58 @@ describe("BusCore delivery gate (session.init / replay_done)", () => {
     expect(delivered).toHaveLength(1);
     expect(delivered[0]).toContain("held");
   });
+
+  // A backstop flush fires on a TIMER because replay_done never arrived. During
+  // an IPC-reconnect storm the session is still re-initialising, so the flushed
+  // keystroke is swallowed and never starts a turn (dossier 20260613T033017).
+  const turnEvt = (agent: string): BusEvent => ({
+    ts: 1,
+    agent_id: agent,
+    session_id: "s",
+    topic: "prompt", // tailer: claude wrote the ingested user line = turn started
+    payload: { text: "x" },
+  });
+
+  it("re-delivers ONCE when a backstop-flushed prompt never starts a turn (idle-REPL wedge)", async () => {
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      deliveryBackstopMs: 20,
+      flushVerifyMs: 30,
+      onError: () => {},
+    });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    bus.ingestSessionEvent(initEvt("alpha"));
+    await prompt("alpha", "held");
+    expect(delivered).toHaveLength(0);
+    await new Promise((r) => setTimeout(r, 45)); // > backstop → first (swallowed) flush
+    expect(delivered).toHaveLength(1);
+    await new Promise((r) => setTimeout(r, 45)); // > flushVerify, no turn activity → re-deliver
+    expect(delivered).toHaveLength(2);
+    expect(delivered[1]).toContain("held");
+    await new Promise((r) => setTimeout(r, 45)); // never more than once
+    expect(delivered).toHaveLength(2);
+  });
+
+  it("does NOT re-deliver a backstop-flushed prompt that starts a turn", async () => {
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      deliveryBackstopMs: 20,
+      flushVerifyMs: 30,
+      onError: () => {},
+    });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    bus.ingestSessionEvent(initEvt("alpha"));
+    await prompt("alpha", "held");
+    await new Promise((r) => setTimeout(r, 45)); // > backstop → flush
+    expect(delivered).toHaveLength(1);
+    bus.ingestSessionEvent(turnEvt("alpha")); // turn started → cancel pending re-delivery
+    await new Promise((r) => setTimeout(r, 45)); // > flushVerify
+    expect(delivered).toHaveLength(1); // not re-delivered
+  });
 });

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -134,6 +134,9 @@ export interface BusCoreOptions {
    *  the backstop path is verified — the real `replay_done` path is known-ready.
    *  Defaults to 8000. Lowered in tests. */
   flushVerifyMs?: number;
+  /** Grace (ms) after a delivery handler settles before a verify re-delivers,
+   *  to let the asynchronous turn-start tailer event land first. Default 1500. */
+  flushVerifyGraceMs?: number;
   /** Slash-command delegate (Agent C wires this). */
   slashCommandHandler?: SlashCommandHandler;
   /** REPL prompt delegate for PTY-stdin agents. Wired by the Session Manager. */
@@ -263,9 +266,18 @@ export class BusCoreImpl implements BusCore {
    */
   private readonly flushVerify = new Map<
     string,
-    Map<string, { wrapped: string; timer: ReturnType<typeof setTimeout> }>
+    Map<string, { wrapped: string; graced: boolean; timer: ReturnType<typeof setTimeout> }>
   >();
   private readonly flushVerifyMs: number;
+  /**
+   * Grace (ms) between a delivery handler settling and declaring the prompt
+   * swallowed. The turn-start `prompt` event reaches the bus asynchronously via
+   * the JSONL tailer and can lag a little behind the handler return; without a
+   * grace the verify could fire in that window and re-deliver a prompt whose
+   * turn actually started (post-settle/pre-ingest double-submit). Defaults to
+   * min(1500, flushVerifyMs/4) so it scales down with the lowered test timings.
+   */
+  private readonly flushVerifyGraceMs: number;
   /**
    * In-flight `streamPromptHandler` count per agent. A delivery handler that
    * hasn't settled is legitimately working — notably it holds through
@@ -318,6 +330,8 @@ export class BusCoreImpl implements BusCore {
     this.ringbufferCapacity = opts.ringbufferCapacity ?? DEFAULT_RINGBUFFER_CAPACITY;
     this.deliveryBackstopMs = opts.deliveryBackstopMs ?? 4000;
     this.flushVerifyMs = opts.flushVerifyMs ?? 8000;
+    this.flushVerifyGraceMs =
+      opts.flushVerifyGraceMs ?? Math.min(1500, Math.ceil(this.flushVerifyMs / 4));
     this.eventLogAppend = opts.eventLogAppend ?? eventLogAppend;
     this.slashCommandHandler = opts.slashCommandHandler ?? null;
     this.streamPromptHandler = opts.streamPromptHandler ?? null;
@@ -628,12 +642,23 @@ export class BusCoreImpl implements BusCore {
       // fail and a healthy turn get re-delivered / double-submitted (#252
       // ultra-review HIGH). Keep the original wrapped to re-deliver verbatim.
       const key = sanitizePtyPromptText(wrapped);
-      if (pending.has(key)) continue; // already awaiting — don't stack a 2nd timer
-      pending.set(key, { wrapped, timer: this.scheduleFlushVerify(agent_id, key) });
+      // pending.has(key) covers BOTH an active verify AND a re-delivered entry
+      // left in place to enforce at-most-once (see scheduleFlushVerify): a later
+      // backstop flush therefore never arms a 2nd verify for the same prompt.
+      if (pending.has(key)) continue;
+      pending.set(key, {
+        wrapped,
+        graced: false,
+        timer: this.scheduleFlushVerify(agent_id, key, this.flushVerifyMs),
+      });
     }
   }
 
-  private scheduleFlushVerify(agent_id: string, key: string): ReturnType<typeof setTimeout> {
+  private scheduleFlushVerify(
+    agent_id: string,
+    key: string,
+    delayMs: number,
+  ): ReturnType<typeof setTimeout> {
     return setTimeout(() => {
       const pending = this.flushVerify.get(agent_id);
       const entry = pending?.get(key);
@@ -641,18 +666,30 @@ export class BusCoreImpl implements BusCore {
       // Compaction-aware: a delivery handler still in-flight is legitimately
       // working (it holds through auto-compaction, up to maxCompactionWaitMs ≫
       // flushVerifyMs). Re-delivering now would double-submit once compaction
-      // finishes (#252 regression). Defer: re-arm and re-check after the handler
-      // settles — it will either start a turn (cancels this verify via the
-      // matching `prompt` event) or return turn-less (re-deliver next tick).
+      // finishes (#252 regression). Defer: re-arm and re-check after it settles.
       if ((this.inFlightDeliveries.get(agent_id) ?? 0) > 0) {
-        entry.timer = this.scheduleFlushVerify(agent_id, key);
+        entry.graced = false;
+        entry.timer = this.scheduleFlushVerify(agent_id, key, this.flushVerifyMs);
         return;
       }
-      // No turn started and the handler is idle → the keystroke was swallowed by
-      // a still-(re)initialising TUI. Re-deliver ONCE, through the gate so an
-      // in-progress re-init re-holds it instead of swallowing it again (#252).
-      pending.delete(key);
-      if (pending.size === 0) this.flushVerify.delete(agent_id);
+      // Post-settle grace: the handler has returned but the turn-start `prompt`
+      // event reaches the bus asynchronously (JSONL tailer) and can lag behind.
+      // Wait one short grace for it before declaring the prompt swallowed, else a
+      // turn that started right as the handler returned would be re-delivered
+      // (the post-settle/pre-ingest double-submit window).
+      if (!entry.graced) {
+        entry.graced = true;
+        entry.timer = this.scheduleFlushVerify(agent_id, key, this.flushVerifyGraceMs);
+        return;
+      }
+      // No turn after settle + grace → genuinely swallowed by a still-(re)init
+      // TUI. Re-deliver through the gate so an in-progress re-init re-holds it
+      // instead of swallowing it again. KEEP the entry in `pending` (don't
+      // delete) and do NOT re-arm: a later backstop flush sees pending.has(key)
+      // and skips it, so a prompt gets AT MOST ONE re-delivery for its whole
+      // lifetime (the watchdog is the net beyond that). The entry is cleared
+      // when the re-delivery's turn-start lands (noteFlushTurnStart) or on
+      // socket close / shutdown (clearFlushVerify).
       this.onError(
         new Error(
           `backstop-flushed prompt produced no turn within ${this.flushVerifyMs}ms; re-delivering once for agent_id=${agent_id}`,
@@ -660,7 +697,7 @@ export class BusCoreImpl implements BusCore {
         { ctx: "flushVerify", agent_id },
       );
       this.deliverOrQueuePrompt(agent_id, entry.wrapped);
-    }, this.flushVerifyMs);
+    }, delayMs);
   }
 
   /** A tailer `prompt` event proves THAT specific prompt started its turn: its

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -30,6 +30,7 @@ import { randomUUID } from "node:crypto";
 import type { EventRecord, EventEntryInput } from "../event-log";
 import { append as eventLogAppend } from "../event-log";
 import { bindUdsServer, encodeFrame, resolveDefaultUdsPath, type IpcServer } from "./core-ipc";
+import { sanitizePtyPromptText } from "../runner/pty-prompt-sanitizer";
 import {
   DEFAULT_RINGBUFFER_CAPACITY,
   drainSubscriber,
@@ -260,7 +261,10 @@ export class BusCoreImpl implements BusCore {
    * ones, and each prompt is verified/re-delivered independently. The watchdog
    * stays the ultimate net. Maps agent → (wrapped prompt → verify timer).
    */
-  private readonly flushVerify = new Map<string, Map<string, ReturnType<typeof setTimeout>>>();
+  private readonly flushVerify = new Map<
+    string,
+    Map<string, { wrapped: string; timer: ReturnType<typeof setTimeout> }>
+  >();
   private readonly flushVerifyMs: number;
   /**
    * In-flight `streamPromptHandler` count per agent. A delivery handler that
@@ -403,7 +407,7 @@ export class BusCoreImpl implements BusCore {
     this.deliveryQueue.clear();
     this.agentLiveSession.clear();
     for (const pending of this.flushVerify.values())
-      for (const timer of pending.values()) clearTimeout(timer);
+      for (const entry of pending.values()) clearTimeout(entry.timer);
     this.flushVerify.clear();
     this.inFlightDeliveries.clear();
   }
@@ -615,15 +619,25 @@ export class BusCoreImpl implements BusCore {
       this.flushVerify.set(agent_id, pending);
     }
     for (const wrapped of prompts) {
-      if (pending.has(wrapped)) continue; // already awaiting — don't stack a 2nd timer
-      pending.set(wrapped, this.scheduleFlushVerify(agent_id, wrapped));
+      // Key by the text the tailer will actually observe, NOT the raw wrapped
+      // string: the PTY layer runs sanitizePtyPromptText (collapses newlines to
+      // spaces, strips control chars) before typing, and claude records — and
+      // the tailer re-emits as the `prompt` event — that sanitized form. Keying
+      // by the raw wrapped (with literal newlines) would never match a
+      // multi-line prompt's turn-start event, so attribution would silently
+      // fail and a healthy turn get re-delivered / double-submitted (#252
+      // ultra-review HIGH). Keep the original wrapped to re-deliver verbatim.
+      const key = sanitizePtyPromptText(wrapped);
+      if (pending.has(key)) continue; // already awaiting — don't stack a 2nd timer
+      pending.set(key, { wrapped, timer: this.scheduleFlushVerify(agent_id, key) });
     }
   }
 
-  private scheduleFlushVerify(agent_id: string, wrapped: string): ReturnType<typeof setTimeout> {
+  private scheduleFlushVerify(agent_id: string, key: string): ReturnType<typeof setTimeout> {
     return setTimeout(() => {
       const pending = this.flushVerify.get(agent_id);
-      if (!pending?.has(wrapped)) return;
+      const entry = pending?.get(key);
+      if (!pending || !entry) return;
       // Compaction-aware: a delivery handler still in-flight is legitimately
       // working (it holds through auto-compaction, up to maxCompactionWaitMs ≫
       // flushVerifyMs). Re-delivering now would double-submit once compaction
@@ -631,13 +645,13 @@ export class BusCoreImpl implements BusCore {
       // settles — it will either start a turn (cancels this verify via the
       // matching `prompt` event) or return turn-less (re-deliver next tick).
       if ((this.inFlightDeliveries.get(agent_id) ?? 0) > 0) {
-        pending.set(wrapped, this.scheduleFlushVerify(agent_id, wrapped));
+        entry.timer = this.scheduleFlushVerify(agent_id, key);
         return;
       }
       // No turn started and the handler is idle → the keystroke was swallowed by
       // a still-(re)initialising TUI. Re-deliver ONCE, through the gate so an
       // in-progress re-init re-holds it instead of swallowing it again (#252).
-      pending.delete(wrapped);
+      pending.delete(key);
       if (pending.size === 0) this.flushVerify.delete(agent_id);
       this.onError(
         new Error(
@@ -645,7 +659,7 @@ export class BusCoreImpl implements BusCore {
         ),
         { ctx: "flushVerify", agent_id },
       );
-      this.deliverOrQueuePrompt(agent_id, wrapped);
+      this.deliverOrQueuePrompt(agent_id, entry.wrapped);
     }, this.flushVerifyMs);
   }
 
@@ -657,10 +671,14 @@ export class BusCoreImpl implements BusCore {
   private noteFlushTurnStart(agent_id: string, ingestedText: string): void {
     const pending = this.flushVerify.get(agent_id);
     if (!pending) return;
-    const timer = pending.get(ingestedText);
-    if (!timer) return;
-    clearTimeout(timer);
-    pending.delete(ingestedText);
+    // ingestedText is the line claude recorded (already PTY-sanitized) and the
+    // map keys are sanitized too; sanitize again — it is idempotent — to be
+    // robust against any residual normalization before the exact-match lookup.
+    const key = sanitizePtyPromptText(ingestedText);
+    const entry = pending.get(key);
+    if (!entry) return;
+    clearTimeout(entry.timer);
+    pending.delete(key);
     if (pending.size === 0) this.flushVerify.delete(agent_id);
   }
 
@@ -669,7 +687,7 @@ export class BusCoreImpl implements BusCore {
   private clearFlushVerify(agent_id: string): void {
     const pending = this.flushVerify.get(agent_id);
     if (!pending) return;
-    for (const timer of pending.values()) clearTimeout(timer);
+    for (const entry of pending.values()) clearTimeout(entry.timer);
     this.flushVerify.delete(agent_id);
   }
 

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -464,9 +464,11 @@ export class BusCoreImpl implements BusCore {
       text: req.text,
       metadata: req.metadata,
     };
+    let ipcSendFailed = false;
     if (this.ipcServer) {
       const sent = this.ipcServer.send(req.agent_id, ipcMsg);
       if (!sent) {
+        ipcSendFailed = true;
         this.onError(new Error(`No MCP connection for agent_id=${req.agent_id}`), {
           ctx: "sendPrompt",
         });
@@ -508,7 +510,17 @@ export class BusCoreImpl implements BusCore {
         }
       }
       const wrapped = `<channel ${attrs.join(" ")}>${escapeXmlText(req.text)}</channel>`;
+      // If the agent's session is (re)initialising the prompt is HELD and the
+      // backstop flush-verify path already covers it. The uncovered case is an
+      // IMMEDIATE delivery whose IPC send just failed: the MCP/IPC socket
+      // blipped at the prompt boundary, so the PTY keystroke can coincide with a
+      // reconnect and be swallowed without starting a turn — and the #222
+      // reconciler disarms on "reconnected during confirm window" WITHOUT
+      // checking a turn started (dossier 20260614T034258). Verify turn-start for
+      // that prompt and re-deliver once if none lands.
+      const deliveredImmediately = !this.agentInitializing.has(req.agent_id);
       this.deliverOrQueuePrompt(req.agent_id, wrapped);
+      if (ipcSendFailed && deliveredImmediately) this.armFlushVerify(req.agent_id, [wrapped]);
     }
     return { promise_id };
   }

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -115,22 +115,6 @@ export type SlashCommandHandler = (agent_id: string, cmd: string) => Promise<voi
  */
 export type StreamPromptHandler = (agent_id: string, text: string) => Promise<void>;
 
-/**
- * Tailer topics that prove an agent's turn actually started — used to cancel a
- * pending backstop-flush re-delivery (`armFlushVerify`). `prompt` is the
- * earliest and most reliable: the JSONL tailer emits it when claude writes the
- * ingested user line, which happens on ingest before any thinking, so a slow
- * (no-tool) turn never trips a false re-delivery. The in-turn signals are
- * belt-and-suspenders. `session.init`/`replay_done` are deliberately excluded —
- * they mark (re)init, not a turn.
- */
-const TURN_ACTIVITY_TOPICS: ReadonlySet<string> = new Set([
-  "prompt",
-  "tool_result",
-  "usage",
-  "response.turn_end",
-]);
-
 export interface BusCoreOptions {
   /** Path to bind the UDS server. If omitted, no IPC server is started. */
   socketPath?: string;
@@ -267,16 +251,26 @@ export class BusCoreImpl implements BusCore {
    * fires on a TIMER because `replay_done` never arrived — but during an
    * IPC-reconnect storm the session is still re-initialising, so the flushed
    * keystroke can be swallowed and never start a turn (dossier 20260613T033017).
-   * After such a flush we watch for proof a turn started (a tailer event for the
-   * agent) and, if none lands within `flushVerifyMs`, re-deliver ONCE — by then
-   * the session is past re-init. One re-delivery max; the watchdog stays the
-   * ultimate net. Maps agent → {held prompts, verify timer}.
+   * After such a flush we watch for proof THAT prompt started a turn — a tailer
+   * `prompt` event whose ingested text matches the wrapped string we delivered
+   * (exact attribution; an unrelated later prompt's turn must not satisfy an
+   * earlier swallowed one) — and, if none lands within `flushVerifyMs`,
+   * re-deliver THAT prompt ONCE through the gate. Per-prompt timers, not one
+   * per agent: a second flush adds to the set instead of discarding pending
+   * ones, and each prompt is verified/re-delivered independently. The watchdog
+   * stays the ultimate net. Maps agent → (wrapped prompt → verify timer).
    */
-  private readonly flushVerify = new Map<
-    string,
-    { prompts: string[]; timer: ReturnType<typeof setTimeout> }
-  >();
+  private readonly flushVerify = new Map<string, Map<string, ReturnType<typeof setTimeout>>>();
   private readonly flushVerifyMs: number;
+  /**
+   * In-flight `streamPromptHandler` count per agent. A delivery handler that
+   * hasn't settled is legitimately working — notably it holds through
+   * auto-compaction (maxCompactionWaitMs, up to 240s ≫ flushVerifyMs). The
+   * flush-verify timer must NOT re-deliver while a handler is in-flight or it
+   * double-submits the prompt once compaction finishes (#252 regression). It
+   * defers until the handler settles instead.
+   */
+  private readonly inFlightDeliveries = new Map<string, number>();
   /**
    * Silent-drop safety net (issue #215): tracks per-agent whether the
    * current turn has called the `reply` MCP tool with `intent: "final"`.
@@ -376,6 +370,11 @@ export class BusCoreImpl implements BusCore {
           if (heldInitTimer) clearTimeout(heldInitTimer);
           this.agentInitializing.delete(agentId);
           this.deliveryQueue.delete(agentId);
+          // Same hazard for a pending flush-verify timer: if it fired after a
+          // restart that reused this agent_id it would type a stale keystroke
+          // into the fresh session (#252 HIGH).
+          this.clearFlushVerify(agentId);
+          this.inFlightDeliveries.delete(agentId);
           this.logIpc("close", {
             agent: agentId,
             connections: this.ipcServer?.connectionCount() ?? 0,
@@ -403,8 +402,10 @@ export class BusCoreImpl implements BusCore {
     this.agentInitializing.clear();
     this.deliveryQueue.clear();
     this.agentLiveSession.clear();
-    for (const v of this.flushVerify.values()) clearTimeout(v.timer);
+    for (const pending of this.flushVerify.values())
+      for (const timer of pending.values()) clearTimeout(timer);
     this.flushVerify.clear();
+    this.inFlightDeliveries.clear();
   }
 
   /* ─────────────────────────────── prompts ─────────────────────────────── */
@@ -528,9 +529,17 @@ export class BusCoreImpl implements BusCore {
 
   private streamDeliver(agent_id: string, wrapped: string): void {
     if (!this.streamPromptHandler) return;
-    void this.streamPromptHandler(agent_id, wrapped).catch((err) =>
-      this.onError(err, { ctx: "streamPromptHandler", agent_id }),
-    );
+    // Track the handler as in-flight so a flush-verify timer can tell a prompt
+    // that is legitimately being processed (e.g. holding through compaction)
+    // from one that was silently swallowed (#252).
+    this.inFlightDeliveries.set(agent_id, (this.inFlightDeliveries.get(agent_id) ?? 0) + 1);
+    void this.streamPromptHandler(agent_id, wrapped)
+      .catch((err) => this.onError(err, { ctx: "streamPromptHandler", agent_id }))
+      .finally(() => {
+        const n = (this.inFlightDeliveries.get(agent_id) ?? 1) - 1;
+        if (n <= 0) this.inFlightDeliveries.delete(agent_id);
+        else this.inFlightDeliveries.set(agent_id, n);
+      });
   }
 
   /** `session.init` → start holding PTY-stdin prompts for this agent, UNLESS
@@ -582,36 +591,73 @@ export class BusCoreImpl implements BusCore {
     if (viaBackstop) this.armFlushVerify(agent_id, q);
   }
 
-  /** Arm turn-start verification after a backstop flush. If no tailer event for
-   *  the agent lands within `flushVerifyMs` (i.e. the flushed keystroke was
-   *  swallowed by a still-initialising TUI), re-deliver the prompts ONCE — the
-   *  session is past re-init by now. Cleared by `noteAgentTurnActivity` on the
-   *  first sign of a turn. One re-delivery max: a second backstop flush replaces
-   *  the pending verify rather than stacking, and the watchdog remains the
-   *  ultimate net if even the re-delivery fails to land. */
+  /** Arm per-prompt turn-start verification after a backstop flush. Each flushed
+   *  prompt gets its own one-shot timer; a prompt already awaiting verification
+   *  is left untouched (a second flush ADDS to the set, never discards pending
+   *  ones — #252). The timer is cancelled by `noteFlushTurnStart` when the
+   *  matching `prompt` lands, and re-delivers exactly that prompt otherwise. */
   private armFlushVerify(agent_id: string, prompts: string[]): void {
-    const existing = this.flushVerify.get(agent_id);
-    if (existing) clearTimeout(existing.timer);
-    const timer = setTimeout(() => {
-      this.flushVerify.delete(agent_id);
+    let pending = this.flushVerify.get(agent_id);
+    if (!pending) {
+      pending = new Map();
+      this.flushVerify.set(agent_id, pending);
+    }
+    for (const wrapped of prompts) {
+      if (pending.has(wrapped)) continue; // already awaiting — don't stack a 2nd timer
+      pending.set(wrapped, this.scheduleFlushVerify(agent_id, wrapped));
+    }
+  }
+
+  private scheduleFlushVerify(agent_id: string, wrapped: string): ReturnType<typeof setTimeout> {
+    return setTimeout(() => {
+      const pending = this.flushVerify.get(agent_id);
+      if (!pending?.has(wrapped)) return;
+      // Compaction-aware: a delivery handler still in-flight is legitimately
+      // working (it holds through auto-compaction, up to maxCompactionWaitMs ≫
+      // flushVerifyMs). Re-delivering now would double-submit once compaction
+      // finishes (#252 regression). Defer: re-arm and re-check after the handler
+      // settles — it will either start a turn (cancels this verify via the
+      // matching `prompt` event) or return turn-less (re-deliver next tick).
+      if ((this.inFlightDeliveries.get(agent_id) ?? 0) > 0) {
+        pending.set(wrapped, this.scheduleFlushVerify(agent_id, wrapped));
+        return;
+      }
+      // No turn started and the handler is idle → the keystroke was swallowed by
+      // a still-(re)initialising TUI. Re-deliver ONCE, through the gate so an
+      // in-progress re-init re-holds it instead of swallowing it again (#252).
+      pending.delete(wrapped);
+      if (pending.size === 0) this.flushVerify.delete(agent_id);
       this.onError(
         new Error(
           `backstop-flushed prompt produced no turn within ${this.flushVerifyMs}ms; re-delivering once for agent_id=${agent_id}`,
         ),
         { ctx: "flushVerify", agent_id },
       );
-      for (const wrapped of prompts) this.streamDeliver(agent_id, wrapped);
+      this.deliverOrQueuePrompt(agent_id, wrapped);
     }, this.flushVerifyMs);
-    this.flushVerify.set(agent_id, { prompts, timer });
   }
 
-  /** Any tailer event for the agent (claude ingested a prompt, emitted a tool
-   *  result/usage, or ended a turn) proves the backstop-flushed prompt DID start
-   *  a turn → cancel the pending re-delivery. */
-  private noteAgentTurnActivity(agent_id: string): void {
-    const v = this.flushVerify.get(agent_id);
-    if (!v) return;
-    clearTimeout(v.timer);
+  /** A tailer `prompt` event proves THAT specific prompt started its turn: its
+   *  ingested text is the user line claude recorded = the wrapped string we
+   *  delivered. Cancel only the matching pending verify, so an unrelated later
+   *  prompt's turn never silences a still-swallowed earlier prompt's
+   *  re-delivery (#252). */
+  private noteFlushTurnStart(agent_id: string, ingestedText: string): void {
+    const pending = this.flushVerify.get(agent_id);
+    if (!pending) return;
+    const timer = pending.get(ingestedText);
+    if (!timer) return;
+    clearTimeout(timer);
+    pending.delete(ingestedText);
+    if (pending.size === 0) this.flushVerify.delete(agent_id);
+  }
+
+  /** Cancel and drop every pending flush-verify for an agent (socket close, or
+   *  shutdown) so no stale timer fires into a restarted/reused session. */
+  private clearFlushVerify(agent_id: string): void {
+    const pending = this.flushVerify.get(agent_id);
+    if (!pending) return;
+    for (const timer of pending.values()) clearTimeout(timer);
     this.flushVerify.delete(agent_id);
   }
 
@@ -824,12 +870,18 @@ export class BusCoreImpl implements BusCore {
     if (e.agent_id) {
       if (e.topic === "session.init") this.markAgentInitializing(e.agent_id, e.session_id);
       else if (e.topic === "bus.events.replay_done") this.markAgentReady(e.agent_id, e.session_id);
-      // Turn-start proof for a pending backstop-flush verification: a tailer
-      // `prompt` (claude wrote the ingested user line — fires within ms of
-      // ingest, before any thinking, so a slow-but-healthy turn never triggers a
-      // spurious re-delivery), or any in-turn output. NOT `session.init`/
-      // `replay_done` (those are init, not a turn).
-      else if (TURN_ACTIVITY_TOPICS.has(e.topic)) this.noteAgentTurnActivity(e.agent_id);
+      // Turn-start proof for a pending backstop-flush verification. ONLY the
+      // tailer `prompt` topic qualifies — it carries the ingested user line
+      // (= the wrapped string we delivered), so we can attribute the turn to the
+      // exact flushed prompt and cancel only its verify. Fires within ms of
+      // ingest (before any thinking), so a slow-but-healthy turn never trips a
+      // spurious re-delivery. In-turn topics (tool_result/usage/turn_end) carry
+      // no prompt identity and are deliberately NOT used: an unrelated prompt's
+      // activity must not silence a still-swallowed prompt's re-delivery.
+      else if (e.topic === "prompt") {
+        const text = (e.payload as { text?: string } | undefined)?.text;
+        if (typeof text === "string") this.noteFlushTurnStart(e.agent_id, text);
+      }
     }
     // Silent-drop safety net (#215): the JSONL tailer publishes a
     // `response.turn_end` event when claude stops with `end_turn`. Hook

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -288,6 +288,18 @@ export class BusCoreImpl implements BusCore {
    */
   private readonly inFlightDeliveries = new Map<string, number>();
   /**
+   * Agents with a turn currently streaming (tailer `prompt` seen, no
+   * `response.turn_end` yet). A prompt delivered while a neighbor turn is in
+   * progress can only be a queued keystroke in the REPL input box — the PTY
+   * confirm-loop cannot attribute the neighbor's stream to it and may falsely
+   * report it as turn-started (#250 ultra HIGH). The bus has reliable
+   * attribution (the per-prompt `prompt` tailer event), so deliveries made
+   * during an active turn arm a flush-verify; that verify is DEFERRED while a
+   * turn is still active (the prompt legitimately waits behind it — re-delivering
+   * sooner would double-submit), then re-delivers only if no turn ever starts.
+   */
+  private readonly agentTurnActive = new Set<string>();
+  /**
    * Silent-drop safety net (issue #215): tracks per-agent whether the
    * current turn has called the `reply` MCP tool with `intent: "final"`.
    * Reset on every new inbound prompt (`sendPrompt`), set to `true` when
@@ -393,6 +405,7 @@ export class BusCoreImpl implements BusCore {
           // into the fresh session (#252 HIGH).
           this.clearFlushVerify(agentId);
           this.inFlightDeliveries.delete(agentId);
+          this.agentTurnActive.delete(agentId);
           this.logIpc("close", {
             agent: agentId,
             connections: this.ipcServer?.connectionCount() ?? 0,
@@ -424,6 +437,7 @@ export class BusCoreImpl implements BusCore {
       for (const entry of pending.values()) clearTimeout(entry.timer);
     this.flushVerify.clear();
     this.inFlightDeliveries.clear();
+    this.agentTurnActive.clear();
   }
 
   /* ─────────────────────────────── prompts ─────────────────────────────── */
@@ -536,9 +550,18 @@ export class BusCoreImpl implements BusCore {
       // reconciler disarms on "reconnected during confirm window" WITHOUT
       // checking a turn started (dossier 20260614T034258). Verify turn-start for
       // that prompt and re-deliver once if none lands.
+      // Arm a turn-start verify when the PTY confirm-loop can't be trusted to
+      // attribute the turn to THIS prompt: (a) the IPC send just failed (socket
+      // blip), or (b) a neighbor turn is already streaming, so this keystroke is
+      // queued in the REPL box and the confirm-loop may read the neighbor's
+      // stream as this prompt's turn-start (#250 HIGH). The verify defers while a
+      // turn stays active and re-delivers only if no turn ever starts.
       const deliveredImmediately = !this.agentInitializing.has(req.agent_id);
+      const neighborTurnActive = this.agentTurnActive.has(req.agent_id);
       this.deliverOrQueuePrompt(req.agent_id, wrapped);
-      if (ipcSendFailed && deliveredImmediately) this.armFlushVerify(req.agent_id, [wrapped]);
+      if ((ipcSendFailed || neighborTurnActive) && deliveredImmediately) {
+        this.armFlushVerify(req.agent_id, [wrapped]);
+      }
     }
     return { promise_id };
   }
@@ -663,11 +686,13 @@ export class BusCoreImpl implements BusCore {
       const pending = this.flushVerify.get(agent_id);
       const entry = pending?.get(key);
       if (!pending || !entry) return;
-      // Compaction-aware: a delivery handler still in-flight is legitimately
-      // working (it holds through auto-compaction, up to maxCompactionWaitMs ≫
-      // flushVerifyMs). Re-delivering now would double-submit once compaction
-      // finishes (#252 regression). Defer: re-arm and re-check after it settles.
-      if ((this.inFlightDeliveries.get(agent_id) ?? 0) > 0) {
+      // Defer while the prompt legitimately can't have started its turn yet:
+      //  - a delivery handler is still in-flight (compaction-aware: it holds
+      //    through auto-compaction, up to maxCompactionWaitMs ≫ flushVerifyMs); or
+      //  - a neighbor turn is still streaming, so this prompt is queued behind it
+      //    in the REPL box and can only start once that turn ends (#250 HIGH).
+      // Re-delivering in either case would double-submit. Re-arm and re-check.
+      if ((this.inFlightDeliveries.get(agent_id) ?? 0) > 0 || this.agentTurnActive.has(agent_id)) {
         entry.graced = false;
         entry.timer = this.scheduleFlushVerify(agent_id, key, this.flushVerifyMs);
         return;
@@ -947,7 +972,11 @@ export class BusCoreImpl implements BusCore {
       // activity must not silence a still-swallowed prompt's re-delivery.
       else if (e.topic === "prompt") {
         const text = (e.payload as { text?: string } | undefined)?.text;
+        // Cancel the matching prompt's verify FIRST (attribution), then mark the
+        // agent as having an active turn so a LATER prompt delivered during it
+        // arms — and defers — its own verify.
         if (typeof text === "string") this.noteFlushTurnStart(e.agent_id, text);
+        this.agentTurnActive.add(e.agent_id);
       }
     }
     // Silent-drop safety net (#215): the JSONL tailer publishes a
@@ -957,6 +986,9 @@ export class BusCoreImpl implements BusCore {
     if (e.topic === "response.turn_end" && e.agent_id) {
       const payload = e.payload as { text?: string };
       this.handleTurnEnd(e.agent_id, payload?.text ?? "");
+      // The turn ended → the REPL is free, so a prompt queued behind it can now
+      // start; stop deferring its flush-verify (see agentTurnActive).
+      this.agentTurnActive.delete(e.agent_id);
     }
     this.publish(e);
   }

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -115,6 +115,22 @@ export type SlashCommandHandler = (agent_id: string, cmd: string) => Promise<voi
  */
 export type StreamPromptHandler = (agent_id: string, text: string) => Promise<void>;
 
+/**
+ * Tailer topics that prove an agent's turn actually started — used to cancel a
+ * pending backstop-flush re-delivery (`armFlushVerify`). `prompt` is the
+ * earliest and most reliable: the JSONL tailer emits it when claude writes the
+ * ingested user line, which happens on ingest before any thinking, so a slow
+ * (no-tool) turn never trips a false re-delivery. The in-turn signals are
+ * belt-and-suspenders. `session.init`/`replay_done` are deliberately excluded —
+ * they mark (re)init, not a turn.
+ */
+const TURN_ACTIVITY_TOPICS: ReadonlySet<string> = new Set([
+  "prompt",
+  "tool_result",
+  "usage",
+  "response.turn_end",
+]);
+
 export interface BusCoreOptions {
   /** Path to bind the UDS server. If omitted, no IPC server is started. */
   socketPath?: string;
@@ -126,6 +142,13 @@ export interface BusCoreOptions {
    *  agent's session (re)initialises before it's flushed even without a
    *  `replay_done`. Defaults to 4000. Lowered in tests. */
   deliveryBackstopMs?: number;
+  /** After a BACKSTOP flush (timer-driven, not a real `replay_done`), the
+   *  session may still be mid-(re)init and swallow the keystroke, so the prompt
+   *  never starts a turn (the socket=no wedge, dossier 20260613T033017). Verify
+   *  a turn actually starts within this window; if not, re-deliver ONCE. Only
+   *  the backstop path is verified — the real `replay_done` path is known-ready.
+   *  Defaults to 8000. Lowered in tests. */
+  flushVerifyMs?: number;
   /** Slash-command delegate (Agent C wires this). */
   slashCommandHandler?: SlashCommandHandler;
   /** REPL prompt delegate for PTY-stdin agents. Wired by the Session Manager. */
@@ -240,6 +263,21 @@ export class BusCoreImpl implements BusCore {
   private readonly agentLiveSession = new Map<string, string>();
   private readonly deliveryBackstopMs: number;
   /**
+   * Pending turn-start verification for a BACKSTOP-flushed prompt. The backstop
+   * fires on a TIMER because `replay_done` never arrived — but during an
+   * IPC-reconnect storm the session is still re-initialising, so the flushed
+   * keystroke can be swallowed and never start a turn (dossier 20260613T033017).
+   * After such a flush we watch for proof a turn started (a tailer event for the
+   * agent) and, if none lands within `flushVerifyMs`, re-deliver ONCE — by then
+   * the session is past re-init. One re-delivery max; the watchdog stays the
+   * ultimate net. Maps agent → {held prompts, verify timer}.
+   */
+  private readonly flushVerify = new Map<
+    string,
+    { prompts: string[]; timer: ReturnType<typeof setTimeout> }
+  >();
+  private readonly flushVerifyMs: number;
+  /**
    * Silent-drop safety net (issue #215): tracks per-agent whether the
    * current turn has called the `reply` MCP tool with `intent: "final"`.
    * Reset on every new inbound prompt (`sendPrompt`), set to `true` when
@@ -281,6 +319,7 @@ export class BusCoreImpl implements BusCore {
     this.socketPath = opts.socketPath ?? null;
     this.ringbufferCapacity = opts.ringbufferCapacity ?? DEFAULT_RINGBUFFER_CAPACITY;
     this.deliveryBackstopMs = opts.deliveryBackstopMs ?? 4000;
+    this.flushVerifyMs = opts.flushVerifyMs ?? 8000;
     this.eventLogAppend = opts.eventLogAppend ?? eventLogAppend;
     this.slashCommandHandler = opts.slashCommandHandler ?? null;
     this.streamPromptHandler = opts.streamPromptHandler ?? null;
@@ -364,6 +403,8 @@ export class BusCoreImpl implements BusCore {
     this.agentInitializing.clear();
     this.deliveryQueue.clear();
     this.agentLiveSession.clear();
+    for (const v of this.flushVerify.values()) clearTimeout(v.timer);
+    this.flushVerify.clear();
   }
 
   /* ─────────────────────────────── prompts ─────────────────────────────── */
@@ -516,7 +557,7 @@ export class BusCoreImpl implements BusCore {
         ),
         { ctx: "deliveryBackstop", agent_id },
       );
-      this.markAgentReady(agent_id);
+      this.markAgentReady(agent_id, undefined, true);
     }, this.deliveryBackstopMs);
     this.agentInitializing.set(agent_id, timer);
   }
@@ -525,7 +566,7 @@ export class BusCoreImpl implements BusCore {
    *  (so a late `session.init` for it can't re-arm a hold), clear any pending
    *  hold, and flush held prompts in order. Called unconditionally on
    *  `replay_done`, which the tailer emits for every session generation. */
-  private markAgentReady(agent_id: string, session_id?: string): void {
+  private markAgentReady(agent_id: string, session_id?: string, viaBackstop = false): void {
     if (session_id) this.agentLiveSession.set(agent_id, session_id);
     const timer = this.agentInitializing.get(agent_id);
     if (timer) clearTimeout(timer);
@@ -534,6 +575,44 @@ export class BusCoreImpl implements BusCore {
     if (!q || q.length === 0) return;
     this.deliveryQueue.delete(agent_id);
     for (const wrapped of q) this.streamDeliver(agent_id, wrapped);
+    // A backstop flush is timer-driven (no `replay_done`), so the session may
+    // still be mid-(re)init and swallow the keystroke; verify a turn actually
+    // starts and re-deliver once if not. The real `replay_done` path is
+    // known-ready and needs no verification.
+    if (viaBackstop) this.armFlushVerify(agent_id, q);
+  }
+
+  /** Arm turn-start verification after a backstop flush. If no tailer event for
+   *  the agent lands within `flushVerifyMs` (i.e. the flushed keystroke was
+   *  swallowed by a still-initialising TUI), re-deliver the prompts ONCE — the
+   *  session is past re-init by now. Cleared by `noteAgentTurnActivity` on the
+   *  first sign of a turn. One re-delivery max: a second backstop flush replaces
+   *  the pending verify rather than stacking, and the watchdog remains the
+   *  ultimate net if even the re-delivery fails to land. */
+  private armFlushVerify(agent_id: string, prompts: string[]): void {
+    const existing = this.flushVerify.get(agent_id);
+    if (existing) clearTimeout(existing.timer);
+    const timer = setTimeout(() => {
+      this.flushVerify.delete(agent_id);
+      this.onError(
+        new Error(
+          `backstop-flushed prompt produced no turn within ${this.flushVerifyMs}ms; re-delivering once for agent_id=${agent_id}`,
+        ),
+        { ctx: "flushVerify", agent_id },
+      );
+      for (const wrapped of prompts) this.streamDeliver(agent_id, wrapped);
+    }, this.flushVerifyMs);
+    this.flushVerify.set(agent_id, { prompts, timer });
+  }
+
+  /** Any tailer event for the agent (claude ingested a prompt, emitted a tool
+   *  result/usage, or ended a turn) proves the backstop-flushed prompt DID start
+   *  a turn → cancel the pending re-delivery. */
+  private noteAgentTurnActivity(agent_id: string): void {
+    const v = this.flushVerify.get(agent_id);
+    if (!v) return;
+    clearTimeout(v.timer);
+    this.flushVerify.delete(agent_id);
   }
 
   async invokeSlashCommand(agent_id: string, cmd: string): Promise<void> {
@@ -745,6 +824,12 @@ export class BusCoreImpl implements BusCore {
     if (e.agent_id) {
       if (e.topic === "session.init") this.markAgentInitializing(e.agent_id, e.session_id);
       else if (e.topic === "bus.events.replay_done") this.markAgentReady(e.agent_id, e.session_id);
+      // Turn-start proof for a pending backstop-flush verification: a tailer
+      // `prompt` (claude wrote the ingested user line — fires within ms of
+      // ingest, before any thinking, so a slow-but-healthy turn never triggers a
+      // spurious re-delivery), or any in-turn output. NOT `session.init`/
+      // `replay_done` (those are init, not a turn).
+      else if (TURN_ACTIVITY_TOPICS.has(e.topic)) this.noteAgentTurnActivity(e.agent_id);
     }
     // Silent-drop safety net (#215): the JSONL tailer publishes a
     // `response.turn_end` event when claude stops with `end_turn`. Hook


### PR DESCRIPTION
## What

After a **backstop flush** (the delivery gate force-flushes held PTY-stdin prompts on a timer because `replay_done` never arrived), the session can still be mid-(re)init and swallow the keystroke, so the prompt never starts a turn — the `socket=no` delivery wedge. This adds a turn-start verification: if the flushed prompt produces no turn within `flushVerifyMs`, it is re-delivered.

The first cut used a single agent-level timer cancellable by any turn activity. A self-review found that design re-introduced, in its own recovery path, the very races it was meant to close. This revision hardens it.

## Design

- **Per-prompt attribution.** Verify timers are keyed by the wrapped prompt string. A pending verify is cancelled only by a tailer `prompt` event whose ingested text matches that exact prompt (the JSONL tailer records the user line = the wrapped string we delivered). An unrelated later prompt's turn no longer satisfies — and silently drops — an earlier still-swallowed prompt. A second flush during the verify window **adds** to the pending set instead of discarding it.
- **Re-deliver through the gate.** Re-delivery goes through `deliverOrQueuePrompt`, so if a fresh `session.init` re-armed the hold, the prompt is re-queued rather than flushed into a still-initialising TUI.
- **Compaction-aware.** A stream handler that hasn't settled is legitimately working — it holds through auto-compaction (`maxCompactionWaitMs`, up to 240 s ≫ `flushVerifyMs`). The verify timer defers re-delivery while a handler is in-flight, eliminating a double-submit when a flush coincided with a long compaction.
- **Socket-close teardown.** Pending verify timers are torn down on socket close (and shutdown), so a stale timer can never type a keystroke into a restarted session that reused the same `agent_id`.

## Safety / correctness notes

- One re-delivery per swallowed prompt; the external health watchdog remains the ultimate net.
- No new keystroke is ever emitted into an initialising or compacting session — the two windows where a keystroke is unsafe.
- Re-delivery is attributed and idempotent per prompt; no path can double-submit.

## Tests

Full bus suite **375 pass / 1 skip / 0 fail**. Added two regression tests:
- re-delivers when only an **unrelated** prompt starts a turn (attribution).
- does **not** re-deliver while a delivery handler is still in-flight (compaction guard).
