### PR TITLE
feat(bus): activate the stall watchdog — forensics + config + wiring (completes PR 1/3, #296)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.170",
+      "version": "2.2.171",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.169",
+      "version": "2.2.170",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.169",
+  "version": "2.2.170",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.170",
+  "version": "2.2.171",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/__tests__/runtime-mount.test.ts
+++ b/src/bus/__tests__/runtime-mount.test.ts
@@ -315,8 +315,9 @@ describe("mountBusRuntime — real UDS path", () => {
     try {
       expect(handle.bus).toBeDefined();
       expect(handle.sessionManager).toBeInstanceOf(SessionManager);
-      // BusCore.state() works post-mount.
-      expect(handle.bus.state().subscriberCount).toBe(0);
+      // BusCore.state() works post-mount. The one subscriber is the stall
+      // watchdog's session-event subscription, started by mountBusRuntime (#296).
+      expect(handle.bus.state().subscriberCount).toBe(1);
     } finally {
       await handle.stop();
     }

--- a/src/bus/__tests__/stall-forensics.test.ts
+++ b/src/bus/__tests__/stall-forensics.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  classifyKill,
+  probeProcessTreeCpu,
+  appendStallKillAudit,
+  RECENT_OUTPUT_MS,
+  type StallKillAuditRecord,
+} from "../stall-forensics";
+import type { ForensicSnapshot, ToolCeiling } from "../stall-watchdog";
+
+const BASH: ToolCeiling = { warnSeconds: 300, killSeconds: 900 };
+const snap = (cpuAdvancing: boolean | null, outputRecencyMs: number | null): ForensicSnapshot => ({
+  cpuAdvancing,
+  outputRecencyMs,
+});
+
+/* ── classifyKill truth table ──────────────────────────────────────────── */
+
+describe("classifyKill", () => {
+  it("CPU advancing → suspected_false_positive", () => {
+    const o = classifyKill(snap(true, null), 950_000, BASH);
+    expect(o.classification).toBe("suspected_false_positive");
+    expect(o.suggestedKillSeconds).toBeDefined();
+  });
+
+  it("recent output (< RECENT_OUTPUT_MS) → suspected_false_positive even if CPU flat/unknown", () => {
+    expect(classifyKill(snap(false, RECENT_OUTPUT_MS - 1), 950_000, BASH).classification).toBe(
+      "suspected_false_positive",
+    );
+    expect(classifyKill(snap(null, 500), 950_000, BASH).classification).toBe(
+      "suspected_false_positive",
+    );
+  });
+
+  it("CPU flat + no recent output → genuine_wedge", () => {
+    expect(classifyKill(snap(false, null), 950_000, BASH).classification).toBe("genuine_wedge");
+    expect(classifyKill(snap(false, RECENT_OUTPUT_MS + 1), 950_000, BASH).classification).toBe(
+      "genuine_wedge",
+    );
+  });
+
+  it("CPU unmeasurable + no recent output → unknown (never claim an unconfirmed wedge)", () => {
+    expect(classifyKill(snap(null, null), 950_000, BASH).classification).toBe("unknown");
+    expect(classifyKill(snap(null, RECENT_OUTPUT_MS + 1), 950_000, BASH).classification).toBe(
+      "unknown",
+    );
+  });
+
+  it("suggested ceiling is a whole-minute value ≥ 2× the current kill ceiling", () => {
+    const o = classifyKill(snap(true, null), 950_000, BASH);
+    const suggested = o.suggestedKillSeconds ?? 0;
+    expect(suggested % 60).toBe(0);
+    expect(suggested).toBeGreaterThanOrEqual(BASH.killSeconds * 2);
+  });
+});
+
+/* ── probeProcessTreeCpu (degrades gracefully) ─────────────────────────── */
+
+describe("probeProcessTreeCpu", () => {
+  it("returns null for a non-existent pid (or when /proc is absent) — never throws", async () => {
+    const r = await probeProcessTreeCpu(2_147_483_600, 1);
+    expect(r).toBeNull();
+  });
+
+  it("returns a boolean or null for a live pid, never throws", async () => {
+    const r = await probeProcessTreeCpu(process.pid, 5);
+    expect(r === null || typeof r === "boolean").toBe(true);
+  });
+});
+
+/* ── appendStallKillAudit ──────────────────────────────────────────────── */
+
+describe("appendStallKillAudit", () => {
+  const rec = (over?: Partial<StallKillAuditRecord>): StallKillAuditRecord => ({
+    ts: "2026-07-03T00:00:00Z",
+    agentId: "reg",
+    sessionId: "s1",
+    tool: "Bash",
+    outstandingMs: 950_000,
+    killSeconds: 900,
+    classification: "genuine_wedge",
+    cpuAdvancing: false,
+    outputRecencyMs: null,
+    ...over,
+  });
+
+  it("appends one JSON line per record", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "stallaudit-"));
+    const file = join(dir, "stall-kills.jsonl");
+    try {
+      await appendStallKillAudit(rec(), file);
+      await appendStallKillAudit(
+        rec({ classification: "suspected_false_positive", suggestedKillSeconds: 1920 }),
+        file,
+      );
+      const lines = readFileSync(file, "utf8").trim().split("\n");
+      expect(lines).toHaveLength(2);
+      const second = JSON.parse(lines[1] ?? "{}");
+      expect(second.classification).toBe("suspected_false_positive");
+      expect(second.suggestedKillSeconds).toBe(1920);
+      expect(second.tool).toBe("Bash");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("never throws on an unwritable path (best-effort)", async () => {
+    await appendStallKillAudit(rec(), "/proc/definitely-not-writable/x.jsonl");
+    expect(true).toBe(true); // reached here → no throw
+  });
+});

--- a/src/bus/__tests__/stall-watchdog.test.ts
+++ b/src/bus/__tests__/stall-watchdog.test.ts
@@ -377,3 +377,58 @@ describe("restartFailedAt does not leak across a failed→succeeded restart cycl
     expect(calls).toHaveLength(3);
   });
 });
