### PR TITLE
feat(governance): policy gate on forwarded tool permissions (#258 item 3, slice 1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.167",
+      "version": "2.2.168",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.166",
+      "version": "2.2.167",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.166",
+  "version": "2.2.167",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.167",
+  "version": "2.2.168",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/permission-policy-gate.test.ts
+++ b/src/bus/__tests__/permission-policy-gate.test.ts
@@ -87,6 +87,38 @@ describe("Bus permission policy gate (#258 item 3)", () => {
     expect(captured!.channelId).toBe("chat-1");
   });
 
+  it("ignores mis-attributable identity when same-agent prompts interleave (#284 MEDIUM)", async () => {
+    let captured: { userId?: string; skillName?: string; channelId?: string } | undefined;
+    const { bus } = makeBus((ctx) => {
+      captured = { userId: ctx.userId, skillName: ctx.skillName, channelId: ctx.channelId };
+      return defaultDeny(); // don't auto-deny — only assert the threaded context
+    });
+    // Two prompts on the SAME agent, the second arriving before the first
+    // completes: the origin slot is overwritten while P1 is still in flight, so
+    // the cached identity is ambiguous and must NOT reach the security gate.
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "telegram",
+      origin_id: "chat-A",
+      user_id: "user-A",
+      text: "/quant a",
+      metadata: { command: "/quant" },
+    });
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "webui",
+      origin_id: "chat-B",
+      user_id: "user-B",
+      text: "/admin b",
+      metadata: { command: "/admin" },
+    });
+    feed(bus, "Bash", "abcde");
+    expect(captured).toBeDefined();
+    expect(captured!.userId).toBeUndefined();
+    expect(captured!.skillName).toBeUndefined();
+    expect(captured!.channelId).toBeUndefined();
+  });
+
   it("fails OPEN to the operator card when policy evaluation throws", () => {
     const { bus, events } = makeBus(() => {
       throw new Error("engine boom");

--- a/src/bus/__tests__/permission-policy-gate.test.ts
+++ b/src/bus/__tests__/permission-policy-gate.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "bun:test";
+import { randomUUID } from "crypto";
+import { createBusCore, type BusCore, type BusCoreOptions } from "../core";
+import type { PolicyDecision } from "../../policy/engine";
+
+// Minimal event-log stub so the bus never touches disk.
+const mockAppend = (async () => ({ id: randomUUID() })) as unknown as never;
+
+function makeBus(evaluatePolicy: BusCoreOptions["evaluatePolicy"]): {
+  bus: BusCore;
+  events: Array<{ topic: string; payload: unknown }>;
+} {
+  const events: Array<{ topic: string; payload: unknown }> = [];
+  const bus = createBusCore({ eventLogAppend: mockAppend, evaluatePolicy });
+  bus.subscribe({}, (e) => events.push(e as { topic: string; payload: unknown }));
+  return { bus, events };
+}
+
+function feed(bus: BusCore, tool: string, requestId: string): void {
+  (bus as unknown as { handleIpcMessage(a: string, m: unknown): void }).handleIpcMessage("alpha", {
+    type: "permission_request",
+    agent_id: "alpha",
+    request: { request_id: requestId, tool_name: tool, description: "", input_preview: "" },
+  });
+}
+
+const explicitDeny = (ruleId: string): PolicyDecision =>
+  ({
+    requestId: "r",
+    action: "deny",
+    matchedRuleId: ruleId,
+    reason: "explicit deny",
+    evaluatedAt: "t",
+    cacheable: false,
+  }) as PolicyDecision;
+
+// The engine returns action:"deny" with NO matchedRuleId when nothing matches.
+const defaultDeny = (): PolicyDecision =>
+  ({
+    requestId: "r",
+    action: "deny",
+    reason: "No matching policy rule - default deny",
+    evaluatedAt: "t",
+    cacheable: false,
+  }) as PolicyDecision;
+
+const topics = (events: Array<{ topic: string; payload: unknown }>, topic: string) =>
+  events.filter((e) => e.topic === topic);
+
+describe("Bus permission policy gate (#258 item 3)", () => {
+  it("auto-denies (deny-wins) when an explicit deny rule matches — no operator card", () => {
+    const { bus, events } = makeBus((ctx) =>
+      ctx.toolName === "Bash" ? explicitDeny("deny-bash") : defaultDeny(),
+    );
+    feed(bus, "Bash", "abcde");
+    const responses = topics(events, "channel.permission_response");
+    expect(responses).toHaveLength(1);
+    expect((responses[0].payload as { behavior: string }).behavior).toBe("deny");
+    expect(topics(events, "channel.permission_request")).toHaveLength(0);
+  });
+
+  it("falls through to the operator card on the engine's no-match default-deny (no matchedRuleId)", () => {
+    const { bus, events } = makeBus(() => defaultDeny());
+    feed(bus, "Read", "fghij");
+    expect(topics(events, "channel.permission_request")).toHaveLength(1);
+    expect(topics(events, "channel.permission_response")).toHaveLength(0);
+  });
+
+  it("fails OPEN to the operator card when policy evaluation throws", () => {
+    const { bus, events } = makeBus(() => {
+      throw new Error("engine boom");
+    });
+    feed(bus, "Bash", "klmno");
+    expect(topics(events, "channel.permission_request")).toHaveLength(1);
+    expect(topics(events, "channel.permission_response")).toHaveLength(0);
+  });
+});

--- a/src/bus/__tests__/permission-policy-gate.test.ts
+++ b/src/bus/__tests__/permission-policy-gate.test.ts
@@ -66,6 +66,27 @@ describe("Bus permission policy gate (#258 item 3)", () => {
     expect(topics(events, "channel.permission_response")).toHaveLength(0);
   });
 
+  it("threads inbound userId + skillName (metadata.command) into the policy request (#258 slice 2)", async () => {
+    let captured: { userId?: string; skillName?: string; channelId?: string } | undefined;
+    const { bus } = makeBus((ctx) => {
+      captured = { userId: ctx.userId, skillName: ctx.skillName, channelId: ctx.channelId };
+      return defaultDeny(); // don't auto-deny — we only assert the threaded context
+    });
+    await bus.sendPrompt({
+      agent_id: "alpha",
+      origin: "telegram",
+      origin_id: "chat-1",
+      user_id: "user-9",
+      text: "/quant do the thing",
+      metadata: { command: "/quant" },
+    });
+    feed(bus, "Bash", "abcde");
+    expect(captured).toBeDefined();
+    expect(captured!.userId).toBe("user-9");
+    expect(captured!.skillName).toBe("quant");
+    expect(captured!.channelId).toBe("chat-1");
+  });
+
   it("fails OPEN to the operator card when policy evaluation throws", () => {
     const { bus, events } = makeBus(() => {
       throw new Error("engine boom");

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -226,7 +226,10 @@ export class BusCoreImpl implements BusCore {
    * sending another prompt; interleaved prompts on the same agent
    * fall back to broadcast behaviour at the adapter level.
    */
-  private readonly lastPromptOrigin = new Map<string, { origin: BusOrigin; origin_id: string }>();
+  private readonly lastPromptOrigin = new Map<
+    string,
+    { origin: BusOrigin; origin_id: string; userId?: string; skillName?: string }
+  >();
 
   /**
    * Delivery gate. A prompt typed into a PTY-resident agent while its session
@@ -514,6 +517,14 @@ export class BusCoreImpl implements BusCore {
     this.lastPromptOrigin.set(req.agent_id, {
       origin: req.origin,
       origin_id: req.origin_id,
+      // #258 item 3 slice 2: carry the inbound identity so the per-tool
+      // permission gate can scope policy by user and (when a surface tags the
+      // submit with metadata.command) by skill.
+      userId: req.user_id || undefined,
+      skillName:
+        typeof req.metadata?.command === "string"
+          ? req.metadata.command.replace(/^\//, "")
+          : undefined,
     });
     // Silent-drop safety net (#215): new prompt → reset the "did this
     // turn call reply?" flag. If the agent ends the turn (response.turn_end)
@@ -1084,13 +1095,15 @@ export class BusCoreImpl implements BusCore {
   private permissionPolicyDenies(
     agentId: string,
     request: PermissionRequest,
-    origin?: { origin: BusOrigin; origin_id: string },
+    origin?: { origin: BusOrigin; origin_id: string; userId?: string; skillName?: string },
   ): boolean {
     try {
       const ctx: ToolRequestContext = {
         eventId: randomUUID(),
         source: origin?.origin ?? "bus",
         channelId: origin?.origin_id,
+        userId: origin?.userId,
+        skillName: origin?.skillName,
         toolName: request.tool_name,
         timestamp: new Date().toISOString(),
       };

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -47,9 +47,11 @@ import type {
   BusOrigin,
   IpcMessage,
   IpcPrompt,
+  PermissionRequest,
   PermissionResponse,
 } from "./types";
 import { CHANNEL_DRIVEN_ORIGINS } from "./types";
+import { evaluate, type PolicyDecision, type ToolRequestContext } from "../policy/engine";
 
 /** Escape XML text content (`&`, `<`, `>`) so a `</channel>` in user text
  *  can't close the wrapper element early and inject sibling markup. */
@@ -144,6 +146,12 @@ export interface BusCoreOptions {
   /** Logger; defaults to console.error. */
   onError?: (err: unknown, ctx?: Record<string, unknown>) => void;
   /**
+   * Policy evaluator for the per-tool permission gate (#258 item 3). Defaults to
+   * the policy-engine singleton `evaluate`; injectable so tests (and future
+   * callers) supply a deterministic decision without the global rule file.
+   */
+  evaluatePolicy?: (ctx: ToolRequestContext) => PolicyDecision;
+  /**
    * Reconciliation signal (issue #222). Fired when an IPC `send` to an agent
    * fails because Bus core has no live MCP connection for it. The daemon
    * wires this to a debounced reconciler that checks process liveness via
@@ -205,6 +213,7 @@ export class BusCoreImpl implements BusCore {
   private slashCommandHandler: SlashCommandHandler | null;
   private streamPromptHandler: StreamPromptHandler | null;
   private readonly onError: (err: unknown, ctx?: Record<string, unknown>) => void;
+  private readonly evaluatePolicy: (ctx: ToolRequestContext) => PolicyDecision;
   // Settable post-hoc (like streamPromptHandler): the bus is constructed
   // before the SessionManager exists, so the reconciler is wired afterwards.
   private onMcpSendFailed: (agentId: string, ctx: { reason: string }) => void = () => {};
@@ -362,6 +371,7 @@ export class BusCoreImpl implements BusCore {
     this.slashCommandHandler = opts.slashCommandHandler ?? null;
     this.streamPromptHandler = opts.streamPromptHandler ?? null;
     this.onError = opts.onError ?? ((err, ctx) => console.error("[bus]", err, ctx));
+    this.evaluatePolicy = opts.evaluatePolicy ?? evaluate;
     if (opts.onMcpSendFailed) this.onMcpSendFailed = opts.onMcpSendFailed;
   }
 
@@ -1059,6 +1069,42 @@ export class BusCoreImpl implements BusCore {
     this.publish(e);
   }
 
+  /**
+   * Consult the policy engine for a forwarded tool permission request and
+   * report whether an EXPLICIT deny rule matches (#258 item 3). Deny-wins: an
+   * operator-authored deny (skill overlay, scoped, or global) short-circuits to
+   * a deny response without bothering the operator. The engine's no-match
+   * default-deny (no matchedRuleId) is deliberately NOT treated as a deny here,
+   * so tools stay available when no rules are configured. Fail-OPEN: any
+   * evaluation error returns false so the request falls through to the card.
+   *
+   * skillName / userId are not yet threaded to this seam, so skill overlays and
+   * per-user rules engage once that context reaches the bus (follow-up slice).
+   */
+  private permissionPolicyDenies(
+    agentId: string,
+    request: PermissionRequest,
+    origin?: { origin: BusOrigin; origin_id: string },
+  ): boolean {
+    try {
+      const ctx: ToolRequestContext = {
+        eventId: randomUUID(),
+        source: origin?.origin ?? "bus",
+        channelId: origin?.origin_id,
+        toolName: request.tool_name,
+        timestamp: new Date().toISOString(),
+      };
+      const decision = this.evaluatePolicy(ctx);
+      return decision.action === "deny" && !!decision.matchedRuleId;
+    } catch (err) {
+      this.onError(err instanceof Error ? err : new Error(String(err)), {
+        ctx: "permission-policy-eval",
+        agentId,
+      });
+      return false;
+    }
+  }
+
   ingestPermissionDecision(req: IngestPermissionDecisionRequest): void {
     // Two side effects: emit an audit event AND forward the decision to the
     // MCP server so it can hand it back to claude.
@@ -1241,6 +1287,19 @@ export class BusCoreImpl implements BusCore {
         // surface so the prompt UI lands only on the channel that
         // triggered the tool call.
         const permOrigin = this.lastPromptOrigin.get(agentId);
+        // #258 item 3 (minimal slice): consult policy before the operator card.
+        // Only an EXPLICIT matched deny rule auto-denies (deny-wins); the
+        // engine's no-match default-deny must NOT short-circuit here, or every
+        // tool would be blocked when no rules are configured. Fail-OPEN: any
+        // evaluation error falls through to the normal human-in-the-loop card.
+        if (this.permissionPolicyDenies(agentId, msg.request, permOrigin)) {
+          this.ingestPermissionDecision({
+            agent_id: agentId,
+            request_id: msg.request.request_id,
+            behavior: "deny",
+          });
+          break;
+        }
         this.publish({
           ts: Date.now(),
           agent_id: agentId,

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -232,6 +232,18 @@ export class BusCoreImpl implements BusCore {
   >();
 
   /**
+   * Agents whose `lastPromptOrigin` is currently AMBIGUOUS for security
+   * attribution: a second prompt overwrote the slot while a prior prompt was
+   * still in flight (the residual #239 interleave race). Best-effort *routing*
+   * tolerates this, but the per-tool permission gate must NOT make a deny
+   * decision from a possibly mis-attributed user/skill — when an agent is in
+   * this set the gate ignores the cached identity and falls through to the
+   * human card (fail-OPEN). Cleared whenever the slot returns to a clean
+   * single-prompt state (a `set` onto an empty slot) or is torn down (#284 MEDIUM).
+   */
+  private readonly originAmbiguous = new Set<string>();
+
+  /**
    * Delivery gate. A prompt typed into a PTY-resident agent while its session
    * is (re)initialising — `session.init` seen but `bus.events.replay_done` not
    * yet — is swallowed by the not-yet-ready TUI and never starts a turn
@@ -414,6 +426,7 @@ export class BusCoreImpl implements BusCore {
           // agent (after a reconnect) would inherit the dead session's
           // origin and misroute (5-agent review on PR #138, A1 finding).
           this.lastPromptOrigin.delete(agentId);
+          this.originAmbiguous.delete(agentId);
           this.currentTurnReplied.delete(agentId);
           this.currentTurnFinalPublished.delete(agentId);
           // The subprocess is gone -- tear down this agent's delivery-gate
@@ -476,6 +489,7 @@ export class BusCoreImpl implements BusCore {
     this.flushVerify.clear();
     this.inFlightDeliveries.clear();
     this.agentTurnActive.clear();
+    this.originAmbiguous.clear();
     this.pendingRedelivery.clear();
   }
 
@@ -514,6 +528,17 @@ export class BusCoreImpl implements BusCore {
     this.publish(promptEvent);
     // Remember the origin so `ingestReply` can attach it to the
     // outbound `response.text` event for surface-aware routing.
+    //
+    // #284 MEDIUM: if a prior prompt is still in flight (the slot is already
+    // occupied), this overwrite makes the cached identity ambiguous for the
+    // security gate — mark the agent so the permission gate won't attribute a
+    // deny to the wrong user/skill. A `set` onto an empty slot is a clean,
+    // unambiguous single prompt, so clear any prior taint.
+    if (this.lastPromptOrigin.has(req.agent_id)) {
+      this.originAmbiguous.add(req.agent_id);
+    } else {
+      this.originAmbiguous.delete(req.agent_id);
+    }
     this.lastPromptOrigin.set(req.agent_id, {
       origin: req.origin,
       origin_id: req.origin_id,
@@ -959,6 +984,7 @@ export class BusCoreImpl implements BusCore {
     //   - `permission_request` IPC handler (origin on channel.permission_request)
     if (req.intent === "final") {
       this.lastPromptOrigin.delete(req.agent_id);
+      this.originAmbiguous.delete(req.agent_id);
       // Silent-drop safety net (#215): the agent called `reply` with a final
       // intent → mark this turn as delivered, so the `response.turn_end`
       // handler skips the synthetic-delivery fallback for this turn.
@@ -1089,8 +1115,11 @@ export class BusCoreImpl implements BusCore {
    * so tools stay available when no rules are configured. Fail-OPEN: any
    * evaluation error returns false so the request falls through to the card.
    *
-   * skillName / userId are not yet threaded to this seam, so skill overlays and
-   * per-user rules engage once that context reaches the bus (follow-up slice).
+   * `origin` carries the inbound channel/user/skill (slice 2) so skill overlays
+   * and per-user rules can scope the decision. The caller passes it ONLY when
+   * attribution is unambiguous (see the gate's `gateOrigin`): under a same-agent
+   * interleave the cached identity may belong to a different prompt, so the
+   * caller passes `undefined` and only tool-only/global rules apply (#284 MEDIUM).
    */
   private permissionPolicyDenies(
     agentId: string,
@@ -1259,6 +1288,7 @@ export class BusCoreImpl implements BusCore {
         // this agent doesn't inherit it and misroute (5-agent review
         // on PR #138, A1 finding).
         this.lastPromptOrigin.delete(agentId);
+        this.originAmbiguous.delete(agentId);
         // Silent-drop safety net (#215): cancelled turn won't produce
         // a real reply OR a `response.turn_end` event — drop the
         // tracking flag to keep the map bounded.
@@ -1300,12 +1330,23 @@ export class BusCoreImpl implements BusCore {
         // surface so the prompt UI lands only on the channel that
         // triggered the tool call.
         const permOrigin = this.lastPromptOrigin.get(agentId);
+        // #284 MEDIUM: `lastPromptOrigin` is single-slot / last-write-wins with
+        // no per-request correlation (residual #239 interleave race). It is fine
+        // for best-effort *routing* of the operator card below, but it must NOT
+        // drive a SECURITY deny when a concurrent same-agent prompt may have
+        // overwritten the identity — a wrong user/skill could auto-deny the wrong
+        // request or skip a deny that applies. Only feed identity into the gate
+        // when attribution is unambiguous (a clean single in-flight prompt);
+        // otherwise evaluate with no origin so identity/channel-scoped rules fall
+        // through to the human card (fail-OPEN) while tool-only/global denies still apply.
+        const gateOrigin =
+          permOrigin && !this.originAmbiguous.has(agentId) ? permOrigin : undefined;
         // #258 item 3 (minimal slice): consult policy before the operator card.
         // Only an EXPLICIT matched deny rule auto-denies (deny-wins); the
         // engine's no-match default-deny must NOT short-circuit here, or every
         // tool would be blocked when no rules are configured. Fail-OPEN: any
         // evaluation error falls through to the normal human-in-the-loop card.
-        if (this.permissionPolicyDenies(agentId, msg.request, permOrigin)) {
+        if (this.permissionPolicyDenies(agentId, msg.request, gateOrigin)) {
           this.ingestPermissionDecision({
             agent_id: agentId,
             request_id: msg.request.request_id,
@@ -1335,6 +1376,7 @@ export class BusCoreImpl implements BusCore {
         // scheduler events for this agent don't inherit the stale
         // origin (5-agent review on PR #138, A1 finding).
         this.lastPromptOrigin.delete(agentId);
+        this.originAmbiguous.delete(agentId);
         // Silent-drop safety net (#215): error path won't produce a
         // turn_end either — clear tracking too.
         this.currentTurnReplied.delete(agentId);

--- a/src/commands/discord.ts
+++ b/src/commands/discord.ts
@@ -1298,6 +1298,11 @@ async function handleMessageCreate(
           threadInfo?.agentName,
           streamCb?.onChunk,
           streamCb?.onToolEvent,
+          undefined, // modelOverride
+          // #284 LOW: thread the inbound identity so the policy gate can scope by
+          // user and (for a slash command) by skill, matching the bus adapter.
+          // `command` is "/x" → skillName "x"; undefined for plain chat.
+          { userId, skillName: command ? command.replace(/^\//, "") : undefined },
         );
       } finally {
         if (streamCb) {

--- a/src/policy/engine.ts
+++ b/src/policy/engine.ts
@@ -22,7 +22,7 @@ import { randomUUID } from "crypto";
 // Scoped per-channel/per-user policies. Imported for use at evaluate-time only
 // (not at module init), so the channel-policies↔engine cycle never hits a TDZ.
 import { getScopedRules, mergeScopedPolicies } from "./channel-policies";
-import { getCachedSkillOverlayRules } from "./skill-overlays";
+import { getCachedSkillOverlayRules, hasCachedSkillOverlay } from "./skill-overlays";
 
 const POLICY_DIR = join(process.cwd(), ".claude", "claudeclaw");
 const POLICY_FILE = join(POLICY_DIR, "policies.json");
@@ -406,6 +406,19 @@ export function clearCache(): void {
 // Internal Helpers
 // ============================================================================
 
+// #284 LOW: dedupe the "overlay not cached in this process" warning so a hot
+// path doesn't spam the log — one line per skill name is enough to flag the gap.
+const warnedUncachedOverlays = new Set<string>();
+function warnUncachedSkillOverlay(skillName: string): void {
+  if (warnedUncachedOverlays.has(skillName)) return;
+  warnedUncachedOverlays.add(skillName);
+  console.warn(
+    `[policy] skill "${skillName}" has no overlay cached in this process — its ` +
+      `deny overlay (if any) is not enforced on this evaluation path; the ` +
+      `request still falls through to the normal approval gate.`,
+  );
+}
+
 function getApplicableRules(request: ToolRequestContext): PolicyRule[] {
   // Evaluate against the GLOBAL rules merged with the scoped per-channel /
   // per-user rules for THIS request — previously only `loadedRules` (global)
@@ -425,6 +438,14 @@ function getApplicableRules(request: ToolRequestContext): PolicyRule[] {
   // request carries no skillName or the skill declared no deniedTools.
   const overlayRules = getCachedSkillOverlayRules(request.skillName);
   if (overlayRules.length > 0) candidates = candidates.concat(overlayRules);
+  else if (request.skillName && !hasCachedSkillOverlay(request.skillName)) {
+    // #284 LOW: overlay enforcement is process-local — if this skill's SKILL.md
+    // was never resolved (or has expired) in THIS process, its deny overlay is
+    // silently absent on this evaluation path. Surface the gap once per skill so
+    // an operator can see a deny overlay may not be enforced here. No behaviour
+    // change: the request still falls through to the normal approval gate.
+    warnUncachedSkillOverlay(request.skillName);
+  }
   return candidates.filter((rule) => {
     // Skip disabled rules
     if (rule.enabled === false) return false;

--- a/src/policy/skill-overlays.ts
+++ b/src/policy/skill-overlays.ts
@@ -194,8 +194,34 @@ export function overlayToRules(overlay: SkillOverlay, basePriority: number = 100
  * here keyed by skillName. The cache is populated when a surface resolves a
  * slash command to a skill (the SKILL.md content is already in hand at that
  * point), then read synchronously during evaluation.
+ *
+ * Lifecycle (#284 LOW): a long-running daemon must not hold overlay rules
+ * forever. Each entry carries `cachedAt`; entries older than OVERLAY_CACHE_TTL_MS
+ * expire (forcing re-population on the next slash-command resolve, which is
+ * where fresh SKILL.md content is available, so an edited SKILL.md is not served
+ * stale indefinitely), and the cache is bounded to OVERLAY_CACHE_MAX entries
+ * (oldest evicted first) so it can't grow unbounded.
  */
-const overlayRulesCache = new Map<string, PolicyRule[]>();
+interface CachedOverlay {
+  rules: PolicyRule[];
+  cachedAt: number;
+}
+const overlayRulesCache = new Map<string, CachedOverlay>();
+const OVERLAY_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const OVERLAY_CACHE_MAX = 256;
+
+/** Drop expired entries and bound the cache to OVERLAY_CACHE_MAX (oldest first). */
+function pruneOverlayCache(now: number): void {
+  for (const [name, entry] of overlayRulesCache) {
+    if (now - entry.cachedAt > OVERLAY_CACHE_TTL_MS) overlayRulesCache.delete(name);
+  }
+  // Map preserves insertion order, so the first key is the oldest.
+  while (overlayRulesCache.size > OVERLAY_CACHE_MAX) {
+    const oldest = overlayRulesCache.keys().next().value;
+    if (oldest === undefined) break;
+    overlayRulesCache.delete(oldest);
+  }
+}
 
 /**
  * Parse a skill's overlay from its (already-loaded) SKILL.md content and cache
@@ -204,13 +230,44 @@ const overlayRulesCache = new Map<string, PolicyRule[]>();
  */
 export function cacheSkillOverlayFromContent(skillName: string, content: string): void {
   const overlay = parseSkillMetadata(content, skillName);
-  overlayRulesCache.set(skillName, overlay ? overlayToRules(overlay) : []);
+  const now = Date.now();
+  // Delete-then-set so a refreshed entry moves to the most-recent insertion
+  // slot, keeping the size-based eviction order meaningful.
+  overlayRulesCache.delete(skillName);
+  overlayRulesCache.set(skillName, {
+    rules: overlay ? overlayToRules(overlay) : [],
+    cachedAt: now,
+  });
+  pruneOverlayCache(now);
 }
 
-/** Synchronously get cached overlay deny rules for a skill (empty if none). */
+/** Synchronously get cached overlay deny rules for a skill (empty if none/expired). */
 export function getCachedSkillOverlayRules(skillName?: string): PolicyRule[] {
   if (!skillName) return [];
-  return overlayRulesCache.get(skillName) ?? [];
+  const entry = overlayRulesCache.get(skillName);
+  if (!entry) return [];
+  if (Date.now() - entry.cachedAt > OVERLAY_CACHE_TTL_MS) {
+    overlayRulesCache.delete(skillName);
+    return [];
+  }
+  return entry.rules;
+}
+
+/**
+ * Whether a non-expired overlay entry is cached for this skill. Lets callers
+ * distinguish "skill declared no deny overlay" (cached empty) from "overlay was
+ * never resolved in this process / has expired" — the process-local-cache gap
+ * the engine surfaces for observability (#284 LOW).
+ */
+export function hasCachedSkillOverlay(skillName?: string): boolean {
+  if (!skillName) return false;
+  const entry = overlayRulesCache.get(skillName);
+  if (!entry) return false;
+  if (Date.now() - entry.cachedAt > OVERLAY_CACHE_TTL_MS) {
+    overlayRulesCache.delete(skillName);
+    return false;
+  }
+  return true;
 }
 
 /** Clear the overlay rules cache (tests / skill reload). */


### PR DESCRIPTION
## What

Wires the policy engine into the **bus permission path** so an operator-authored **deny** rule auto-rejects a tool request *before* it reaches the human-in-the-loop card. This is **#258 item 3, slice 1** — the first real consumer of a per-tool policy gate.

Independent of #277/#282 (it uses only `evaluate()` + explicit rules, already on `main`).

## Why

#258 items 2/3: skill-overlay deny rules (and scoped/global denies) had no live enforcement point — the runner's `evaluateToolForExecution` is inert and the gateway gates message *admission*, not individual tool calls. The bus permission flow (`permission_request` → operator card) is the one place a tool is gated *before it runs*. This injects policy there.

## Changes (`src/bus/core.ts`)

- The `permission_request` handler consults the policy engine before publishing the operator card. **deny-wins**: an EXPLICIT matched deny rule (global, scoped, or — once `skillName` reaches this seam — a skill overlay) short-circuits to a deny response.
- **Critical safety**: the engine's no-match **default-deny** (no `matchedRuleId`) is deliberately NOT treated as an auto-deny — otherwise every tool would be blocked when no rules are configured. Only an operator-authored deny acts.
- **Fail-OPEN**: any evaluation error falls through to the normal operator card, so a broken policy layer can never wedge an agent's tools.
- The policy evaluator is **injected via `BusCoreOptions`** (defaults to the engine singleton `evaluate`), mirroring the existing `eventLogAppend` DI — keeps the gate deterministically testable without the global rule file.

## Scope boundaries (honest)

- **Minimal slice**: gates the FORWARDED (default/plan/auto-mode) permission requests that reach bus core. `skillName`/`userId` are not yet threaded to this seam, so **skill-overlay and per-user rules engage in a follow-up slice** once that context is tracked per agent.
- Agents on the legacy `claude -p` path (e.g. `pty.enabled: false`) don't route permissions through bus core — wiring that spawn to a `--permission-prompt-tool` is a separate phase.

## Tests

Explicit deny → auto-deny + no card; no-match default-deny → falls through to card; evaluator throws → fails open to card. Full suite: **identical pre-existing failure set, +3 net pass.**

Refs #258 (item 3).
