### PR TITLE
Wire restart-based session rotation (closes #227)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.151",
+      "version": "2.2.152",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.151",
+  "version": "2.2.152",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/rotate-agent.test.ts
+++ b/src/bus/__tests__/rotate-agent.test.ts
@@ -8,8 +8,6 @@
 import { describe, it, expect } from "bun:test";
 import { createRotateAgent, type RotateAgentDeps } from "../runtime-mount";
 
-const silentLogger = { warn: () => {} };
-
 interface Behaviour {
   /** Value peekSessionId resolves to. Default "old-session-id". */
   peekResult?: string | undefined;
@@ -31,6 +29,8 @@ function makeDeps(b: Behaviour = {}) {
   const calls: string[] = [];
   const restartArgs: string[] = [];
   const summarizeArgs: Array<[string, string]> = [];
+  const errors: unknown[][] = [];
+  const logger = { warn: () => {}, error: (...args: unknown[]) => errors.push(args) };
   const deps: RotateAgentDeps = {
     restart: async (id) => {
       calls.push("restart");
@@ -48,9 +48,9 @@ function makeDeps(b: Behaviour = {}) {
       if (b.summarizeThrows) throw new Error("summary blew up");
     },
     getSummaryPath: () => b.summaryPath ?? "/tmp/summaries",
-    logger: silentLogger,
+    logger,
   };
-  return { deps, calls, restartArgs, summarizeArgs };
+  return { deps, calls, restartArgs, summarizeArgs, errors };
 }
 
 describe("createRotateAgent (#227 rotation orchestrator)", () => {
@@ -96,12 +96,16 @@ describe("createRotateAgent (#227 rotation orchestrator)", () => {
     expect(restartArgs).toEqual(["agent-1"]);
   });
 
-  it("propagates a restart rejection and does NOT summarize", async () => {
-    const { deps, calls } = makeDeps({ restartThrows: true });
+  it("logs CRITICAL and propagates a restart rejection, and does NOT summarize", async () => {
+    const { deps, calls, errors } = makeDeps({ restartThrows: true });
     const rotate = createRotateAgent(deps);
 
     await expect(rotate("agent-1")).rejects.toThrow("restart failed");
     expect(calls).toEqual(["peek", "restart"]); // threw in restart, never summarized
+    // A failed rotation restart must be surfaced loudly (watchdog-keyable),
+    // and must rethrow so the caller doesn't log a false "rotated".
+    expect(errors).toHaveLength(1);
+    expect(String(errors[0][0])).toContain("CRITICAL");
   });
 
   it("a background summary failure does not reject rotate()", async () => {

--- a/src/bus/__tests__/rotate-agent.test.ts
+++ b/src/bus/__tests__/rotate-agent.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for createRotateAgent — the #227 restart-based session-rotation
+ * orchestrator wired into the bus bridge's post-turn rotation gate.
+ *
+ * Run with: bun test src/__tests__/bus/rotate-agent.test.ts
+ */
+
+import { describe, it, expect } from "bun:test";
+import { createRotateAgent, type RotateAgentDeps } from "../runtime-mount";
+
+const silentLogger = { warn: () => {} };
+
+interface Behaviour {
+  /** Value peekSessionId resolves to. Default "old-session-id". */
+  peekResult?: string | undefined;
+  /** Make peekSessionId reject. */
+  peekThrows?: boolean;
+  /** Make restart reject. */
+  restartThrows?: boolean;
+  /** Make summarize reject (background failure). */
+  summarizeThrows?: boolean;
+  /** Configured summary dir. Default "/tmp/summaries"; "" disables summary. */
+  summaryPath?: string;
+}
+
+/**
+ * Build deps with call-order tracking. The call log is owned here so every
+ * dep records consistently regardless of which behaviour flags are set.
+ */
+function makeDeps(b: Behaviour = {}) {
+  const calls: string[] = [];
+  const restartArgs: string[] = [];
+  const summarizeArgs: Array<[string, string]> = [];
+  const deps: RotateAgentDeps = {
+    restart: async (id) => {
+      calls.push("restart");
+      restartArgs.push(id);
+      if (b.restartThrows) throw new Error("restart failed");
+    },
+    peekSessionId: async () => {
+      calls.push("peek");
+      if (b.peekThrows) throw new Error("peek blew up");
+      return "peekResult" in b ? b.peekResult : "old-session-id";
+    },
+    summarize: async (sid, path) => {
+      calls.push("summarize");
+      summarizeArgs.push([sid, path]);
+      if (b.summarizeThrows) throw new Error("summary blew up");
+    },
+    getSummaryPath: () => b.summaryPath ?? "/tmp/summaries",
+    logger: silentLogger,
+  };
+  return { deps, calls, restartArgs, summarizeArgs };
+}
+
+describe("createRotateAgent (#227 rotation orchestrator)", () => {
+  it("peeks the old id BEFORE restart, then summarizes it AFTER restart", async () => {
+    const { deps, calls, restartArgs, summarizeArgs } = makeDeps();
+    const rotate = createRotateAgent(deps);
+
+    await rotate("agent-1");
+
+    // Order is the whole point: capture old id → restart → summarize old id.
+    expect(calls).toEqual(["peek", "restart", "summarize"]);
+    expect(restartArgs).toEqual(["agent-1"]);
+    // Summarizes the OLD session id (now freed), never the live one.
+    expect(summarizeArgs).toEqual([["old-session-id", "/tmp/summaries"]]);
+  });
+
+  it("skips summary when no summary path is configured but still restarts", async () => {
+    const { deps, calls } = makeDeps({ summaryPath: "" });
+    const rotate = createRotateAgent(deps);
+
+    await rotate("agent-1");
+
+    expect(calls).toEqual(["peek", "restart"]);
+  });
+
+  it("skips summary when the old session id is unknown but still restarts", async () => {
+    const { deps, calls } = makeDeps({ peekResult: undefined });
+    const rotate = createRotateAgent(deps);
+
+    await rotate("agent-1");
+
+    expect(calls).toEqual(["peek", "restart"]);
+  });
+
+  it("a peek failure does not block the restart (no old id → no summary)", async () => {
+    const { deps, calls, restartArgs } = makeDeps({ peekThrows: true });
+    const rotate = createRotateAgent(deps);
+
+    await rotate("agent-1");
+
+    // peek attempted then threw (swallowed); restart still ran; no summary.
+    expect(calls).toEqual(["peek", "restart"]);
+    expect(restartArgs).toEqual(["agent-1"]);
+  });
+
+  it("propagates a restart rejection and does NOT summarize", async () => {
+    const { deps, calls } = makeDeps({ restartThrows: true });
+    const rotate = createRotateAgent(deps);
+
+    await expect(rotate("agent-1")).rejects.toThrow("restart failed");
+    expect(calls).toEqual(["peek", "restart"]); // threw in restart, never summarized
+  });
+
+  it("a background summary failure does not reject rotate()", async () => {
+    const { deps } = makeDeps({ summarizeThrows: true });
+    const rotate = createRotateAgent(deps);
+
+    // Must resolve cleanly — the summary is fire-and-forget.
+    await expect(rotate("agent-1")).resolves.toBeUndefined();
+  });
+});

--- a/src/bus/__tests__/runtime-mount.test.ts
+++ b/src/bus/__tests__/runtime-mount.test.ts
@@ -15,7 +15,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { mountBusRuntime, type BusRuntimeHandle } from "../runtime-mount";
 import type { BusCore } from "../core";
-import { SessionManager } from "../session-manager";
+import { SessionManager, type RestartOptions } from "../session-manager";
 
 /* ────────────────────────────────────────────────────────────────────── */
 /* FakeBus — records start/stop + slash-handler installation.             */
@@ -382,6 +382,37 @@ function cfg(id: string, overrides: Partial<AgentConfig> = {}): AgentConfig {
     ...overrides,
   };
 }
+
+/** Captures the (id, opts) every restart() call receives. */
+class RestartSpySessionManager extends FakeSessionManager {
+  public readonly restartLog: Array<{ id: string; opts: RestartOptions }> = [];
+  async restart(id: string, opts: RestartOptions = {}): Promise<AgentProcess> {
+    this.restartLog.push({ id, opts });
+    return {
+      onData: () => () => {},
+      onExit: () => () => {},
+      send_prompt: async () => {},
+      send_slash: async () => {},
+      kill: async () => {},
+    } as unknown as AgentProcess;
+  }
+}
+
+describe("mountBusRuntime — rotateAgent wiring (#227)", () => {
+  it("forwards reason:'rotation' to sessionManager.restart (crash-loop budget exemption)", async () => {
+    const bus = createFakeBus();
+    const sm = new RestartSpySessionManager();
+    const handle = await mountBusRuntime({ bus, sessionManager: sm, logger: SILENT_LOGGER });
+    try {
+      await handle.rotateAgent("agent-x");
+      // The load-bearing literal: rotation must be budget-exempt, which depends
+      // entirely on restart() receiving { reason: "rotation" }.
+      expect(sm.restartLog).toEqual([{ id: "agent-x", opts: { reason: "rotation" } }]);
+    } finally {
+      await handle.stop();
+    }
+  });
+});
 
 describe("mountBusRuntime — auto-spawn happy path", () => {
   let handle: BusRuntimeHandle | null = null;

--- a/src/bus/__tests__/webui-bridge.test.ts
+++ b/src/bus/__tests__/webui-bridge.test.ts
@@ -362,9 +362,12 @@ describe("streamBusPrompt — per-agent bookkeeping (#213, split per #218)", () 
   let frozenCwd: string;
   let tmp: string;
 
-  async function driveOneTurn(agentId: string): Promise<void> {
+  async function driveOneTurn(
+    agentId: string,
+    extraOpts: { rotateAgent?: (id: string) => Promise<void> } = {},
+  ): Promise<void> {
     const bus = makeBus();
-    const pending = streamBusPrompt(bus, agentId, "hi", { timeoutMs: 2000 });
+    const pending = streamBusPrompt(bus, agentId, "hi", { timeoutMs: 2000, ...extraOpts });
     await Promise.resolve();
     await Promise.resolve();
     bus.ingestReply({ agent_id: agentId, text: "ok", intent: "final" });
@@ -393,7 +396,7 @@ describe("streamBusPrompt — per-agent bookkeeping (#213, split per #218)", () 
     expect((await peekSession("alpha"))?.messageCount).toBe(1);
   });
 
-  it("WARNs and defers to #227 when the agent crosses the threshold — without rotating", async () => {
+  it("WARNs (no rotation) when the threshold trips but no rotateAgent hook is injected", async () => {
     // Point config at a settings file inside this test's temp dir (removed in
     // afterEach) so we never read or write the developer's real settings.json.
     const settingsFile = join(tmp, ".claude", "claudeclaw", "settings.json");
@@ -407,17 +410,46 @@ describe("streamBusPrompt — per-agent bookkeeping (#213, split per #218)", () 
       await createSession("22222222-2222-2222-2222-222222222222", "beta");
       await incrementMessageCount("beta"); // 0 -> 1; the next turn trips the gate
 
-      await driveOneTurn("beta"); // 1 -> 2, needsRotation(2 >= 2) === true
+      await driveOneTurn("beta"); // 1 -> 2, needsRotation(2 >= 2) === true; no hook
 
-      const warned = warnSpy.mock.calls.some((c) => String(c[0]).includes("deferred to #227"));
+      const warned = warnSpy.mock.calls.some((c) =>
+        String(c[0]).includes("no rotateAgent hook injected"),
+      );
       expect(warned).toBe(true);
 
-      // The rotation MECHANISM is not wired: the session is counted, not reset.
+      // Without a hook the live conversation is NOT rotated: counted, not reset.
       const after = await peekSession("beta");
       expect(after?.messageCount).toBe(2);
       expect(after?.sessionId).toBe("22222222-2222-2222-2222-222222222222");
     } finally {
       warnSpy.mockRestore();
+    }
+  });
+
+  it("invokes the injected rotateAgent hook when the agent crosses the threshold (#227)", async () => {
+    const settingsFile = join(tmp, ".claude", "claudeclaw", "settings.json");
+    mkdirSync(join(tmp, ".claude", "claudeclaw"), { recursive: true });
+    writeFileSync(settingsFile, JSON.stringify({ session: { autoRotate: true, maxMessages: 2 } }));
+    _setSettingsFileForTests(settingsFile);
+
+    try {
+      await reloadSettings();
+      await createSession("33333333-3333-3333-3333-333333333333", "gamma");
+
+      const rotated: string[] = [];
+      const rotateAgent = async (id: string) => {
+        rotated.push(id);
+      };
+
+      // Turn 1: 0 -> 1, below threshold (maxMessages 2) — hook must NOT fire.
+      await driveOneTurn("gamma", { rotateAgent });
+      expect(rotated).toEqual([]);
+
+      // Turn 2: 1 -> 2, needsRotation(2 >= 2) === true — hook fires with the id.
+      await driveOneTurn("gamma", { rotateAgent });
+      expect(rotated).toEqual(["gamma"]);
+    } finally {
+      _setSettingsFileForTests();
     }
   });
 

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -240,7 +240,7 @@ export interface RotateAgentDeps {
   summarize: (sessionId: string, summaryPath: string) => Promise<unknown>;
   /** Resolve the configured summary dir, or "" to skip summarization. Must not throw. */
   getSummaryPath: () => string;
-  logger: Pick<Console, "warn">;
+  logger: Pick<Console, "warn" | "error">;
 }
 
 /**
@@ -262,7 +262,22 @@ export function createRotateAgent(deps: RotateAgentDeps): (agentId: string) => P
       deps.logger.warn(`[bus-runtime] rotation: peek session for ${agentId} failed`, err);
     }
 
-    await deps.restart(agentId);
+    // A rotation restart drops the live PTY BEFORE respawning. If the respawn
+    // throws (spawn-time fault), the agent is left with no live process — worse
+    // than the pre-#227 "warn and keep serving". restart() is budget-exempt for
+    // rotation so it won't rate-limit-throw, but a genuine spawn fault still can.
+    // Surface it as CRITICAL (watchdog-keyable) and rethrow so the caller does
+    // NOT mistake a failed rotation for a successful one.
+    try {
+      await deps.restart(agentId);
+    } catch (err) {
+      deps.logger.error(
+        `[bus-runtime] CRITICAL agent=${agentId} rotation restart failed — ` +
+          `the agent may have no live PTY until it is respawned (operator/watchdog action needed)`,
+        err,
+      );
+      throw err;
+    }
 
     const summaryPath = deps.getSummaryPath();
     if (oldSessionId && summaryPath) {
@@ -347,11 +362,17 @@ export async function mountBusRuntime(
     // (Injecting that summary into the fresh PTY's bootstrap has no bus consumer
     // yet — the legacy runner consumes loadLatestSummary, the bus spawn path
     // does not — so it stays a follow-up.)
+    // Declared before the rotation wiring so `getSummaryPath` can short-circuit
+    // once teardown has begun — never start a new ~60s summary subprocess while
+    // the handle is stopping (it would outlive stop()). Set true in stop().
+    let stopped = false;
+
     const rotateAgent = createRotateAgent({
       restart: (id) => sessionManager.restart(id, { reason: "rotation" }),
       peekSessionId: async (id) => (await peekSession(id))?.sessionId,
       summarize: generateSummary,
       getSummaryPath: () => {
+        if (stopped) return ""; // tearing down — don't spawn a new summarizer
         try {
           return getSettings().session.summaryPath ?? "";
         } catch {
@@ -433,7 +454,6 @@ export async function mountBusRuntime(
         : `adapters=[${adapters.map((a) => a.name).join(", ")}]`;
     logger.info(`[bus-runtime] mounted; socket=${socketPath}; ${spawnedLabel}; ${adaptersLabel}`);
 
-    let stopped = false;
     return {
       bus,
       sessionManager,

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -40,6 +40,9 @@ import type { MountedAdapter } from "./adapter-wiring";
 import { stopBusAdapters } from "./adapter-wiring";
 import { detectOrphanAgents, formatOrphanWarnings } from "./orphan-agent-detect";
 import { createPromptStreamHandler } from "./receipt-wiring";
+import { peekSession } from "../sessions";
+import { generateSummary } from "../rotation";
+import { getSettings } from "../config";
 
 export interface BusRuntimeHandle {
   /** The mounted BusCore. Adapters / tests subscribe via this. */
@@ -76,6 +79,14 @@ export interface BusRuntimeHandle {
    * to legacy surfaces). Throws if the handle has already been stopped.
    */
   spawnAgents(batch?: readonly AgentConfig[], spawnOriginOverride?: BusOrigin): Promise<void>;
+  /**
+   * Restart-based session rotation for one agent (#227). Drops the live PTY,
+   * mints a fresh session id, respawns, and best-effort summarizes the old
+   * session in the background. Wired into the bridge's post-turn rotation gate
+   * (`streamBusPrompt`'s `rotateAgent` option) so a threshold trip actually
+   * rotates the live conversation instead of only logging a warning.
+   */
+  rotateAgent(agentId: string): Promise<void>;
   /**
    * Register adapters with the handle's stop lifecycle. Sprint 5.2b
    * (PR #123) Codex P1/P2 fold-in: callers wire adapters AFTER the
@@ -216,6 +227,55 @@ export function resolveDaemonSocketPath(override?: string): string {
 }
 
 /**
+ * Injectable dependencies for {@link createRotateAgent}. Kept narrow so the
+ * rotation orchestration is unit-testable without spawning a real PTY, reading
+ * settings, or shelling out to the summarizer.
+ */
+export interface RotateAgentDeps {
+  /** Drop the live PTY + mint a fresh session id + respawn (the #226 primitive, with reason "rotation"). */
+  restart: (agentId: string) => Promise<unknown>;
+  /** The agent's CURRENT (about-to-be-rotated) session id, read BEFORE restart. */
+  peekSessionId: (agentId: string) => Promise<string | undefined>;
+  /** Summarize a (no-longer-live) session id into the summary dir. */
+  summarize: (sessionId: string, summaryPath: string) => Promise<unknown>;
+  /** Resolve the configured summary dir, or "" to skip summarization. Must not throw. */
+  getSummaryPath: () => string;
+  logger: Pick<Console, "warn">;
+}
+
+/**
+ * Build the restart-based session-rotation orchestrator (#227).
+ *
+ * Order matters: capture the OLD session id, then `restart()` (which drops the
+ * live PTY, mints+persists a fresh session id, respawns — re-arming the message
+ * counter via the new session.json), THEN summarize the OLD id. Summarizing
+ * after the restart is what sidesteps claude's locked-`--resume` refusal (the
+ * old id is no longer live — #227 critical 3), and it runs in the background so
+ * the turn that tripped the threshold isn't blocked on the ~60s summarizer.
+ */
+export function createRotateAgent(deps: RotateAgentDeps): (agentId: string) => Promise<void> {
+  return async (agentId: string): Promise<void> => {
+    let oldSessionId: string | undefined;
+    try {
+      oldSessionId = await deps.peekSessionId(agentId);
+    } catch (err) {
+      deps.logger.warn(`[bus-runtime] rotation: peek session for ${agentId} failed`, err);
+    }
+
+    await deps.restart(agentId);
+
+    const summaryPath = deps.getSummaryPath();
+    if (oldSessionId && summaryPath) {
+      void deps
+        .summarize(oldSessionId, summaryPath)
+        .catch((err) =>
+          deps.logger.warn(`[bus-runtime] rotation summary for ${agentId} failed`, err),
+        );
+    }
+  };
+}
+
+/**
  * Mount the Bus runtime stack and return a teardown handle.
  *
  * Idempotency: each call returns a fresh handle. Callers must invoke
@@ -274,6 +334,32 @@ export async function mountBusRuntime(
         log: (msg, fields) => logger.error("[mcp-reconcile]", msg, fields),
       }),
     );
+
+    // #227 restart-based session rotation. The bus PTY is spawned once at boot
+    // and kept alive, so the session JSONL grows unbounded and per-prompt
+    // latency creeps up (#213). When the per-agent message/age threshold trips,
+    // the bridge calls this to actually rotate: restart() drops the live PTY,
+    // mints+persists a FRESH session id, and respawns (criticals 1 & 2 — the
+    // counter re-arms because a new session.json exists). The summary is the
+    // rotation caller's concern per restart()'s contract: generated against the
+    // now-freed OLD id (never the live one — critical 3) and in the background
+    // so the turn that tripped the threshold isn't blocked on the summarizer.
+    // (Injecting that summary into the fresh PTY's bootstrap has no bus consumer
+    // yet — the legacy runner consumes loadLatestSummary, the bus spawn path
+    // does not — so it stays a follow-up.)
+    const rotateAgent = createRotateAgent({
+      restart: (id) => sessionManager.restart(id, { reason: "rotation" }),
+      peekSessionId: async (id) => (await peekSession(id))?.sessionId,
+      summarize: generateSummary,
+      getSummaryPath: () => {
+        try {
+          return getSettings().session.summaryPath ?? "";
+        } catch {
+          return ""; // settings not loaded (early boot / tests) — skip summary
+        }
+      },
+      logger,
+    });
 
     const declaredAgents = opts.agents ?? [];
 
@@ -352,6 +438,7 @@ export async function mountBusRuntime(
       bus,
       sessionManager,
       socketPath,
+      rotateAgent,
       get spawnedAgentIds() {
         // Snapshot via getter so the handle reflects the current state
         // even after stop() empties the list.

--- a/src/bus/webui-bridge.ts
+++ b/src/bus/webui-bridge.ts
@@ -69,6 +69,17 @@ export interface StreamBusPromptOptions {
    * process-wide singleton (`getDefaultReceiptStore`). Override is for tests.
    */
   receiptStore?: ReceiptStore;
+  /**
+   * Restart-based session rotation hook (#227). When the per-agent message/age
+   * threshold trips after a successful turn, the bridge calls this to drop the
+   * live PTY and respawn it on a fresh session id (`restart()`, #226), which is
+   * what actually rotates the live bus conversation. Injected by the daemon
+   * (it owns the SessionManager — `BusRuntimeHandle.rotateAgent`). When omitted
+   * (early boot / tests / webui without a SessionManager) the bridge falls back
+   * to a WARN, the pre-#227 behaviour. Awaited so the next prompt (serialized
+   * on the same per-agent slot) lands on the fresh PTY.
+   */
+  rotateAgent?: (agentId: string) => Promise<void>;
 }
 
 export interface BusPromptResult {
@@ -132,11 +143,12 @@ export async function streamBusPrompt(
       // global bootstrap tracker. Best-effort: a tracking failure must
       // never break the prompt the caller is awaiting.
       //
-      // The rotation MECHANISM is intentionally NOT wired here. Filesystem
-      // rotation can't rotate a live bus PTY — it keeps the same session
-      // id and process alive — so when the gate trips we only surface a
-      // WARN. The restart-based rotation that actually delivers #213 is
-      // tracked in #227 (built on the restart() primitive, #226).
+      // #227: when the threshold trips we now perform RESTART-BASED rotation
+      // via the injected `rotateAgent` hook — restart() drops the live PTY and
+      // respawns it on a fresh session id, which is the only thing that
+      // actually rotates a live bus conversation (filesystem rotation alone
+      // keeps the same process + id alive). Without the hook (early boot /
+      // tests / no SessionManager) we keep the pre-#227 WARN.
       try {
         await incrementMessageCount(agentId);
         let sessionConfig: ReturnType<typeof getSettings>["session"] | null = null;
@@ -148,11 +160,20 @@ export async function streamBusPrompt(
         if (sessionConfig?.autoRotate) {
           const peeked = await peekSession(agentId);
           if (peeked && needsRotation(peeked, sessionConfig)) {
-            console.warn(
-              `[${new Date().toLocaleTimeString()}] [bus] agent=${agentId} session needs rotation ` +
-                `(${peeked.messageCount ?? 0} msgs >= ${sessionConfig.maxMessages}) — ` +
-                `restart-based rotation not yet wired; deferred to #227.`,
-            );
+            if (opts.rotateAgent) {
+              await opts.rotateAgent(agentId);
+              console.log(
+                `[${new Date().toLocaleTimeString()}] [bus] agent=${agentId} session rotated ` +
+                  `(${peeked.messageCount ?? 0} msgs >= ${sessionConfig.maxMessages}) — ` +
+                  `fresh PTY + session id; next prompt lands on the new session.`,
+              );
+            } else {
+              console.warn(
+                `[${new Date().toLocaleTimeString()}] [bus] agent=${agentId} session needs rotation ` +
+                  `(${peeked.messageCount ?? 0} msgs >= ${sessionConfig.maxMessages}) — ` +
+                  `no rotateAgent hook injected; rotation skipped.`,
+              );
+            }
           }
         }
       } catch (e) {

--- a/src/commands/start.ts
+++ b/src/commands/start.ts
@@ -1100,6 +1100,11 @@ export async function start(args: string[] = []) {
                 origin: "webui",
                 originId: "chat",
                 onChunk,
+                // #227: actually rotate the live PTY when the threshold trips.
+                // Bare reference is safe — rotateAgent is a closure over the
+                // SessionManager (no `this`); evaluated per-call so the handle
+                // is set by the time a chat request runs.
+                rotateAgent: busRuntimeHandle?.rotateAgent,
               });
               // Codex P2 on #136: surface timeout / dispatch failure to
               // the SSE stream so a failed turn doesn't render as a
@@ -1132,6 +1137,8 @@ export async function start(args: string[] = []) {
                         origin: sendOpts?.origin as import("../bus/types").BusOrigin | undefined,
                         originId: sendOpts?.originId,
                         timeoutMs: sendOpts?.timeoutMs,
+                        // #227: rotate the live PTY when the threshold trips.
+                        rotateAgent: busRuntimeHandle?.rotateAgent,
                       },
                     ),
                 }

--- a/src/rotation.ts
+++ b/src/rotation.ts
@@ -66,8 +66,19 @@ export async function rotateSession(config: SessionConfig): Promise<string | nul
   return freshSummary;
 }
 
-/** Write a summary for the given session. Returns the summary content on success, null on timeout or failure. */
-async function generateSummary(sessionId: string, summaryPath: string): Promise<string | null> {
+/**
+ * Write a summary for the given session. Returns the summary content on
+ * success, null on timeout or failure.
+ *
+ * Exported for the bus restart-based rotation path (#227): after
+ * `sessionManager.restart(reason:"rotation")` drops the live PTY, the rotation
+ * caller summarizes the BACKED-UP (old) session id here — never the live one,
+ * which would hit claude's locked-`--resume` refusal (the #227 critical 3).
+ */
+export async function generateSummary(
+  sessionId: string,
+  summaryPath: string,
+): Promise<string | null> {
   await mkdir(summaryPath, { recursive: true });
 
   let summaryPrompt: string;


### PR DESCRIPTION
## Wire restart-based session rotation (closes #227)

The bus spawns the agent PTY once at boot and keeps it alive, so the session JSONL grows unbounded and per-prompt latency creeps up (#213). The per-agent message/age bookkeeping landed in #218, and the `restart()` respawn primitive landed in #226 — but nothing connected them: when the threshold tripped, the bridge only logged a WARN ("deferred to #227"). This wires the trigger.

### What changes
- **`webui-bridge.ts`** — when `needsRotation` trips after a successful turn, the bridge now calls an injected `rotateAgent` hook instead of warning. Awaited inside the per-agent serialization so the next prompt lands on the fresh PTY. No hook injected (early boot / tests) → unchanged WARN fallback.
- **`runtime-mount.ts`** — `createRotateAgent()` orchestrator (exported, dependency-injected for testability) wired as `BusRuntimeHandle.rotateAgent`. It:
  1. reads the OLD session id,
  2. `await sessionManager.restart(agentId, { reason: "rotation" })` — drops the live PTY, mints+persists a fresh session id, respawns. This is what re-arms the message counter (a new `session.json` exists — issue **critical 2**) and actually rotates the live conversation (**critical 1**). `reason: "rotation"` keeps it out of the crash-loop budget.
  3. summarizes the now-freed OLD id in the **background** — never the live id, which would hit claude's locked-`--resume` refusal (**critical 3**) — and not at all once teardown has begun.
- **`start.ts`** — injects `busRuntimeHandle.rotateAgent` at the `streamBusPrompt` call sites.
- **`rotation.ts`** — exports `generateSummary` for the rotation caller.

### Self-review fold-ins (ultra-reviewed this diff before opening)
- A rotation restart drops the PTY before respawning; if the respawn throws, the agent is left offline — worse than the old "warn and keep serving". `createRotateAgent` now logs a **CRITICAL** (watchdog-keyable) and rethrows on restart failure, so the caller never records a false "rotated".
- The background summary subprocess is **not started once the handle is stopping**, closing a shutdown-race orphan window.
- Tests assert `restart` actually receives `{ reason: "rotation" }` (the budget exemption) and that a restart failure logs CRITICAL.

### Tests
Full bus suite **394 pass / 0 fail**: `createRotateAgent` ordering/skip/failure cases, the bridge gate (hook fires at threshold, not below; WARN when no hook), and the wiring-level `reason:"rotation"` assertion. (Pre-existing implicit-any lints in the test file and the unrelated `start.ts` type errors are not touched; Parse & build is transpile-only.)

### Deliberately deferred (follow-up)
Injecting the generated summary into the *fresh* PTY's bootstrap as continuation context is **not** included: the bus spawn path has no `loadLatestSummary` consumer yet (only the legacy runner does). The summary is generated and persisted; consuming it at bus-spawn time is a separate change. The deeper "roll back to the live process if the rotation respawn fails" belongs in the `restart()` primitive (#226), noted there rather than papered over here.