+
+/* ── stop() during an in-flight kill (Codex P2 on #300) ────────────────── */
+
+describe("stop() while a kill is mid-flight", () => {
+  it("does not restart after stop() resolves, and stop() awaits the in-flight kill", async () => {
+    let releaseForensic!: () => void;
+    const forensicGate = new Promise<void>((r) => {
+      releaseForensic = r;
+    });
+    const calls = { restart: 0, forensic: 0, recordKill: 0 };
+    const deps: StallWatchdogDeps = {
+      subscribe: () => () => {},
+      restart: async () => {
+        calls.restart++;
+      },
+      captureForensic: async () => {
+        calls.forensic++;
+        await forensicGate; // block the kill mid-flight, at the forensic snapshot
+        return { cpuAdvancing: false, outputRecencyMs: 9_000_000 };
+      },
+      recordKill: async () => {
+        calls.recordKill++;
+        return { classification: "genuine_wedge" };
+      },
+      notify: () => {},
+      now: () => 0,
+    };
+    const wd = new StallWatchdog(DEFAULT_STALL_CONFIG, deps);
+    wd.ingest(evt("response.tool_use", 0, { id: "b1", name: "Bash" }));
+
+    // Fire a sweep that enters handleKill and blocks at captureForensic.
+    const sweepP = wd.sweep(950_000);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(calls.forensic).toBe(1); // kill is in flight
+    expect(calls.restart).toBe(0);
+
+    // Begin teardown while the kill is blocked; stop() must await the in-flight kill.
+    const stopP = wd.stop();
+    let stopResolved = false;
+    void stopP.then(() => {
+      stopResolved = true;
+    });
+    await Promise.resolve();
+    expect(stopResolved).toBe(false); // stop() is waiting on the in-flight kill
+
+    // Release the snapshot: handleKill resumes and must bail at the stopped-check.
+    releaseForensic();
+    await stopP;
+    await sweepP;
+
+    expect(calls.restart).toBe(0); // no restart started after stop() began
+    expect(calls.recordKill).toBe(0); // and the kill aborted before recording
+  });
+});

--- a/src/bus/__tests__/stall-watchdog.test.ts
+++ b/src/bus/__tests__/stall-watchdog.test.ts
@@ -7,6 +7,7 @@ import {
   newSessionState,
   StallWatchdog,
   DEFAULT_STALL_CONFIG,
+  parseStallWatchdogConfig,
   type StallWatchdogDeps,
   type ForensicSnapshot,
   type StallKillOutcome,
@@ -271,5 +272,89 @@ describe("StallWatchdog kill orchestration", () => {
     await wd.sweep(950_000); // fail → cooldown from t=950_000
     await wd.sweep(1_300_000); // +350s > 300s cooldown → retried
     expect(rec.restart).toHaveLength(2);
+  });
+});
+
+/* ── parseStallWatchdogConfig ──────────────────────────────────────────── */
+
+describe("parseStallWatchdogConfig", () => {
+  it("returns defaults for missing/invalid input", () => {
+    expect(parseStallWatchdogConfig(undefined)).toEqual(DEFAULT_STALL_CONFIG);
+    expect(parseStallWatchdogConfig(null)).toEqual(DEFAULT_STALL_CONFIG);
+    expect(parseStallWatchdogConfig("nope")).toEqual(DEFAULT_STALL_CONFIG);
+  });
+
+  it("applies valid overrides and falls back per-field on garbage", () => {
+    const c = parseStallWatchdogConfig({
+      enabled: false,
+      sweepIntervalMs: 5000,
+      action: "warn",
+      ceilings: { bash: { warnSeconds: 120, killSeconds: 600 }, fast: { killSeconds: "bad" } },
+      autoDiscovery: { enabled: false, cpuProbeMs: 2000 },
+      restartFailureCooldownMs: 60_000,
+    });
+    expect(c.enabled).toBe(false);
+    expect(c.sweepIntervalMs).toBe(5000);
+    expect(c.action).toBe("warn");
+    expect(c.ceilings.bash).toEqual({ warnSeconds: 120, killSeconds: 600 });
+    // fast.killSeconds was garbage → whole field falls back to the default ceiling.
+    expect(c.ceilings.fast).toEqual(DEFAULT_STALL_CONFIG.ceilings.fast);
+    expect(c.autoDiscovery).toEqual({ enabled: false, cpuProbeMs: 2000 });
+    expect(c.restartFailureCooldownMs).toBe(60_000);
+  });
+
+  it("rejects out-of-range / wrong-type scalars", () => {
+    const c = parseStallWatchdogConfig({
+      sweepIntervalMs: 10, // below the 1000ms floor → default
+      action: "explode", // invalid enum → default
+      autoDiscovery: { cpuProbeMs: 5 }, // below the 100ms floor → default
+    });
+    expect(c.sweepIntervalMs).toBe(DEFAULT_STALL_CONFIG.sweepIntervalMs);
+    expect(c.action).toBe(DEFAULT_STALL_CONFIG.action);
+    expect(c.autoDiscovery.cpuProbeMs).toBe(DEFAULT_STALL_CONFIG.autoDiscovery.cpuProbeMs);
+  });
+});
+
+/* ── restartFailedAt reset invariant (#297 review follow-up) ───────────── */
+
+describe("restartFailedAt does not leak across a failed→succeeded restart cycle", () => {
+  it("a re-observed session kills cleanly after an earlier failed restart recovered", async () => {
+    const calls: string[] = [];
+    let failNext = true;
+    const deps: StallWatchdogDeps = {
+      subscribe: () => () => {},
+      restart: async () => {
+        calls.push("restart");
+        if (failNext) {
+          failNext = false;
+          throw new Error("rate-limited");
+        }
+      },
+      captureForensic: async () => ({ cpuAdvancing: false, outputRecencyMs: 9_000_000 }),
+      recordKill: async () => ({ classification: "genuine_wedge" }),
+      notify: () => {},
+      now: () => 0,
+    };
+    const cfg = { ...DEFAULT_STALL_CONFIG, restartFailureCooldownMs: 10_000 };
+    const wd = new StallWatchdog(cfg, deps);
+
+    // t=950s: Bash stalled → kill → restart THROWS → cooldown armed, session kept.
+    wd.ingest(evt("response.tool_use", 0, { id: "b1", name: "Bash" }));
+    await wd.sweep(950_000);
+    expect(calls).toHaveLength(1);
+
+    // within cooldown (Δ5s < 10s) → suppressed.
+    await wd.sweep(955_000);
+    expect(calls).toHaveLength(1);
+
+    // after cooldown (Δ15s > 10s) → retry succeeds → session dropped.
+    await wd.sweep(965_000);
+    expect(calls).toHaveLength(2);
+
+    // Re-observe the SAME session id with a fresh stalled tool. It must rebuild a
+    // clean state (no leftover restartFailedAt/cooldown) and kill normally.
+    wd.ingest(evt("response.tool_use", 970_000, { id: "b2", name: "Bash" }));
+    await wd.sweep(970_000 + 950_000);
+    expect(calls).toHaveLength(3);
   });
 });

