### PR TITLE
ci(security): gate Claude auto-review to trusted authors; maintainer label for external PRs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.161",
+      "version": "2.2.162",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.161",
+  "version": "2.2.162",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -55,7 +55,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          # Pin to the immutable commit SHA from the event payload, NOT the
+          # mutable branch ref. For a maintainer-labeled external PR this closes
+          # the TOCTOU race where a fork author pushes a new commit after the
+          # label but before checkout — the privileged job would otherwise run
+          # against code the maintainer never approved.
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
 
       - name: Run Claude Code Review

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,27 +2,40 @@ name: Claude Code Review
 
 on:
   pull_request_target:
-    types: [opened, synchronize, ready_for_review, reopened]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+    # `labeled` lets a maintainer opt an EXTERNAL PR in for review by adding the
+    # `claude-review` label (adding labels requires triage/write, so only
+    # maintainers can trigger it). Trusted-author PRs auto-run on the other types.
+    types: [opened, synchronize, ready_for_review, reopened, labeled]
 
 jobs:
   claude-review:
-    # Skip automated sync PRs — they're opened by github-actions[bot] and need no auto-review
-    if: github.event.pull_request.user.login != 'github-actions[bot]' && !startsWith(github.head_ref, 'sync/')
+    # SECURITY GATE. This is a `pull_request_target` job: it runs in the base
+    # repo's context with repo secrets (CLAUDE_CODE_OAUTH_TOKEN) and a
+    # write-capable GITHUB_TOKEN, and it checks out the (untrusted) PR head.
+    # The job-level `if` is the real trust control — it must NOT start for an
+    # arbitrary external contributor:
+    #   * Auto-run only for OWNER / MEMBER / COLLABORATOR authors (your own +
+    #     org/collaborator PRs).
+    #   * External authors (CONTRIBUTOR / FIRST_TIME_CONTRIBUTOR / NONE) never
+    #     auto-run — a maintainer must add the `claude-review` label, which fires
+    #     the `labeled` event. (Re-label to re-review after new commits.)
+    if: >-
+      github.event.pull_request.user.login != 'github-actions[bot]'
+      && !startsWith(github.head_ref, 'sync/')
+      && (
+        contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+        || (github.event.action == 'labeled' && github.event.label.name == 'claude-review')
+      )
 
     runs-on: ubuntu-latest
-    # Informational only — transient action infrastructure errors shouldn't block PRs
+    # Informational only — transient action infrastructure errors shouldn't block PRs.
     continue-on-error: true
     permissions:
       contents: read
       pull-requests: write
       issues: write
-      id-token: write
+      # NOTE: `id-token: write` deliberately removed — OIDC is not used here and
+      # it needlessly widens the blast radius of this privileged job.
 
     steps:
       - name: Check token configured
@@ -52,6 +65,9 @@ jobs:
         with:
           github_token: ${{ github.token }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # The job-level `if` is the trust gate. `'*'` here only lets Claude
+          # proceed on a maintainer-labeled external PR (whose author is non-write);
+          # the job would never have started without a trusted author or a label.
           allowed_non_write_users: '*'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'


### PR DESCRIPTION
## Why

`claude-code-review.yml` was disabled because it's a `pull_request_target` job — it runs in the base repo's context with **repo secrets** (`CLAUDE_CODE_OAUTH_TOKEN`, an account-level token) and a **write-capable `GITHUB_TOKEN`**, while checking out the **untrusted PR head**. As written (`allowed_non_write_users: '*'`, no author gate), *any* external contributor could trigger that privileged run — a secret-exfiltration / prompt-injection risk. With external contributors opening PRs, this must be gated before re-enabling.

## What changed

- **Job-level trust gate** — auto-run only for `OWNER` / `MEMBER` / `COLLABORATOR` PR authors (your own + org/collaborator PRs).
- **Maintainer trigger for external PRs** — external authors (`CONTRIBUTOR` / `FIRST_TIME_CONTRIBUTOR` / `NONE`) never auto-run. A maintainer adds the **`claude-review`** label (label already created); that fires the new `labeled` trigger. Adding labels needs triage/write, so only maintainers can do it. Re-label to re-review after new commits.
- **Removed `id-token: write`** — OIDC isn't used here; drops an unnecessary privilege.
- Inline comments document that the **job `if` is the trust control** — the action's `allowed_non_write_users: '*'` only lets Claude proceed once a trusted author or a maintainer label has already let the job start.

## Behaviour matrix

| PR author | Event | Runs? |
|---|---|---|
| You / org member / collaborator | opened / synchronize / reopened | ✅ auto |
| External contributor | opened / synchronize | ❌ no |
| External contributor | maintainer adds `claude-review` label | ✅ |

## After merge

The workflow is still **manually disabled**. Re-enable with:

```
gh workflow enable claude-code-review.yml --repo TerrysPOV/ClaudeClaw-Plus
```

No source/runtime code touched — workflow + version bump only.

https://claude.ai/code/session_01RJZianxrwQWLhYGmALm7L9
