### PR TITLE
fix(bus): match the REPL footer marker whitespace-tolerant

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.155",
+      "version": "2.2.156",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.156",
+      "version": "2.2.157",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.156",
+  "version": "2.2.157",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.155",
+  "version": "2.2.156",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/session-agent-process.test.ts
+++ b/src/bus/__tests__/session-agent-process.test.ts
@@ -387,3 +387,44 @@ describe("PtyAgentProcess boot-dialog watcher (structural / ANSI-resilient)", ()
     expect(writes).toEqual([]); // disengaged -> no key into a live REPL
   });
 });
+
+// #271 regression: the CLI renders the REPL footer with CHA cursor positioning
+// (ESC[NG between tokens), not literal spaces. After the ANSI stripper runs the
+// markers collapse — "shift+tab to cycle" -> "shift+tabtocycle" — so the OLD
+// literal-substring matchers (`includes("to cycle")` / `includes("tab to
+// cycle")`) never matched on the real render. Every test above feeds a
+// PRE-SPACED footer, which is exactly why the bug hid. These feed the raw
+// CHA-sequenced footer through the real `stripAnsiEscapes` path so a future
+// regression to literal matching is caught.
+describe("PtyAgentProcess CHA-collapsed REPL footer (#271)", () => {
+  // The captured raw footer from the PR: cursor-positioned tokens with no
+  // literal spaces. `\x1b[NG` is the CHA (Cursor Horizontal Absolute) escape.
+  const CHA_IDLE_FOOTER = "\n⏵ accept edits on (shift+tab\x1b[39Gto\x1b[42Gcycle)";
+
+  it("delivery-confirm: re-nudges on the CHA-collapsed idle footer (turn never started)", async () => {
+    const { handle, writes, emit } = bootPty();
+    const proc = new PtyAgentProcess("z", handle, { submitConfirmMs: 60, maxSubmitNudges: 2 });
+    const p = proc.send_prompt_stream("hello");
+    // Idle REPL re-rendering its footer via CHA positioning. With the old
+    // `includes("to cycle")` this stripped to "tocycle" and never matched, so
+    // the loop read every window as turn-started and emitted only 1 CR.
+    const iv = setInterval(() => emit(CHA_IDLE_FOOTER), 8);
+    await p;
+    clearInterval(iv);
+    // 1 initial submit + 2 re-nudges — the `/to\s*cycle/` matcher fires on the
+    // collapsed render exactly as it would on the spaced one.
+    expect(writes.filter((w) => w === "\r").length).toBe(3);
+  });
+
+  it("boot-ready: disengages the watcher on the CHA-collapsed footer", async () => {
+    const { handle, writes, emit } = bootPty();
+    new PtyAgentProcess("epsilon", handle);
+    // Raw CHA footer with the boot-ready "tab to cycle" core collapsed to
+    // "tabtocycle". The `/tab\s*to\s*cycle/` matcher must still disengage.
+    emit("⏵⏵ bypass permissions on (shift+tab\x1b[39Gto\x1b[42Gcycle) · ← for agents");
+    writes.length = 0;
+    emit(" ❯ 1. I am using this for local development\r\n Enter to confirm");
+    await new Promise((r) => setTimeout(r, 20));
+    expect(writes).toEqual([]); // disengaged -> no key into a live REPL
+  });
+});

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -276,7 +276,7 @@ export class PtyAgentProcess implements AgentProcess {
         }
         // A turn-start is POSITIVE evidence -- the streaming view replaced the
         // footer. An EMPTY confirm window is NOT that: a long-idle, quiet REPL
