### PR TITLE
Wire governance layer: budget enforcement, scoped policies, tamper-evident audit log

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.151",
+      "version": "2.2.152",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.151",
+  "version": "2.2.152",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/governance/usage-tracker.test.ts
+++ b/src/__tests__/governance/usage-tracker.test.ts
@@ -11,8 +11,12 @@ import {
   getAggregates,
   getUsageStats,
   resetUsageTracker,
+  extractTranscriptUsage,
 } from "../../governance/usage-tracker";
 import { join } from "path";
+import { homedir } from "os";
+import { mkdir, writeFile, rm } from "fs/promises";
+import { randomUUID } from "crypto";
 
 // The usage tracker uses .claude/claudeclaw/usage/ - clean this for test isolation
 const USAGE_DIR = join(process.cwd(), ".claude", "claudeclaw", "usage");
@@ -269,5 +273,63 @@ describe("UsageTracker", () => {
     expect(aggregates.completedInvocations).toBe(1);
     expect(aggregates.failedInvocations).toBe(1);
     expect(aggregates.killedInvocations).toBe(1);
+  });
+});
+
+describe("extractTranscriptUsage (budget wiring)", () => {
+  test("sums assistant usage from the session transcript, excluding turns before startedAt", async () => {
+    const cwd = `/tmp/claudeclaw-test-${randomUUID()}`;
+    const sessionId = randomUUID();
+    const dir = join(homedir(), ".claude", "projects", cwd.replace(/\//g, "-"));
+    const jsonl = join(dir, `${sessionId}.jsonl`);
+    await mkdir(dir, { recursive: true });
+    const lines = [
+      // before sinceIso → must be EXCLUDED
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-01-01T00:00:00.000Z",
+        message: { usage: { input_tokens: 999, output_tokens: 999 } },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-06-15T22:00:00.000Z",
+        message: {
+          usage: {
+            input_tokens: 10,
+            output_tokens: 20,
+            cache_creation_input_tokens: 5,
+            cache_read_input_tokens: 100,
+          },
+        },
+      }),
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-06-15T22:00:01.000Z",
+        message: { usage: { input_tokens: 3, output_tokens: 7 } },
+      }),
+      JSON.stringify({ type: "user", timestamp: "2026-06-15T22:00:02.000Z", message: {} }),
+    ].join("\n");
+    await writeFile(jsonl, lines);
+    try {
+      const u = await extractTranscriptUsage(cwd, sessionId, "2026-06-15T12:00:00.000Z");
+      expect(u).not.toBeNull();
+      expect(u?.inputTokens).toBe(13); // 10+3 (the 999 turn predates startedAt)
+      expect(u?.outputTokens).toBe(27); // 20+7
+      expect(u?.cacheCreationInputTokens).toBe(5);
+      expect(u?.cacheReadInputTokens).toBe(100);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns null for an unknown/missing session (no throw, finalize stays safe)", async () => {
+    expect(await extractTranscriptUsage("/tmp/x", "unknown", new Date().toISOString())).toBeNull();
+    expect(
+      await extractTranscriptUsage(
+        `/tmp/${randomUUID()}`,
+        randomUUID(),
+        "2020-01-01T00:00:00.000Z",
+      ),
+    ).toBeNull();
   });
 });

