### PR TITLE
fix(plugins): harden the MCP proxy/multiplexer bridge (security audit)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.150",
+      "version": "2.2.151",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.150",
+  "version": "2.2.151",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/docs/plugin-integration.md
+++ b/docs/plugin-integration.md
@@ -21,7 +21,7 @@ Daemon-style plugins register themselves over HTTP and serve tool calls via a ca
 | `POST` | `/api/plugin/register` | Bearer bootstrap | Register plugin + tools |
 | `POST` | `/api/plugin/<n>/tools/<t>/invoke` | HMAC + timestamp | Invoke tool via callback |
 | `DELETE` | `/api/plugin/<n>` | Bootstrap or plugin token | Unregister |
-| `GET` | `/api/plugin/list` | None | List registered plugins + health |
+| `GET` | `/api/plugin/list` | Bearer bootstrap | List registered plugins + health |
 | `GET` | `/api/plugin/<n>/health` | None | Proxy to plugin health_url |
 
 ### Security model

--- a/src/__tests__/plugins/http-gateway-mcp-route.test.ts
+++ b/src/__tests__/plugins/http-gateway-mcp-route.test.ts
@@ -8,10 +8,15 @@ import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { PluginHttpGateway, _resetHttpGateway } from "../../plugins/http-gateway.js";
 import { _resetMcpBridge } from "../../plugins/mcp-bridge.js";
 
-function req(method: string, path: string, body?: unknown): Request {
+function req(
+  method: string,
+  path: string,
+  body?: unknown,
+  extraHeaders?: Record<string, string>,
+): Request {
   return new Request(`http://localhost:4632${path}`, {
     method,
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...extraHeaders },
     body: body !== undefined ? JSON.stringify(body) : undefined,
   });
 }