--- a/src/bus/__tests__/stall-watchdog.test.ts
+++ b/src/bus/__tests__/stall-watchdog.test.ts
@@ -313,6 +313,25 @@ describe("parseStallWatchdogConfig", () => {
     expect(c.action).toBe(DEFAULT_STALL_CONFIG.action);
     expect(c.autoDiscovery.cpuProbeMs).toBe(DEFAULT_STALL_CONFIG.autoDiscovery.cpuProbeMs);
   });
+
+  it("clamps a per-tool warnSeconds above its killSeconds down to kill", () => {
+    // warn > kill would be a dead warn (kill fires first) — pin it to the kill line.
+    const c = parseStallWatchdogConfig({
+      ceilings: { bash: { warnSeconds: 5000, killSeconds: 900 } },
+    });
+    expect(c.ceilings.bash).toEqual({ warnSeconds: 900, killSeconds: 900 });
+  });
+
+  it("floors restartFailureCooldownMs at sweepIntervalMs (no per-sweep alert storm)", () => {
+    const c = parseStallWatchdogConfig({ sweepIntervalMs: 30_000, restartFailureCooldownMs: 500 });
+    // 500ms < one sweep → rejected → default (which is ≥ one sweep).
+    expect(c.restartFailureCooldownMs).toBe(DEFAULT_STALL_CONFIG.restartFailureCooldownMs);
+    // A cooldown ≥ the sweep is kept as-is.
+    expect(
+      parseStallWatchdogConfig({ sweepIntervalMs: 30_000, restartFailureCooldownMs: 45_000 })
+        .restartFailureCooldownMs,
+    ).toBe(45_000);
+  });
 });
 
 /* ── restartFailedAt reset invariant (#297 review follow-up) ───────────── */

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -43,6 +43,8 @@ import { createPromptStreamHandler } from "./receipt-wiring";
 import { peekSession } from "../sessions";
 import { generateSummary } from "../rotation";
 import { getSettings } from "../config";
