### PR TITLE
fix(governance): disable watchdog by default + honour enabled flag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.155",
+      "version": "2.2.156",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.155",
+  "version": "2.2.156",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/governance/watchdog.ts
+++ b/src/governance/watchdog.ts
@@ -76,6 +76,10 @@ interface WatchdogIndex {
 }
 
 // Default configuration
+// Default: disabled. activeInvocations are not yet cleaned up on turn-end, so
+// stale records older than maxRuntimeSeconds silently suspend healthy agents
+// (see issue: governance watchdog activeInvocations leak). Re-enable via
+// settings.governance.watchdog.enabled once the lifecycle hook lands.
 let watchdogConfig: WatchdogConfig = {
   limits: {
     maxToolCalls: 100,
@@ -84,7 +88,7 @@ let watchdogConfig: WatchdogConfig = {
     maxRepeatedTools: 5,
     repeatedToolThreshold: 3, // 3+ repeated patterns triggers warning
   },
-  enabled: true,
+  enabled: false,
   checkIntervalMs: 5000, // Check every 5 seconds
 };
 
@@ -343,6 +347,22 @@ export async function checkLimits(context: {
   await initWatchdog();
 
   const now = new Date().toISOString();
+
+  // Short-circuit when disabled. Without a lifecycle hook to delete invocations
+  // on turn-end, even a single long-lived agent process accumulates stale
+  // records that eventually trip maxRuntimeSeconds. Honour `enabled` so
+  // operators can opt out until that lifecycle path is wired.
+  if (!watchdogConfig.enabled) {
+    return {
+      invocationId: context.invocationId,
+      state: "healthy",
+      reason: "Watchdog disabled via config",
+      triggeredLimits: [],
+      recommendedAction: "continue",
+      evaluatedAt: now,
+    };
+  }
+
   const record = watchdogIndex!.activeInvocations[context.invocationId];
 
   if (!record) {


### PR DESCRIPTION
## Summary

Closes #268.

The governance watchdog has been silently suspending healthy cron agents for ~9 days. Production daemon had 1,096 stale invocation records and was emitting a `maxRuntimeSeconds=N/7200` suspend handoff on every cron tick — masquerading as PTY timeouts in the user-facing layer while the agents themselves completed turns cleanly.

Root cause: `checkLimits` evaluates `Date.now() - record.startedAt` against `maxRuntimeSeconds`, but no path removes records on turn-end. A long-lived agent process accumulates a record per cron firing; once a record is older than 2h every subsequent check returns `state: "suspend"`. See #268 for full evidence (handoff counts, watchdog-index dump, etc.).

## Changes

This is a deliberately minimal **get-back-on-track** change. Two small adjustments:

1. **`checkLimits` short-circuits when `watchdogConfig.enabled === false`.** The field was parsed (`watchdog.ts:59,87,110`) but never consulted, so operators had no way to opt out.
2. **Default `enabled` flips to `false`** until the lifecycle hook lands.

A follow-up PR should:
- Wire `configureWatchdog()` into daemon startup via `parseGovernanceConfig` so the flag is operator-controllable from `settings.json`.
- Add an `onTurnEnd(invocationId)` lifecycle hook in the bus and PTY paths to delete the record.
- Add startup-time eviction of records older than ~24h to defend against future leaks.
- Flip the default back to `true` once (1)-(3) are in.

## Server status

Hot-patched on production at 2026-06-22T17:00 UTC:
- `/opt/claudeclaw/src/governance/watchdog.ts` replaced with this diff.
- `watchdog-index.json` truncated (backup preserved as `.bak-20260622`).
- `systemctl restart claudeclaw`. New PID 715802, all 4 PTY claudes respawned cleanly.
- Test `send` round-trip: completed in ~19s, turn count incremented to 2, zero new watchdog handoffs since restart.

Once this PR merges and auto-deploys, the hot-patch becomes the canonical fix.

## Test plan

- [x] `bun test src/__tests__/governance/watchdog.test.ts` — 16/16 pass.
- [x] `bun run lint` — no new errors (967 pre-existing warnings, all noise).
- [x] Live test on production daemon: agent `send` completes cleanly, zero watchdog suspend handoffs.
- [ ] CI plugin-version-guard + marketplace-version-guard (versions bumped to 2.2.156).