### PR TITLE
fix(governance): client getBudgetState takes a BudgetScope, not a bare channelId

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ \u2014 governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.158",
+      "version": "2.2.159",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.158",
+  "version": "2.2.159",
   "description": "ClaudeClaw+ \u2014 governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/governance/client.ts
+++ b/src/governance/client.ts
@@ -21,6 +21,7 @@ import {
 } from "../policy/approval-queue";
 import { logPolicyDecision } from "../policy/audit-log";
 import * as governance from "./index";
+import type { BudgetScope } from "./budget-engine";
 
 export interface GovernanceClientConfig {
   policyEnabled?: boolean;
@@ -140,8 +141,8 @@ export class GovernanceClient {
   /**
    * Get budget state.
    */
-  async getBudgetState(channelId?: string) {
-    return governance.getBudgetState(channelId);
+  async getBudgetState(scope?: BudgetScope) {
+    return governance.getBudgetState(scope ?? {});
   }
 
   /**

--- a/src/orchestrator/governance-adapter.ts
+++ b/src/orchestrator/governance-adapter.ts
@@ -10,7 +10,7 @@
  *
  * Real GovernanceClient (source):
  *   evaluateToolRequest(request: ToolRequestContext): PolicyDecision
- *   getBudgetState(channelId?: string)
+ *   getBudgetState(scope?: BudgetScope)
  */
 
 import type { GovernanceClient as RealGovernanceClient } from "../governance/client";


### PR DESCRIPTION
## Summary

`GovernanceClient.getBudgetState(channelId?: string)` forwarded a raw string into `getBudgetState(scope: BudgetScope)`. A string carries none of the scope fields, so the wrapper never actually filtered by channel — and it is a type mismatch (`string` is not assignable to `BudgetScope`).

This is the small follow-up flagged in #273. The wrapper is currently unreferenced (no `src` callers), so this is a pure type-correctness fix before anything wires it up.

## Change

- `getBudgetState(scope: BudgetScope = {})` — accept and pass through a proper scope.
- Doc comment in `governance-adapter.ts` updated to match.

## Notes

- Resolves the `string` → `BudgetScope` type error on this method (net −1 type error).
- Full governance suite green; no new lint/type diagnostics introduced.