-        // emits nothing, so `!includes("to cycle")` on an empty buffer falsely
+        // emits nothing, so `!/to\s*cycle/.test(...)` on an empty buffer falsely
         // reads as turn-started, stops the nudging, and leaves the prompt
         // un-submitted until the 5-min receipt timeout. This is the residual
         // idle-REPL wedge (dossier 20260612T080557: idle 7h, stdin written,

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -284,7 +284,7 @@ export class PtyAgentProcess implements AgentProcess {
         // fix stack already active). Require real output before trusting the
         // footer's absence; an empty/whitespace window stays inconclusive and
         // spends a nudge instead of claiming a phantom success.
-        if (this.recentOut.trim().length > 0 && !this.recentOut.includes("to cycle")) {
+        if (this.recentOut.trim().length > 0 && !/to\s*cycle/.test(this.recentOut)) {
           outcome = "turn-started";
           // A turn confirmed → re-arm the one-shot wedge warning, so a LATER
           // genuine wedge on this long-lived process still surfaces a diagnostic
@@ -359,7 +359,7 @@ export class PtyAgentProcess implements AgentProcess {
     // cycle" / a future "tab to cycle permission modes"); "tab to cycle" is its
     // version-stable core and — unlike the bare "to cycle" — cannot trip on
     // arbitrary boot prose, which would disengage early and re-expose #195.
-    if (buf.includes("tab to cycle")) {
+    if (/tab\s*to\s*cycle/.test(buf)) {
       this.endBootDialogPhase();
       return;
     }


### PR DESCRIPTION
## What this changes

The bus PTY agent detects the REPL-ready footer via literal substrings:

- `recentOut.includes("to cycle")` — the delivery-confirm re-nudge loop
- `buf.includes("tab to cycle")` — the boot-ready watcher

The CLI renders that status line with **CHA cursor positioning** (`ESC[NG`
between tokens), not literal spaces. After the ANSI stripper runs, the markers
collapse to `tocycle` / `tabtocycle`, so the spaced literals never match.

Captured by driving the real CLI through the bus's own spawn args + ANSI
stripper:

```
[6Gbypass[13Gpermissions[25Gon[28G(shift+tab[39Gto[42Gcycle)
→ stripped: "...permissionson(shift+tabtocycle)..."
```

## Effect

With the marker never matching:

- **delivery-confirm**: `!recentOut.includes("to cycle")` is always true, so any
  post-CR window that carries output reads as `turn-started` — the re-nudge path
  effectively never fires.
- **boot-ready**: the watcher only disengages on its timeout, never on the
  footer marker.

## Honest scope

This is a **robustness/correctness fix, not a fix for an observed incident.** I
found it while debugging an unrelated outage (an expired OAuth token, since
resolved) — the symptoms looked like submit wedges but were auth (401). The
matcher mismatch is real and captured, but I have **no production wedge
attributable to it**: the net it restores guards the documented paste/redraw
race, which I did not reproduce in the wild. Submitting purely because the
matcher objectively cannot match the current render, and the surrounding
comments already intend it to survive footer rewrites.

## Fix

Whitespace-tolerant matchers, each keeping its original guard:

| matcher | before | after |
|---|---|---|
| delivery-confirm | `includes("to cycle")` | `/to\s*cycle/` (bare-core, unchanged intent) |
| boot-ready | `includes("tab to cycle")` | `/tab\s*to\s*cycle/` (keeps the stricter `tab` prefix that avoids tripping on model prose like "to cycle permission modes") |

`\s*` matches both the spaced render and the CHA-collapsed render, on every
CLI version.

## Scope / risk

- 2 lines changed in `src/bus/session-agent-process.ts`. No happy-path change
  (a streaming turn has no footer → still detected as started); the change only
  restores correct detection of the idle/failed case.
- Plugin + marketplace versions bumped (Version Guard).

## Testing

- Reproduced the collapse via a `bun-pty` harness running the real CLI with the
  bus's spawn args + stripper: the stripped footer is `tocycle` (no space), so
  `includes("to cycle")` returns false at an idle REPL.
- `biome check` clean on the changed file.
- `bun build src/index.ts` (smoke / type check) clean — 378 modules, no errors.
- `bun test src/bus/__tests__/session-agent-process.test.ts` → 18 pass / 0 fail
  (incl. the boot-footer disengage test that exercises this matcher).
- `bun test src/__tests__/watchdog.test.ts` (the deploy gate) → 17 pass / 0 fail.
- No regressions; version guards satisfied (plugin + marketplace bumped).