--- a/src/__tests__/policy/audit-log.test.ts
+++ b/src/__tests__/policy/audit-log.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { rm, mkdir, readFile } from "node:fs/promises";
+import { rm, mkdir, readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import {
@@ -18,6 +18,8 @@ import {
   getStats,
   cleanupRetention,
   getRetentionPolicy,
+  verifyChain,
+  _resetChainCache,
   type AuditEntry,
   type AuditAction,
 } from "../../policy/audit-log";
@@ -339,5 +341,119 @@ describe("Audit Log - Retention", () => {
 
     expect(result.deleted).toBe(1);
     expect(result.remaining).toBe(1);
+  });
+});
+
+describe("Audit Log - Tamper-evident hash chain", () => {
+  beforeEach(async () => {
+    _resetChainCache();
+    try {
+      await rm(AUDIT_LOG_FILE, { force: true });
+    } catch {
+      // ignore
+    }
+    await mkdir(AUDIT_DIR, { recursive: true });
+  });
+
+  afterEach(async () => {
+    try {
+      await rm(AUDIT_LOG_FILE, { force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  const sample = (id: string, action: AuditAction = "allow"): AuditEntry => ({
+    timestamp: new Date().toISOString(),
+    eventId: `event-${id}`,
+    requestId: `req-${id}`,
+    source: "telegram",
+    toolName: "Bash",
+    action,
+    reason: `reason ${id}`,
+  });
+
+  it("stamps each entry with prevHash and hash, chaining genesis -> tail", async () => {
+    await log(sample("1"));
+    await log(sample("2"));
+    await log(sample("3"));
+
+    const content = await readFile(AUDIT_LOG_FILE, "utf8");
+    const entries = content
+      .trim()
+      .split("\n")
+      .map((l) => JSON.parse(l) as AuditEntry);
+
+    expect(entries).toHaveLength(3);
+    expect(entries[0].prevHash).toBe("0".repeat(64));
+    expect(entries[0].hash).toBeDefined();
+    // each entry's prevHash is the previous entry's hash
+    expect(entries[1].prevHash).toBe(entries[0].hash);
+    expect(entries[2].prevHash).toBe(entries[1].hash);
+  });
+
+  it("verifyChain() reports a valid, intact chain", async () => {
+    await log(sample("1"));
+    await log(sample("2"));
+
+    const result = await verifyChain();
+    expect(result.valid).toBe(true);
+    expect(result.entries).toBe(2);
+    expect(result.brokenAt).toBeUndefined();
+  });
+
+  it("verifyChain() detects a tampered entry (content edited in place)", async () => {
+    await log(sample("1"));
+    await log(sample("2", "deny"));
+    await log(sample("3"));
+
+    // Tamper: flip the middle entry's action without recomputing its hash.
+    const lines = (await readFile(AUDIT_LOG_FILE, "utf8")).trim().split("\n");
+    const middle = JSON.parse(lines[1]) as AuditEntry;
+    middle.action = "allow"; // was "deny"
+    lines[1] = JSON.stringify(middle);
+    await writeFile(AUDIT_LOG_FILE, lines.join("\n") + "\n", "utf8");
+
+    const result = await verifyChain();
+    expect(result.valid).toBe(false);
+    expect(result.brokenAt).toBe(1);
+    expect(result.reason).toContain("hash mismatch");
+  });
+
+  it("verifyChain() detects a removed entry (chain link broken)", async () => {
+    await log(sample("1"));
+    await log(sample("2"));
+    await log(sample("3"));
+
+    // Remove the middle entry -> entry 3's prevHash no longer matches.
+    const lines = (await readFile(AUDIT_LOG_FILE, "utf8")).trim().split("\n");
+    await writeFile(AUDIT_LOG_FILE, [lines[0], lines[2]].join("\n") + "\n", "utf8");
+
+    const result = await verifyChain();
+    expect(result.valid).toBe(false);
+    expect(result.brokenAt).toBe(1);
+    expect(result.reason).toContain("prevHash mismatch");
+  });
+
+  it("cleanupRetention() re-seals survivors so the chain stays valid", async () => {
+    const oldDate = new Date();
+    oldDate.setDate(oldDate.getDate() - 90);
+    await log({ ...sample("old"), timestamp: oldDate.toISOString() });
+    await log(sample("recent-1"));
+    await log(sample("recent-2"));
+
+    const result = await cleanupRetention({ maxAgeDays: 30 });
+    expect(result.deleted).toBe(1);
+    expect(result.remaining).toBe(2);
+
+    const verified = await verifyChain();
+    expect(verified.valid).toBe(true);
+    expect(verified.entries).toBe(2);
+  });
+
+  it("verifyChain() returns valid for an empty/absent log", async () => {
+    const result = await verifyChain();
+    expect(result.valid).toBe(true);
+    expect(result.entries).toBe(0);
   });
 });

--- a/src/__tests__/policy/channel-policies.test.ts
+++ b/src/__tests__/policy/channel-policies.test.ts
@@ -17,7 +17,7 @@ import {
   reloadScopedPolicy,
   type ScopedPolicyConfig,
 } from "../../policy/channel-policies";
-import { loadRules, type ToolRequestContext, type PolicyRule } from "../../policy/engine";
+import { loadRules, evaluate, type ToolRequestContext, type PolicyRule } from "../../policy/engine";
 
 const POLICY_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const SCOPED_POLICY_FILE = join(POLICY_DIR, "scoped-policies.json");
@@ -107,6 +107,70 @@ describe("Channel Policies - Scoped Rules", () => {
     const denyRule = rules.find((r) => r.id === "channel-deny-bash");
     expect(denyRule).toBeDefined();
     expect(denyRule?.action).toBe("deny");
+  });
+
+  it("evaluate() ENFORCES a scoped channel deny over a global allow (the wiring, governance audit HIGH)", async () => {
+    const POLICY_FILE = join(POLICY_DIR, "policies.json");
+    try {
+      // Global rule ALLOWS Bash everywhere (low priority).
+      await writeFile(
+        POLICY_FILE,
+        JSON.stringify({
+          rules: [
+            {
+              id: "global-allow-bash",
+              priority: 1,
+              tool: "Bash",
+              action: "allow",
+              reason: "global allow",
+            },
+          ],
+        }),
+        "utf8",
+      );
+      await loadRules();
+      // Scoped policy DENIES Bash in one specific channel (higher priority).
+      await writeFile(
+        SCOPED_POLICY_FILE,
+        JSON.stringify({
+          version: 1,
+          sources: {
+            telegram: {
+              source: "telegram",
+              channels: {
+                "telegram:123": {
+                  channelId: "telegram:123",
+                  denyRules: [
+                    {
+                      id: "channel-deny-bash",
+                      priority: 200,
+                      tool: "Bash",
+                      action: "deny",
+                      reason: "channel deny",
+                    },
+                  ],
+                },
+              },
+            },
+          },
+          globalRules: [],
+          updatedAt: new Date().toISOString(),
+        }),
+        "utf8",
+      );
+      reloadScopedPolicy();
+
+      // In the denied channel → scoped deny now participates and wins.
+      const denied = evaluate(createRequest({ toolName: "Bash", channelId: "telegram:123" }));
+      expect(denied.action).toBe("deny");
+      expect(denied.matchedRuleId).toBe("channel-deny-bash");
+
+      // In a different channel → the scoped rule does not apply, global allow stands.
+      const allowed = evaluate(createRequest({ toolName: "Bash", channelId: "telegram:999" }));
+      expect(allowed.action).toBe("allow");
+    } finally {
+      await rm(POLICY_FILE, { force: true });
+    }
   });
 
   it("should resolve user-specific overrides", async () => {

--- a/src/__tests__/policy/channel-policies.test.ts
+++ b/src/__tests__/policy/channel-policies.test.ts
@@ -285,6 +285,32 @@ describe("Channel Policies - Merge Scoped Policies", () => {
     expect(merged[0].action).toBe("deny");
   });
 
+  it("must NOT let a same-id scoped ALLOW delete a global DENY (fail-open guard, governance audit MEDIUM)", () => {
+    // A hardened global deny and a lower-trust scoped allow reuse the same id.
+    const globalRules: PolicyRule[] = [
+      { id: "hardened", tool: "Bash", action: "deny", reason: "global hardened deny" },
+    ];
+    const scopedRules: PolicyRule[] = [
+      { id: "hardened", tool: "Bash", action: "allow", reason: "scoped allow reusing the id" },
+    ];
+
+    const merged = mergeScopedPolicies(globalRules, scopedRules);
+
+    // The deny must survive (more restrictive wins on id collision).
+    expect(merged).toHaveLength(1);
+    expect(merged[0].action).toBe("deny");
+  });
+
+  it("still lets a same-id scoped DENY override a global ALLOW (hardening direction)", () => {
+    const globalRules: PolicyRule[] = [{ id: "x", tool: "Bash", action: "allow" }];
+    const scopedRules: PolicyRule[] = [{ id: "x", tool: "Bash", action: "deny" }];
+
+    const merged = mergeScopedPolicies(globalRules, scopedRules);
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0].action).toBe("deny");
+  });
+
   it("should filter out disabled rules", () => {
     const globalRules: PolicyRule[] = [
       { id: "disabled-global", tool: "View", action: "allow", enabled: false },

--- a/src/gateway/index.ts
+++ b/src/gateway/index.ts
@@ -158,6 +158,8 @@ export class Gateway {
   private async checkToolApproval(
     event: NormalizedEvent,
     decision: PolicyDecision,
+    toolName: string,
+    toolArgs?: Record<string, unknown>,
   ): Promise<{ needsApproval: boolean; approvalId?: string }> {
     if (decision.action !== "require_approval") {
       return { needsApproval: false };
@@ -170,7 +172,11 @@ export class Gateway {
       channelId: event.channelId,
       threadId: event.threadId,
       userId: event.userId,
-      toolName: decision.matchedRuleId || "unknown",
+      // Use the REAL tool identity, not the matched rule id — the approval
+      // record/queue must carry what is being approved, not which rule fired
+      // (governance audit: toolName was being overwritten with matchedRuleId).
+      toolName,
+      toolArgs,
       timestamp: new Date(event.timestamp).toISOString(),
     };
 
@@ -224,13 +230,19 @@ export class Gateway {
 
       // Step 2b: Evaluate policy for inbound event
       // This evaluates the incoming message as a "tool" request
-      const policyDecision = this.evaluatePolicy(event, "InboundMessage", {
+      const inboundToolArgs = {
         messageLength: event.text?.length ?? 0,
         hasAttachments: (event.attachments ?? []).length > 0,
-      });
+      };
+      const policyDecision = this.evaluatePolicy(event, "InboundMessage", inboundToolArgs);
 
       // Check if approval is required
-      const { needsApproval, approvalId } = await this.checkToolApproval(event, policyDecision);
+      const { needsApproval, approvalId } = await this.checkToolApproval(
+        event,
+        policyDecision,
+        "InboundMessage",
+        inboundToolArgs,
+      );
       if (needsApproval) {
         return {
           success: false,

--- a/src/governance/budget-engine.ts
+++ b/src/governance/budget-engine.ts
@@ -576,12 +576,21 @@ export async function getBudgetState(scope: BudgetScope): Promise<BudgetStateSum
     // was compared against everyone's total (governance audit). Map the single-
     // value scope fields onto the usage filter (UsageFilters can't express the
     // string[] multi-value form; those still aggregate broadly — noted).
+    //
+    // IMPORTANT: only filter on fields the PRODUCER actually populates on each
+    // usage record. recordInvocationStart currently persists channelId/userId as
+    // undefined (runner getPolicyContext does not thread them yet), so filtering
+    // on channelId here would match ZERO records -> spend reads 0 -> a per-channel
+    // budget would silently never trip (fail-OPEN). Until the producer carries
+    // channelId/userId, we deliberately DO NOT push those filters and instead
+    // aggregate broadly for channel/user-scoped policies (over-count = fail-SAFE).
+    // Tracked for Terry: thread channelId/userId from event context into the
+    // invocation record, then re-enable channelId filtering here.
     const asFilter = (v?: string | string[]) => (typeof v === "string" ? v : undefined);
     const filters: UsageFilters = {
       startDate,
       endDate,
       source: asFilter(policy.scope.source),
-      channelId: asFilter(policy.scope.channelId),
       sessionId: asFilter(policy.scope.sessionId),
       provider: asFilter(policy.scope.provider),
       model: asFilter(policy.scope.model),

--- a/src/governance/budget-engine.ts
+++ b/src/governance/budget-engine.ts
@@ -571,10 +571,20 @@ export async function getBudgetState(scope: BudgetScope): Promise<BudgetStateSum
     // Get period bounds
     const { startDate, endDate } = getPeriodBounds(policy.period);
 
-    // Get usage for the period
+    // Get usage for the period, SCOPED to the policy — previously this summed
+    // GLOBAL spend against a scoped threshold, so a per-channel/per-model budget
+    // was compared against everyone's total (governance audit). Map the single-
+    // value scope fields onto the usage filter (UsageFilters can't express the
+    // string[] multi-value form; those still aggregate broadly — noted).
+    const asFilter = (v?: string | string[]) => (typeof v === "string" ? v : undefined);
     const filters: UsageFilters = {
       startDate,
       endDate,
+      source: asFilter(policy.scope.source),
+      channelId: asFilter(policy.scope.channelId),
+      sessionId: asFilter(policy.scope.sessionId),
+      provider: asFilter(policy.scope.provider),
+      model: asFilter(policy.scope.model),
     };
 
     const aggregates = await getAggregates(filters);

--- a/src/governance/usage-tracker.ts
+++ b/src/governance/usage-tracker.ts
@@ -17,8 +17,9 @@
 
 import { join } from "path";
 import { existsSync } from "fs";
-import { appendFile, readdir } from "fs/promises";
+import { appendFile, readdir, readFile } from "fs/promises";
 import { randomUUID } from "crypto";
+import { homedir } from "os";
 
 const USAGE_DIR = join(process.cwd(), ".claude", "claudeclaw", "usage");
 const USAGE_INDEX_FILE = join(USAGE_DIR, "usage-index.json");
@@ -40,6 +41,62 @@ export interface EstimatedCost {
   cacheCost?: number;
   totalCost?: number;
   pricingVersion?: string;
+}
+
+/**
+ * Sum the token usage of an invocation by reading claude's own session
+ * transcript. Both execution paths (legacy stream-json AND the PTY supervisor)
+ * leave the per-turn usage in `~/.claude/projects/<mangled-cwd>/<sessionId>.jsonl`
+ * — the daemon's only reliable, path-agnostic source of real token counts
+ * (the budget layer was previously fed `undefined`, so enforcement never fired).
+ * Sums every `assistant` message at or after `sinceIso` (the invocation start),
+ * which covers multi-message tool-use turns. Best-effort: returns null on any
+ * read/parse failure or if no usage is found, so a finalize never throws.
+ */
+export async function extractTranscriptUsage(
+  cwd: string,
+  sessionId: string,
+  sinceIso: string,
+): Promise<UsageMetrics | null> {
+  try {
+    if (!sessionId || sessionId === "unknown") return null;
+    const mangled = cwd.replace(/\//g, "-");
+    const jsonlPath = join(homedir(), ".claude", "projects", mangled, `${sessionId}.jsonl`);
+    if (!existsSync(jsonlPath)) return null;
+    const since = Date.parse(sinceIso);
+    const content = await readFile(jsonlPath, "utf8");
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let cacheCreationInputTokens = 0;
+    let cacheReadInputTokens = 0;
+    let found = false;
+    for (const line of content.split("\n")) {
+      if (!line.trim()) continue;
+      let entry: {
+        type?: string;
+        timestamp?: string;
+        message?: { usage?: Record<string, number> };
+      };
+      try {
+        entry = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (entry.type !== "assistant" || !entry.message?.usage) continue;
+      const ts = Date.parse(entry.timestamp ?? "");
+      if (Number.isFinite(since) && Number.isFinite(ts) && ts < since) continue;
+      const u = entry.message.usage;
+      found = true;
+      inputTokens += u.input_tokens ?? 0;
+      outputTokens += u.output_tokens ?? 0;
+      cacheCreationInputTokens += u.cache_creation_input_tokens ?? 0;
+      cacheReadInputTokens += u.cache_read_input_tokens ?? 0;
+    }
+    if (!found) return null;
+    return { inputTokens, outputTokens, cacheCreationInputTokens, cacheReadInputTokens };
+  } catch {
+    return null;
+  }
 }
 
 export interface InvocationUsageRecord {

--- a/src/governance/usage-tracker.ts
+++ b/src/governance/usage-tracker.ts
@@ -575,7 +575,7 @@ export async function getAggregates(filters: UsageFilters = {}): Promise<{
       // record (negative, NaN, Infinity) must not poison the aggregate the
       // budget engine reads, or skew spend up/down (governance audit).
       const safe = (n: unknown): number =>
-        typeof n === "number" && Number.isFinite(n) && n > 0 ? n : 0;
+        typeof n === "number" && Number.isFinite(n) && n >= 0 ? n : 0;
       const inputTokens = safe(record.usage?.inputTokens);
       const outputTokens = safe(record.usage?.outputTokens);
       const cacheCreationTokens = safe(record.usage?.cacheCreationInputTokens);

--- a/src/governance/usage-tracker.ts
+++ b/src/governance/usage-tracker.ts
@@ -571,19 +571,24 @@ export async function getAggregates(filters: UsageFilters = {}): Promise<{
         result.killedInvocations++;
       }
 
-      // Tokens
-      const inputTokens = record.usage?.inputTokens ?? 0;
-      const outputTokens = record.usage?.outputTokens ?? 0;
-      const cacheCreationTokens = record.usage?.cacheCreationInputTokens ?? 0;
-      const cacheReadTokens = record.usage?.cacheReadInputTokens ?? 0;
+      // Tokens — clamp to a finite, non-negative value. A corrupted or tampered
+      // record (negative, NaN, Infinity) must not poison the aggregate the
+      // budget engine reads, or skew spend up/down (governance audit).
+      const safe = (n: unknown): number =>
+        typeof n === "number" && Number.isFinite(n) && n > 0 ? n : 0;
+      const inputTokens = safe(record.usage?.inputTokens);
+      const outputTokens = safe(record.usage?.outputTokens);
+      const cacheCreationTokens = safe(record.usage?.cacheCreationInputTokens);
+      const cacheReadTokens = safe(record.usage?.cacheReadInputTokens);
 
       result.totalInputTokens += inputTokens;
       result.totalOutputTokens += outputTokens;
       result.totalCacheCreationTokens += cacheCreationTokens;
       result.totalCacheReadTokens += cacheReadTokens;
 
-      // Cost
-      const cost = record.estimatedCost?.totalCost ?? 0;
+      // Cost — same clamp (a negative cost would let a tampered record reduce
+      // the aggregate and mask real spend below a block threshold).
+      const cost = safe(record.estimatedCost?.totalCost);
       result.totalEstimatedCost += cost;
 
       // By provider

--- a/src/policy/audit-log.ts
+++ b/src/policy/audit-log.ts
@@ -78,10 +78,20 @@ const GENESIS_HASH = "0".repeat(64);
 // ============================================================================
 //
 // Each entry carries `prevHash` (the previous entry's `hash`) and `hash`
-// (sha256 over prevHash + the entry's own content). Inserting, removing,
-// reordering or editing any entry breaks the chain at that point, which
-// `verifyChain()` detects. Writes are serialized through `writeChain` so the
-// chain stays consistent even with concurrent (fire-and-forget) callers.
+// (sha256 over prevHash + the entry's own content). Editing, inserting,
+// reordering or deleting a MID-STREAM entry breaks the link at the following
+// entry, which `verifyChain()` detects. Writes are serialized through
+// `writeChain` so the chain stays consistent even with concurrent
+// (fire-and-forget) callers.
+//
+// KNOWN LIMITS (tracked for follow-up, no external anchor yet):
+// - Tail truncation (deleting the most recent N entries) is NOT detected,
+//   because nothing records the expected length/tail hash externally. Detecting
+//   it requires a sealed high-water mark (count + tail hash) in a separate store.
+// - Tamper-evidence assumes a SINGLE writer process (the cwd-rooted daemon). The
+//   in-memory lastHash cache is not shared across processes.
+// - Hashing uses JSON.stringify (engine key-order), not a canonical
+//   serialization, so cross-implementation verification is not guaranteed.
 
 let lastHash: string | null = null;
 let writeChain: Promise<void> = Promise.resolve();
@@ -406,56 +416,69 @@ export async function cleanupRetention(
   cutoffDate.setDate(cutoffDate.getDate() - maxAgeDays);
   const cutoffTimestamp = cutoffDate.toISOString();
 
-  if (!existsSync(AUDIT_LOG_FILE)) {
-    return { deleted: 0, remaining: 0 };
-  }
-
-  const content = await readFile(AUDIT_LOG_FILE, "utf8");
-  const lines = content.split("\n").filter((line) => line.trim());
-
-  const keptLines: string[] = [];
-  let deleted = 0;
-
-  for (const line of lines) {
-    try {
-      const entry: AuditEntry = JSON.parse(line);
-
-      if (entry.timestamp < cutoffTimestamp) {
-        deleted++;
-        continue;
-      }
-
-      keptLines.push(line);
-    } catch {
-      // Skip malformed entries - count as deleted
-      deleted++;
+  // Serialize the whole read -> reseal -> rename against concurrent log()
+  // appends. Outside writeChain, an append landing between readFile and rename
+  // would be silently clobbered, and the lastHash assignment could interleave
+  // with a log() write and leave the cache pointing at a tail no longer on disk.
+  const result = writeChain.then(async () => {
+    if (!existsSync(AUDIT_LOG_FILE)) {
+      return { deleted: 0, remaining: 0 };
     }
-  }
 
-  // Write kept lines back atomically (temp file + rename). Removing entries
-  // necessarily breaks the original chain, so re-seal the survivors into a
-  // fresh chain — retention is an authorized operation and verifyChain() must
-  // still pass afterwards.
-  if (deleted > 0) {
-    let prev = GENESIS_HASH;
-    const resealed = keptLines.map((line) => {
-      const parsed = JSON.parse(line) as AuditEntry;
-      const { prevHash: _p, hash: _h, ...content } = parsed;
-      const hash = computeEntryHash(prev, content as Record<string, unknown>);
-      const chained = { ...content, prevHash: prev, hash };
-      prev = hash;
-      return JSON.stringify(chained);
-    });
-    const tmpPath = AUDIT_LOG_FILE + ".tmp";
-    await writeFile(tmpPath, resealed.map((l) => l + "\n").join(""), "utf8");
-    await rename(tmpPath, AUDIT_LOG_FILE);
-    lastHash = resealed.length > 0 ? prev : GENESIS_HASH;
-  }
+    const content = await readFile(AUDIT_LOG_FILE, "utf8");
+    const lines = content.split("\n").filter((line) => line.trim());
 
-  return {
-    deleted,
-    remaining: keptLines.length,
-  };
+    const keptLines: string[] = [];
+    let deleted = 0;
+
+    for (const line of lines) {
+      try {
+        const entry: AuditEntry = JSON.parse(line);
+
+        if (entry.timestamp < cutoffTimestamp) {
+          deleted++;
+          continue;
+        }
+
+        keptLines.push(line);
+      } catch {
+        // Skip malformed entries - count as deleted
+        deleted++;
+      }
+    }
+
+    // Write kept lines back atomically (temp file + rename). Removing entries
+    // necessarily breaks the original chain, so re-seal the survivors into a
+    // fresh chain — retention is an authorized operation and verifyChain() must
+    // still pass afterwards.
+    if (deleted > 0) {
+      let prev = GENESIS_HASH;
+      const resealed = keptLines.map((line) => {
+        const parsed = JSON.parse(line) as AuditEntry;
+        const { prevHash: _p, hash: _h, ...entryContent } = parsed;
+        const hash = computeEntryHash(prev, entryContent as Record<string, unknown>);
+        const chained = { ...entryContent, prevHash: prev, hash };
+        prev = hash;
+        return JSON.stringify(chained);
+      });
+      const tmpPath = AUDIT_LOG_FILE + ".tmp";
+      await writeFile(tmpPath, resealed.map((l) => l + "\n").join(""), "utf8");
+      await rename(tmpPath, AUDIT_LOG_FILE);
+      lastHash = resealed.length > 0 ? prev : GENESIS_HASH;
+    }
+
+    return {
+      deleted,
+      remaining: keptLines.length,
+    };
+  });
+
+  // Keep the chain alive even if cleanup throws; surface the error to the caller.
+  writeChain = result.then(
+    () => {},
+    () => {},
+  );
+  return result;
 }
 
 // ============================================================================

--- a/src/policy/audit-log.ts
+++ b/src/policy/audit-log.ts
@@ -17,6 +17,7 @@
 import { appendFile, readFile, mkdir, writeFile, rename } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
+import { createHash } from "node:crypto";
 
 // ============================================================================
 // Types
@@ -39,6 +40,10 @@ export interface AuditEntry {
   matchedRuleId?: string;
   operatorId?: string;
   metadata?: Record<string, unknown>;
+  /** Hash of the previous entry's `hash` field, forming a tamper-evident chain. */
+  prevHash?: string;
+  /** sha256(prevHash + JSON(entry-without-prevHash/hash)). */
+  hash?: string;
 }
 
 // ============================================================================
@@ -66,6 +71,54 @@ const AUDIT_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const AUDIT_LOG_FILE = join(AUDIT_DIR, "audit-log.jsonl");
 const DEFAULT_RETENTION_DAYS = 30;
 const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
+const GENESIS_HASH = "0".repeat(64);
+
+// ============================================================================
+// Tamper-evident hash chain
+// ============================================================================
+//
+// Each entry carries `prevHash` (the previous entry's `hash`) and `hash`
+// (sha256 over prevHash + the entry's own content). Inserting, removing,
+// reordering or editing any entry breaks the chain at that point, which
+// `verifyChain()` detects. Writes are serialized through `writeChain` so the
+// chain stays consistent even with concurrent (fire-and-forget) callers.
+
+let lastHash: string | null = null;
+let writeChain: Promise<void> = Promise.resolve();
+
+/** Stable hash of an entry's content (prevHash/hash fields excluded by caller). */
+function computeEntryHash(prevHash: string, content: Record<string, unknown>): string {
+  return createHash("sha256")
+    .update(prevHash + JSON.stringify(content))
+    .digest("hex");
+}
+
+/** Resolve the chain tail hash, re-seeding from disk and resetting on file loss. */
+async function getLastHash(): Promise<string> {
+  if (!existsSync(AUDIT_LOG_FILE)) {
+    lastHash = GENESIS_HASH;
+    return lastHash;
+  }
+  if (lastHash !== null) return lastHash;
+  const content = await readFile(AUDIT_LOG_FILE, "utf8");
+  const lines = content.split("\n").filter((l) => l.trim());
+  if (lines.length === 0) {
+    lastHash = GENESIS_HASH;
+    return lastHash;
+  }
+  try {
+    const last = JSON.parse(lines[lines.length - 1]) as AuditEntry;
+    lastHash = last.hash ?? GENESIS_HASH;
+  } catch {
+    lastHash = GENESIS_HASH;
+  }
+  return lastHash;
+}
+
+/** Reset the in-memory chain cache (test isolation helper). */
+export function _resetChainCache(): void {
+  lastHash = null;
+}
 
 // ============================================================================
 // Core API
@@ -75,17 +128,29 @@ const MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
  * Log a policy decision or operator action.
  */
 export async function log(entry: AuditEntry): Promise<void> {
-  // Ensure directory exists
-  if (!existsSync(AUDIT_DIR)) {
-    await mkdir(AUDIT_DIR, { recursive: true });
-  }
+  // Serialize writes so the hash chain stays consistent under concurrent
+  // (often fire-and-forget) callers. A failed write must not stall the chain.
+  const result = writeChain.then(async () => {
+    if (!existsSync(AUDIT_DIR)) {
+      await mkdir(AUDIT_DIR, { recursive: true });
+    }
 
-  // Create a new object with timestamp if not provided (never mutate the input)
-  const finalEntry = entry.timestamp ? entry : { ...entry, timestamp: new Date().toISOString() };
+    // Never mutate the input; strip any caller-supplied chain fields so we
+    // hash only the entry content.
+    const { prevHash: _p, hash: _h, ...rest } = entry;
+    const content: AuditEntry = rest.timestamp
+      ? { ...rest }
+      : { ...rest, timestamp: new Date().toISOString() };
 
-  // Append to log file
-  const line = JSON.stringify(finalEntry) + "\n";
-  await appendFile(AUDIT_LOG_FILE, line, "utf8");
+    const prevHash = await getLastHash();
+    const hash = computeEntryHash(prevHash, content as Record<string, unknown>);
+    const chained = { ...content, prevHash, hash };
+
+    await appendFile(AUDIT_LOG_FILE, JSON.stringify(chained) + "\n", "utf8");
+    lastHash = hash;
+  });
+  writeChain = result.catch(() => {});
+  return result;
 }
 
 /**
@@ -367,17 +432,98 @@ export async function cleanupRetention(
     }
   }
 
-  // Write kept lines back atomically (temp file + rename)
+  // Write kept lines back atomically (temp file + rename). Removing entries
+  // necessarily breaks the original chain, so re-seal the survivors into a
+  // fresh chain — retention is an authorized operation and verifyChain() must
+  // still pass afterwards.
   if (deleted > 0) {
+    let prev = GENESIS_HASH;
+    const resealed = keptLines.map((line) => {
+      const parsed = JSON.parse(line) as AuditEntry;
+      const { prevHash: _p, hash: _h, ...content } = parsed;
+      const hash = computeEntryHash(prev, content as Record<string, unknown>);
+      const chained = { ...content, prevHash: prev, hash };
+      prev = hash;
+      return JSON.stringify(chained);
+    });
     const tmpPath = AUDIT_LOG_FILE + ".tmp";
-    await writeFile(tmpPath, keptLines.map((l) => l + "\n").join(""), "utf8");
+    await writeFile(tmpPath, resealed.map((l) => l + "\n").join(""), "utf8");
     await rename(tmpPath, AUDIT_LOG_FILE);
+    lastHash = resealed.length > 0 ? prev : GENESIS_HASH;
   }
 
   return {
     deleted,
     remaining: keptLines.length,
   };
+}
+
+// ============================================================================
+// Chain verification
+// ============================================================================
+
+export interface ChainVerification {
+  valid: boolean;
+  entries: number;
+  /** Index (0-based) of the first entry that breaks the chain, if any. */
+  brokenAt?: number;
+  reason?: string;
+}
+
+/**
+ * Verify the tamper-evident hash chain over the audit log.
+ *
+ * Walks every entry, recomputing each hash from the running previous hash and
+ * the entry content. Any insertion, deletion, reorder or edit surfaces as a
+ * prevHash or hash mismatch at the affected index.
+ */
+export async function verifyChain(): Promise<ChainVerification> {
+  if (!existsSync(AUDIT_LOG_FILE)) {
+    return { valid: true, entries: 0 };
+  }
+
+  const content = await readFile(AUDIT_LOG_FILE, "utf8");
+  const lines = content.split("\n").filter((l) => l.trim());
+  let prev = GENESIS_HASH;
+
+  for (let i = 0; i < lines.length; i++) {
+    let entry: AuditEntry;
+    try {
+      entry = JSON.parse(lines[i]);
+    } catch {
+      return { valid: false, entries: lines.length, brokenAt: i, reason: "unparseable entry" };
+    }
+
+    if (entry.prevHash === undefined || entry.hash === undefined) {
+      return {
+        valid: false,
+        entries: lines.length,
+        brokenAt: i,
+        reason: "entry missing chain fields (legacy or stripped)",
+      };
+    }
+    if (entry.prevHash !== prev) {
+      return {
+        valid: false,
+        entries: lines.length,
+        brokenAt: i,
+        reason: "prevHash mismatch (entry inserted, removed or reordered)",
+      };
+    }
+    const { prevHash: _p, hash: storedHash, ...entryContent } = entry;
+    const recomputed = computeEntryHash(prev, entryContent as Record<string, unknown>);
+    if (recomputed !== storedHash) {
+      return {
+        valid: false,
+        entries: lines.length,
+        brokenAt: i,
+        reason: "hash mismatch (entry content tampered)",
+      };
+    }
+    prev = storedHash;
+  }
+
+  return { valid: true, entries: lines.length };
 }
 
 /**

--- a/src/policy/channel-policies.ts
+++ b/src/policy/channel-policies.ts
@@ -153,8 +153,21 @@ export function mergeScopedPolicies(
     ruleMap.set(rule.id, rule);
   }
 
-  // Add scoped rules (may override global rules with same ID)
+  // Restrictiveness rank used to resolve id collisions safely.
+  const rank = (a: string): number => (a === "deny" ? 2 : a === "require_approval" ? 1 : 0);
+
+  // Add scoped rules. On an id collision keep the MORE RESTRICTIVE action so a
+  // lower-trust scoped ALLOW (from the operator-writable scoped-policies.json)
+  // can never silently delete a global hardened DENY — that dedup-by-id override
+  // is a fail-OPEN. An operator wanting a per-channel exception must use a
+  // distinct, higher-priority allow id (resolved by sortRules), not reuse a
+  // deny's id. A scoped DENY overriding a same-id global allow is still allowed
+  // (hardening); same-rank collisions let the scoped rule win as before.
   for (const rule of enabledScoped) {
+    const existing = ruleMap.get(rule.id);
+    if (existing && rank(existing.action) > rank(rule.action)) {
+      continue; // keep the more-restrictive existing rule
+    }
     ruleMap.set(rule.id, rule);
   }
 

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -19,6 +19,9 @@ import { readFile, writeFile, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { randomUUID } from "crypto";
+// Scoped per-channel/per-user policies. Imported for use at evaluate-time only
+// (not at module init), so the channel-policies↔engine cycle never hits a TDZ.
+import { getScopedRules, mergeScopedPolicies } from "./channel-policies";
 
 const POLICY_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const POLICY_FILE = join(POLICY_DIR, "policies.json");
@@ -403,7 +406,19 @@ export function clearCache(): void {
 // ============================================================================
 
 function getApplicableRules(request: ToolRequestContext): PolicyRule[] {
-  return loadedRules.filter((rule) => {
+  // Evaluate against the GLOBAL rules merged with the scoped per-channel /
+  // per-user rules for THIS request — previously only `loadedRules` (global)
+  // was consulted, so any deny/require_approval an operator wrote in
+  // scoped-policies.json was silently inert (governance audit HIGH).
+  // getScopedRules() already folds in the globals; mergeScopedPolicies dedups by
+  // id (scoped overrides a same-id global). Falls back to globals on any error.
+  let candidates: PolicyRule[];
+  try {
+    candidates = mergeScopedPolicies(loadedRules, getScopedRules(request));
+  } catch {
+    candidates = loadedRules;
+  }
+  return candidates.filter((rule) => {
     // Skip disabled rules
     if (rule.enabled === false) return false;
 

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -40,7 +40,11 @@ import {
   recordInvocationStart,
   recordInvocationCompletion,
   recordInvocationFailure,
+  extractTranscriptUsage,
+  type EstimatedCost,
+  type UsageMetrics,
 } from "./governance/usage-tracker";
+import { calculateEstimatedCost } from "./governance/budget-engine";
 import {
   recordExecutionMetric,
   checkLimits,
@@ -1783,6 +1787,7 @@ async function execClaude(
       model: primaryConfig.model,
       metadata: { taskType, routingReasoning },
     };
+    const invocationStartedAt = new Date().toISOString();
     await recordInvocationStart(invocationContext, invocationId);
 
     // Capture memory file mtime before invocation (for fallback write detection)
@@ -2098,8 +2103,39 @@ async function execClaude(
       exitCode,
     };
 
-    // Record successful completion
-    await recordInvocationCompletion(invocationId, undefined, undefined);
+    // Record successful completion WITH the real token usage + cost so the
+    // budget layer can actually enforce. Previously this passed undefined →
+    // every record had estimatedCost undefined → totalEstimatedCost stayed 0 →
+    // budgetState never left "healthy" → the block branch was unreachable
+    // (governance audit CRITICAL). Usage is read from claude's own session
+    // transcript (works for BOTH the legacy stream-json and the PTY paths);
+    // cost is computed from the configured pricing tier. Best-effort: a failure
+    // here never breaks the invocation.
+    let invocationUsage: UsageMetrics | undefined;
+    let invocationCost: EstimatedCost | undefined;
+    try {
+      const u = await extractTranscriptUsage(
+        spawnCwd ?? PROJECT_DIR,
+        sessionId,
+        invocationStartedAt,
+      );
+      if (u) {
+        invocationUsage = u;
+        const c = calculateEstimatedCost(u, invocationContext.provider, invocationContext.model);
+        if (c) {
+          invocationCost = {
+            currency: "USD",
+            inputCost: c.breakdown.inputCost,
+            outputCost: c.breakdown.outputCost,
+            cacheCost: c.breakdown.cacheCost,
+            totalCost: c.totalCost,
+          };
+        }
+      }
+    } catch {
+      // best-effort — usage accounting must never break the invocation
+    }
+    await recordInvocationCompletion(invocationId, invocationUsage, invocationCost);
 
     // Check watchdog limits
     const watchdogDecision = await checkLimits({ invocationId, sessionId: invocationSessionId });


### PR DESCRIPTION
## Wire the governance layer that was built but never invoked

A security + correctness audit of the governance layer found several features implemented and tested but **never called on the production request path**. This PR wires the ones that are clean wiring, with tests, and adversarially ultra-reviews its own diff (the review caught 4 MEDIUM + 1 NIT regressions in the first cut, all fixed here). Items that need new input plumbing or an operator surface are written up in a tracking issue rather than half-wired.

### What this wires

**CRITICAL — budget enforcement received no usage/cost.** `recordInvocationCompletion` was always called with `undefined` usage, so every budget read 0 spend and no budget could ever trip. Added `extractTranscriptUsage()` which reads the CLI session JSONL transcript (path-agnostic across the legacy stream-json and PTY paths) and sums this invocation's assistant-turn usage, then feeds `calculateEstimatedCost` → `recordInvocationCompletion`.

**HIGH — scoped (per-channel / per-user) policy rules were inert.** They loaded from disk but were never merged into evaluation. `getApplicableRules` now does `mergeScopedPolicies(loadedRules, getScopedRules(request))` (guarded, falls back to global rules on error). E2E test added.

**HIGH — audit log was not tamper-evident.** Each entry now carries `prevHash` + `sha256(prevHash + content)`; writes are serialized so the chain holds under concurrent fire-and-forget callers; `verifyChain()` detects edit/insert/reorder/mid-delete; `cleanupRetention()` re-seals survivors. Known limits (tail-truncation, multi-process, canonical JSON) are documented in-code and in the tracking issue.

**Correctness quick-wins.** Real `toolName`/`toolArgs` passed to `checkToolApproval`; `getBudgetState` filters usage by `policy.scope`; token/cost reads clamped against negative/NaN/Infinity.

### Fixes from the self-ultra-review (folded in)
- **budget fail-open:** `getBudgetState` no longer filters on `channelId`/`userId` — the producer (`recordInvocationStart`) persists them as `undefined`, so the filter would match 0 records and a per-channel budget would silently never block. Aggregates broadly (fail-safe) until the producer threads those fields.
- **policy fail-open:** `mergeScopedPolicies` keeps the **more restrictive** action on an id collision, so a lower-trust scoped ALLOW can no longer delete a same-id global hardened DENY.
- **audit race:** `cleanupRetention` now runs its read/reseal/rename through the same `writeChain` serialization (no clobbered append, no stale `lastHash`).
- nit: `safe()` clamp uses `>= 0` to match its non-negative intent.

### Tests
166 pass in the policy + governance suites (including new coverage for `extractTranscriptUsage`, scoped-deny enforcement via `evaluate()`, the same-id deny-preservation guard, and the audit hash-chain incl. tamper/removal/retention/empty cases). The one pre-existing `Telemetry > should return budget health` failure is unrelated to this diff (fails on `main` too).

### Not in this PR (tracking issue)
Skill-overlay deny rules (no caller + needs `skillName` source), real-time watchdog enforcement (`kill` is a dead branch; mid-turn hook is a feature), HITL approval surface (needs operator UI), the root-cause `channelId/userId/skillName` threading gap in `getPolicyContext`, the audit hash-chain hardening limits, and a deny-precedence doc note.