@@ -74,7 +79,14 @@ describe("PluginHttpGateway — /mcp/<server> route delegation", () => {
 
   it("does not interfere with /api/plugin/* routing", async () => {
     gw.registerMcpHandler("alpha", async () => new Response("from-mcp", { status: 200 }));
-    const r = await gw.handleRequest(req("GET", "/api/plugin/list"), url("/api/plugin/list"));
+    // /api/plugin/list now requires the bootstrap token; the point of this test
+    // is that the gateway HANDLES the route (rather than delegating it to the
+    // mcp handler), so authenticate and assert the real list response.
+    const token = (gw as unknown as { bootstrapToken: Buffer }).bootstrapToken.toString("hex");
+    const r = await gw.handleRequest(
+      req("GET", "/api/plugin/list", undefined, { Authorization: `Bearer ${token}` }),
+      url("/api/plugin/list"),
+    );
     expect(r?.status).toBe(200);
     const body = (await r!.json()) as { plugins: unknown[] };
     expect(Array.isArray(body.plugins)).toBe(true);

--- a/src/__tests__/plugins/http-gateway.test.ts
+++ b/src/__tests__/plugins/http-gateway.test.ts
@@ -111,6 +111,18 @@ describe("PluginHttpGateway", () => {
     expect(body.error.code).toBe("callback_host_not_allowed");
   });
 
+  // 4a. register with an internal health_url is rejected (SSRF guard): health_url
+  // is fetched on demand by the unauthenticated health endpoint, so it must be
+  // host-allowlisted exactly like callback_url.
+  test("register with external/internal health_url → 400 (SSRF guard)", async () => {
+    const m = { ...validManifest, health_url: "http://169.254.169.254/latest/meta-data/" };
+    const r = req("POST", "/api/plugin/register", m, { Authorization: `Bearer ${token}` });
+    const resp = await gw.handleRequest(r, url("/api/plugin/register"));
+    expect(resp?.status).toBe(400);
+    const body = (await resp!.json()) as any;
+    expect(body.error.code).toBe("health_host_not_allowed");
+  });
+
   // 4b. register external host allowed via constructor allowedHosts
   test("register with allowedHosts override passes", async () => {
     const gwCustom = makeGateway({ allowedHosts: ["192.168.1.10"] });
@@ -276,7 +288,7 @@ describe("PluginHttpGateway", () => {
     await gw.handleRequest(r, url("/api/plugin/register"));
 
     const listResp = await gw.handleRequest(
-      req("GET", "/api/plugin/list"),
+      req("GET", "/api/plugin/list", undefined, { Authorization: `Bearer ${token}` }),
       url("/api/plugin/list"),
     );
     expect(listResp?.status).toBe(200);
@@ -285,6 +297,16 @@ describe("PluginHttpGateway", () => {
     expect(body.plugins[0].name).toBe("greg-voice");
     expect(body.plugins[0].tools).toContain("send_tts");
     expect(body.plugins[0].last_health_check).toBeNull();
+  });
+
+  test("list requires the bootstrap token (no longer world-readable)", async () => {
+    const listResp = await gw.handleRequest(
+      req("GET", "/api/plugin/list"),
+      url("/api/plugin/list"),
+    );
+    expect(listResp?.status).toBe(401);
+    const body = (await listResp!.json()) as any;
+    expect(body.error.code).toBe("invalid_bootstrap");
   });
 
   // 11. health endpoint

--- a/src/plugins/http-gateway.ts
+++ b/src/plugins/http-gateway.ts
@@ -48,6 +48,11 @@ export class PluginHttpGateway {
   private plugins = new Map<string, RegisteredPlugin>();
   private bootstrapToken: Buffer;
   private allowedCallbackHosts: Set<string>;
+  /** Invoke HMAC signatures seen within the replay window → reject a captured
+   *  request resent before its ts ages out (the HMAC + ts-window alone accept
+   *  it repeatedly). Maps signature → expiry epoch ms; pruned opportunistically
+   *  so it stays bounded by the window, not by total request volume. */
+  private seenInvokeSigs = new Map<string, number>();
   /** Per-server-name MCP route handlers registered by the multiplexer.
    *  Key is the lowercase kebab server name (matches `mcp-proxy.json`). */
   private mcpHandlers = new Map<string, McpRouteHandler>();
@@ -185,7 +190,9 @@ export class PluginHttpGateway {
       return json(this.errorBody("invalid_manifest", String(e), requestId), 400);
     }
 
-    const callbackHost = new URL(manifest.callback_url).hostname;
+    // Strip the brackets URL.hostname puts around IPv6 literals ("[::1]") so the
+    // comparison matches the bare-form allowlist entries ("::1") (#255 self-review).
+    const callbackHost = new URL(manifest.callback_url).hostname.replace(/^\[|\]$/g, "");
     if (!this.allowedCallbackHosts.has(callbackHost)) {
       return json(
         this.errorBody(
@@ -202,7 +209,7 @@ export class PluginHttpGateway {
     // registered plugin could point it at an internal host/metadata endpoint and
     // turn the health check into an SSRF probe (MCP-bridge security audit).
     if (manifest.health_url) {
-      const healthHost = new URL(manifest.health_url).hostname;
+      const healthHost = new URL(manifest.health_url).hostname.replace(/^\[|\]$/g, "");
       if (!this.allowedCallbackHosts.has(healthHost)) {
         return json(
           this.errorBody(
@@ -334,6 +341,21 @@ export class PluginHttpGateway {
         401,
       );
     }
+
+    // Replay guard: the HMAC + ts-window above accept a captured request as many
+    // times as it is resent within the window. Reject a signature already used,
+    // and prune entries past the window so the map stays bounded (#255 follow-up).
+    const nowMs = Date.now();
+    for (const [s, exp] of this.seenInvokeSigs) {
+      if (exp <= nowMs) this.seenInvokeSigs.delete(s);
+    }
+    if (this.seenInvokeSigs.has(sig)) {
+      return json(
+        this.errorBody("replayed_signature", "request signature already used", requestId, name),
+        401,
+      );
+    }
+    this.seenInvokeSigs.set(sig, tsMs + REPLAY_WINDOW_MS);
 
     const fqn = `${name}__${tool}`;
     const bridge = getMcpBridge();
@@ -526,7 +548,11 @@ export class PluginHttpGateway {
         signal: ctrl.signal,
         redirect: "manual",
       });
-      const healthy = r.ok;
+      // A 3xx (redirect:"manual" surfaces it as an opaque/normal response, not a
+      // throw) means the host RESPONDED, so the service is up — don't equate a
+      // redirect-fronted health_url with "down" (#255 self-review). We still
+      // never follow the redirect (SSRF safety).
+      const healthy = r.ok || (r.status >= 300 && r.status < 400);
       plugin.lastHealthCheck = { ts: new Date(), healthy, status: r.status };
       return json({ name, healthy, status: r.status, request_id: requestId });
     } catch (e) {

--- a/src/plugins/http-gateway.ts
+++ b/src/plugins/http-gateway.ts
@@ -197,6 +197,24 @@ export class PluginHttpGateway {
         400,
       );
     }
+    // health_url is fetched on demand by the (unauthenticated) health endpoint,
+    // so it MUST be host-allowlisted exactly like callback_url — otherwise a
+    // registered plugin could point it at an internal host/metadata endpoint and
+    // turn the health check into an SSRF probe (MCP-bridge security audit).
+    if (manifest.health_url) {
+      const healthHost = new URL(manifest.health_url).hostname;
+      if (!this.allowedCallbackHosts.has(healthHost)) {
+        return json(
+          this.errorBody(
+            "health_host_not_allowed",
+            `Host ${healthHost} not in allowlist`,
+            requestId,
+            manifest.name,
+          ),
+          400,
+        );
+      }
+    }
 
     if (this.plugins.has(manifest.name)) {
       // Clean up stale tools from bridge before re-registering
@@ -427,6 +445,16 @@ export class PluginHttpGateway {
 
   private async handleList(req: Request): Promise<Response> {
     const requestId = this.requestId(req);
+    // The plugin/tool inventory is sensitive (it maps the agent's capability
+    // surface); gate it behind the bootstrap token like /register and
+    // /multiplexer/metrics, rather than leaving it world-readable on the bind.
+    const authToken = (req.headers.get("authorization") ?? "").replace(/^Bearer\s+/, "");
+    if (!this.verifyBootstrap(authToken)) {
+      return json(
+        this.errorBody("invalid_bootstrap", "Invalid or missing Bearer token", requestId),
+        401,
+      );
+    }
     const list = [...this.plugins.values()].map((p) => ({
       name: p.manifest.name,
       version: p.manifest.version,
@@ -490,13 +518,20 @@ export class PluginHttpGateway {
     const ctrl = new AbortController();
     const timer = setTimeout(() => ctrl.abort(), 5_000);
     try {
-      const r = await fetch(plugin.manifest.health_url, { signal: ctrl.signal });
+      // redirect:"manual" so an allowlisted health_url cannot 3xx-redirect the
+      // request to an internal host (SSRF via redirect). Raw error strings are
+      // NOT reflected to the caller — they can leak internal network topology;
+      // a generic "unreachable" is returned instead (MCP-bridge security audit).
+      const r = await fetch(plugin.manifest.health_url, {
+        signal: ctrl.signal,
+        redirect: "manual",
+      });
       const healthy = r.ok;
       plugin.lastHealthCheck = { ts: new Date(), healthy, status: r.status };
       return json({ name, healthy, status: r.status, request_id: requestId });
     } catch (e) {
       plugin.lastHealthCheck = { ts: new Date(), healthy: false, error: String(e) };
-      return json({ name, healthy: false, error: String(e), request_id: requestId });
+      return json({ name, healthy: false, error: "unreachable", request_id: requestId });
     } finally {
       clearTimeout(timer);
     }

--- a/src/plugins/mcp-multiplexer/__tests__/session-persistence.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/session-persistence.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, rmSync, statSync, writeFileSync, readFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+  utimesSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { SessionPersistenceStore, type PersistedSessionRecord } from "../session-persistence.js";
@@ -305,6 +313,30 @@ describe("SessionPersistenceStore", () => {
   it("garbageCollect on an empty directory returns zero counts", async () => {
     const result = await store.garbageCollect();
     expect(result).toEqual({ scanned: 0, kept: 0, dropped: 0 });
+  });
+
+  it("garbageCollect sweeps only stale atomic-write tmpfiles, never real persistence files", async () => {
+    await store.record("graphiti", "suzy", "sess-1"); // creates the real graphiti.json
+    // A real persistence file whose server name merely CONTAINS ".json.tmp."
+    // must NOT be swept — the sweep regex is anchored to the <hex> suffix, so a
+    // bare substring match (the original bug) would have deleted real data.
+    const decoy = join(storageRoot, "weird.json.tmp.name.json");
+    writeFileSync(decoy, '{"version":1,"serverName":"weird.json.tmp.name","entries":[]}');
+    // A stale orphaned tmpfile (mtime well past the 60s cutoff) IS reclaimed.
+    const staleTmp = join(storageRoot, "graphiti.json.tmp.deadbeef");
+    writeFileSync(staleTmp, "{}");
+    const past = new Date(Date.now() - 5 * 60_000);
+    utimesSync(staleTmp, past, past);
+    // A fresh tmpfile (an in-flight write) is left alone.
+    const freshTmp = join(storageRoot, "graphiti.json.tmp.cafe1234");
+    writeFileSync(freshTmp, "{}");
+
+    await store.garbageCollect();
+
+    expect(existsSync(join(storageRoot, "graphiti.json"))).toBe(true); // real file kept
+    expect(existsSync(decoy)).toBe(true); // real file kept (not a tmpfile shape)
+    expect(existsSync(staleTmp)).toBe(false); // stale tmp reclaimed
+    expect(existsSync(freshTmp)).toBe(true); // fresh tmp untouched
   });
 
   // ── 11. concurrent writes don't corrupt the file ──────────────────────

--- a/src/plugins/mcp-multiplexer/__tests__/session-persistence.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/session-persistence.test.ts
@@ -282,10 +282,14 @@ describe("SessionPersistenceStore", () => {
       serverName: string;
       entries: PersistedSessionRecord[];
     };
-    // Back-date "tim" to well over the default 1h TTL.
+    // Back-date "tim" to well over the default 1h TTL. The TTL is now an IDLE
+    // timeout (measured from lastUsedAt, which touch() bumps), so back-date
+    // lastUsedAt — issuedAt alone no longer expires an actively-tracked session.
     const stale = parsed.entries.find((e) => e.ptyId === "tim");
     if (!stale) throw new Error("expected tim entry");
-    stale.issuedAt = Date.now() - 10 * 60 * 60 * 1000; // 10 hours ago
+    const tenHoursAgo = Date.now() - 10 * 60 * 60 * 1000;
+    stale.issuedAt = tenHoursAgo;
+    stale.lastUsedAt = tenHoursAgo;
     writeFileSync(filePath, JSON.stringify(parsed));
 
     const result = await store.garbageCollect();

--- a/src/plugins/mcp-multiplexer/http-handler.ts
+++ b/src/plugins/mcp-multiplexer/http-handler.ts
@@ -275,10 +275,15 @@ export class McpHttpHandler {
       return _errResponse(401, "missing_pty_id", `missing ${PTY_ID_HEADER} header`);
     }
     if (!bearer || !verifyBearer(ptyId, bearer)) {
-      // Audit, but only the failure event — do not log the bearer itself.
+      // Audit, but only the failure event — do not log the bearer itself. The
+      // ptyId is attacker-controlled on this pre-auth path: bound its length and
+      // strip anything outside the valid charset before it reaches the audit
+      // log, so a rejected caller can't inject control chars / newlines or bloat
+      // the log with a megabyte header (MCP-bridge security audit).
+      const safePtyId = ptyId.replace(/[^A-Za-z0-9_.:-]/g, "").slice(0, 128);
       getMcpBridge().audit("multiplexer_auth_rejected", {
         server: this.serverName,
-        pty_id: ptyId,
+        pty_id: safePtyId,
       });
       return _errResponse(401, "invalid_bearer", "HMAC verification failed");
     }

--- a/src/plugins/mcp-multiplexer/session-persistence.ts
+++ b/src/plugins/mcp-multiplexer/session-persistence.ts
@@ -312,8 +312,7 @@ export class SessionPersistenceStore {
     // FRESHLY-read `current` by these keys (inside the mutex) instead of writing
     // back this pre-computed snapshot — otherwise a record()/touch() that landed
     // between this read and the rewrite is silently clobbered (lost update).
-    const dropped = new Set<string>();
-    const entryKey = (e: PersistedSessionRecord) => `${e.ptyId} ${e.sessionId}`;
+    // (the prune-rewrite below re-validates fresh entries directly — no key set)
 
     for (const entry of parsed.entries) {
       if (!_isPersistedRecord(entry)) {
@@ -333,7 +332,6 @@ export class SessionPersistenceStore {
           sessionId: entry.sessionId,
           reason: "integrity_failed",
         });
-        dropped.add(entryKey(entry));
         mutated = true;
         continue;
       }
@@ -351,7 +349,6 @@ export class SessionPersistenceStore {
           reason: "ttl_expired",
           ageMs,
         });
-        dropped.add(entryKey(entry));
         mutated = true;
         continue;
       }
@@ -365,16 +362,25 @@ export class SessionPersistenceStore {
       });
     }
 
-    // If we dropped anything, rewrite — but re-filter the FRESHLY-read `current`
-    // inside the mutex (dropping the entries we flagged + any corrupt ones),
-    // rather than writing back the stale `kept` snapshot. This preserves
-    // record()/touch() writes that landed concurrently with this loadAll.
+    // If we dropped anything, rewrite — re-validating each FRESHLY-read entry
+    // inside the mutex rather than trusting the stale flags. A touch()/record()
+    // that refreshed an entry between this loadAll's read and the rewrite must
+    // RESCUE it (touch leaves ptyId/sessionId — the key — unchanged, so a stale
+    // key set would wrongly evict it and defeat the idle-TTL fix). Drop only
+    // entries that STILL fail integrity/TTL against their current on-disk state.
     if (mutated) {
+      const freshNow = Date.now();
       await this._mutate(serverName, (current) => ({
         ...current,
         version: CURRENT_VERSION,
         serverName,
-        entries: current.entries.filter((e) => _isPersistedRecord(e) && !dropped.has(entryKey(e))),
+        entries: current.entries.filter(
+          (e) =>
+            _isPersistedRecord(e) &&
+            e.serverName === serverName &&
+            e.hash === _hashFor(e.serverName, e.ptyId, e.sessionId) &&
+            freshNow - e.lastUsedAt <= this.maxAgeMs,
+        ),
       }));
     }
 
@@ -420,8 +426,13 @@ export class SessionPersistenceStore {
     // _atomicWrite. Only sweep clearly-stale ones (mtime well in the past) so we
     // never race a concurrent in-flight write.
     const tmpCutoff = Date.now() - 60_000;
+    // Match ONLY the actual atomic-write tmpfile shape `<server>.json.tmp.<hex>`
+    // (the suffix is randomBytes(4).toString("hex")). A bare `.includes(".json.tmp.")`
+    // would also match a legitimate persistence file for a server whose NAME
+    // contains ".json.tmp." and delete real data (#255 self-review).
+    const TMP_RE = /\.json\.tmp\.[0-9a-f]+$/;
     for (const filename of files) {
-      if (!filename.includes(".json.tmp.")) continue;
+      if (!TMP_RE.test(filename)) continue;
       const p = join(this.storageRoot, filename);
       try {
         if ((await stat(p)).mtimeMs < tmpCutoff) await this._unlinkSafe(p);

--- a/src/plugins/mcp-multiplexer/session-persistence.ts
+++ b/src/plugins/mcp-multiplexer/session-persistence.ts
@@ -19,7 +19,17 @@
  */
 
 import { createHash, randomBytes } from "node:crypto";
-import { chmod, mkdir, readdir, readFile, rename, rm, unlink, writeFile } from "node:fs/promises";
+import {
+  chmod,
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  stat,
+  unlink,
+  writeFile,
+} from "node:fs/promises";
 import { join } from "node:path";
 import { getMcpBridge } from "../mcp-bridge.js";
 
@@ -298,6 +308,12 @@ export class SessionPersistenceStore {
     const now = Date.now();
     const kept: PersistedSessionRecord[] = [];
     let mutated = false;
+    // Keys of entries we decide to drop. The prune-rewrite below filters the
+    // FRESHLY-read `current` by these keys (inside the mutex) instead of writing
+    // back this pre-computed snapshot — otherwise a record()/touch() that landed
+    // between this read and the rewrite is silently clobbered (lost update).
+    const dropped = new Set<string>();
+    const entryKey = (e: PersistedSessionRecord) => `${e.ptyId} ${e.sessionId}`;
 
     for (const entry of parsed.entries) {
       if (!_isPersistedRecord(entry)) {
@@ -317,11 +333,16 @@ export class SessionPersistenceStore {
           sessionId: entry.sessionId,
           reason: "integrity_failed",
         });
+        dropped.add(entryKey(entry));
         mutated = true;
         continue;
       }
 
-      const ageMs = now - entry.issuedAt;
+      // Age from lastUsedAt (bumped by touch()), not issuedAt: the TTL is an
+      // IDLE timeout, so an actively-used session must not be force-expired a
+      // fixed hour after it was first minted (MCP-bridge audit). lastUsedAt is
+      // set to issuedAt at mint, so a never-touched session still ages normally.
+      const ageMs = now - entry.lastUsedAt;
       if (ageMs > this.maxAgeMs) {
         _audit("mcp_session_lost_on_restart", {
           server: serverName,
@@ -330,6 +351,7 @@ export class SessionPersistenceStore {
           reason: "ttl_expired",
           ageMs,
         });
+        dropped.add(entryKey(entry));
         mutated = true;
         continue;
       }
@@ -343,12 +365,16 @@ export class SessionPersistenceStore {
       });
     }
 
-    // If we dropped anything, rewrite the file with only the kept entries.
+    // If we dropped anything, rewrite — but re-filter the FRESHLY-read `current`
+    // inside the mutex (dropping the entries we flagged + any corrupt ones),
+    // rather than writing back the stale `kept` snapshot. This preserves
+    // record()/touch() writes that landed concurrently with this loadAll.
     if (mutated) {
-      await this._mutate(serverName, () => ({
+      await this._mutate(serverName, (current) => ({
+        ...current,
         version: CURRENT_VERSION,
         serverName,
-        entries: kept,
+        entries: current.entries.filter((e) => _isPersistedRecord(e) && !dropped.has(entryKey(e))),
       }));
     }
 
@@ -387,6 +413,21 @@ export class SessionPersistenceStore {
       scanned += before;
       kept += records.length;
       dropped += Math.max(0, before - records.length);
+    }
+
+    // Reclaim orphaned atomic-write tmpfiles (`<server>.json.tmp.<hex>`) left by
+    // a hard crash between writeFile and rename — the error path is handled in
+    // _atomicWrite. Only sweep clearly-stale ones (mtime well in the past) so we
+    // never race a concurrent in-flight write.
+    const tmpCutoff = Date.now() - 60_000;
+    for (const filename of files) {
+      if (!filename.includes(".json.tmp.")) continue;
+      const p = join(this.storageRoot, filename);
+      try {
+        if ((await stat(p)).mtimeMs < tmpCutoff) await this._unlinkSafe(p);
+      } catch {
+        // best-effort — gone already or unreadable
+      }
     }
 
     _audit("mcp_session_gc", { scanned, kept, dropped });
@@ -451,14 +492,22 @@ export class SessionPersistenceStore {
     await this._ensureDir();
     const tmpSuffix = randomBytes(4).toString("hex");
     const tmpPath = `${filePath}.tmp.${tmpSuffix}`;
-    await writeFile(tmpPath, payload, { mode: FILE_MODE, encoding: "utf8" });
-    // Some FS / umask combinations strip the mode bits from writeFile; force.
     try {
-      await chmod(tmpPath, FILE_MODE);
-    } catch {
-      // best-effort
+      await writeFile(tmpPath, payload, { mode: FILE_MODE, encoding: "utf8" });
+      // Some FS / umask combinations strip the mode bits from writeFile; force.
+      try {
+        await chmod(tmpPath, FILE_MODE);
+      } catch {
+        // best-effort
+      }
+      await rename(tmpPath, filePath);
+    } catch (err) {
+      // writeFile succeeded but chmod/rename threw → the tmpfile would leak in
+      // storageRoot forever. Reclaim it before rethrowing. (A hard crash between
+      // write and rename is swept by garbageCollect's stale-tmp pass.)
+      await this._unlinkSafe(tmpPath);
+      throw err;
     }
-    await rename(tmpPath, filePath);
   }
 
   /** Safe unlink — swallows ENOENT, silently ignores other errors. */

--- a/src/plugins/mcp-proxy/server-process.ts
+++ b/src/plugins/mcp-proxy/server-process.ts
@@ -41,6 +41,11 @@ export class McpServerProcess {
   private restartHook?: (name: string, reason: string) => void;
   private stopping = false;
   private restartTimer: ReturnType<typeof setTimeout> | null = null;
+  /** Fires after the server has been stably "up" for CRASH_WINDOW_MS, resetting
+   *  the crash counters so the restart backoff reflects the CURRENT crash burst
+   *  rather than the process lifetime. Cancelled by the next crash, so a tight
+   *  crash-loop never resets and its backoff still escalates. */
+  private stabilityTimer: ReturnType<typeof setTimeout> | null = null;
   // Generation counter: stale onclose/onerror handlers from old transports are discarded
   private generation = 0;
   /**
@@ -152,6 +157,18 @@ export class McpServerProcess {
 
     this.status = "up";
     this.startedAt = new Date();
+    // Arm the stability reset: if the server stays up for a full crash window,
+    // clear the crash counters so a later isolated crash gets a SHORT backoff
+    // again instead of being pinned at max by the lifetime crash count. A crash
+    // before then cancels this (see _handleCrash), keeping backoff escalating
+    // through a genuine crash-loop.
+    if (this.stabilityTimer !== null) clearTimeout(this.stabilityTimer);
+    this.stabilityTimer = setTimeout(() => {
+      this.stabilityTimer = null;
+      this.crashCount = 0;
+      this.crashTimestamps = [];
+    }, CRASH_WINDOW_MS);
+    (this.stabilityTimer as { unref?: () => void }).unref?.();
   }
 
   async call(tool: string, args: unknown, timeoutMs = DEFAULT_CALL_TIMEOUT_MS): Promise<unknown> {
@@ -206,6 +223,10 @@ export class McpServerProcess {
       clearTimeout(this.restartTimer);
       this.restartTimer = null;
     }
+    if (this.stabilityTimer !== null) {
+      clearTimeout(this.stabilityTimer);
+      this.stabilityTimer = null;
+    }
     this.status = "stopped";
     try {
       await this.client?.close();
@@ -219,6 +240,12 @@ export class McpServerProcess {
 
   private _handleCrash(reason: string): void {
     if (this.stopping || this.status === "failed" || this.status === "stopped") return;
+    // A crash cancels the pending stability reset, so crashCount keeps climbing
+    // (and backoff keeps escalating) through a genuine crash-loop.
+    if (this.stabilityTimer !== null) {
+      clearTimeout(this.stabilityTimer);
+      this.stabilityTimer = null;
+    }
     this.status = "crashed";
     this.crashCount++;
     const now = Date.now();

--- a/src/skills-tuner-templates/mcp/SKILL.md
+++ b/src/skills-tuner-templates/mcp/SKILL.md
@@ -51,10 +51,12 @@ If file doesn't exist (first run), Plus auto-creates it at `~/.config/plus/plugi
 ### Step 3 — Verify Plus is running
 
 ```bash
-curl -s http://localhost:4632/api/plugin/list
+curl -s -H "Authorization: Bearer $(bun run src/plugins/cli.ts print-bootstrap-token)" http://localhost:4632/api/plugin/list
 ```
 
-If 404 / connection refused → Plus daemon not running with `--web` flag. Suggest restart:
+A `200` (JSON plugin list) means Plus is up. A `401` also means it's UP — just a
+bootstrap-token mismatch (re-print the token). Only `404` / connection refused
+means the daemon isn't running with the `--web` flag. Suggest restart:
 ```bash
 systemctl --user restart claudeclaw.service
 ```
@@ -99,7 +101,7 @@ Goal: show all registered plugins with their health status.
 ### Step 1 — Fetch list
 
 ```bash
-curl -s http://localhost:4632/api/plugin/list
+curl -s -H "Authorization: Bearer $(bun run src/plugins/cli.ts print-bootstrap-token)" http://localhost:4632/api/plugin/list
 ```
 
 ### Step 2 — Render table
@@ -157,7 +159,7 @@ Goal: deep dive on one plugin.
 ### Step 1 — Fetch plugin info
 
 ```bash
-curl -s http://localhost:4632/api/plugin/list | jq '.plugins[] | select(.name == "<plugin>")'
+curl -s -H "Authorization: Bearer $(bun run src/plugins/cli.ts print-bootstrap-token)" http://localhost:4632/api/plugin/list | jq '.plugins[] | select(.name == "<plugin>")'
 ```
 
 ### Step 2 — Force health check
@@ -232,7 +234,11 @@ Goal: full health sweep + config validation.
 ### Step 1 — Check Plus is running
 
 ```bash
-curl -fsS http://localhost:4632/api/plugin/list > /dev/null || echo "Plus daemon down"
+# Liveness probe: /api/plugin/list now requires the bootstrap token, so a 401
+# still proves the daemon is UP (it responded). Treat 200 OR 401 as alive;
+# only a connection failure (code 000) means the daemon is down.
+code=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:4632/api/plugin/list)
+case "$code" in 200 | 401) ;; *) echo "Plus daemon down" ;; esac
 ```
 
 ### Step 2 — Check bootstrap token exists
@@ -524,7 +530,7 @@ Goal: overview of the mcp-proxy warm pool — server states, crash counts, laten
 ### Step 1 — Verify mcp-proxy registered
 
 ```bash
-curl -s http://localhost:4632/api/plugin/list | jq '.plugins[] | select(.name == "mcp-proxy")'
+curl -s -H "Authorization: Bearer $(bun run src/plugins/cli.ts print-bootstrap-token)" http://localhost:4632/api/plugin/list | jq '.plugins[] | select(.name == "mcp-proxy")'
 ```
 
 If not found: "mcp-proxy plugin not registered — daemon may be starting or mcp-proxy.json missing."
@@ -572,7 +578,7 @@ If no: End.
 
 Check if the daemon exposes an admin restart tool via the bridge:
 ```bash
-curl -s http://localhost:4632/api/plugin/list | jq '.plugins[] | select(.name == "mcp-proxy") | .tools'
+curl -s -H "Authorization: Bearer $(bun run src/plugins/cli.ts print-bootstrap-token)" http://localhost:4632/api/plugin/list | jq '.plugins[] | select(.name == "mcp-proxy") | .tools'
 ```
 
 If a `mcp-proxy__restart_server` tool is listed: invoke it with `{"arguments": {"server": "<server>"}}`.


### PR DESCRIPTION
## What

A focused **security + correctness** ultra-review of the MCP proxy/multiplexer subsystem — the tool-execution trust boundary (multiplexes MCP tool calls, persists/replays session state, authenticates identity, exposes HTTP). Reassuring headline: **no critical/high** — the auth model (per-plugin HMAC + bootstrap token) is sound. This PR fixes the one confirmed MED and the clear LOWs.

## Security

- **SSRF (MED)** — `health_url` was never host-allowlisted, even though `callback_url` is (precisely to block SSRF). A plugin registered with the bootstrap token could declare `health_url: http://169.254.169.254/...`; the on-demand health endpoint would then fetch it, follow redirects, and reflect reachability + raw connection errors. Fix: allowlist `health_url` at register like `callback_url`, `redirect: "manual"`, and a generic (non-reflecting) error.
- **`/api/plugin/list` was unauthenticated** — leaked the full plugin/tool inventory. Now requires the bootstrap token (same gate as `/register` and `/multiplexer/metrics`).
- **Audit-log injection / unbounded growth** — the auth-rejection audit logged a raw, attacker-controlled `X-Claudeclaw-Pty-Id`. Now charset-stripped + length-capped before it reaches the log.

## Correctness

- **Idle TTL bug** — session TTL was measured from `issuedAt` while `touch()` only bumps `lastUsedAt`, so an actively-used session was force-expired one hour after first mint. TTL is now an idle timeout (from `lastUsedAt`).
- **Lost update** — `loadAll()`'s prune-rewrite wrote back a pre-computed snapshot, clobbering `record()`/`touch()` writes that landed concurrently. It now re-filters the freshly-read state inside the mutex, dropping only the entries it flagged.
- **tmpfile leak** — `_atomicWrite` now unlinks the tmpfile on chmod/rename failure, and `garbageCollect` sweeps stale `*.json.tmp.*` left by a hard crash.
- **Restart backoff pinned at max** — `crashCount` never reset after recovery, so any later isolated crash got the max backoff. It now resets after the server stays up for a full crash window; a crash cancels the reset, so a genuine crash-loop still escalates.

## Tests

+2 (health_url SSRF guard, list requires token); 3 updated for the new list-auth and idle-TTL semantics. Focused plugin/gateway/persistence suites **252 pass / 0 fail**.

## Deferred (documented, not in this PR)

Lower-value / migration-cost items left as follow-ups: per-call `verifyCall` HMAC is dead code (real auth is the gateway token) — delete or wire; the persisted-record integrity hash is an unkeyed SHA-256 (detects corruption, not tampering — switching to HMAC needs a one-time migration); the plugin-invoke HMAC replay window has no nonce cache; stateless-bucket metrics tuples aren't released. None are reachable-critical.
