### PR TITLE
fix(governance): thread channelId + userId + skillName into runner context (#258 item 1, live budget/usage)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.163",
+      "version": "2.2.164",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.159",
+      "version": "2.2.160",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,8 +7,8 @@
     {
       "name": "claudeclaw-plus",
       "source": "./",
-      "description": "ClaudeClaw+ \u2014 governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.158",
+      "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
+      "version": "2.2.159",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.164",
+      "version": "2.2.165",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.164",
+  "version": "2.2.165",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.158",
-  "description": "ClaudeClaw+ \u2014 governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
+  "version": "2.2.159",
+  "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.163",
+  "version": "2.2.164",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.159",
+  "version": "2.2.160",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/governance/budget-engine.test.ts
+++ b/src/__tests__/governance/budget-engine.test.ts
@@ -367,4 +367,79 @@ describe("BudgetEngine", () => {
     // Should evaluate session policy
     expect(eval_.some((e) => e.policyId === policy.id)).toBe(true);
   });
+
+  // #277 (Terry HIGH): evaluateBudget must derive its spend filter from the
+  // policy scope, not the request context. A global / unscoped budget previously
+  // filtered by the current channelId -> under-count -> fail-open.
+  test("global budget aggregates spend across ALL channels — no per-channel fail-open (#277)", async () => {
+    await upsertBudgetPolicy({
+      name: "Global Daily",
+      scope: {},
+      thresholds: { warnAt: 0.001, degradeAt: 0.01, blockAt: 0.02 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+    for (const channelId of ["chan-A", "chan-B"]) {
+      const s = await recordInvocationStart({ channelId, provider: "anthropic", model: "claude-3-haiku" });
+      await recordInvocationCompletion(
+        s.invocationId,
+        { inputTokens: 100, outputTokens: 100 },
+        { currency: "USD", totalCost: 0.0008 },
+      );
+    }
+    // Evaluated as a request from chan-A: a GLOBAL budget must still see BOTH
+    // channels (0.0016), not just chan-A (0.0008) — the pre-fix under-count.
+    const evals = await evaluateBudget({ channelId: "chan-A" });
+    const global = evals.find((e) => e.policyName === "Global Daily");
+    expect(global).toBeDefined();
+    expect(global!.currentSpend).toBeCloseTo(0.0016, 5);
+    expect(global!.state).not.toBe("healthy");
+  });
+
+  test("channel-scoped budget meters only its own channel (#277)", async () => {
+    await upsertBudgetPolicy({
+      name: "ChanA Budget",
+      scope: { channelId: "chan-A" },
+      thresholds: { warnAt: 0.01, degradeAt: 0.02, blockAt: 0.05 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+    for (const channelId of ["chan-A", "chan-B"]) {
+      const s = await recordInvocationStart({ channelId, provider: "anthropic", model: "claude-3-haiku" });
+      await recordInvocationCompletion(
+        s.invocationId,
+        { inputTokens: 100, outputTokens: 100 },
+        { currency: "USD", totalCost: 0.0008 },
+      );
+    }
+    const evals = await evaluateBudget({ channelId: "chan-A" });
+    const chanA = evals.find((e) => e.policyName === "ChanA Budget");
+    expect(chanA).toBeDefined();
+    expect(chanA!.currentSpend).toBeCloseTo(0.0008, 5); // chan-A only, not chan-B
+  });
+
+  test("user-scoped budget meters only its own user (#277)", async () => {
+    await upsertBudgetPolicy({
+      name: "UserX Budget",
+      scope: { userId: "user-x" },
+      thresholds: { warnAt: 0.01, degradeAt: 0.02, blockAt: 0.05 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+    for (const userId of ["user-x", "user-y"]) {
+      const s = await recordInvocationStart({ userId, provider: "anthropic", model: "claude-3-haiku" });
+      await recordInvocationCompletion(
+        s.invocationId,
+        { inputTokens: 100, outputTokens: 100 },
+        { currency: "USD", totalCost: 0.0008 },
+      );
+    }
+    const evals = await evaluateBudget({ userId: "user-x" });
+    const userX = evals.find((e) => e.policyName === "UserX Budget");
+    expect(userX).toBeDefined();
+    expect(userX!.currentSpend).toBeCloseTo(0.0008, 5); // user-x only, not user-y
+  });
 });

--- a/src/__tests__/governance/budget-engine.test.ts
+++ b/src/__tests__/governance/budget-engine.test.ts
@@ -381,7 +381,11 @@ describe("BudgetEngine", () => {
       enabled: true,
     });
     for (const channelId of ["chan-A", "chan-B"]) {
-      const s = await recordInvocationStart({ channelId, provider: "anthropic", model: "claude-3-haiku" });
+      const s = await recordInvocationStart({
+        channelId,
+        provider: "anthropic",
+        model: "claude-3-haiku",
+      });
       await recordInvocationCompletion(
         s.invocationId,
         { inputTokens: 100, outputTokens: 100 },
@@ -407,7 +411,11 @@ describe("BudgetEngine", () => {
       enabled: true,
     });
     for (const channelId of ["chan-A", "chan-B"]) {
-      const s = await recordInvocationStart({ channelId, provider: "anthropic", model: "claude-3-haiku" });
+      const s = await recordInvocationStart({
+        channelId,
+        provider: "anthropic",
+        model: "claude-3-haiku",
+      });
       await recordInvocationCompletion(
         s.invocationId,
         { inputTokens: 100, outputTokens: 100 },
@@ -430,7 +438,11 @@ describe("BudgetEngine", () => {
       enabled: true,
     });
     for (const userId of ["user-x", "user-y"]) {
-      const s = await recordInvocationStart({ userId, provider: "anthropic", model: "claude-3-haiku" });
+      const s = await recordInvocationStart({
+        userId,
+        provider: "anthropic",
+        model: "claude-3-haiku",
+      });
       await recordInvocationCompletion(
         s.invocationId,
         { inputTokens: 100, outputTokens: 100 },

--- a/src/__tests__/governance/budget-engine.test.ts
+++ b/src/__tests__/governance/budget-engine.test.ts
@@ -153,6 +153,31 @@ describe("BudgetEngine", () => {
     expect(evaluation[0].state).toBe("healthy");
   });
 
+  // Regression guard for #258 item 1: a per-channel budget policy must only
+  // participate when the request actually carries a channelId. The runner used
+  // to pass channelId: undefined into selectModel/recordInvocationStart, so
+  // channel-scoped budgets could never match and per-channel enforcement was
+  // silently inert. Threading threadId -> channelId in the runner is what makes
+  // these two assertions diverge.
+  test("channel-scoped policy participates only when channelId is threaded (#258)", async () => {
+    const policy = await upsertBudgetPolicy({
+      name: "Channel-Scoped Block",
+      scope: { channelId: "greg-chat" },
+      thresholds: { warnAt: 0.001, degradeAt: 0.002, blockAt: 0.003 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    // Pre-fix runner behaviour: no channelId on the request -> scoped policy skipped.
+    const unscoped = await evaluateBudget({});
+    expect(unscoped.some((e) => e.policyId === policy.id)).toBe(false);
+
+    // Post-fix: channelId threaded -> the same policy now participates.
+    const scoped = await evaluateBudget({ channelId: "greg-chat" });
+    expect(scoped.some((e) => e.policyId === policy.id)).toBe(true);
+  });
+
   test("should evaluate warn state at threshold", async () => {
     const policy = await upsertBudgetPolicy({
       name: "Warn Test",

--- a/src/__tests__/governance/budget-engine.test.ts
+++ b/src/__tests__/governance/budget-engine.test.ts
@@ -178,6 +178,27 @@ describe("BudgetEngine", () => {
     expect(scoped.some((e) => e.policyId === policy.id)).toBe(true);
   });
 
+  // Regression guard for #258 item 1 (userId half): per-user budgets only
+  // participate once userId is threaded from the surface into the request.
+  test("user-scoped policy participates only when userId is threaded (#258)", async () => {
+    const policy = await upsertBudgetPolicy({
+      name: "User-Scoped Block",
+      scope: { userId: "user-42" },
+      thresholds: { warnAt: 0.001, degradeAt: 0.002, blockAt: 0.003 },
+      period: "daily",
+      currency: "USD",
+      enabled: true,
+    });
+
+    // No userId on the request -> scoped policy must be skipped.
+    const unscoped = await evaluateBudget({});
+    expect(unscoped.some((e) => e.policyId === policy.id)).toBe(false);
+
+    // userId threaded -> the same policy now participates.
+    const scoped = await evaluateBudget({ userId: "user-42" });
+    expect(scoped.some((e) => e.policyId === policy.id)).toBe(true);
+  });
+
   test("should evaluate warn state at threshold", async () => {
     const policy = await upsertBudgetPolicy({
       name: "Warn Test",

--- a/src/__tests__/governance/usage-tracker.test.ts
+++ b/src/__tests__/governance/usage-tracker.test.ts
@@ -54,6 +54,8 @@ describe("UsageTracker", () => {
     const context = {
       sessionId: "session-123",
       channelId: "telegram:12345",
+      userId: "user-42",
+      skillName: "quant",
       source: "telegram",
       provider: "anthropic",
       model: "claude-3-5-sonnet",
@@ -64,6 +66,10 @@ describe("UsageTracker", () => {
     expect(record.invocationId).toBeDefined();
     expect(record.sessionId).toBe("session-123");
     expect(record.channelId).toBe("telegram:12345");
+    // #258 item 1: userId/skillName threaded from the surface are persisted for
+    // per-user spend attribution and skill-level cost reporting.
+    expect(record.userId).toBe("user-42");
+    expect(record.skillName).toBe("quant");
     expect(record.provider).toBe("anthropic");
     expect(record.model).toBe("claude-3-5-sonnet");
     expect(record.status).toBe("started");

--- a/src/commands/slack.ts
+++ b/src/commands/slack.ts
@@ -1215,7 +1215,19 @@ async function handleMessage(event: SlackMessage): Promise<void> {
 
     let result: Awaited<ReturnType<typeof runUserMessage>>;
     try {
-      result = await runUserMessage("slack", prefixedPrompt, sessionThreadId, agentName);
+      result = await runUserMessage(
+        "slack",
+        prefixedPrompt,
+        sessionThreadId,
+        agentName,
+        undefined,
+        undefined,
+        undefined,
+        {
+          userId: userId !== undefined ? String(userId) : undefined,
+          skillName: skillContext ? command!.replace(/^\//, "") : undefined,
+        },
+      );
     } finally {
       clearInterval(statusRefreshInterval);
     }

--- a/src/commands/telegram.ts
+++ b/src/commands/telegram.ts
@@ -1745,6 +1745,10 @@ async function handleMessage(message: TelegramMessage): Promise<void> {
         stream.onChunk,
         stream.onToolEvent,
         modelOverride,
+        {
+          userId: userId !== undefined ? String(userId) : undefined,
+          skillName: skillContext ? command!.replace(/^\//, "") : undefined,
+        },
       );
       const streamResult = await stream.waitForStreamMsg();
       streamMsgId = streamResult.msgId;

--- a/src/governance/budget-engine.ts
+++ b/src/governance/budget-engine.ts
@@ -495,8 +495,7 @@ export async function evaluateBudget(context: {
     const filters: UsageFilters = {
       startDate,
       endDate,
-      sessionId:
-        policy.period === "session" ? context.sessionId : asFilter(policy.scope.sessionId),
+      sessionId: policy.period === "session" ? context.sessionId : asFilter(policy.scope.sessionId),
       channelId: asFilter(policy.scope.channelId),
       userId: asFilter(policy.scope.userId),
       source: asFilter(policy.scope.source),

--- a/src/governance/budget-engine.ts
+++ b/src/governance/budget-engine.ts
@@ -366,6 +366,7 @@ function matchesScope(
   record: {
     source?: string;
     channelId?: string;
+    userId?: string;
     sessionId?: string;
     provider?: string;
     model?: string;
@@ -384,6 +385,14 @@ function matchesScope(
   if (scope.channelId) {
     const channels = Array.isArray(scope.channelId) ? scope.channelId : [scope.channelId];
     if (!record.channelId || !channels.includes(record.channelId)) {
+      return false;
+    }
+  }
+
+  // Check userId (#258 item 1: per-user budget scoping)
+  if (scope.userId) {
+    const users = Array.isArray(scope.userId) ? scope.userId : [scope.userId];
+    if (!record.userId || !users.includes(record.userId)) {
       return false;
     }
   }

--- a/src/governance/budget-engine.ts
+++ b/src/governance/budget-engine.ts
@@ -482,15 +482,26 @@ export async function evaluateBudget(context: {
     // Get period bounds
     const { startDate, endDate } = getPeriodBounds(policy.period);
 
-    // Get usage for the period
+    // Get usage for the period, SCOPED TO THE POLICY (not the request context).
+    // Filtering by context.channelId unconditionally (as before) made a global /
+    // source-scoped / monthly budget count ONLY the current channel's spend ->
+    // under-count -> the cap trips late or never (#277 Terry HIGH: threading
+    // channelId had activated this fail-open). Mirror getBudgetState: only
+    // constrain a dimension the policy actually scopes on; multi-value (string[])
+    // and unscoped dimensions aggregate broadly (over-count = fail-SAFE). channelId
+    // and userId are now persisted per record (#258 item 1), so per-channel /
+    // per-user budgets meter their own spend.
+    const asFilter = (v?: string | string[]) => (typeof v === "string" ? v : undefined);
     const filters: UsageFilters = {
       startDate,
       endDate,
-      sessionId: policy.period === "session" ? context.sessionId : undefined,
-      channelId: context.channelId,
-      source: context.source,
-      provider: context.provider,
-      model: context.model,
+      sessionId:
+        policy.period === "session" ? context.sessionId : asFilter(policy.scope.sessionId),
+      channelId: asFilter(policy.scope.channelId),
+      userId: asFilter(policy.scope.userId),
+      source: asFilter(policy.scope.source),
+      provider: asFilter(policy.scope.provider),
+      model: asFilter(policy.scope.model),
     };
 
     const aggregates = await getAggregates(filters);
@@ -601,20 +612,18 @@ export async function getBudgetState(scope: BudgetScope): Promise<BudgetStateSum
     // value scope fields onto the usage filter (UsageFilters can't express the
     // string[] multi-value form; those still aggregate broadly — noted).
     //
-    // IMPORTANT: only filter on fields the PRODUCER actually populates on each
-    // usage record. recordInvocationStart currently persists channelId/userId as
-    // undefined (runner getPolicyContext does not thread them yet), so filtering
-    // on channelId here would match ZERO records -> spend reads 0 -> a per-channel
-    // budget would silently never trip (fail-OPEN). Until the producer carries
-    // channelId/userId, we deliberately DO NOT push those filters and instead
-    // aggregate broadly for channel/user-scoped policies (over-count = fail-SAFE).
-    // Tracked for Terry: thread channelId/userId from event context into the
-    // invocation record, then re-enable channelId filtering here.
+    // channelId/userId are now persisted on each usage record (the runner threads
+    // them from the inbound event — #258 item 1), so we filter on them too: a
+    // per-channel / per-user budget meters only its own spend instead of the
+    // global total. Multi-value (string[]) scopes still aggregate broadly
+    // (over-count = fail-SAFE).
     const asFilter = (v?: string | string[]) => (typeof v === "string" ? v : undefined);
     const filters: UsageFilters = {
       startDate,
       endDate,
       source: asFilter(policy.scope.source),
+      channelId: asFilter(policy.scope.channelId),
+      userId: asFilter(policy.scope.userId),
       sessionId: asFilter(policy.scope.sessionId),
       provider: asFilter(policy.scope.provider),
       model: asFilter(policy.scope.model),

--- a/src/governance/usage-tracker.ts
+++ b/src/governance/usage-tracker.ts
@@ -507,6 +507,7 @@ export async function getChannelUsage(channelId: string): Promise<InvocationUsag
 export interface UsageFilters {
   sessionId?: string;
   channelId?: string;
+  userId?: string;
   source?: string;
   provider?: string;
   model?: string;
@@ -559,6 +560,7 @@ export async function getAggregates(filters: UsageFilters = {}): Promise<{
       // Apply filters
       if (filters.sessionId && record.sessionId !== filters.sessionId) continue;
       if (filters.channelId && record.channelId !== filters.channelId) continue;
+      if (filters.userId && record.userId !== filters.userId) continue;
       if (filters.source && record.source !== filters.source) continue;
       if (filters.provider && record.provider !== filters.provider) continue;
       if (filters.model && record.model !== filters.model) continue;

--- a/src/governance/usage-tracker.ts
+++ b/src/governance/usage-tracker.ts
@@ -107,6 +107,8 @@ export interface InvocationUsageRecord {
   source?: string;
   channelId?: string;
   threadId?: string;
+  userId?: string;
+  skillName?: string;
   provider: string;
   model: string;
   startedAt: string;
@@ -128,6 +130,8 @@ export interface InvocationContext {
   source?: string;
   channelId?: string;
   threadId?: string;
+  userId?: string;
+  skillName?: string;
   provider: string;
   model: string;
   metadata?: Record<string, unknown>;
@@ -259,6 +263,8 @@ export async function recordInvocationStart(
       source: context.source,
       channelId: context.channelId,
       threadId: context.threadId,
+      userId: context.userId,
+      skillName: context.skillName,
       provider: context.provider,
       model: context.model,
       startedAt: now,

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1488,7 +1488,7 @@ async function evaluateToolForExecution(
 /**
  * Get context for policy evaluation from current session and settings.
  */
-async function getPolicyContext(source: string): Promise<{
+async function getPolicyContext(source: string, channelId?: string): Promise<{
   eventId: string;
   source: string;
   channelId?: string;
@@ -1502,7 +1502,7 @@ async function getPolicyContext(source: string): Promise<{
   return {
     eventId: crypto.randomUUID(),
     source,
-    channelId: undefined, // Will be populated from event context
+    channelId, // #258 item 1: threaded from inbound event (undefined for non-channel sources)
     userId: undefined,
     skillName: undefined,
     sessionId: existing?.sessionId,
@@ -1625,7 +1625,7 @@ async function execClaude(
         prompt,
         taskType: agentic.defaultMode,
         sessionId: existing?.sessionId,
-        channelId: undefined,
+        channelId: threadId, // #258 item 1: per-channel budget/policy scoping
         source: name,
       });
       primaryConfig = {
@@ -1777,7 +1777,7 @@ async function execClaude(
       sessionId: existing?.sessionId,
       claudeSessionId: existing?.sessionId ?? null,
       source: name,
-      channelId: undefined,
+      channelId: threadId, // #258 item 1: persist channel scope into usage record
       provider:
         primaryConfig.model.startsWith("gpt") ||
         primaryConfig.model.startsWith("o1") ||

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -1488,7 +1488,12 @@ async function evaluateToolForExecution(
 /**
  * Get context for policy evaluation from current session and settings.
  */
-async function getPolicyContext(source: string, channelId?: string): Promise<{
+async function getPolicyContext(
+  source: string,
+  channelId?: string,
+  userId?: string,
+  skillName?: string,
+): Promise<{
   eventId: string;
   source: string;
   channelId?: string;
@@ -1503,8 +1508,8 @@ async function getPolicyContext(source: string, channelId?: string): Promise<{
     eventId: crypto.randomUUID(),
     source,
     channelId, // #258 item 1: threaded from inbound event (undefined for non-channel sources)
-    userId: undefined,
-    skillName: undefined,
+    userId,
+    skillName,
     sessionId: existing?.sessionId,
     claudeSessionId: existing?.sessionId ?? null,
   };
@@ -1562,6 +1567,14 @@ export async function compactCurrentThreadSession(
     : { success: false, message: `❌ Compact failed (${existing.sessionId.slice(0, 8)})` };
 }
 
+/**
+ * Identity fields threaded from the inbound surface for policy/budget scoping (#258 item 1).
+ */
+interface PolicyIdentity {
+  userId?: string;
+  skillName?: string;
+}
+
 async function execClaude(
   name: string,
   prompt: string,
@@ -1572,6 +1585,7 @@ async function execClaude(
   timeoutCategory?: string,
   onChunk?: (text: string) => void,
   onToolEvent?: (line: string) => void,
+  identity?: PolicyIdentity,
 ): Promise<RunResult> {
   mainRunCount++;
   persistRunCount();
@@ -1626,6 +1640,7 @@ async function execClaude(
         taskType: agentic.defaultMode,
         sessionId: existing?.sessionId,
         channelId: threadId, // #258 item 1: per-channel budget/policy scoping
+        userId: identity?.userId,
         source: name,
       });
       primaryConfig = {
@@ -1778,6 +1793,8 @@ async function execClaude(
       claudeSessionId: existing?.sessionId ?? null,
       source: name,
       channelId: threadId, // #258 item 1: persist channel scope into usage record
+      userId: identity?.userId,
+      skillName: identity?.skillName,
       provider:
         primaryConfig.model.startsWith("gpt") ||
         primaryConfig.model.startsWith("o1") ||
@@ -2388,6 +2405,7 @@ export async function run(
   timeoutCategory?: string,
   onChunk?: (text: string) => void,
   onToolEvent?: (line: string) => void,
+  identity?: PolicyIdentity,
 ): Promise<RunResult> {
   return enqueue(
     () =>
@@ -2401,6 +2419,7 @@ export async function run(
         timeoutCategory,
         onChunk,
         onToolEvent,
+        identity,
       ),
     threadId,
   );
@@ -2674,6 +2693,7 @@ export async function runUserMessage(
   onChunk?: (text: string) => void,
   onToolEvent?: (line: string) => void,
   modelOverride?: string,
+  identity?: PolicyIdentity,
 ): Promise<RunResult> {
   return run(
     name,
@@ -2685,6 +2705,7 @@ export async function runUserMessage(
     undefined,
     onChunk,
     onToolEvent,
+    identity,
   );
 }
 


### PR DESCRIPTION
## What

Threads the inbound identity context — **`channelId`, `userId`, and `skillName`** — down into the runner's governance call-sites so per-channel and per-user budget/policy rules can actually match, and so usage records carry channel/user/skill attribution. This closes **#258 item 1** (the root-cause context-threading gap).

## Why

#258 item 1 identified that `getPolicyContext()` and the two live governance objects in `execClaude` hardcode `channelId/userId/skillName: undefined`:

- `selectModel({ …, channelId, userId })` (model router) → `matchesScope` in the budget engine could never match a channel- **or** user-scoped policy → **scoped budget / model-routing enforcement was structurally inert on the runner path**.
- `recordInvocationStart({ … })` → usage records carried no channel/user/skill attribution, forcing the budget engine into broad (over-counting, fail-safe) aggregation for scoped policies.

The values exist on the inbound surface event; this PR threads them through.

## Changes

- **`runner.ts`** — new `PolicyIdentity { userId?, skillName? }` threaded `runUserMessage → run → execClaude` (appended optional param, existing callers unaffected). `channelId` comes from the already-in-scope `threadId`. Populated at: the `selectModel` request (`channelId`, `userId`), the `recordInvocationStart` record (`channelId`, `userId`, `skillName`), and `getPolicyContext` (all three) so the documented helper is complete when its consumer is wired (item 2).
- **`governance/budget-engine.ts`** — `matchesScope` now evaluates `scope.userId` (the field existed on `BudgetScope` but was never checked), mirroring the existing `channelId` check, so **per-user budgets participate once `userId` is threaded**.
- **`governance/usage-tracker.ts`** — `InvocationContext`/`InvocationUsageRecord` carry `userId` + `skillName`; `recordInvocationStart` persists them (per-user spend + skill-level cost attribution).
- **Surfaces** — `telegram` (`message.from?.id`) and `slack` (`event.user`) pass the inbound user id; for slash commands that resolve to a skill, they pass the resolved skill name. `skillName` is empty for ordinary chat — exactly the cases skill overlays (item 2) target.

## Scope boundary

`skillName` is **threaded and persisted** here, but its policy **consumer** (skill-overlay deny rules, `getPolicyContext`'s tool path) is intentionally left to **item 2**, which the issue flags as a design decision ("where in the path should skill overlays be consulted"). This PR provides the `skillName` source that item 2 is blocked on.

## Verification

- `bun test src/__tests__/governance src/__tests__/policy` → all green.
- **Full suite: identical failure set before/after** — the change introduces **0 new failures** (the repo's pre-existing failures in escalation / pause-controller / event-processor / mcp-multiplexer / job-loading are untouched). +1 net pass from the new test.
- Regression guards added: a channel-scoped **and** a user-scoped budget policy each participate only when the respective id is threaded; the invocation record round-trips `userId` + `skillName`.

## Compliance / governance note

This restores the intended **per-channel and per-user budget ceilings and policy scoping** on the runner path — a channel/tenant/user can no longer silently bypass a scoped spend or routing rule because the request context arrived empty.

Completes the **live budget/usage** half of #258 item 1 (channelId/userId now scope model-routing + spend). The policy-path half via getPolicyContext stays inert until a caller exists — the per-tool gate is #284.

