### PR TITLE
fix(bus): honor telegram.receiveEnabled on the bus adapter (send-only)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.152",
+      "version": "2.2.153",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.153",
+      "version": "2.2.154",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.153",
+  "version": "2.2.154",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.152",
+  "version": "2.2.153",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -154,6 +154,8 @@ class FakeTelegramApi implements TelegramApi {
   public readonly editMessages: Array<{ chat_id: number; message_id: number; text: string }> = [];
   public readonly reactions: SetReactionCall[] = [];
   public readonly callbackAcks: AnswerCallbackCall[] = [];
+  /** #201: count inbound polls so send-only configs can assert zero. */
+  public getUpdatesCalls = 0;
 
   private nextUpdateId = 1;
   private readonly pending: TelegramUpdate[][] = [];
@@ -165,6 +167,7 @@ class FakeTelegramApi implements TelegramApi {
     _timeoutSeconds: number,
     signal: AbortSignal,
   ): Promise<TelegramGetUpdatesResult> {
+    this.getUpdatesCalls += 1;
     const batch = this.pending.shift();
     if (batch !== undefined) {
       return { ok: true, result: batch };
@@ -503,6 +506,41 @@ describe("TelegramAdapter — bus.sendPrompt shape", () => {
 /* ────────────────────────────────────────────────────────────────────── */
 /* response.text → sendMessage                                              */
 /* ────────────────────────────────────────────────────────────────────── */
+
+describe("TelegramAdapter — receiveEnabled:false (send-only, #201)", () => {
+  it("never polls getUpdates when receiveEnabled is false", async () => {
+    adapter = await startAdapter({ receiveEnabled: false });
+    // Give a real poll loop time to fire at least once if it were started.
+    await new Promise((r) => setTimeout(r, 30));
+    expect(api.getUpdatesCalls).toBe(0);
+  });
+
+  it("polls getUpdates by default (receiveEnabled omitted)", async () => {
+    adapter = await startAdapter();
+    await waitFor(() => api.getUpdatesCalls > 0);
+    expect(api.getUpdatesCalls).toBeGreaterThan(0);
+  });
+
+  it("still delivers outbound response.text via origin_id while send-only", async () => {
+    // No inbound is ever consumed, but a reply routed by origin_id (e.g. a
+    // cron/heartbeat-driven notification) must still reach the chat.
+    adapter = await startAdapter({
+      receiveEnabled: false,
+      routing: { chats: { "100": "triage" } },
+    });
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "send-only ping", origin: "telegram", origin_id: "100" },
+    });
+    await waitFor(() => api.sendMessages.length > 0);
+    expect(api.getUpdatesCalls).toBe(0);
+    expect(api.sendMessages[0]?.chat_id).toBe(100);
+    expect(api.sendMessages[0]?.text).toBe("send-only ping");
+  });
+});
 
 describe("TelegramAdapter — response.text outbound", () => {
   async function feedInbound(): Promise<void> {

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -508,11 +508,26 @@ describe("TelegramAdapter — bus.sendPrompt shape", () => {
 /* ────────────────────────────────────────────────────────────────────── */
 
 describe("TelegramAdapter — receiveEnabled:false (send-only, #201)", () => {
-  it("never polls getUpdates when receiveEnabled is false", async () => {
+  it("never polls getUpdates and drops enqueued inbound when receiveEnabled is false", async () => {
     adapter = await startAdapter({ receiveEnabled: false });
-    // Give a real poll loop time to fire at least once if it were started.
+    // Structural guarantee: an inbound update that IS waiting is never consumed
+    // (the long-poll loop was never started), so it never reaches the bus. This
+    // asserts the real "inbound ignored" contract rather than a wall-clock proxy.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 50,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          text: "should be ignored",
+        },
+      },
+    ]);
+    // A started poll loop calls getUpdates synchronously on its first iteration;
+    // a short tick gives any erroneously-started loop room to consume + route.
     await new Promise((r) => setTimeout(r, 30));
     expect(api.getUpdatesCalls).toBe(0);
+    expect(bus.prompts).toHaveLength(0);
   });
 
   it("polls getUpdates by default (receiveEnabled omitted)", async () => {
@@ -539,6 +554,30 @@ describe("TelegramAdapter — receiveEnabled:false (send-only, #201)", () => {
     expect(api.getUpdatesCalls).toBe(0);
     expect(api.sendMessages[0]?.chat_id).toBe(100);
     expect(api.sendMessages[0]?.text).toBe("send-only ping");
+  });
+
+  it("stop() cleanly tears down a send-only start (subscriptions closed)", async () => {
+    adapter = await startAdapter({
+      receiveEnabled: false,
+      routing: { chats: { "100": "triage" } },
+    });
+    const reply = (text: string) =>
+      bus.emit({
+        ts: Date.now(),
+        agent_id: "triage",
+        session_id: "s1",
+        topic: "response.text",
+        payload: { text, origin: "telegram", origin_id: "100" },
+      });
+    reply("first");
+    await waitFor(() => api.sendMessages.length === 1);
+    // The send-only branch never set loopPromise/inflightAbort; stop() must
+    // still resolve and close the outbound subscriptions symmetrically.
+    await adapter.stop();
+    adapter = null; // afterEach already stopped — avoid a double stop()
+    reply("second");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(api.sendMessages).toHaveLength(1);
   });
 });
 

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -43,6 +43,13 @@ export interface TelegramAdapterOptions {
   };
   /** Poll interval ms between successive `getUpdates` calls. Default 1000. */
   pollIntervalMs?: number;
+  /**
+   * When false, the adapter wires outbound (`response.text` → send) but never
+   * starts the inbound `getUpdates` long-poll — a send-only deployment. Mirrors
+   * the legacy pty path (`if (receiveEnabled) startPolling()` in
+   * `start.ts` initTelegram). Defaults to true. See #201.
+   */
+  receiveEnabled?: boolean;
   /** Milliseconds before an unanswered turn's receipt (#211) auto-closes as
    *  `timeout`. Defaults to 5 min (RECEIPT_TIMEOUT_MS). Lowered in tests. */
   receiptTimeoutMs?: number;
@@ -103,6 +110,8 @@ export class TelegramAdapter {
   private readonly routingChats: Record<string, string>;
   private readonly defaultAgentId: string | undefined;
   private readonly pollIntervalMs: number;
+  /** When false, skip the inbound long-poll (send-only). See #201. */
+  private readonly receiveEnabled: boolean;
   private readonly receiptTimeoutMs: number;
   private readonly receiptMaxBudgetMultiplier: number;
   private readonly receiptStore: ReceiptStore;
@@ -201,6 +210,7 @@ export class TelegramAdapter {
     this.routingChats = { ...opts.routing.chats };
     this.defaultAgentId = opts.routing.defaultAgentId;
     this.pollIntervalMs = opts.pollIntervalMs ?? 1000;
+    this.receiveEnabled = opts.receiveEnabled ?? true;
     this.receiptTimeoutMs = opts.receiptTimeoutMs ?? TelegramAdapter.RECEIPT_TIMEOUT_MS;
     this.receiptMaxBudgetMultiplier =
       opts.receiptMaxBudgetMultiplier ?? TelegramAdapter.DEFAULT_MAX_TURN_BUDGET_MULTIPLIER;
@@ -219,6 +229,16 @@ export class TelegramAdapter {
     if (this.defaultAgentId) agentIds.add(this.defaultAgentId);
     for (const agentId of agentIds) {
       this.subscribeForAgent(agentId);
+    }
+
+    // Send-only (#201): outbound subscriptions are wired above, but a config
+    // with receiveEnabled:false explicitly opted out of consuming inbound, so
+    // never start the long-poll. Mirrors the legacy pty gate.
+    if (!this.receiveEnabled) {
+      this.logger.info(
+        "[telegram-adapter] receiveEnabled=false — outbound only, not polling for inbound updates.",
+      );
+      return;
     }
 
     const gen = this.generation;

--- a/src/bus/__tests__/adapter-wiring.test.ts
+++ b/src/bus/__tests__/adapter-wiring.test.ts
@@ -212,6 +212,72 @@ describe("wireBusAdapters — gating", () => {
   });
 });
 
+describe("wireBusAdapters — Telegram explicit-busRouting send-only pass-through (#201)", () => {
+  /** Minimal bus that supports the outbound subscribe/close the adapter needs. */
+  function subscribeBus(): BusCore {
+    return {
+      subscribe: () => {
+        const sub = {
+          id: "sub",
+          close() {},
+          get overflowCount() {
+            return 0;
+          },
+          get depth() {
+            return 0;
+          },
+        };
+        return sub;
+      },
+    } as unknown as BusCore;
+  }
+
+  it("mounts the adapter but never starts the inbound poll (guards the cfg.receiveEnabled wiring line)", async () => {
+    // Unlike the token-only send-only path (skipped entirely), an explicit
+    // busRouting send-only config MUST mount so outbound stays wired — but the
+    // inbound long-poll must not start. pollLoop calls api.getUpdates()
+    // synchronously on its first iteration, so if the `receiveEnabled` line in
+    // mountTelegram were dropped (defaulting to polling), a getUpdates fetch
+    // would fire during start(). Stub fetch just long enough to witness that.
+    const fetchCalls: string[] = [];
+    const origFetch = globalThis.fetch;
+    globalThis.fetch = ((input: unknown) => {
+      const url =
+        typeof input === "string"
+          ? input
+          : String((input as { url?: string } | undefined)?.url ?? input);
+      fetchCalls.push(url);
+      return Promise.reject(new Error("network blocked in test"));
+    }) as unknown as typeof fetch;
+    try {
+      const result = await wireBusAdapters({
+        bus: subscribeBus(),
+        settings: baseSettings({
+          telegram: {
+            token: "123:abc",
+            allowedUserIds: [],
+            listenChats: [],
+            receiveEnabled: false,
+            dmIsolation: "shared",
+            busRouting: { chats: { "100": "triage" } },
+          } as Settings["telegram"],
+        }),
+        defaultAgentId: "default",
+        logger: SILENT_LOGGER,
+      });
+      const tg = result.adapters.find((a) => a.name === "telegram");
+      expect(tg).toBeDefined();
+      expect(result.errors.telegram).toBeUndefined();
+      // getUpdates is dispatched synchronously inside start(); by the time
+      // wireBusAdapters resolved it would already be recorded if polling started.
+      expect(fetchCalls.some((u) => u.includes("getUpdates"))).toBe(false);
+      await tg?.stop();
+    } finally {
+      globalThis.fetch = origFetch;
+    }
+  });
+});
+
 describe("configuredBusAdapterNames — Telegram token-only mount (#197)", () => {
   const tgSettings = (token: string, busRouting?: { chats: Record<string, string> }) =>
     baseSettings({

--- a/src/bus/adapter-wiring.ts
+++ b/src/bus/adapter-wiring.ts
@@ -202,13 +202,11 @@ async function mountTelegram(
   let routing = cfg.busRouting;
   if (!routing) {
     if (!defaultAgentId) return null;
-    // Respect send-only configs (Codex P2 on #197). TelegramAdapter.start()
-    // unconditionally begins polling for inbound, so deriving a token-only
-    // mount when `receiveEnabled: false` would start consuming messages a
-    // send-only operator explicitly opted out of. The legacy path gates
-    // polling on receiveEnabled (start.ts initTelegram); mirror that here by
-    // not auto-mounting. (Explicit busRouting is left as-is — the bus
-    // adapter's pre-existing receiveEnabled handling is out of scope for #197.)
+    // Respect send-only configs (Codex P2 on #197). A token-only mount has an
+    // empty chats map and no inbound to populate a target chat, so with
+    // receiveEnabled:false there is nothing to route outbound to either — skip
+    // entirely rather than mount a no-op. (Explicit busRouting honors
+    // receiveEnabled at the adapter level — see #201, below.)
     if (cfg.receiveEnabled === false) {
       logger.info(
         "[bus-adapters] telegram: token set but receiveEnabled=false and no busRouting — not mounting (send-only).",
@@ -236,6 +234,9 @@ async function mountTelegram(
     token: cfg.token,
     allowedUserIds: cfg.allowedUserIds,
     routing,
+    // #201: honor send-only configs even with explicit busRouting — the
+    // adapter wires outbound but skips the inbound long-poll. Default true.
+    receiveEnabled: cfg.receiveEnabled,
     logger,
   });
   await adapter.start();


### PR DESCRIPTION
## Problem

On the bus runtime, the Telegram adapter never read `telegram.receiveEnabled`. `TelegramAdapter.start()` unconditionally started its `getUpdates` long-poll, so a send-only config (`receiveEnabled: false`) still consumed inbound and routed it to an agent.

The legacy pty path honors the flag (`if (receiveEnabled) startPolling()` in `start.ts` initTelegram). #197 fixed only the **token-only derive** path (`mountTelegram` skips the derive when `receiveEnabled === false`) and explicitly left **explicit-busRouting out of scope** — see the comment it added in `adapter-wiring.ts`.

## Fix

- `TelegramAdapter` gains a `receiveEnabled` option (default `true`). `start()` still wires the outbound subscriptions but **skips the inbound `pollLoop`** when it is `false` — mirroring the legacy gate.
- `mountTelegram` passes `telegram.receiveEnabled` through to the adapter, and the now-stale "out of scope for #197" comment is updated.
- Outbound still works send-only: a reply routed by `origin_id` (e.g. a cron/heartbeat-driven notification) reaches the chat without ever polling inbound.

## Tests

3 new cases in the adapter suite:
- never polls `getUpdates` when `receiveEnabled` is `false`
- polls by default when the option is omitted
- still delivers outbound `response.text` via `origin_id` while send-only

43/43 adapter + 17/17 bus-wiring tests pass, biome clean, no new typecheck errors (the 5 pre-existing test-fake errors are identical before/after).

Closes #201
