### PR TITLE
fix(bus): close wedge-stack integration defects (stack ultra-review)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.150",
+      "version": "2.2.151",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.150",
+  "version": "2.2.151",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/core.test.ts
+++ b/src/bus/__tests__/core.test.ts
@@ -1020,6 +1020,63 @@ describe("BusCore IPC", () => {
     expect(delivered).toHaveLength(1); // verify torn down → NOT re-delivered
   });
 
+  it("re-delivers a prompt held at socket close once the fresh session is ready (#252 stack ultra B1)", async () => {
+    // A reconciler restart of an alive-but-deaf agent closes the socket while a
+    // prompt is still held (or awaiting verify). onClose snapshots it; the fresh
+    // generation's replay_done re-delivers it through the gate instead of the
+    // prompt being silently dropped (no recovery layer owned it before).
+    const sockPath = join(tempDir, "bus.sock");
+    const delivered: string[] = [];
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      socketPath: sockPath,
+      deliveryBackstopMs: 5000, // large: the prompt stays HELD (not backstop-flushed) until close
+      onError: () => {},
+      streamPromptHandler: async (_a, text) => {
+        delivered.push(text);
+      },
+    });
+    await bus.start();
+    const client = await connectIpcClient(sockPath);
+    const hello: IpcHello = {
+      type: "hello",
+      agent_id: "alpha",
+      capabilities: ["claude/channel", "claude/channel/permission"],
+    };
+    client.send(hello);
+    await new Promise((r) => setTimeout(r, 20));
+    bus.ingestSessionEvent({
+      ts: 1,
+      agent_id: "alpha",
+      session_id: "s",
+      topic: "session.init",
+      payload: {},
+    });
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "telegram",
+      origin_id: "i",
+      user_id: "u",
+      text: "carryme",
+    });
+    await new Promise((r) => setTimeout(r, 30));
+    expect(delivered).toHaveLength(0); // held while (re)initialising
+    client.close(); // onClose → snapshot the held prompt into pendingRedelivery
+    await new Promise((r) => setTimeout(r, 40));
+    expect(delivered).toHaveLength(0); // still nothing — no ready session yet
+    // The fresh generation reaches replay_done → carried prompt re-delivered.
+    bus.ingestSessionEvent({
+      ts: 1,
+      agent_id: "alpha",
+      session_id: "s2",
+      topic: "bus.events.replay_done",
+      payload: {},
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(delivered).toHaveLength(1);
+    expect(delivered[0]).toContain("carryme");
+  });
+
   describe("silent-drop safety net (issue #215)", () => {
     function makeBus(): BusCore {
       return createBusCore({
@@ -1693,5 +1750,30 @@ describe("BusCore delivery gate (session.init / replay_done)", () => {
     bus.ingestSessionEvent(turnEvt("alpha", delivered[0])); // "queued" starts its OWN turn → cancel
     await new Promise((r) => setTimeout(r, 100)); // > flushVerify + grace
     expect(delivered).toHaveLength(1); // attributed → not re-delivered
+  });
+
+  it("recovers a stuck neighbor-turn flag on replay_done so flush-verify is not disabled forever (#252 stack ultra HIGH)", async () => {
+    // A turn whose `response.turn_end` is never seen (interrupted by a reconciler
+    // restart whose new tailer seeks past it) would leave agentTurnActive stuck
+    // true, permanently DEFERRING every flush-verify for the agent. A new session
+    // generation (replay_done) must clear it so the safety net comes back.
+    bus = createBusCore({
+      eventLogAppend: createMockEventLog().append,
+      flushVerifyMs: 40,
+      onError: () => {},
+    });
+    const delivered: string[] = [];
+    bus.setStreamPromptHandler(async (_a, text) => {
+      delivered.push(text);
+    });
+    bus.ingestSessionEvent(turnEvt("alpha", "<channel>orphan</channel>")); // turn starts, NO turn_end ever
+    await prompt("alpha", "p1"); // immediate delivery during the (stuck) active turn → arms a verify
+    expect(delivered).toHaveLength(1);
+    await new Promise((r) => setTimeout(r, 70)); // > flushVerify: deferred while agentTurnActive stuck true
+    expect(delivered).toHaveLength(1); // not re-delivered — verify is (correctly) deferred...
+    bus.ingestSessionEvent(replayEvt("alpha")); // ...until a new generation clears the stuck flag
+    await new Promise((r) => setTimeout(r, 70)); // verify now fires → re-deliver "p1"
+    expect(delivered).toHaveLength(2);
+    expect(delivered[1]).toContain("p1");
   });
 });

--- a/src/bus/__tests__/mcp-reconciler.test.ts
+++ b/src/bus/__tests__/mcp-reconciler.test.ts
@@ -83,6 +83,22 @@ describe("createMcpReconciler (#222)", () => {
     expect(h.logs.some((l) => l.msg === "reconcile-skip")).toBe(true);
   });
 
+  it("does NOT restart while a turn is actively streaming — defers until the turn ends (#252 stack ultra)", async () => {
+    let turnActive = true;
+    const h = harness({ isTurnActive: () => turnActive });
+    const onFail = createMcpReconciler(h.deps);
+    onFail("default", { reason: "test" });
+    await h.flush(); // confirm window fires: turn active → skip + re-arm, no restart
+    expect(h.restartCalls).toEqual([]);
+    expect(
+      h.logs.some((l) => l.msg === "reconcile-skip" && l.fields.reason === "turn-active"),
+    ).toBe(true);
+    // The turn ends; the deferred re-check now restarts the still-deaf agent.
+    turnActive = false;
+    await h.flush();
+    expect(h.restartCalls).toEqual(["default"]);
+  });
+
   it("coalesces a burst of signals into a single restart", async () => {
     const h = harness();
     const onFail = createMcpReconciler(h.deps);

--- a/src/bus/core-ipc.ts
+++ b/src/bus/core-ipc.ts
@@ -217,10 +217,21 @@ export async function bindUdsServer(path: string, handlers: IpcServerHandlers): 
       close(socket) {
         allSockets.delete(socket);
         const aid = socket.data?.agentId;
-        if (aid && connectionsByAgent.get(aid) === socket) {
-          connectionsByAgent.delete(aid);
+        if (aid) {
+          if (connectionsByAgent.get(aid) === socket) {
+            // This socket is the agent's CURRENT connection — a real disconnect.
+            connectionsByAgent.delete(aid);
+            handlers.onClose(aid);
+          }
+          // else: a newer hello for the same agent_id already superseded this
+          // socket (reconnect / reconciler restart reusing agent_id, see the
+          // `prev.end()` takeover in handleMessage). This is the OLD socket
+          // closing late; firing onClose would tear down the FRESH generation's
+          // delivery-gate / flush-verify / silent-drop state (#252 stack ultra).
+          // The new socket owns the agent now — skip the stale teardown.
+        } else {
+          handlers.onClose(null); // pre-handshake socket closed
         }
-        handlers.onClose(aid ?? null);
       },
       error(socket, err) {
         handlers.onError(err, socket.data?.agentId ?? null);

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -180,6 +180,9 @@ export interface BusCore {
   ): void;
   /** True if Bus core currently holds a live MCP/IPC connection for the agent (#222). */
   isAgentConnected(agentId: string): boolean;
+  /** True if the agent has a turn currently streaming (#222 reconciler reads
+   *  this to skip restarting a deaf-but-mid-turn agent). */
+  isAgentTurnActive(agentId: string): boolean;
   ingestReply(req: IngestReplyRequest): void;
   ingestSessionEvent(e: BusEvent): void;
   ingestPermissionDecision(req: IngestPermissionDecisionRequest): void;
@@ -300,6 +303,17 @@ export class BusCoreImpl implements BusCore {
    */
   private readonly agentTurnActive = new Set<string>();
   /**
+   * Prompts that were outstanding (held in the delivery queue, or flushed and
+   * awaiting turn-start verification) when an agent's socket closed — typically
+   * a #222 reconciler restart of an alive-but-deaf agent. Without this they are
+   * silently dropped: onClose tears down the queue and the verify, and the
+   * restart resumes the session WITHOUT re-typing the keystroke, so no recovery
+   * layer owns the prompt (#252 stack ultra). Snapshotted on close, re-delivered
+   * through the gate when the fresh generation reaches `replay_done`. Cleared on
+   * shutdown; superseded if the agent never comes back (no further replay_done).
+   */
+  private readonly pendingRedelivery = new Map<string, string[]>();
+  /**
    * Silent-drop safety net (issue #215): tracks per-agent whether the
    * current turn has called the `reply` MCP tool with `intent: "final"`.
    * Reset on every new inbound prompt (`sendPrompt`), set to `true` when
@@ -399,6 +413,17 @@ export class BusCoreImpl implements BusCore {
           const heldInitTimer = this.agentInitializing.get(agentId);
           if (heldInitTimer) clearTimeout(heldInitTimer);
           this.agentInitializing.delete(agentId);
+          // Snapshot any outstanding prompts (still-held queue + flushed-and-
+          // awaiting-verify) BEFORE tearing them down, so a reconciler restart
+          // of an alive-but-deaf agent re-delivers them once the fresh session
+          // is ready instead of silently dropping them (#252 stack ultra). The
+          // timers themselves still die here (no stale keystroke into a reused
+          // agent_id — the #252 HIGH); only the prompt text is carried over.
+          const carryOver = new Set<string>(this.deliveryQueue.get(agentId) ?? []);
+          const pendingVerify = this.flushVerify.get(agentId);
+          if (pendingVerify)
+            for (const entry of pendingVerify.values()) carryOver.add(entry.wrapped);
+          if (carryOver.size > 0) this.pendingRedelivery.set(agentId, [...carryOver]);
           this.deliveryQueue.delete(agentId);
           // Same hazard for a pending flush-verify timer: if it fired after a
           // restart that reused this agent_id it would type a stale keystroke
@@ -438,6 +463,7 @@ export class BusCoreImpl implements BusCore {
     this.flushVerify.clear();
     this.inFlightDeliveries.clear();
     this.agentTurnActive.clear();
+    this.pendingRedelivery.clear();
   }
 
   /* ─────────────────────────────── prompts ─────────────────────────────── */
@@ -633,6 +659,23 @@ export class BusCoreImpl implements BusCore {
     const timer = this.agentInitializing.get(agent_id);
     if (timer) clearTimeout(timer);
     this.agentInitializing.delete(agent_id);
+    // A (re)ready session generation cannot have the previous turn still
+    // streaming, so clear the neighbor-turn flag here too. This is the
+    // generation boundary that recovers a stuck agentTurnActive after a
+    // reconciler restart whose new tailer (startAt:"end") never replays the
+    // interrupted turn's end_turn — without it, flush-verify would defer
+    // forever for this agent and leak a lingering entry per prompt (#252 stack
+    // ultra HIGH).
+    this.agentTurnActive.delete(agent_id);
+    // Re-deliver prompts carried over from a prior socket close (e.g. a #222
+    // reconciler restart of a deaf agent): the fresh session is now ready, so
+    // push them through the gate. Independent of the held-queue below, and done
+    // first so they keep their original order ahead of anything newly held.
+    const carried = this.pendingRedelivery.get(agent_id);
+    if (carried) {
+      this.pendingRedelivery.delete(agent_id);
+      for (const wrapped of carried) this.deliverOrQueuePrompt(agent_id, wrapped);
+    }
     const q = this.deliveryQueue.get(agent_id);
     if (!q || q.length === 0) return;
     this.deliveryQueue.delete(agent_id);
@@ -778,6 +821,15 @@ export class BusCoreImpl implements BusCore {
 
   isAgentConnected(agentId: string): boolean {
     return this.connectedAgents.has(agentId);
+  }
+
+  /** True if the agent has a turn currently streaming (tailer `prompt` seen, no
+   *  `response.turn_end` yet). The #222 reconciler reads this to avoid a
+   *  destructive restart of an agent that is merely deaf-but-mid-turn — the turn
+   *  still completes and is delivered by the silent-drop net (#215), which rides
+   *  the tailer, not the dead MCP socket. */
+  isAgentTurnActive(agentId: string): boolean {
+    return this.agentTurnActive.has(agentId);
   }
 
   /* ─────────────────────────────── subscriptions ─────────────────────────────── */
@@ -1139,6 +1191,10 @@ export class BusCoreImpl implements BusCore {
         // tracking flag to keep the map bounded.
         this.currentTurnReplied.delete(agentId);
         this.currentTurnFinalPublished.delete(agentId);
+        // A cancelled/errored turn emits no response.turn_end, so the
+        // neighbor-turn flag would never clear via the tailer — drop it here
+        // too, else flush-verify defers forever for this agent (#252 stack ultra).
+        this.agentTurnActive.delete(agentId);
         break;
       case "request_human": {
         // Forward the correlation id along with the question. Without
@@ -1197,6 +1253,10 @@ export class BusCoreImpl implements BusCore {
         // turn_end either — clear tracking too.
         this.currentTurnReplied.delete(agentId);
         this.currentTurnFinalPublished.delete(agentId);
+        // A cancelled/errored turn emits no response.turn_end, so the
+        // neighbor-turn flag would never clear via the tailer — drop it here
+        // too, else flush-verify defers forever for this agent (#252 stack ultra).
+        this.agentTurnActive.delete(agentId);
         break;
       // hello already handled in the IPC layer; outbound types (prompt,
       // permission_response, ask_answer) shouldn't arrive from MCP.

--- a/src/bus/mcp-reconciler.ts
+++ b/src/bus/mcp-reconciler.ts
@@ -30,6 +30,11 @@ export interface McpReconcilerDeps {
   isConnected(agentId: string): boolean;
   /** True iff the agent's process is alive (not exited) per the Session Manager. */
   isProcessAlive(agentId: string): boolean;
+  /** True iff a turn is currently streaming for the agent (bus tracks this via
+   *  the JSONL tailer). Optional; when present, `attempt()` defers a restart of
+   *  a deaf-but-mid-turn agent so a live turn is not interrupted (#252 stack
+   *  ultra) — the turn still delivers via the tailer-based silent-drop net. */
+  isTurnActive?(agentId: string): boolean;
   /** Respawn the agent (Session Manager `restart()` — same session_id, resumes). */
   restart(agentId: string): Promise<unknown>;
   /** Structured logger. Lands in the daemon log, grep-able. */
@@ -106,6 +111,21 @@ export function createMcpReconciler(
     // supervisor owns respawn. The reconciler only handles alive-but-deaf.
     if (!deps.isProcessAlive(agentId)) {
       deps.log("reconcile-skip", { agent: agentId, reason: "process-not-alive" });
+      return;
+    }
+    // Deaf-but-mid-turn: the MCP socket is down but a turn is actively streaming
+    // (PTY-confirmed). A restart would interrupt a live turn whose output the
+    // silent-drop net (#215, tailer-based, does NOT need the MCP socket) can
+    // still deliver. Defer: re-arm a confirm so we restart only once the turn
+    // ends (bounded — agentTurnActive clears on turn_end / replay_done).
+    if (deps.isTurnActive?.(agentId)) {
+      deps.log("reconcile-skip", {
+        agent: agentId,
+        reason: "turn-active",
+        note: "deferring restart until the turn ends",
+      });
+      s.pendingConfirm = true; // keep coalescing further signals; re-check after the turn
+      setTimer(() => attempt(agentId, reason), confirmMs);
       return;
     }
     if (s.inFlight) return;

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -269,6 +269,7 @@ export async function mountBusRuntime(
       createMcpReconciler({
         isConnected: (agentId) => bus.isAgentConnected(agentId),
         isProcessAlive: (agentId) => sessionManager.health()[agentId]?.alive ?? false,
+        isTurnActive: (agentId) => bus.isAgentTurnActive(agentId),
         restart: (agentId) => sessionManager.restart(agentId),
         log: (msg, fields) => logger.error("[mcp-reconcile]", msg, fields),
       }),


### PR DESCRIPTION
## What

A whole-stack ultra-review of the merged wedge/delivery subsystem (#215 silent-drop, #222 reconciler, #248/#250 PTY confirm-loop, #252 flush-verify) — reviewing how the layers **interact** now that they all run together, not each PR in isolation. It surfaced three integration defects, none of which a per-PR review could see. This PR fixes all three.

## A — `agentTurnActive` could stick true forever (was: flush-verify silently disabled + leak)

The neighbor-turn flag (used so a prompt delivered during a live turn is verified rather than trusted to the PTY confirm-loop) was cleared only on `response.turn_end` / `onClose` / `stop`. A turn whose `turn_end` the bus never sees — interrupted by a #222 reconciler restart whose fresh tailer (`startAt:"end"`) seeks past it, or a cancel/error turn — left it stuck `true`. Consequences: every `scheduleFlushVerify` then **defers forever** (the #252 re-delivery net is dead for that agent), and each later prompt arms a verify entry that defers and is never deleted (a slow leak).

**Fix:** also clear `agentTurnActive` on `markAgentReady` (a `replay_done` is a new session generation — the previous turn cannot still be streaming) and in the `cancel`/`error` IPC handlers (mirroring the other per-turn flags).

## B — a reconciler restart dropped the prompt that triggered it

When #222 restarts an alive-but-deaf agent, `onClose` tore down the held queue and the armed verify, and `restart()` resumes the session without re-typing the keystroke — so **no recovery layer owned re-delivery** and the prompt was silently lost (degraded to the watchdog).

**Fix:** `onClose` snapshots the agent's outstanding prompts (held queue + flushed-awaiting-verify) and the fresh generation's `replay_done` re-delivers them through the gate. The timers themselves still die on close (no stale keystroke into a reused `agent_id` — the #252 hardening), only the prompt text is carried over. Additionally, the reconciler now **skips a destructive restart of a deaf-but-mid-turn agent** (new optional `isTurnActive` dep) and defers until the turn ends — that turn still delivers via the tailer-based silent-drop net (#215), which doesn't need the MCP socket.

## C — a superseded old socket's late close wiped the fresh generation's state

On a same-`agent_id` reconnect/restart the new `hello` calls `prev.end()`, but the old socket's later `close` still fired `onClose(agentId)` unconditionally — tearing down the **new** generation's delivery-gate / flush-verify / silent-drop state.

**Fix:** `core-ipc.ts` now only invokes `onClose` when the closing socket is still the agent's current connection; a superseded socket's close is ignored.

## Tests

+3 regression tests (stuck-flag recovery on `replay_done`; re-delivery of a prompt held at close; reconciler skip-while-turn-active). Full bus suite **386 pass / 0 fail**.
