### PR TITLE
fix(governance): getBudgetHealth returns scoped policies (empty query = all)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "claudeclaw-plus",
       "source": "./",
-      "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.157",
+      "description": "ClaudeClaw+ \u2014 governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
+      "version": "2.2.158",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.157",
-  "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
+  "version": "2.2.158",
+  "description": "ClaudeClaw+ \u2014 governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/governance/budget-engine.ts
+++ b/src/governance/budget-engine.ts
@@ -547,6 +547,20 @@ export async function getBudgetState(scope: BudgetScope): Promise<BudgetStateSum
 
   const summaries: BudgetStateSummary[] = [];
 
+  // An empty query scope means "every policy" — the budget-health / dashboard
+  // view passes {}. matchesScope() answers "does this query select this policy?",
+  // and with no fields set it rejects every SCOPED policy (the scoped field has
+  // nothing in the empty query to match against), so getBudgetHealth() silently
+  // dropped all channel/user/model-scoped budgets. Treat an empty query as
+  // "select all"; a non-empty query still filters as before.
+  const selectsAllPolicies =
+    !scope.source &&
+    !scope.channelId &&
+    !scope.userId &&
+    !scope.sessionId &&
+    !scope.provider &&
+    !scope.model;
+
   for (const policy of budgetPolicies!) {
     if (!policy.enabled) {
       continue;
@@ -554,6 +568,7 @@ export async function getBudgetState(scope: BudgetScope): Promise<BudgetStateSum
 
     // Check if policy matches the requested scope
     if (
+      !selectsAllPolicies &&
       !matchesScope(
         scope as {
           source?: string;


### PR DESCRIPTION
## Summary

`getBudgetHealth()` silently dropped every **scoped** budget policy — channel/user/model/session/provider-scoped budgets never appeared in the health view; only global (unscoped) policies surfaced.

## Root cause

`getBudgetHealth()` calls `getBudgetState({})` (empty scope = "list every policy"). `getBudgetState` filters each policy through `matchesScope(query, policy.scope)`. With an empty query, `matchesScope` rejects any policy that *has* a scope field — there is nothing in the empty query to match the scoped field against — so scoped policies were excluded from the result set.

## Fix

Treat an empty query scope as "select all" in `getBudgetState`. A non-empty query still filters exactly as before.

- **Enforcement is unchanged** — the evaluate/check path always passes a concrete (non-empty) call scope, which still filters correctly. Only the **health/dashboard listing** is corrected.
- One root cause, one scoped change.

## Tests

- Restores the previously-failing `Telemetry > should return budget health` test (creates a channel-scoped policy, asserts it appears in `getBudgetHealth()`).
- Full governance suite green; no new lint/type diagnostics introduced.