+import { StallWatchdog, DEFAULT_STALL_CONFIG, type StallWatchdogConfig } from "./stall-watchdog";
+import { probeProcessTreeCpu, classifyKill, appendStallKillAudit } from "./stall-forensics";
 
 export interface BusRuntimeHandle {
   /** The mounted BusCore. Adapters / tests subscribe via this. */
@@ -454,6 +456,72 @@ export async function mountBusRuntime(
         : `adapters=[${adapters.map((a) => a.name).join(", ")}]`;
     logger.info(`[bus-runtime] mounted; socket=${socketPath}; ${spawnedLabel}; ${adaptersLabel}`);
 
+    // #296 PR#1 — Stall watchdog. Detect a bus PTY session wedged mid-tool-call
+    // (a `tool_use` with no `tool_result` past its per-tool ceiling) and
+    // kill+respawn it so a single hung tool can never take the daemon offline
+    // (the #295 outage). Recovery reuses `restart()` (inherits the restart
+    // rate-limiter); every kill is audited by the auto-discovery forensic
+    // (`stall-forensics`). Started here — after a successful mount — so a failed
+    // mount never leaves a dangling sweep timer; torn down in `stop()`.
+    let stallConfig: StallWatchdogConfig;
+    try {
+      stallConfig = getSettings().stallWatchdog;
+    } catch {
+      stallConfig = DEFAULT_STALL_CONFIG; // settings not loaded (early boot / tests)
+    }
+    const stallWatchdog = new StallWatchdog(stallConfig, {
+      subscribe: (handler) => {
+        const sub = bus.subscribe(
+          {
+            topics: [
+              "response.tool_use",
+              "tool_result",
+              "response.turn_end",
+              "session.init",
+              "session.end",
+            ],
+          },
+          handler,
+        );
+        return () => sub.close();
+      },
+      restart: async (agentId, o) => {
+        await sessionManager.restart(agentId, { reason: o.reason });
+      },
+      captureForensic: async (agentId) => {
+        const proc = sessionManager.getAgent(agentId);
+        if (!proc) return { cpuAdvancing: null, outputRecencyMs: null };
+        const cpuAdvancing = await probeProcessTreeCpu(
+          proc.pid,
+          stallConfig.autoDiscovery.cpuProbeMs,
+        );
+        const outputRecencyMs = proc.lastDataAt === null ? null : Date.now() - proc.lastDataAt;
+        return { cpuAdvancing, outputRecencyMs };
+      },
+      recordKill: async (input) => {
+        const outcome = classifyKill(input.snapshot, input.outstandingMs, input.ceiling);
+        await appendStallKillAudit({
+          ts: new Date().toISOString(),
+          agentId: input.agentId,
+          sessionId: input.sessionId,
+          tool: input.tool,
+          outstandingMs: input.outstandingMs,
+          killSeconds: input.ceiling.killSeconds,
+          classification: outcome.classification,
+          cpuAdvancing: input.snapshot.cpuAdvancing,
+          outputRecencyMs: input.snapshot.outputRecencyMs,
+          suggestedKillSeconds: outcome.suggestedKillSeconds,
+        });
+        return outcome;
+      },
+      notify: (level, message) => {
+        if (level === "critical") logger.error("[stall-watchdog]", message);
+        else logger.warn("[stall-watchdog]", message);
+      },
+      now: () => Date.now(),
+    });
+    stallWatchdog.start();
+
     return {
       bus,
       sessionManager,
@@ -512,6 +580,9 @@ export async function mountBusRuntime(
       async stop() {
         if (stopped) return;
         stopped = true;
+        // Stall watchdog first: cancel its sweep timer + bus subscription so it
+        // can't fire a restart against a session we're tearing down.
+        stallWatchdog.stop();
         // Adapters first: stop inbound traffic so nothing new hits the
         // bus while we're tearing down agents. Sprint 5.2b.
         await stopBusAdapters(adapters, logger);

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -580,9 +580,9 @@ export async function mountBusRuntime(
       async stop() {
         if (stopped) return;
         stopped = true;
-        // Stall watchdog first: cancel its sweep timer + bus subscription so it
-        // can't fire a restart against a session we're tearing down.
-        stallWatchdog.stop();
+        // Stall watchdog first: cancel its sweep timer + bus subscription and
+        // await any in-flight kill so it can't respawn a session mid-teardown.
+        await stallWatchdog.stop();
         // Adapters first: stop inbound traffic so nothing new hits the
         // bus while we're tearing down agents. Sprint 5.2b.
         await stopBusAdapters(adapters, logger);

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -49,6 +49,13 @@ export interface AgentProcess {
   readonly agent_id: string;
   readonly supervision: SupervisionMode;
   readonly pid: number;
+  /**
+   * Epoch ms of the most recent raw output chunk seen on the crash-signal
+   * channel, or `null` if none yet. Used by the stall watchdog's auto-discovery
+   * forensic as an "is this process emitting anything?" liveness signal — NOT
+   * parsed as model output.
+   */
+  readonly lastDataAt: number | null;
   /** Relay a slash command (e.g. `compact`, `clear`, `quit`). No leading slash. */
   send_slash(cmd: string): Promise<void>;
   /** Send a stream-json line. Only valid in `process-stream-json` mode. */
@@ -90,6 +97,10 @@ export class PtyAgentProcess implements AgentProcess {
   private readonly pty: PtyHandle;
   private readonly exitHandlers: ExitHandler[] = [];
   private readonly dataHandlers: DataHandler[] = [];
+  private _lastDataAt: number | null = null;
+  get lastDataAt(): number | null {
+    return this._lastDataAt;
+  }
   private _exited = false;
   /** Serializes the write/settle/CR sequence so concurrent prompts can't
    *  interleave in the PTY input buffer (review #141 P1). */
@@ -150,6 +161,7 @@ export class PtyAgentProcess implements AgentProcess {
       PtyAgentProcess.BOOT_DIALOG_MAX_MS,
     );
     pty.onData((chunk) => {
+      this._lastDataAt = Date.now();
       if (this.bootDialogActive) this.handleBootDialog(chunk);
       // Keep a small ANSI-stripped tail so send_prompt_stream can tell whether a
       // submit actually started a turn (the idle REPL footer disappears on turn
@@ -474,6 +486,10 @@ export class ChildAgentProcess implements AgentProcess {
   private readonly child: ChildProcess;
   private readonly exitHandlers: ExitHandler[] = [];
   private readonly dataHandlers: DataHandler[] = [];
+  private _lastDataAt: number | null = null;
+  get lastDataAt(): number | null {
+    return this._lastDataAt;
+  }
   private _exited = false;
 
   constructor(agent_id: string, supervision: SupervisionMode, child: ChildProcess) {
@@ -484,6 +500,7 @@ export class ChildAgentProcess implements AgentProcess {
     // Capture stdout/stderr for crash-diag observation. We do NOT parse output —
     // this is purely a crash-signal channel (spec §5.3).
     const forward = (chunk: Buffer | string): void => {
+      this._lastDataAt = Date.now();
       const s = typeof chunk === "string" ? chunk : chunk.toString("utf8");
       for (const h of this.dataHandlers) {
         try {

--- a/src/bus/stall-forensics.ts
+++ b/src/bus/stall-forensics.ts
@@ -1,0 +1,179 @@
+/**
+ * Stall-watchdog auto-discovery forensics.
+ *
+ * When the stall watchdog kills a wedged session it first captures a best-effort
+ * liveness snapshot, then classifies the kill as a genuine wedge vs a suspected
+ * false positive (a legit long-running tool we killed too early). A false
+ * positive flags the operator with a suggestion to raise the exact ceiling — so
+ * conservative defaults self-correct instead of silently harming.
+ *
+ * OS-specific bits (the `/proc` CPU probe) live here, isolated behind a
+ * degrade-to-`null` contract so nothing depends on `/proc` existing (dev/mac).
+ * `classifyKill` is pure. SPEC: `.planning/stall-watchdog/SPEC.md` §3.4.
+ */
+
+import { readdir, readFile, mkdir, appendFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { ForensicSnapshot, StallKillOutcome, ToolCeiling } from "./stall-watchdog";
+
+/** CPU-tree advance (clock ticks) over the probe window above which we call it "active".
+ *  USER_HZ is typically 100 (10ms/tick); 2 ticks ≈ 20ms of CPU distinguishes work
+ *  from idle scheduler noise. */
+export const CPU_FLOOR_TICKS = 2;
+
+/** Raw output seen within this window ⇒ the tool was alive when we killed it. */
+export const RECENT_OUTPUT_MS = 60_000;
+
+/* ── /proc CPU probe (Linux; null elsewhere) ─────────────────────────────── */
+
+interface ProcStat {
+  ppid: number;
+  /** utime + stime in clock ticks. */
+  cpu: number;
+}
+
+async function readProcStat(pid: number): Promise<ProcStat | null> {
+  try {
+    const txt = await readFile(`/proc/${pid}/stat`, "utf8");
+    // `comm` (field 2) is parenthesised and may contain spaces/parens — parse
+    // everything after the LAST ')'. Then rest[0]=state(f3), rest[1]=ppid(f4),
+    // rest[11]=utime(f14), rest[12]=stime(f15).
+    const rparen = txt.lastIndexOf(")");
+    if (rparen < 0) return null;
+    const rest = txt
+      .slice(rparen + 1)
+      .trim()
+      .split(/\s+/);
+    const ppid = Number.parseInt(rest[1] ?? "", 10);
+    const utime = Number.parseInt(rest[11] ?? "", 10);
+    const stime = Number.parseInt(rest[12] ?? "", 10);
+    if (!Number.isFinite(ppid) || !Number.isFinite(utime) || !Number.isFinite(stime)) return null;
+    return { ppid, cpu: utime + stime };
+  } catch {
+    return null;
+  }
+}
+
+/** Sum utime+stime (ticks) across `root` and all its descendants. null if `/proc`
+ *  is unavailable or `root` is gone. */
+async function sampleTreeCpu(root: number): Promise<number | null> {
+  let entries: string[];
+  try {
+    entries = await readdir("/proc");
+  } catch {
+    return null; // non-Linux — no /proc
+  }
+  const pids = entries.filter((e) => /^\d+$/.test(e)).map(Number);
+  const stats = new Map<number, ProcStat>();
+  await Promise.all(
+    pids.map(async (p) => {
+      const s = await readProcStat(p);
+      if (s) stats.set(p, s);
+    }),
+  );
+  if (!stats.has(root)) return null; // the session process is already gone
+
+  const children = new Map<number, number[]>();
+  for (const [p, s] of stats) {
+    const arr = children.get(s.ppid);
+    if (arr) arr.push(p);
+    else children.set(s.ppid, [p]);
+  }
+
+  const tree = new Set<number>([root]);
+  const stack = [root];
+  while (stack.length) {
+    const p = stack.pop();
+    if (p === undefined) break;
+    for (const c of children.get(p) ?? []) {
+      if (!tree.has(c)) {
+        tree.add(c);
+        stack.push(c);
+      }
+    }
+  }
+
+  let sum = 0;
+  for (const p of tree) sum += stats.get(p)?.cpu ?? 0;
+  return sum;
+}
+
+/**
+ * Sample the CPU of the process tree rooted at `pid` twice, `probeMs` apart.
+ * Returns `true` if it advanced past the floor (the tool tree is doing work),
+ * `false` if flat (idle/blocked), or `null` if unmeasurable (non-Linux / pid gone).
+ * Best-effort — never throws.
+ */
+export async function probeProcessTreeCpu(pid: number, probeMs: number): Promise<boolean | null> {
+  const a = await sampleTreeCpu(pid);
+  if (a === null) return null;
+  await new Promise((r) => setTimeout(r, probeMs));
+  const b = await sampleTreeCpu(pid);
+  if (b === null) return null;
+  return b - a > CPU_FLOOR_TICKS;
+}
+
+/* ── Classification (pure) ───────────────────────────────────────────────── */
+
+/** Round up to the next whole minute (seconds). */
+function ceilToMinute(seconds: number): number {
+  return Math.ceil(seconds / 60) * 60;
+}
+
+/**
+ * Pure: was the kill justified? A wedge is idle (flat CPU, no recent output); a
+ * legit-long tool shows CPU progress OR recent output. When unmeasurable we say
+ * `unknown` (never claim a wedge we couldn't confirm). For a suspected false
+ * positive, suggest a ceiling ~2× the observed runtime (min 2× current kill).
+ */
+export function classifyKill(
+  snapshot: ForensicSnapshot,
+  outstandingMs: number,
+  ceiling: ToolCeiling,
+): StallKillOutcome {
+  const recentOutput =
+    snapshot.outputRecencyMs !== null && snapshot.outputRecencyMs < RECENT_OUTPUT_MS;
+
+  if (snapshot.cpuAdvancing === true || recentOutput) {
+    const suggestedKillSeconds = Math.max(
+      ceiling.killSeconds * 2,
+      ceilToMinute((outstandingMs / 1000) * 2),
+    );
+    return { classification: "suspected_false_positive", suggestedKillSeconds };
+  }
+  if (snapshot.cpuAdvancing === false) {
+    return { classification: "genuine_wedge" };
+  }
+  return { classification: "unknown" };
+}
+
+/* ── Audit log ───────────────────────────────────────────────────────────── */
+
+export interface StallKillAuditRecord {
+  ts: string;
+  agentId: string;
+  sessionId: string;
+  tool: string;
+  outstandingMs: number;
+  killSeconds: number;
+  classification: StallKillOutcome["classification"];
+  cpuAdvancing: boolean | null;
+  outputRecencyMs: number | null;
+  suggestedKillSeconds?: number;
+}
+
+const AUDIT_DIR = join(process.cwd(), ".claude", "claudeclaw");
+const AUDIT_FILE = join(AUDIT_DIR, "stall-kills.jsonl");
+
+/** Append one kill record to `.claude/claudeclaw/stall-kills.jsonl`. Best-effort. */
+export async function appendStallKillAudit(
+  record: StallKillAuditRecord,
+  file: string = AUDIT_FILE,
+): Promise<void> {
+  try {
+    await mkdir(join(file, ".."), { recursive: true });
+    await appendFile(file, `${JSON.stringify(record)}\n`);
+  } catch {
+    /* auditing must never break recovery */
+  }
+}

--- a/src/bus/stall-watchdog.ts
+++ b/src/bus/stall-watchdog.ts
@@ -113,6 +113,49 @@ export function ceilingFor(name: string, ceilings: StallCeilings): ToolCeiling {
   return ceilings[classifyTool(name)];
 }
 
+/* ── Config parsing (mirror of `parseWatchdogConfig`) ────────────────────── */
+
+function posNum(v: unknown, fallback: number, min: number): number {
+  return typeof v === "number" && Number.isFinite(v) && v >= min ? v : fallback;
+}
+
+function parseCeiling(raw: unknown, d: ToolCeiling): ToolCeiling {
+  const r = (raw ?? {}) as Record<string, unknown>;
+  return {
+    warnSeconds: posNum(r.warnSeconds, d.warnSeconds, 1),
+    killSeconds: posNum(r.killSeconds, d.killSeconds, 1),
+  };
+}
+
+/**
+ * Validate a raw settings value into a `StallWatchdogConfig`. Unknown keys are
+ * ignored; each invalid/missing field falls back to `DEFAULT_STALL_CONFIG`.
+ */
+export function parseStallWatchdogConfig(raw: unknown): StallWatchdogConfig {
+  const d = DEFAULT_STALL_CONFIG;
+  if (!raw || typeof raw !== "object") return structuredClone(d);
+  const r = raw as Record<string, unknown>;
+  const rc = (r.ceilings ?? {}) as Record<string, unknown>;
+  const ad = (r.autoDiscovery ?? {}) as Record<string, unknown>;
+  return {
+    enabled: typeof r.enabled === "boolean" ? r.enabled : d.enabled,
+    sweepIntervalMs: posNum(r.sweepIntervalMs, d.sweepIntervalMs, 1000),
+    ceilings: {
+      fast: parseCeiling(rc.fast, d.ceilings.fast),
+      bash: parseCeiling(rc.bash, d.ceilings.bash),
+      task: parseCeiling(rc.task, d.ceilings.task),
+      mcp: parseCeiling(rc.mcp, d.ceilings.mcp),
+      default: parseCeiling(rc.default, d.ceilings.default),
+    },
+    action: r.action === "warn" || r.action === "restart" ? r.action : d.action,
+    autoDiscovery: {
+      enabled: typeof ad.enabled === "boolean" ? ad.enabled : d.autoDiscovery.enabled,
+      cpuProbeMs: posNum(ad.cpuProbeMs, d.autoDiscovery.cpuProbeMs, 100),
+    },
+    restartFailureCooldownMs: posNum(r.restartFailureCooldownMs, d.restartFailureCooldownMs, 0),
+  };
+}
+
 /* ── Per-session state + decision ────────────────────────────────────────── */
 
 interface OutstandingTool {

--- a/src/bus/stall-watchdog.ts
+++ b/src/bus/stall-watchdog.ts
@@ -282,6 +282,12 @@ export class StallWatchdog {
   private unsubscribe: (() => void) | null = null;
   /** Sessions with a kill in flight — never double-restart the same one. */
   private readonly killing = new Set<string>();
+  /** Set once stop() begins, so no NEW kill starts a restart during teardown. */
+  private stopped = false;
+  /** In-flight handleKill promises so stop() can await them before it returns,
+   *  preventing a mid-flight restart from respawning a session the daemon has
+   *  already torn down (Codex P2 on #300). */
+  private readonly inFlight = new Set<Promise<void>>();
 
   constructor(
     private readonly config: StallWatchdogConfig,
@@ -377,7 +383,12 @@ export class StallWatchdog {
         continue;
       }
       this.killing.add(k);
-      kills.push(this.handleKill(s, decision, now).finally(() => this.killing.delete(k)));
+      const p = this.handleKill(s, decision, now).finally(() => {
+        this.killing.delete(k);
+        this.inFlight.delete(p);
+      });
+      this.inFlight.add(p);
+      kills.push(p);
     }
     // Await in-flight kills so sweeps never overlap on the same session and
     // tests observe the full capture→restart→classify sequence.
@@ -398,6 +409,12 @@ export class StallWatchdog {
         /* forensic is best-effort — never block recovery */
       }
     }
+
+    // If teardown began while we were capturing the forensic snapshot, abort
+    // before restarting — a restart here would respawn a session the daemon is
+    // tearing down (Codex P2 on #300). A kill already past this point is awaited
+    // by stop() so its respawn is torn down in order rather than orphaned.
+    if (this.stopped) return;
 
     try {
       await this.deps.restart(s.agentId, {
@@ -465,11 +482,16 @@ export class StallWatchdog {
     (this.timer as { unref?: () => void }).unref?.();
   }
 
-  stop(): void {
+  async stop(): Promise<void> {
+    // Set first so any sweep already inside handleKill won't start a new restart.
+    this.stopped = true;
     if (this.timer) clearInterval(this.timer);
     this.timer = null;
     this.unsubscribe?.();
     this.unsubscribe = null;
+    // Await any kill already past its stopped-check: its restart completes, then
+    // the caller's teardown stops the respawned session in order (no orphan).
+    await Promise.allSettled([...this.inFlight]);
     this.sessions.clear();
   }
 }

--- a/src/bus/stall-watchdog.ts
+++ b/src/bus/stall-watchdog.ts
@@ -121,10 +121,12 @@ function posNum(v: unknown, fallback: number, min: number): number {
 
 function parseCeiling(raw: unknown, d: ToolCeiling): ToolCeiling {
   const r = (raw ?? {}) as Record<string, unknown>;
-  return {
-    warnSeconds: posNum(r.warnSeconds, d.warnSeconds, 1),
-    killSeconds: posNum(r.killSeconds, d.killSeconds, 1),
-  };
+  const killSeconds = posNum(r.killSeconds, d.killSeconds, 1);
+  // Clamp warn to kill: a warn set ABOVE its kill is dead (kill fires first), so
+  // a `warn > kill` misconfig is pinned to the kill line rather than silently
+  // never warning.
+  const warnSeconds = Math.min(posNum(r.warnSeconds, d.warnSeconds, 1), killSeconds);
+  return { warnSeconds, killSeconds };
 }
 
 /**
@@ -137,9 +139,10 @@ export function parseStallWatchdogConfig(raw: unknown): StallWatchdogConfig {
   const r = raw as Record<string, unknown>;
   const rc = (r.ceilings ?? {}) as Record<string, unknown>;
   const ad = (r.autoDiscovery ?? {}) as Record<string, unknown>;
+  const sweepIntervalMs = posNum(r.sweepIntervalMs, d.sweepIntervalMs, 1000);
   return {
     enabled: typeof r.enabled === "boolean" ? r.enabled : d.enabled,
-    sweepIntervalMs: posNum(r.sweepIntervalMs, d.sweepIntervalMs, 1000),
+    sweepIntervalMs,
     ceilings: {
       fast: parseCeiling(rc.fast, d.ceilings.fast),
       bash: parseCeiling(rc.bash, d.ceilings.bash),
@@ -152,7 +155,13 @@ export function parseStallWatchdogConfig(raw: unknown): StallWatchdogConfig {
       enabled: typeof ad.enabled === "boolean" ? ad.enabled : d.autoDiscovery.enabled,
       cpuProbeMs: posNum(ad.cpuProbeMs, d.autoDiscovery.cpuProbeMs, 100),
     },
-    restartFailureCooldownMs: posNum(r.restartFailureCooldownMs, d.restartFailureCooldownMs, 0),
+    // Floor the cooldown at one sweep: below that it would re-kill + re-alert
+    // every sweep — exactly the storm the cooldown exists to prevent.
+    restartFailureCooldownMs: posNum(
+      r.restartFailureCooldownMs,
+      d.restartFailureCooldownMs,
+      sweepIntervalMs,
+    ),
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -231,7 +231,9 @@ const DEFAULT_SETTINGS: Settings = {
     },
   },
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
-  stallWatchdog: DEFAULT_STALL_CONFIG,
+  // Clone so a future in-place edit of settings.stallWatchdog can't mutate the
+  // shared exported default.
+  stallWatchdog: structuredClone(DEFAULT_STALL_CONFIG),
   governance: { watchdog: {} },
   session: { autoRotate: false, maxMessages: 50, maxAgeHours: 24, summaryPath: "" },
   // Default runtime: `bus` (Sprint 5.4 flip after Hetzner staging soak ended

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,11 @@ import { mkdir } from "fs/promises";
 import { existsSync } from "fs";
 import { normalizeTimezoneName, resolveTimezoneOffsetMinutes } from "./timezone";
 import { parseWatchdogConfig, type WatchdogConfig } from "./watchdog";
+import {
+  DEFAULT_STALL_CONFIG,
+  parseStallWatchdogConfig,
+  type StallWatchdogConfig,
+} from "./bus/stall-watchdog";
 import { parsePlugins, type PluginEntry } from "./plugins";
 import { parseMemorySearchSettings, type MemorySearchSettings } from "./memory";
 
@@ -226,6 +231,7 @@ const DEFAULT_SETTINGS: Settings = {
     },
   },
   watchdog: { maxConsecutiveTimeouts: null, maxRuntimeSeconds: null },
+  stallWatchdog: DEFAULT_STALL_CONFIG,
   governance: { watchdog: {} },
   session: { autoRotate: false, maxMessages: 50, maxAgeHours: 24, summaryPath: "" },
   // Default runtime: `bus` (Sprint 5.4 flip after Hetzner staging soak ended
@@ -680,6 +686,7 @@ export interface Settings {
   pty: PtyConfig;
   mcp: McpConfig;
   watchdog: WatchdogSettings;
+  stallWatchdog: StallWatchdogConfig;
   governance: GovernanceConfig;
   plugins: Record<string, PluginEntry>;
   session: SessionConfig;
@@ -1091,6 +1098,7 @@ function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Set
     agents: parseBusAgents(raw.agents),
     mcp: parseMcpConfig(raw.mcp, raw.web?.enabled),
     watchdog: parseWatchdogConfig(raw.watchdog),
+    stallWatchdog: parseStallWatchdogConfig(raw.stallWatchdog),
     governance: parseGovernanceConfig(raw.governance),
     plugins: parsePlugins(raw.plugins),
     memorySearch: parseMemorySearchSettings(raw.memorySearch),


### PR DESCRIPTION
Completes **PR 1/3 of #296** — the stall watchdog that fixes the #295 outage (a bus PTY session wedged ~11h on a hung `Bash` tool call). #297 landed the detection core as dead code; **this PR wires it in — it is the commit that actually makes the watchdog run.**

> ⚠️ **Merging this activates the watchdog on the daemon** (and deploys). It ships **enabled** by default. That's intended, but reviewers should know the stakes are "live behaviour change", not "more dead code".

@Nibbler1250 — requesting your review again (thanks for the #297 pass; all of it is folded in here).

## What's in this PR
- **`src/bus/stall-forensics.ts`** (already reviewed as the first commit) — `probeProcessTreeCpu` (best-effort `/proc` CPU-tree sampler, `null` off-Linux), pure `classifyKill`, `appendStallKillAudit`. 9 tests.
- **`src/config.ts`** — `parseStallWatchdogConfig` (per-field validation + clamps, falls back to `DEFAULT_STALL_CONFIG`) wired into `Settings` / `DEFAULT_SETTINGS` / `parseSettings`. Ships **enabled**; every ceiling + cooldown overridable in `settings.json`.
- **`src/bus/session-agent-process.ts`** — track `lastDataAt` on both `PtyAgentProcess` and `ChildAgentProcess` (the forensic "output recency" liveness signal). `pid` was already exposed.
- **`src/bus/runtime-mount.ts`** — instantiate `StallWatchdog` after a *successful* mount (so a failed mount never leaves a dangling sweep timer), binding the real deps:
  - `subscribe` → `BusCore.subscribe` (topics: tool_use / tool_result / turn_end / init / end)
  - `restart` → `SessionManager.restart({ reason: "stall" })` — **inherits `MAX_RESTARTS_PER_WINDOW`**, so a recurring stall can't respawn-loop
  - `captureForensic` → `probeProcessTreeCpu(pid)` + `lastDataAt`
  - `recordKill` → `classifyKill` + `appendStallKillAudit`
  - `notify` → structured `logger` (see follow-up below)
  - torn down first in `stop()`.

## #297 review follow-up — addressed
The `@claude` review's deferred note (`restartFailedAt` reset invariant) is now **implemented behaviour + tested**: a re-observed session kills cleanly after a failed→(cooldown)→succeeded restart cycle (no leaked cooldown). See `stall-watchdog.test.ts`.

## Tests
64 stall/forensics/mount tests green; `session-agent-process` (20) and config (81) unaffected; `bun run lint` clean. New: `parseStallWatchdogConfig` validation, the `restartFailedAt` invariant, and the mount test updated (mount now starts exactly one subscriber — the watchdog).

## Security posture (self-review)
Minimal surface: reads `/proc/<pid>/stat` (pid is an integer from `getAgent`, read-only, no injection); appends a `JSON.stringify`'d record to `.claude/claudeclaw/stall-kills.jsonl`; recovery reuses the existing `SessionManager.restart`. No shell exec, no user-input interpolation, no secrets. All best-effort paths swallow errors so forensics/audit can never block recovery.

## Known follow-up (not in this PR) — tracked in #301
`notify` currently routes to the structured `logger` (operator-visible in daemon logs). **Delivering the false-positive flag to Discord** is a deliberate follow-up, tracked in **#301** (same shape as #227's deferred summary-injection) — the audit trail + logs capture it today; the chat surfacing needs the operator-alert path.

Refs: #296 (epic), #295 (incident), #297 (detection core, merged).
