### PR TITLE
feat(bus): first-class agent-job primitive — dispatch_job (PR 3/3 of #296)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.174",
+      "version": "2.2.175",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.172",
+      "version": "2.2.173",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.173",
+      "version": "2.2.174",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.172",
+  "version": "2.2.173",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.173",
+  "version": "2.2.174",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.174",
+  "version": "2.2.175",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.planning/agent-job-primitive/HANDOVER.md
+++ b/.planning/agent-job-primitive/HANDOVER.md
@@ -1,0 +1,161 @@
+# HANDOVER — PR 3/3 of #296: first-class agent-job primitive
+
+Resume point for a clean session. Everything below is current as of branch
+`feat/agent-job-primitive` @ `cb5cf22` (pushed to remote `povai` =
+`TerrysPOV/ClaudeClaw-Plus`). Read the SPEC next to this file first:
+`.planning/agent-job-primitive/SPEC.md`.
+
+## 0. How to resume (the worktree is in ephemeral /tmp and may be gone)
+
+The branch is pushed; recreate a worktree from it:
+
+```bash
+cd /Users/terrenceyodaiken/claude-workspace/claudeclaw-plus
+git fetch povai
+git worktree add /path/to/wt-jobs feat/agent-job-primitive   # tracks povai/feat/agent-job-primitive
+cd /path/to/wt-jobs && ln -s /Users/terrenceyodaiken/claude-workspace/claudeclaw-plus/node_modules node_modules
+```
+
+Operator is **Terrence** (GitHub `TerrysPOV`). This is his own fork/PR, so PR
+creation is allowed; the SDC gate (`gh pr create`) needs the four markers or
+`ALLOW_PR_PUBLISH=1`. Never `gh pr merge` without his explicit per-merge word.
+
+## 1. What this is
+
+Epic **#296** = the 3-PR fix for the #295 daemon outage (an agent hand-rolled
+`/tmp/fire-*.ts` that `Bun.spawn(claude -p …)` + `nohup … &`, which held the
+Bash tool's pipe and wedged the session ~11h).
+
+- **PR 1 — stall watchdog (recovery):** MERGED (#297 + #300). Live on the daemon.
+- **PR 2 — Bash-exec guard (prevention):** MERGED (#302).
+- **PR 3 — agent-job primitive (root-smell fix): THIS BRANCH, in progress.**
+  Gives agent jobs a supported home so no agent ever hand-rolls `claude -p` again.
+
+## 2. Design decisions (frozen — do not re-litigate)
+
+- Dedicated **headless job** via `runClaudeOnce` + `loadAgentPrompts` (NOT a prompt
+  to the agent's live PTY).
+- **Fire-and-return** — the tool returns a `job_id` immediately, never awaits the job.
+- **In-memory registry**, no cross-restart persistence (matches the scheduler).
+- **Result delivery = Terry's call "1 a + c":** deliver the finished result back to
+  the *dispatching agent* via the bus AND keep it queryable via `job_status`.
+- **Concurrency cap = Terry's call "2 yes":** default 3, configurable; excess queue.
+
+## 3. What is DONE (committed on this branch, type-clean, tests green)
+
+- **`src/bus/agent-jobs.ts`** — `AgentJobRunner` (the heart). Dependency-injected:
+  `dispatch()` (fire-and-return, validates via `isKnownAgent`, returns `{jobId,status}`
+  or `{error}`), in-memory registry, concurrency cap + queue, `cancel()` (running via
+  `AbortSignal`, queued without spawning), `stop()`, `status()`/`list()`, and
+  `deliverResult` on every terminal state. **10 unit tests** in
+  `src/bus/__tests__/agent-jobs.test.ts` (fake `runAgentJob`, no real claude). Green.
+- **`src/runner.ts`**:
+  - `runClaudeOnce` gained an optional 7th param `signal?: AbortSignal` — aborts like a
+    timeout (rejects the race → existing catch kills the proc). Backward-compatible.
+  - New exported **`runAgentJobHeadless({agent, prompt, model?, timeoutMs, signal})`** →
+    `{exitCode, resultText?, error?, timedOut?}`. Loads persona via `loadAgentPrompts`,
+    runs `claude -p` in the agent's dir (`loadAgent().dir`) with plain output, maps
+    exit 124→timedOut. This is the real fire-script replacement.
+- **`src/agents.ts`** — exported `agentExists(name): boolean` (dispatch-time validation).
+- **`src/bus/mcp-tools.ts`** — added the 4 tool defs to `BUS_MCP_TOOLS`:
+  `dispatch_job` / `job_status` / `list_jobs` / `cancel_job`.
+
+## 4. THE REMAINING WORK — daemon-side IPC wiring (the hard, security-sensitive part)
+
+**Key architecture fact that reshapes this:** `BusMcpServer` is a **per-agent
+SUBPROCESS** that connects to the daemon's `BusCore` over a **unix socket**
+(`connectBusIpc`/`wrapSocket`, `src/bus/mcp-server.ts:150-200,753`). So the
+`AgentJobRunner` **must live in the daemon** (only it can spawn/track processes),
+and the 4 tools must **route over the socket IPC as request/response**. The
+`AgentJobRunner` cannot be held by the MCP subprocess.
+
+**Mirror the `request_human` round-trip** (`src/bus/mcp-server.ts:667-694`): mint an
+id → register a pending-response promise in a map (like `pendingAnswers`, field at
+`mcp-server.ts:386`) → `this.ipc.send(msg)` → `await` the promise → return
+`{content:[{type:"text", text: JSON.stringify(result)}]}`. The reply comes back as a
+correlated IPC message that resolves the pending promise.
+
+Steps (each is testable; keep the DI seams):
+
+1. **`src/bus/types.ts`** (IPC union, interfaces ~lines 221-304) — add a bidirectional
+   pair. Recommend ONE generic pair with a correlation id rather than 8 types:
+   - `IpcJobRequest { type:"job_request"; agent_id; req_id; op:"dispatch"|"status"|"list"|"cancel"; payload }`
+   - `IpcJobResult { type:"job_result"; req_id; ok; result?; error? }`
+   Add both to whatever discriminated-union type aggregates IPC messages.
+
+2. **`src/bus/mcp-server.ts`** — add cases in the `switch(name)` at **:432** for the 4
+   tools → handlers `handleDispatchJob/handleJobStatus/handleListJobs/handleCancelJob`.
+   Each: mint `req_id = randomUUID()`, register in a new `pendingJobRequests` map,
+   `this.ipc.send({type:"job_request", agent_id:this.agentId, req_id, op, payload})`,
+   `await` the reply, return the JSON. Route the inbound `job_result` in `wireIpc()`
+   (the IPC `onMessage` switch at ~:515) to resolve the pending promise. `this.agentId`
+   is the **dispatcher**. Add `RequestHuman`-style zod arg schemas.
+
+3. **`src/bus/core-ipc.ts`** — handle inbound `job_request`: call the daemon's
+   `AgentJobRunner` method for `op`, send back `{type:"job_result", req_id, ok, result/error}`
+   on that agent's socket. (See how it handles `ask`/`request_human`/`reply` today,
+   e.g. the error-send at `core-ipc.ts:257`.)
+
+4. **`src/bus/runtime-mount.ts`** — instantiate the runner in the daemon:
+   ```ts
+   const jobRunner = new AgentJobRunner(parseAgentJobConfig(settings) ?? DEFAULT_AGENT_JOB_CONFIG, {
+     runAgentJob: (i) => runAgentJobHeadless(i),
+     isKnownAgent: agentExists,
+     deliverResult: (job) => { void bus.sendPrompt({ /* origin:"system", agent: job.dispatcher, text: formatResult(job) */ }); },
+     now: Date.now,
+     genId: () => randomUUID(),
+   });
+   ```
+   Wire `jobRunner` into `core-ipc` (so step 3 can reach it). **Stop it in the handle's
+   `stop()`** next to the stall watchdog stop (search `stallWatchdog.stop()` in
+   `runtime-mount.ts` — put `jobRunner.stop()` beside it). Confirm `bus.sendPrompt`
+   signature at `src/bus/core.ts:162,471` (`SendPromptRequest`) and pick the right
+   `origin`/agent fields for delivering a system message to the dispatcher.
+
+5. **Config** — `src/config.ts`: add `AgentJobConfig` parse (`parseAgentJobConfig`, mirror
+   `parseAgenticConfig`/`parseMcpConfig`) + `DEFAULT_SETTINGS.agentJobs`, wired into
+   `parseSettings`. Reuse the `AgentJobConfig` interface already exported from
+   `agent-jobs.ts` (fields: `maxConcurrent`, `defaultTimeoutMs`, `maxTimeoutMs`;
+   `DEFAULT_AGENT_JOB_CONFIG` also exported there).
+
+6. **Integration test** — a socket round-trip test: dispatch_job over IPC → daemon runner
+   (inject a fake `runAgentJob`) → job_result back → status/cancel. Model on
+   `src/bus/__tests__/sprint-1-e2e.test.ts` and `mcp-server.test.ts` (both construct
+   `BusMcpServer` with an in-memory transport).
+
+7. **Ship** — `bun run bump:plugin-version && bun run bump:marketplace-version`, commit,
+   push, open PR for **@Nibbler1250** (base `main`). Body: what it is, the topology note,
+   the security posture (daemon spawns agent processes on IPC message — call out the
+   validation: `agentExists` + concurrency cap + timeout hard-cap + the persona/dir it
+   runs under). Refs #296, #295.
+
+## 5. Verify before shipping
+
+```bash
+bun test src/bus/__tests__/agent-jobs.test.ts        # core (should stay 10 green)
+bun test src/bus/                                     # + the new integration test
+bunx tsc --noEmit -p .                                # type-clean
+bunx biome check <edited files>                       # lint-clean
+```
+Then the SDC markers (`~/.claude/scripts/sdc/mark-*.sh`, `TEST_ARGS` scoped to touched
+paths — see project CLAUDE.md) or `ALLOW_PR_PUBLISH=1 gh pr create …`.
+
+## 6. Gotchas learned this session
+
+- `settings` in `runner.ts` = `getSettings()` (imported :28), NOT a module global.
+- Biome forbids non-null `!` (`lint/style/noNonNullAssertion`) — use a throwing accessor
+  or `?.`/`??` in tests (see `at()` helper in `agent-jobs.test.ts`).
+- The Edit tool sometimes fails to match a short line verbatim (hit on a `const … = " ";`
+  line) — match with surrounding context or a `replace_all` on a longer unique token.
+- Version guard: branch version must exceed `main`'s (main is `2.2.171`; branch already
+  bumped? check `.claude-plugin/plugin.json` — if not, run both bump scripts before PR).
+- Commit with `SKIP_SIMPLIFY=1` (pre-commit simplify hook) unless running the simplifier.
+- `mark-tests-passing.sh` always needs `TEST_ARGS="<paths>"` (full-suite has pre-existing
+  cross-test flakes).
+
+## 7. Definition of done for PR #3
+
+An agent can call `dispatch_job({agent:"reg", prompt:"…"})`, get a `job_id` back without
+its turn blocking, the daemon runs reg headless (tracked, capped, cancellable), and the
+result is delivered back to the dispatcher + queryable — i.e. **the reg/suzy batch-job
+pattern runs through the primitive, not `/tmp` fire-scripts.**

--- a/.planning/agent-job-primitive/SPEC.md
+++ b/.planning/agent-job-primitive/SPEC.md
@@ -1,0 +1,57 @@
+# SPEC — First-class agent-job primitive (PR 3/3 of #296)
+
+Fixes the *root smell* behind #295; PR 3 of the 3-PR path in #296. PR 1 (stall watchdog) recovers a wedged session; PR 2 (Bash guard) blocks the unsafe `&` pattern; **this PR removes the need to improvise jobs at all.**
+
+## 1. Problem statement
+
+The deepest cause of #295: Claw needed to run `reg`/`suzy` as long **autonomous batch jobs** (60-min research/draft runs), but the bus only offers **interactive, turn-based** agent sessions and gives an agent no tool to dispatch work to another agent. So Claw hand-rolled `/tmp/fire-reg-aissure-*.ts` that `Bun.spawn(["claude","-p", …])` — bypassing the bus (untracked, unobservable, uncancellable) and launching them with `nohup … &` (which wedged the session). PR 1/2 make that improvisation *survivable*; this PR makes it *unnecessary* by giving agent jobs a proper, supported home in the bus.
+
+## 2. Current behaviour (as-is)
+
+- **Agents have no dispatch tool.** `BUS_MCP_TOOLS` (`src/bus/mcp-tools.ts:12`) exposes `reply` / `edit_message` / `ask` / `cancel` / `request_human` — nothing to run a job on another agent. An agent that needs background work has no supported path.
+- **The execution + persona primitives already exist, unused for this.** `runClaudeOnce(args, model, api, env, timeoutMs, cwd)` (`src/runner.ts:739`) spawns claude headless with the sanitised child env, a wall-clock timeout, and process tracking (`mainActiveProcs`). `loadAgentPrompts(agentName)` (`src/runner.ts:1517`, via `loadAgent`/`AgentContext`) assembles an agent's IDENTITY/SOUL/CLAUDE.md. **Claw's fire-script re-implemented both by hand** (`Bun.spawn(claude -p)` + `readFileSafe` of IDENTITY/SOUL/MEMORY).
+- The bus MCP `CallTool` handler (`src/bus/mcp-server.ts:430`, `switch (name)`) is where a new tool is wired.
+- The scheduler (`src/bus/scheduler.ts`) is a cron/heartbeat prompt-emitter (fires `bus.sendPrompt`), not a job runner — a reference for trigger→dispatch, not the execution model.
+
+## 3. Target behaviour (to-be)
+
+A **`dispatch_job` MCP tool** on the bus + a **job runner/registry** so an agent can fire a background job to a named agent, get an id back immediately, and have the result delivered when done.
+
+1. **`dispatch_job({ agent, prompt, model?, timeoutMs? })`** (new `BUS_MCP_TOOLS` entry + `mcp-server.ts` case) → validates `agent` is a known agent, enqueues the job, and **returns `{ job_id, status: "running" }` immediately** (fire-and-return — never blocks the caller's turn).
+2. **Job runner** (`src/bus/agent-jobs.ts`): runs the agent headless via `runClaudeOnce` with `loadAgentPrompts(agent)` as `--append-system-prompt`, the job `prompt` as `-p`, `--output-format stream-json`, and the job's `timeoutMs` (default e.g. 30 min, hard-capped). One process per job, tracked so it can be killed. Best-effort; a job failure never affects the daemon.
+3. **Registry** (in-memory, mirrors the scheduler's no-persistence model): `job_id → { agent, status: running|done|failed|cancelled|timeout, startedAt, endedAt?, exitCode?, resultText?, dispatcher }`.
+4. **Result delivery (see §4 for the decision):** when a job finishes, its final text is delivered back to the **dispatching agent** via the bus (a synthetic notification/prompt: "job <id> for <agent> finished: <result>"), so the dispatcher can act on it — closing the loop the fire-scripts faked by tailing a log. Also queryable (below).
+5. **Observability + control:** `job_status({ job_id })` and `list_jobs()` (registry snapshot); `cancel_job({ job_id })` kills the tracked process and marks it `cancelled`.
+
+Net acceptance: **the reg/suzy batch-job pattern runs through `dispatch_job`, not `/tmp` fire-scripts** — tracked, observable, cancellable, and incapable of wedging the caller (fire-and-return; the headless job is its own process, not the caller's pipe).
+
+## 4. Architecture decisions
+
+- **FROZEN — dedicated headless job (via `runClaudeOnce` + `loadAgentPrompts`), NOT a prompt to the agent's PTY.** Rationale: a 60-min autonomous job must not block the target agent's interactive session, and this exactly matches (and replaces) the fire-script pattern while reusing the runner's env/timeout/tracking. (Rejected: `bus.sendPrompt` to the agent's live PTY — blocks its interactive turn for the job's duration and forces a turn model onto a batch job.)
+- **FROZEN — fire-and-return.** The tool returns a `job_id` synchronously; the job runs in the background. The caller never awaits the job (that awaiting is exactly what wedged #295).
+- **FROZEN — in-memory registry, no cross-restart persistence.** Matches the scheduler's model; a daemon restart cancels in-flight jobs (acceptable — the stall watchdog + restart rotation already assume restart-clears-state). Persisting/resuming jobs is out of scope.
+- **DECISION NEEDED — result delivery.** Options: **(a)** deliver the finished job's text back to the *dispatching agent* as a bus notification (Claw dispatched → gets the result → reports to Terry — matches actual use); **(b)** post the result to a channel/thread directly; **(c)** results only queryable via `job_status` (caller polls). **Recommendation: (a) + (c)** — deliver to the dispatcher AND keep it queryable. (a) closes the loop the fire-scripts faked (tailing a log for the result); (c) covers observability + a dispatcher that's since rotated.
+- **DECISION NEEDED — concurrency cap.** A small max-concurrent-jobs limit (e.g. 3) so a low-spec box can't be swamped by parallel `claude -p` processes; excess jobs queue. Recommend yes, default 3, configurable.
+
+## 5. Key file references
+
+**New:**
+- `src/bus/agent-jobs.ts` — the `AgentJobRunner`: `dispatch()` (spawn via `runClaudeOnce`+`loadAgentPrompts`, register, fire-and-return), `status()`/`list()`, `cancel()`, result-delivery callback, concurrency cap. Pure registry-state helpers split out for unit testing.
+- `src/bus/__tests__/agent-jobs.test.ts` — unit (registry transitions; dispatch returns id immediately; cancel kills + marks; timeout → status; concurrency cap queues) with an injected fake `runClaudeOnce` so no real claude spawns.
+
+**Modify:**
+- `src/bus/mcp-tools.ts` — add `dispatch_job` / `job_status` / `list_jobs` / `cancel_job` to `BUS_MCP_TOOLS` (name + description + input schema).
+- `src/bus/mcp-server.ts` — `switch (name)` cases wiring the tools to the `AgentJobRunner`; inject the runner where the server is constructed.
+- Wiring point (`src/bus/runtime-mount.ts`) — instantiate `AgentJobRunner`, bind `runClaudeOnce`/`loadAgentPrompts` + the result-delivery callback (via `bus.sendPrompt`/`ingestReply`), start/stop with the handle.
+
+**Reference (reuse, do not duplicate):**
+- `src/runner.ts:739` (`runClaudeOnce`), `:1517` (`loadAgentPrompts`), `loadAgent`/`AgentContext` (`src/agents.ts:199`).
+- `src/bus/mcp-server.ts:430` (CallTool switch), `src/bus/mcp-tools.ts:12` (`BUS_MCP_TOOLS`).
+
+## 6. Out of scope (deferred)
+
+- **Cross-restart job persistence / resume** — in-memory only (§4).
+- **Streaming job progress** back to the dispatcher — v1 delivers the final result; live progress is a follow-up.
+- **Retries / backoff on job failure** — the dispatcher decides whether to re-dispatch.
+- **Removing the existing `/tmp` fire-scripts on the server** — operational cleanup once the primitive ships; not code in this PR.
+- **A general "run arbitrary command as a job"** — this is *agent* jobs (named agent + prompt) only.

--- a/src/__tests__/agents.test.ts
+++ b/src/__tests__/agents.test.ts
@@ -13,6 +13,7 @@ import {
   loadAgent,
   listAgents,
   validateAgentName,
+  agentExists,
   parseScheduleToCron,
   validateJobLabel,
   addJob,
@@ -92,6 +93,27 @@ describe("validateAgentName", () => {
     const result = validateAgentName(name);
     expect(result.valid).toBe(false);
     expect(result.error).toBeDefined();
+  });
+});
+
+describe("agentExists — path-traversal guard (#296 PR 3 security review)", () => {
+  it("rejects traversal / separator names WITHOUT touching the filesystem", () => {
+    // The NAME_RE guard short-circuits before existsSync, so these return false
+    // even though the resolved paths (e.g. the repo root, /etc) plainly exist.
+    // Without the guard, the agent-job dispatch path could spawn `claude -p`
+    // with cwd set to an arbitrary directory outside agents/.
+    for (const bad of ["..", "../..", "../../etc", "a/b", "/etc", "foo/../bar", ".", "UPPER"]) {
+      expect(agentExists(bad)).toBe(false);
+    }
+    // Non-strings / empty are also rejected.
+    expect(agentExists("")).toBe(false);
+    expect(agentExists(undefined as unknown as string)).toBe(false);
+  });
+
+  it("still returns true for a real kebab-case agent dir", async () => {
+    const name = uniq("real");
+    await mkdir(join(AGENTS_DIR, name), { recursive: true });
+    expect(agentExists(name)).toBe(true);
   });
 });
 

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -726,6 +726,11 @@ export async function createAgent(opts: AgentCreateOpts): Promise<AgentContext> 
   };
 }
 
+/** Cheap existence check for a named agent (its config dir is present). */
+export function agentExists(name: string): boolean {
+  return typeof name === "string" && name.length > 0 && existsSync(join(agentsDir(), name));
+}
+
 export async function loadAgent(name: string): Promise<AgentContext> {
   const dir = join(agentsDir(), name);
   if (!existsSync(dir)) {

--- a/src/agents.ts
+++ b/src/agents.ts
@@ -726,9 +726,24 @@ export async function createAgent(opts: AgentCreateOpts): Promise<AgentContext> 
   };
 }
 
-/** Cheap existence check for a named agent (its config dir is present). */
+/**
+ * Cheap existence check for a named agent (its config dir is present).
+ *
+ * The `NAME_RE` guard is a SECURITY boundary, not just cosmetics: without it a
+ * name like `../../etc` passes `existsSync(join(agentsDir(), name))` and lets a
+ * caller (e.g. the agent-job dispatch path) escape the `agents/` sandbox and run
+ * `claude -p` with cwd set to an arbitrary existing directory. Restricting to the
+ * kebab-case charset categorically rejects `..`, path separators, and absolute
+ * paths. Every legitimately-created agent already matches `NAME_RE`
+ * (`validateAgentName` is the creation gate), so this never rejects a real agent.
+ */
 export function agentExists(name: string): boolean {
-  return typeof name === "string" && name.length > 0 && existsSync(join(agentsDir(), name));
+  return (
+    typeof name === "string" &&
+    name.length > 0 &&
+    NAME_RE.test(name) &&
+    existsSync(join(agentsDir(), name))
+  );
 }
 
 export async function loadAgent(name: string): Promise<AgentContext> {

--- a/src/bus/__tests__/agent-job-delivery.test.ts
+++ b/src/bus/__tests__/agent-job-delivery.test.ts
@@ -1,0 +1,102 @@
+/**
+ * deliverAgentJobResult — job-result delivery that never clobbers a mid-turn
+ * dispatcher's prompt-origin (#296 PR 3, Codex review).
+ *
+ * Verifies: idle dispatcher → deliver immediately; mid-turn dispatcher → defer
+ * to its next `response.turn_end`; deliver at most once.
+ */
+
+import { describe, it, expect } from "bun:test";
+import { deliverAgentJobResult } from "../runtime-mount";
+import type { BusCore, SendPromptRequest } from "../core";
+import type { JobView } from "../agent-jobs";
+import type { SubscriptionHandler } from "../core-subscription";
+
+function jobView(over: Partial<JobView> = {}): JobView {
+  return {
+    jobId: "job-1",
+    agent: "reg",
+    dispatcher: "claw",
+    status: "done",
+    createdAt: 0,
+    resultText: "done!",
+    ...over,
+  };
+}
+
+/** Minimal fake bus satisfying the slice `deliverAgentJobResult` depends on. */
+function fakeBus(turnActive: boolean) {
+  const prompts: SendPromptRequest[] = [];
+  let active = turnActive;
+  let handler: SubscriptionHandler | null = null;
+  let closed = false;
+  const bus: Pick<BusCore, "sendPrompt" | "isAgentTurnActive" | "subscribe"> = {
+    isAgentTurnActive: () => active,
+    async sendPrompt(req) {
+      prompts.push(req);
+      return { promise_id: "x" };
+    },
+    subscribe(_filter, h) {
+      handler = h;
+      return {
+        id: "s",
+        close() {
+          closed = true;
+        },
+        get overflowCount() {
+          return 0;
+        },
+        get depth() {
+          return 0;
+        },
+      };
+    },
+  };
+  return {
+    bus,
+    prompts,
+    endTurn: () => {
+      active = false;
+    },
+    fireTurnEnd: () =>
+      handler?.({
+        ts: 0,
+        agent_id: "claw",
+        session_id: "",
+        topic: "response.turn_end",
+        payload: {},
+      }),
+    isSubClosed: () => closed,
+  };
+}
+
+const logger = { warn() {} };
+
+describe("deliverAgentJobResult (#296 PR 3 Codex review)", () => {
+  it("delivers immediately when the dispatcher is idle", () => {
+    const f = fakeBus(false);
+    deliverAgentJobResult(f.bus, jobView(), logger);
+    expect(f.prompts).toHaveLength(1);
+    expect(f.prompts[0].agent_id).toBe("claw");
+    expect(f.prompts[0].origin).toBe("cron");
+    expect(f.prompts[0].user_id).toBe("system");
+  });
+
+  it("defers until the dispatcher's next turn_end when it's mid-turn (no origin clobber)", () => {
+    const f = fakeBus(true);
+    deliverAgentJobResult(f.bus, jobView(), logger);
+    expect(f.prompts).toHaveLength(0); // NOT delivered while a turn is live
+    f.endTurn();
+    f.fireTurnEnd();
+    expect(f.prompts).toHaveLength(1); // delivered when the turn ends
+    expect(f.isSubClosed()).toBe(true); // one-shot subscription closed
+  });
+
+  it("delivers at most once even if turn_end fires repeatedly", () => {
+    const f = fakeBus(true);
+    deliverAgentJobResult(f.bus, jobView(), logger);
+    f.fireTurnEnd();
+    f.fireTurnEnd();
+    expect(f.prompts).toHaveLength(1);
+  });
+});

--- a/src/bus/__tests__/agent-jobs-ipc.test.ts
+++ b/src/bus/__tests__/agent-jobs-ipc.test.ts
@@ -38,6 +38,16 @@ interface Deferred {
   aborted: () => boolean;
 }
 
+/** Snake_case shape the tools return to the agent (see toWireJobView in core.ts). */
+interface WireJob {
+  job_id: string;
+  agent: string;
+  dispatcher: string;
+  status: string;
+  result_text?: string;
+  error?: string;
+}
+
 interface Harness {
   bus: BusCore;
   mcp: BusMcpServer;
@@ -168,21 +178,22 @@ describe("Agent-job IPC round-trip — dispatch_job over UDS (#296 PR 3)", () =>
       prompt: "research the thing",
     });
     expect(isError).toBe(false);
-    const dispatch = parsed as { jobId: string; status: string };
-    expect(dispatch.jobId).toBe("job-1");
+    // Agent-facing responses are snake_case (job_id), matching the tool contract.
+    const dispatch = parsed as { job_id: string; status: string };
+    expect(dispatch.job_id).toBe("job-1");
     expect(dispatch.status).toBe("running");
     // Fire-and-return: the job is still running (its fake run hasn't resolved).
     expect(h.runs.has("job-1")).toBe(true);
 
-    const status = (await callTool(h.client, "job_status", { job_id: "job-1" })).parsed as JobView;
-    expect(status.jobId).toBe("job-1");
+    const status = (await callTool(h.client, "job_status", { job_id: "job-1" })).parsed as WireJob;
+    expect(status.job_id).toBe("job-1");
     expect(status.agent).toBe("reg");
     expect(status.dispatcher).toBe("dispatcher-agent"); // stamped from the socket, not the client
     expect(status.status).toBe("running");
 
-    const list = (await callTool(h.client, "list_jobs")).parsed as JobView[];
+    const list = (await callTool(h.client, "list_jobs")).parsed as WireJob[];
     expect(list).toHaveLength(1);
-    expect(list[0].jobId).toBe("job-1");
+    expect(list[0].job_id).toBe("job-1");
   });
 
   it("a finished job transitions to done and is delivered back to the dispatcher", async () => {
@@ -199,9 +210,9 @@ describe("Agent-job IPC round-trip — dispatch_job over UDS (#296 PR 3)", () =>
     expect(h.delivered[0].resultText).toBe("the answer is 42");
     expect(h.delivered[0].dispatcher).toBe("dispatcher-agent");
 
-    const status = (await callTool(h.client, "job_status", { job_id: "job-1" })).parsed as JobView;
+    const status = (await callTool(h.client, "job_status", { job_id: "job-1" })).parsed as WireJob;
     expect(status.status).toBe("done");
-    expect(status.resultText).toBe("the answer is 42");
+    expect(status.result_text).toBe("the answer is 42");
   });
 
   it("cancel_job aborts a running job and marks it cancelled", async () => {
@@ -215,7 +226,7 @@ describe("Agent-job IPC round-trip — dispatch_job over UDS (#296 PR 3)", () =>
     // The runner aborted the run's signal.
     expect(mustRun(h, "job-1").aborted()).toBe(true);
 
-    const status = (await callTool(h.client, "job_status", { job_id: "job-1" })).parsed as JobView;
+    const status = (await callTool(h.client, "job_status", { job_id: "job-1" })).parsed as WireJob;
     expect(status.status).toBe("cancelled");
   });
 

--- a/src/bus/__tests__/agent-jobs-ipc.test.ts
+++ b/src/bus/__tests__/agent-jobs-ipc.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Agent-job IPC round-trip test (#296 PR 3).
+ *
+ * Verifies the daemon-side wiring end-to-end over a REAL UDS, the way a
+ * spawned `claude` reaches Bus core:
+ *
+ *   agent's dispatch_job tool  → IpcJobRequest over UDS → BusCore.handleJobRequest
+ *     → AgentJobRunner.dispatch → IpcJobResult back over UDS → tool result
+ *
+ * The `AgentJobRunner` is REAL (so dispatch validation, the registry, the
+ * concurrency/queue path, cancel, and deliverResult all run); only
+ * `runAgentJob` is faked (a controllable deferred) so no real `claude -p`
+ * spawns. Covers: dispatch returns an id immediately, status/list reflect the
+ * registry, a finished job delivers to the dispatcher, cancel kills a running
+ * job, unknown-agent + not-enabled error paths.
+ *
+ * Modelled on `sprint-1-e2e.test.ts` (same UDS + InMemoryTransport harness).
+ */
+
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { BusMcpServer, buildMcpServer, connectBusIpc } from "../mcp-server.js";
+import { createBusCore, type BusCore } from "../core.js";
+import {
+  AgentJobRunner,
+  DEFAULT_AGENT_JOB_CONFIG,
+  type JobRunResult,
+  type JobView,
+} from "../agent-jobs.js";
+
+interface Deferred {
+  promise: Promise<JobRunResult>;
+  resolve: (r: JobRunResult) => void;
+  aborted: () => boolean;
+}
+
+interface Harness {
+  bus: BusCore;
+  mcp: BusMcpServer;
+  client: Client;
+  runner: AgentJobRunner | null;
+  /** Jobs delivered back to the dispatcher (decision 1a). */
+  delivered: JobView[];
+  /** Per-jobId deferred controlling when the fake run resolves. */
+  runs: Map<string, Deferred>;
+  cleanup: () => Promise<void>;
+}
+
+/** Read + JSON.parse the single text block an agent-job tool returns. */
+async function callTool(
+  client: Client,
+  name: string,
+  args: Record<string, unknown> = {},
+): Promise<{ parsed: unknown; isError: boolean }> {
+  const res = (await client.callTool({ name, arguments: args })) as {
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  };
+  return { parsed: JSON.parse(res.content[0].text), isError: res.isError === true };
+}
+
+async function waitFor(pred: () => boolean, ms = 1000): Promise<void> {
+  const deadline = Date.now() + ms;
+  while (!pred() && Date.now() < deadline) {
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+/** Throwing accessor — biome forbids the `!` non-null assertion (noNonNullAssertion). */
+function mustRun(h: Harness, jobId: string): Deferred {
+  const d = h.runs.get(jobId);
+  if (!d) throw new Error(`no fake run registered for ${jobId}`);
+  return d;
+}
+
+async function setupHarness(opts: { withJobHandler: boolean }): Promise<Harness> {
+  const agentId = "dispatcher-agent";
+  const tmpDir = mkdtempSync(join(tmpdir(), "bus-jobs-ipc-"));
+  const socketPath = join(tmpDir, "bus.sock");
+
+  const delivered: JobView[] = [];
+  const runs = new Map<string, Deferred>();
+  let idSeq = 0;
+
+  let runner: AgentJobRunner | null = null;
+  if (opts.withJobHandler) {
+    runner = new AgentJobRunner(DEFAULT_AGENT_JOB_CONFIG, {
+      // Fake run: park a resolver so the test decides when a job finishes.
+      runAgentJob: (input) => {
+        let resolve!: (r: JobRunResult) => void;
+        const promise = new Promise<JobRunResult>((res) => {
+          resolve = res;
+        });
+        runs.set(input.jobId, {
+          promise,
+          resolve,
+          aborted: () => input.signal.aborted,
+        });
+        return promise;
+      },
+      isKnownAgent: (a) => a === "reg" || a === "suzy",
+      deliverResult: (job) => delivered.push(job),
+      now: () => 1_000 + idSeq,
+      genId: () => `job-${++idSeq}`,
+    });
+  }
+
+  const bus = createBusCore({
+    socketPath,
+    eventLogAppend: async (entry) =>
+      ({ eventId: "test", sequence: 0, timestamp: Date.now(), ...entry }) as never,
+    ...(runner ? { jobHandler: runner } : {}),
+  });
+  await bus.start();
+
+  process.env.CCAW_BUS_SOCK = socketPath;
+  const ipc = await connectBusIpc(process.env);
+  const mcpServer = buildMcpServer();
+  const [serverSide, clientSide] = InMemoryTransport.createLinkedPair();
+  await mcpServer.connect(serverSide);
+  const mcp = new BusMcpServer({ agentId, ipc, mcp: mcpServer });
+  mcp.sendHello();
+
+  await waitFor(() => bus.state().connectedAgents.includes(agentId));
+
+  const client = new Client({ name: "jobs-ipc-client", version: "0" });
+  await client.connect(clientSide);
+
+  return {
+    bus,
+    mcp,
+    client,
+    runner,
+    delivered,
+    runs,
+    async cleanup() {
+      try {
+        await client.close();
+      } catch {}
+      try {
+        await mcpServer.close();
+      } catch {}
+      try {
+        mcp.ipc.close();
+      } catch {}
+      await bus.stop();
+      rmSync(tmpDir, { recursive: true, force: true });
+      delete process.env.CCAW_BUS_SOCK;
+    },
+  };
+}
+
+describe("Agent-job IPC round-trip — dispatch_job over UDS (#296 PR 3)", () => {
+  let h: Harness;
+  afterEach(async () => {
+    await h?.cleanup();
+  });
+
+  it("dispatch returns a job_id immediately; status + list reflect the registry", async () => {
+    h = await setupHarness({ withJobHandler: true });
+
+    const { parsed, isError } = await callTool(h.client, "dispatch_job", {
+      agent: "reg",
+      prompt: "research the thing",
+    });
+    expect(isError).toBe(false);
+    const dispatch = parsed as { jobId: string; status: string };
+    expect(dispatch.jobId).toBe("job-1");
+    expect(dispatch.status).toBe("running");
+    // Fire-and-return: the job is still running (its fake run hasn't resolved).
+    expect(h.runs.has("job-1")).toBe(true);
+
+    const status = (await callTool(h.client, "job_status", { job_id: "job-1" })).parsed as JobView;
+    expect(status.jobId).toBe("job-1");
+    expect(status.agent).toBe("reg");
+    expect(status.dispatcher).toBe("dispatcher-agent"); // stamped from the socket, not the client
+    expect(status.status).toBe("running");
+
+    const list = (await callTool(h.client, "list_jobs")).parsed as JobView[];
+    expect(list).toHaveLength(1);
+    expect(list[0].jobId).toBe("job-1");
+  });
+
+  it("a finished job transitions to done and is delivered back to the dispatcher", async () => {
+    h = await setupHarness({ withJobHandler: true });
+    await callTool(h.client, "dispatch_job", { agent: "reg", prompt: "go" });
+
+    // Resolve the fake run → the runner finishes + delivers.
+    mustRun(h, "job-1").resolve({ exitCode: 0, resultText: "the answer is 42" });
+    await waitFor(() => h.delivered.length > 0);
+
+    expect(h.delivered).toHaveLength(1);
+    expect(h.delivered[0].jobId).toBe("job-1");
+    expect(h.delivered[0].status).toBe("done");
+    expect(h.delivered[0].resultText).toBe("the answer is 42");
+    expect(h.delivered[0].dispatcher).toBe("dispatcher-agent");
+
+    const status = (await callTool(h.client, "job_status", { job_id: "job-1" })).parsed as JobView;
+    expect(status.status).toBe("done");
+    expect(status.resultText).toBe("the answer is 42");
+  });
+
+  it("cancel_job aborts a running job and marks it cancelled", async () => {
+    h = await setupHarness({ withJobHandler: true });
+    await callTool(h.client, "dispatch_job", { agent: "reg", prompt: "long job" });
+
+    const cancel = (await callTool(h.client, "cancel_job", { job_id: "job-1" })).parsed as {
+      ok: boolean;
+    };
+    expect(cancel.ok).toBe(true);
+    // The runner aborted the run's signal.
+    expect(mustRun(h, "job-1").aborted()).toBe(true);
+
+    const status = (await callTool(h.client, "job_status", { job_id: "job-1" })).parsed as JobView;
+    expect(status.status).toBe("cancelled");
+  });
+
+  it("dispatch to an unknown agent returns an error result (no job spawned)", async () => {
+    h = await setupHarness({ withJobHandler: true });
+    const { parsed } = await callTool(h.client, "dispatch_job", {
+      agent: "nobody",
+      prompt: "x",
+    });
+    expect((parsed as { error: string }).error).toContain("unknown agent");
+    expect(h.runs.size).toBe(0);
+  });
+
+  it("cancel of an unknown job_id returns ok:false with a reason", async () => {
+    h = await setupHarness({ withJobHandler: true });
+    const { parsed } = await callTool(h.client, "cancel_job", { job_id: "does-not-exist" });
+    expect(parsed as { ok: boolean; error?: string }).toMatchObject({ ok: false });
+  });
+
+  it("with no job handler wired, job tools return a clean 'not enabled' error (never hang)", async () => {
+    h = await setupHarness({ withJobHandler: false });
+    const { parsed, isError } = await callTool(h.client, "dispatch_job", {
+      agent: "reg",
+      prompt: "x",
+    });
+    expect(isError).toBe(true);
+    expect((parsed as { error: string }).error).toContain("not enabled");
+  });
+});

--- a/src/bus/__tests__/agent-jobs.test.ts
+++ b/src/bus/__tests__/agent-jobs.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from "bun:test";
+import {
+  AgentJobRunner,
+  DEFAULT_AGENT_JOB_CONFIG,
+  type AgentJobConfig,
+  type AgentJobDeps,
+  type JobRunResult,
+  type JobView,
+} from "../agent-jobs";
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+interface FakeRun {
+  input: { jobId: string; agent: string; prompt: string; timeoutMs: number; signal: AbortSignal };
+  resolve: (r: JobRunResult) => void;
+  reject: (e: unknown) => void;
+  aborted: boolean;
+}
+
+/** Index into the recorded runs, throwing (not `!`) if the run isn't there. */
+function at(runs: FakeRun[], i: number): FakeRun {
+  const r = runs[i];
+  if (!r) throw new Error(`expected a run at index ${i}`);
+  return r;
+}
+
+function harness(config: AgentJobConfig = DEFAULT_AGENT_JOB_CONFIG) {
+  let idCounter = 0;
+  let clock = 0;
+  const delivered: JobView[] = [];
+  const runs: FakeRun[] = [];
+  const deps: AgentJobDeps = {
+    runAgentJob: (input) =>
+      new Promise<JobRunResult>((resolve, reject) => {
+        const run: FakeRun = { input, resolve, reject, aborted: false };
+        input.signal.addEventListener("abort", () => {
+          run.aborted = true;
+          reject(new Error("aborted")); // a killed process settles the promise
+        });
+        runs.push(run);
+      }),
+    isKnownAgent: (a) => a === "reg" || a === "suzy",
+    deliverResult: (v) => delivered.push(v),
+    now: () => clock,
+    genId: () => `job-${++idCounter}`,
+  };
+  const runner = new AgentJobRunner(config, deps);
+  return { runner, runs, delivered, setClock: (n: number) => (clock = n) };
+}
+
+const jobIdOf = (r: { jobId: string } | { error: string }) => ("jobId" in r ? r.jobId : "");
+
+/* ── dispatch (fire-and-return + validation) ───────────────────────────── */
+
+describe("AgentJobRunner.dispatch", () => {
+  it("registers a job and returns its id immediately (running under the cap)", () => {
+    const { runner, runs } = harness();
+    const r = runner.dispatch({ agent: "reg", prompt: "research x", dispatcher: "claw" });
+    expect("jobId" in r).toBe(true);
+    if ("jobId" in r) expect(r.status).toBe("running");
+    expect(runs).toHaveLength(1); // started synchronously, not awaited
+  });
+
+  it("rejects unknown agent and empty agent/prompt", () => {
+    const { runner } = harness();
+    expect(runner.dispatch({ agent: "nope", prompt: "x", dispatcher: "claw" })).toEqual({
+      error: "unknown agent: nope",
+    });
+    expect(runner.dispatch({ agent: "", prompt: "x", dispatcher: "claw" })).toEqual({
+      error: "agent is required",
+    });
+    expect(runner.dispatch({ agent: "reg", prompt: "  ", dispatcher: "claw" })).toEqual({
+      error: "prompt is required",
+    });
+  });
+});
+
+/* ── terminal outcomes → status + delivery ─────────────────────────────── */
+
+describe("AgentJobRunner outcomes", () => {
+  it("a completed job → done + resultText, delivered to the dispatcher", async () => {
+    const { runner, runs, delivered } = harness();
+    const id = jobIdOf(runner.dispatch({ agent: "reg", prompt: "x", dispatcher: "claw" }));
+    at(runs, 0).resolve({ exitCode: 0, resultText: "3 proposals written" });
+    await flush();
+    expect(runner.status(id)?.status).toBe("done");
+    expect(runner.status(id)?.resultText).toBe("3 proposals written");
+    const d = delivered.find((x) => x.jobId === id);
+    expect(d?.status).toBe("done");
+    expect(d?.dispatcher).toBe("claw");
+  });
+
+  it("a rejected run → failed", async () => {
+    const { runner, runs } = harness();
+    const id = jobIdOf(runner.dispatch({ agent: "reg", prompt: "x", dispatcher: "claw" }));
+    at(runs, 0).reject(new Error("spawn failed"));
+    await flush();
+    expect(runner.status(id)?.status).toBe("failed");
+    expect(runner.status(id)?.error).toContain("spawn failed");
+  });
+
+  it("a timed-out run → timeout", async () => {
+    const { runner, runs } = harness();
+    const id = jobIdOf(runner.dispatch({ agent: "reg", prompt: "x", dispatcher: "claw" }));
+    at(runs, 0).resolve({ exitCode: 124, timedOut: true });
+    await flush();
+    expect(runner.status(id)?.status).toBe("timeout");
+  });
+});
+
+/* ── concurrency cap ───────────────────────────────────────────────────── */
+
+describe("AgentJobRunner concurrency", () => {
+  it("caps running jobs and queues the excess, starting the next on completion", async () => {
+    const { runner, runs } = harness({ ...DEFAULT_AGENT_JOB_CONFIG, maxConcurrent: 2 });
+    const a = runner.dispatch({ agent: "reg", prompt: "a", dispatcher: "claw" });
+    const b = runner.dispatch({ agent: "reg", prompt: "b", dispatcher: "claw" });
+    const c = runner.dispatch({ agent: "reg", prompt: "c", dispatcher: "claw" });
+    expect("jobId" in a && a.status).toBe("running");
+    expect("jobId" in b && b.status).toBe("running");
+    expect("jobId" in c && c.status).toBe("queued");
+    expect(runs).toHaveLength(2); // only 2 spawned
+
+    at(runs, 0).resolve({ exitCode: 0, resultText: "a" });
+    await flush();
+    expect(runs).toHaveLength(3); // c starts as a slot frees
+    expect(runner.status(jobIdOf(c))?.status).toBe("running");
+  });
+});
+
+/* ── cancel + stop ─────────────────────────────────────────────────────── */
+
+describe("AgentJobRunner cancel/stop", () => {
+  it("cancels a running job (aborts the signal) and delivers cancelled", async () => {
+    const { runner, runs, delivered } = harness();
+    const id = jobIdOf(runner.dispatch({ agent: "reg", prompt: "x", dispatcher: "claw" }));
+    expect(runner.cancel(id)).toEqual({ ok: true });
+    expect(at(runs, 0).aborted).toBe(true);
+    expect(runner.status(id)?.status).toBe("cancelled");
+    await flush();
+    expect(delivered.find((x) => x.jobId === id)?.status).toBe("cancelled");
+  });
+
+  it("cancels a queued job without ever starting it", () => {
+    const { runner, runs, delivered } = harness({ ...DEFAULT_AGENT_JOB_CONFIG, maxConcurrent: 1 });
+    runner.dispatch({ agent: "reg", prompt: "a", dispatcher: "claw" }); // running
+    const q = jobIdOf(runner.dispatch({ agent: "reg", prompt: "b", dispatcher: "claw" })); // queued
+    expect(runner.status(q)?.status).toBe("queued");
+    expect(runner.cancel(q)).toEqual({ ok: true });
+    expect(runner.status(q)?.status).toBe("cancelled");
+    expect(runs).toHaveLength(1); // never spawned
+    expect(delivered.find((x) => x.jobId === q)?.status).toBe("cancelled");
+  });
+
+  it("cancelling a terminal job errors; unknown job errors", async () => {
+    const { runner, runs } = harness();
+    const id = jobIdOf(runner.dispatch({ agent: "reg", prompt: "x", dispatcher: "claw" }));
+    at(runs, 0).resolve({ exitCode: 0, resultText: "done" });
+    await flush();
+    expect(runner.cancel(id)).toEqual({ ok: false, error: "job already done" });
+    expect(runner.cancel("nope")).toEqual({ ok: false, error: "unknown job" });
+  });
+
+  it("stop() aborts everything in flight and refuses new dispatch", () => {
+    const { runner, runs } = harness();
+    runner.dispatch({ agent: "reg", prompt: "x", dispatcher: "claw" });
+    runner.stop();
+    expect(at(runs, 0).aborted).toBe(true);
+    expect(runner.dispatch({ agent: "reg", prompt: "y", dispatcher: "claw" })).toEqual({
+      error: "job runner is stopped",
+    });
+  });
+});

--- a/src/bus/__tests__/agent-jobs.test.ts
+++ b/src/bus/__tests__/agent-jobs.test.ts
@@ -98,6 +98,22 @@ describe("AgentJobRunner.dispatch", () => {
     });
   });
 
+  it("cancelling a queued job frees a maxQueued slot while the worker stays busy (Codex review)", () => {
+    const { runner } = harness({ ...DEFAULT_AGENT_JOB_CONFIG, maxConcurrent: 1, maxQueued: 1 });
+    runner.dispatch({ agent: "reg", prompt: "a", dispatcher: "claw" }); // running (fills worker)
+    const q = jobIdOf(runner.dispatch({ agent: "reg", prompt: "b", dispatcher: "claw" })); // queued
+    // Queue is full → a third is rejected.
+    expect(runner.dispatch({ agent: "reg", prompt: "c", dispatcher: "claw" })).toEqual({
+      error: "job queue is full (max 1)",
+    });
+    // Cancelling the queued job must remove it from the queue so capacity frees
+    // up — even though the single worker is STILL running job "a".
+    expect(runner.cancel(q)).toEqual({ ok: true });
+    expect("jobId" in runner.dispatch({ agent: "reg", prompt: "c", dispatcher: "claw" })).toBe(
+      true,
+    );
+  });
+
   it("evicts oldest TERMINAL records past maxRetained (never a live one)", async () => {
     // maxConcurrent 1, maxRetained 2. Run 3 jobs to completion sequentially.
     const { runner, runs } = harness({

--- a/src/bus/__tests__/agent-jobs.test.ts
+++ b/src/bus/__tests__/agent-jobs.test.ts
@@ -61,10 +61,11 @@ describe("AgentJobRunner.dispatch", () => {
     expect(runs).toHaveLength(1); // started synchronously, not awaited
   });
 
-  it("rejects unknown agent and empty agent/prompt", () => {
+  it("rejects unknown agent and empty agent/prompt/dispatcher", () => {
     const { runner } = harness();
+    // Security review #296 PR 3: the error must NOT echo the raw caller input.
     expect(runner.dispatch({ agent: "nope", prompt: "x", dispatcher: "claw" })).toEqual({
-      error: "unknown agent: nope",
+      error: "unknown agent",
     });
     expect(runner.dispatch({ agent: "", prompt: "x", dispatcher: "claw" })).toEqual({
       error: "agent is required",
@@ -72,6 +73,48 @@ describe("AgentJobRunner.dispatch", () => {
     expect(runner.dispatch({ agent: "reg", prompt: "  ", dispatcher: "claw" })).toEqual({
       error: "prompt is required",
     });
+    expect(runner.dispatch({ agent: "reg", prompt: "x", dispatcher: "  " })).toEqual({
+      error: "dispatcher is required",
+    });
+  });
+
+  it("rejects a prompt over maxPromptChars (DoS bound)", () => {
+    const { runner } = harness({ ...DEFAULT_AGENT_JOB_CONFIG, maxPromptChars: 10 });
+    const r = runner.dispatch({ agent: "reg", prompt: "x".repeat(11), dispatcher: "claw" });
+    expect(r).toEqual({ error: "prompt exceeds 10-char limit" });
+  });
+
+  it("rejects dispatch once the queue is full (maxQueued)", () => {
+    // maxConcurrent 1 → 1 running; maxQueued 1 → 1 waiting; the 3rd is rejected.
+    const { runner } = harness({ ...DEFAULT_AGENT_JOB_CONFIG, maxConcurrent: 1, maxQueued: 1 });
+    expect("jobId" in runner.dispatch({ agent: "reg", prompt: "a", dispatcher: "claw" })).toBe(
+      true,
+    );
+    expect("jobId" in runner.dispatch({ agent: "reg", prompt: "b", dispatcher: "claw" })).toBe(
+      true,
+    );
+    expect(runner.dispatch({ agent: "reg", prompt: "c", dispatcher: "claw" })).toEqual({
+      error: "job queue is full (max 1)",
+    });
+  });
+
+  it("evicts oldest TERMINAL records past maxRetained (never a live one)", async () => {
+    // maxConcurrent 1, maxRetained 2. Run 3 jobs to completion sequentially.
+    const { runner, runs } = harness({
+      ...DEFAULT_AGENT_JOB_CONFIG,
+      maxConcurrent: 1,
+      maxRetained: 2,
+    });
+    const ids: string[] = [];
+    for (let i = 0; i < 3; i++) {
+      ids.push(jobIdOf(runner.dispatch({ agent: "reg", prompt: `p${i}`, dispatcher: "claw" })));
+      at(runs, i).resolve({ exitCode: 0, resultText: `r${i}` });
+      await flush();
+    }
+    // Registry bounded to 2; the oldest (job-1) was evicted, newest two remain.
+    expect(runner.list()).toHaveLength(2);
+    expect(runner.status(ids[0])).toBeNull();
+    expect(runner.status(ids[2])?.status).toBe("done");
   });
 });
 

--- a/src/bus/__tests__/runtime-mount.test.ts
+++ b/src/bus/__tests__/runtime-mount.test.ts
@@ -83,6 +83,9 @@ function createFakeBus(opts: FakeBusOptions = {}): FakeBus {
     // care about ordering observe via the `events` buffer in
     // setSlashCommandHandler.
     setStreamPromptHandler() {},
+    // #296 PR 3 contract — runtime-mount installs the agent-job handler on
+    // start and detaches it on stop. No-op fake.
+    setJobHandler() {},
     // #222 reconciliation contract — runtime-mount installs the reconciler
     // signal handler on start. No-op fake.
     setMcpSendFailedHandler(h) {

--- a/src/bus/agent-jobs.ts
+++ b/src/bus/agent-jobs.ts
@@ -65,6 +65,46 @@ export const DEFAULT_AGENT_JOB_CONFIG: AgentJobConfig = {
   maxTimeoutMs: 60 * 60_000, // 60 min hard cap
 };
 
+/**
+ * Parse `settings.agentJobs` from raw JSON, clamping to sane bounds and
+ * falling back to {@link DEFAULT_AGENT_JOB_CONFIG} for any missing/invalid
+ * field. Mirrors `parseStallWatchdogConfig` — the bus module owns its config
+ * shape so `config.ts` just imports this. `defaultTimeoutMs` is never allowed
+ * to exceed `maxTimeoutMs` (an operator raising only the default shouldn't
+ * silently blow past the hard cap).
+ */
+export function parseAgentJobConfig(raw: unknown): AgentJobConfig {
+  const r = (raw ?? {}) as Partial<Record<keyof AgentJobConfig, unknown>>;
+  const num = (v: unknown, fallback: number, min: number): number =>
+    typeof v === "number" && Number.isFinite(v) && v >= min ? v : fallback;
+  const maxConcurrent = Math.floor(num(r.maxConcurrent, DEFAULT_AGENT_JOB_CONFIG.maxConcurrent, 1));
+  const maxTimeoutMs = num(r.maxTimeoutMs, DEFAULT_AGENT_JOB_CONFIG.maxTimeoutMs, 1_000);
+  const defaultTimeoutMs = Math.min(
+    num(r.defaultTimeoutMs, DEFAULT_AGENT_JOB_CONFIG.defaultTimeoutMs, 1_000),
+    maxTimeoutMs,
+  );
+  return { maxConcurrent, defaultTimeoutMs, maxTimeoutMs };
+}
+
+/**
+ * The daemon-facing surface of the job runner — the four operations Bus core
+ * routes an `IpcJobRequest` to. {@link AgentJobRunner} implements it; Bus core
+ * depends only on this interface so it stays decoupled from the runner's
+ * process-spawning internals (and tests can inject a fake).
+ */
+export interface AgentJobHandler {
+  dispatch(input: {
+    agent: string;
+    prompt: string;
+    dispatcher: string;
+    model?: string;
+    timeoutMs?: number;
+  }): { jobId: string; status: JobStatus } | { error: string };
+  status(jobId: string): JobView | null;
+  list(): JobView[];
+  cancel(jobId: string): { ok: boolean; error?: string };
+}
+
 export interface JobRunResult {
   exitCode: number;
   resultText?: string;
@@ -94,7 +134,7 @@ export interface AgentJobDeps {
   genId(): string;
 }
 
-export class AgentJobRunner {
+export class AgentJobRunner implements AgentJobHandler {
   private readonly jobs = new Map<string, JobRecord>();
   private readonly controllers = new Map<string, AbortController>();
   private readonly queue: string[] = [];

--- a/src/bus/agent-jobs.ts
+++ b/src/bus/agent-jobs.ts
@@ -260,6 +260,12 @@ export class AgentJobRunner implements AgentJobHandler {
       controller.abort(); // running → the runAgentJob rejection/resolution flows into finish()
     } else if (!wasRunning) {
       // queued cancel: it never started, so finish() won't run — deliver + move on here.
+      // Remove it from the queue too (Codex review): maybeStart() only drains
+      // cancelled ids when a slot is free, so while all workers are busy a
+      // lingering cancelled id would inflate this.queue.length and make the
+      // maxQueued check phantom-reject new dispatches.
+      const qi = this.queue.indexOf(jobId);
+      if (qi >= 0) this.queue.splice(qi, 1);
       this.deliver(rec);
       this.maybeStart();
     }

--- a/src/bus/agent-jobs.ts
+++ b/src/bus/agent-jobs.ts
@@ -1,0 +1,261 @@
+/**
+ * AgentJobRunner — a first-class background "agent job" primitive for the bus.
+ *
+ * The root cause of the #295 outage: an agent (Claw) needed to run another agent
+ * (reg/suzy) as a long autonomous BATCH job, but the bus only offers interactive
+ * turn-based sessions and no dispatch tool, so Claw hand-rolled `/tmp` fire-scripts
+ * that `Bun.spawn(["claude","-p",…])` and backgrounded them with `nohup … &` — which
+ * held the tool's pipe and wedged the session for ~11h.
+ *
+ * This gives jobs a supported home: `dispatch()` registers a job and returns its id
+ * IMMEDIATELY (fire-and-return — the caller never awaits, which is exactly what
+ * wedged #295). The job runs headless in its own tracked process (injected
+ * `runAgentJob`, wired to `runClaudeOnce` + `loadAgentPrompts`), bounded by a
+ * concurrency cap, cancellable, and its result delivered back to the dispatcher
+ * AND kept queryable. In-memory only (a restart cancels in-flight jobs — matches
+ * the scheduler + restart-rotation model). SPEC: `.planning/agent-job-primitive/SPEC.md`.
+ */
+
+export type JobStatus = "queued" | "running" | "done" | "failed" | "cancelled" | "timeout";
+
+const TERMINAL: ReadonlySet<JobStatus> = new Set(["done", "failed", "cancelled", "timeout"]);
+
+interface JobRecord {
+  jobId: string;
+  agent: string;
+  dispatcher: string;
+  prompt: string;
+  model?: string;
+  timeoutMs: number;
+  status: JobStatus;
+  createdAt: number;
+  startedAt?: number;
+  endedAt?: number;
+  exitCode?: number;
+  resultText?: string;
+  error?: string;
+}
+
+/** Public snapshot of a job (omits the prompt/model to keep it lean). */
+export interface JobView {
+  jobId: string;
+  agent: string;
+  dispatcher: string;
+  status: JobStatus;
+  createdAt: number;
+  startedAt?: number;
+  endedAt?: number;
+  exitCode?: number;
+  resultText?: string;
+  error?: string;
+}
+
+export interface AgentJobConfig {
+  /** Max jobs running at once; excess queue (a low-spec box can't be swamped). */
+  maxConcurrent: number;
+  /** Default per-job wall-clock, when the caller doesn't specify one. */
+  defaultTimeoutMs: number;
+  /** Hard cap on any job's wall-clock, even if the caller asks for more. */
+  maxTimeoutMs: number;
+}
+
+export const DEFAULT_AGENT_JOB_CONFIG: AgentJobConfig = {
+  maxConcurrent: 3,
+  defaultTimeoutMs: 30 * 60_000, // 30 min
+  maxTimeoutMs: 60 * 60_000, // 60 min hard cap
+};
+
+export interface JobRunResult {
+  exitCode: number;
+  resultText?: string;
+  error?: string;
+  /** True if the run hit its wall-clock timeout. */
+  timedOut?: boolean;
+}
+
+export interface AgentJobDeps {
+  /** Run the agent headless (wraps `runClaudeOnce` + `loadAgentPrompts`). MUST honour
+   *  the AbortSignal — kill the process when it aborts (cancel / stop). */
+  runAgentJob(input: {
+    jobId: string;
+    agent: string;
+    prompt: string;
+    model?: string;
+    timeoutMs: number;
+    signal: AbortSignal;
+  }): Promise<JobRunResult>;
+  /** Is `agent` a known agent that can run a job? */
+  isKnownAgent(agent: string): boolean;
+  /** Deliver a finished job's result back to the dispatcher (decision 1a). Best-effort. */
+  deliverResult(job: JobView): void;
+  /** Clock seam (tests inject a deterministic clock). */
+  now(): number;
+  /** Job-id generator (test seam). */
+  genId(): string;
+}
+
+export class AgentJobRunner {
+  private readonly jobs = new Map<string, JobRecord>();
+  private readonly controllers = new Map<string, AbortController>();
+  private readonly queue: string[] = [];
+  private runningCount = 0;
+  private stopped = false;
+
+  constructor(
+    private readonly config: AgentJobConfig,
+    private readonly deps: AgentJobDeps,
+  ) {}
+
+  /**
+   * Register a job and return its id IMMEDIATELY. The job runs in the background
+   * (or queues if at the concurrency cap). Never awaits the job.
+   */
+  dispatch(input: {
+    agent: string;
+    prompt: string;
+    dispatcher: string;
+    model?: string;
+    timeoutMs?: number;
+  }): { jobId: string; status: JobStatus } | { error: string } {
+    if (this.stopped) return { error: "job runner is stopped" };
+    const agent = (input.agent ?? "").trim();
+    const prompt = (input.prompt ?? "").trim();
+    if (!agent) return { error: "agent is required" };
+    if (!prompt) return { error: "prompt is required" };
+    if (!this.deps.isKnownAgent(agent)) return { error: `unknown agent: ${agent}` };
+
+    const timeoutMs = Math.min(
+      Math.max(input.timeoutMs ?? this.config.defaultTimeoutMs, 1_000),
+      this.config.maxTimeoutMs,
+    );
+    const jobId = this.deps.genId();
+    this.jobs.set(jobId, {
+      jobId,
+      agent,
+      dispatcher: input.dispatcher,
+      prompt,
+      model: input.model,
+      timeoutMs,
+      status: "queued",
+      createdAt: this.deps.now(),
+    });
+    this.queue.push(jobId);
+    this.maybeStart();
+    return { jobId, status: this.jobs.get(jobId)?.status ?? "queued" };
+  }
+
+  status(jobId: string): JobView | null {
+    const rec = this.jobs.get(jobId);
+    return rec ? this.view(rec) : null;
+  }
+
+  list(): JobView[] {
+    return [...this.jobs.values()].map((r) => this.view(r));
+  }
+
+  /** Cancel a queued or running job. Terminal jobs return an error. */
+  cancel(jobId: string): { ok: boolean; error?: string } {
+    const rec = this.jobs.get(jobId);
+    if (!rec) return { ok: false, error: "unknown job" };
+    if (TERMINAL.has(rec.status)) return { ok: false, error: `job already ${rec.status}` };
+
+    const wasRunning = rec.status === "running";
+    rec.status = "cancelled";
+    rec.endedAt = this.deps.now();
+    const controller = this.controllers.get(jobId);
+    if (controller) {
+      controller.abort(); // running → the runAgentJob rejection/resolution flows into finish()
+    } else if (!wasRunning) {
+      // queued cancel: it never started, so finish() won't run — deliver + move on here.
+      this.deliver(rec);
+      this.maybeStart();
+    }
+    return { ok: true };
+  }
+
+  /** Stop the runner: cancel everything in flight + clear the queue. */
+  stop(): void {
+    this.stopped = true;
+    for (const c of this.controllers.values()) c.abort();
+    this.queue.length = 0;
+  }
+
+  private maybeStart(): void {
+    while (
+      !this.stopped &&
+      this.runningCount < this.config.maxConcurrent &&
+      this.queue.length > 0
+    ) {
+      const jobId = this.queue.shift();
+      if (jobId === undefined) break;
+      const rec = this.jobs.get(jobId);
+      if (!rec || rec.status !== "queued") continue; // cancelled while queued → skip
+      this.startJob(rec);
+    }
+  }
+
+  private startJob(rec: JobRecord): void {
+    rec.status = "running";
+    rec.startedAt = this.deps.now();
+    this.runningCount++;
+    const controller = new AbortController();
+    this.controllers.set(rec.jobId, controller);
+    this.deps
+      .runAgentJob({
+        jobId: rec.jobId,
+        agent: rec.agent,
+        prompt: rec.prompt,
+        model: rec.model,
+        timeoutMs: rec.timeoutMs,
+        signal: controller.signal,
+      })
+      .then(
+        (r) => this.finish(rec.jobId, r),
+        (err) =>
+          this.finish(rec.jobId, {
+            exitCode: -1,
+            error: err instanceof Error ? err.message : String(err),
+          }),
+      );
+  }
+
+  private finish(jobId: string, r: JobRunResult): void {
+    const rec = this.jobs.get(jobId);
+    if (!rec) return;
+    this.controllers.delete(jobId);
+    // A cancel that raced in already set the terminal state — don't overwrite it.
+    if (rec.status !== "cancelled") {
+      rec.status = r.timedOut ? "timeout" : r.error ? "failed" : "done";
+      rec.exitCode = r.exitCode;
+      rec.resultText = r.resultText;
+      rec.error = r.error;
+    }
+    if (rec.endedAt === undefined) rec.endedAt = this.deps.now();
+    this.runningCount = Math.max(0, this.runningCount - 1);
+    this.deliver(rec);
+    this.maybeStart();
+  }
+
+  private deliver(rec: JobRecord): void {
+    try {
+      this.deps.deliverResult(this.view(rec));
+    } catch {
+      /* delivery is best-effort — never let it break the runner */
+    }
+  }
+
+  private view(rec: JobRecord): JobView {
+    return {
+      jobId: rec.jobId,
+      agent: rec.agent,
+      dispatcher: rec.dispatcher,
+      status: rec.status,
+      createdAt: rec.createdAt,
+      startedAt: rec.startedAt,
+      endedAt: rec.endedAt,
+      exitCode: rec.exitCode,
+      resultText: rec.resultText,
+      error: rec.error,
+    };
+  }
+}

--- a/src/bus/agent-jobs.ts
+++ b/src/bus/agent-jobs.ts
@@ -57,12 +57,29 @@ export interface AgentJobConfig {
   defaultTimeoutMs: number;
   /** Hard cap on any job's wall-clock, even if the caller asks for more. */
   maxTimeoutMs: number;
+  /**
+   * Max jobs allowed to sit in the queue at once. A dispatch past this is
+   * rejected rather than queued (security review #296 PR 3: an agent looping
+   * `dispatch_job` must not grow the queue unbounded → OOM).
+   */
+  maxQueued: number;
+  /**
+   * Max total job RECORDS retained in the registry. Terminal jobs are evicted
+   * oldest-first past this cap so completed records (which hold prompt +
+   * resultText) can't accumulate for the daemon's lifetime.
+   */
+  maxRetained: number;
+  /** Max characters in a job prompt; a longer dispatch is rejected. */
+  maxPromptChars: number;
 }
 
 export const DEFAULT_AGENT_JOB_CONFIG: AgentJobConfig = {
   maxConcurrent: 3,
   defaultTimeoutMs: 30 * 60_000, // 30 min
   maxTimeoutMs: 60 * 60_000, // 60 min hard cap
+  maxQueued: 50,
+  maxRetained: 200,
+  maxPromptChars: 100_000,
 };
 
 /**
@@ -83,7 +100,12 @@ export function parseAgentJobConfig(raw: unknown): AgentJobConfig {
     num(r.defaultTimeoutMs, DEFAULT_AGENT_JOB_CONFIG.defaultTimeoutMs, 1_000),
     maxTimeoutMs,
   );
-  return { maxConcurrent, defaultTimeoutMs, maxTimeoutMs };
+  const maxQueued = Math.floor(num(r.maxQueued, DEFAULT_AGENT_JOB_CONFIG.maxQueued, 1));
+  const maxRetained = Math.floor(num(r.maxRetained, DEFAULT_AGENT_JOB_CONFIG.maxRetained, 1));
+  const maxPromptChars = Math.floor(
+    num(r.maxPromptChars, DEFAULT_AGENT_JOB_CONFIG.maxPromptChars, 1),
+  );
+  return { maxConcurrent, defaultTimeoutMs, maxTimeoutMs, maxQueued, maxRetained, maxPromptChars };
 }
 
 /**
@@ -158,11 +180,22 @@ export class AgentJobRunner implements AgentJobHandler {
     timeoutMs?: number;
   }): { jobId: string; status: JobStatus } | { error: string } {
     if (this.stopped) return { error: "job runner is stopped" };
+    const dispatcher = (input.dispatcher ?? "").trim();
     const agent = (input.agent ?? "").trim();
     const prompt = (input.prompt ?? "").trim();
+    if (!dispatcher) return { error: "dispatcher is required" };
     if (!agent) return { error: "agent is required" };
     if (!prompt) return { error: "prompt is required" };
-    if (!this.deps.isKnownAgent(agent)) return { error: `unknown agent: ${agent}` };
+    if (prompt.length > this.config.maxPromptChars) {
+      return { error: `prompt exceeds ${this.config.maxPromptChars}-char limit` };
+    }
+    if (!this.deps.isKnownAgent(agent)) return { error: "unknown agent" };
+    // Bound the queue so a caller looping dispatch can't grow it unbounded
+    // (security review #296 PR 3). Running jobs are capped separately by
+    // maxConcurrent; this caps the WAITING backlog.
+    if (this.queue.length >= this.config.maxQueued) {
+      return { error: `job queue is full (max ${this.config.maxQueued})` };
+    }
 
     const timeoutMs = Math.min(
       Math.max(input.timeoutMs ?? this.config.defaultTimeoutMs, 1_000),
@@ -172,7 +205,7 @@ export class AgentJobRunner implements AgentJobHandler {
     this.jobs.set(jobId, {
       jobId,
       agent,
-      dispatcher: input.dispatcher,
+      dispatcher,
       prompt,
       model: input.model,
       timeoutMs,
@@ -180,8 +213,28 @@ export class AgentJobRunner implements AgentJobHandler {
       createdAt: this.deps.now(),
     });
     this.queue.push(jobId);
+    this.evictOldTerminal();
     this.maybeStart();
     return { jobId, status: this.jobs.get(jobId)?.status ?? "queued" };
+  }
+
+  /**
+   * Bound registry memory: when total records exceed `maxRetained`, drop the
+   * OLDEST terminal records (never a queued/running one — those are live).
+   * Terminal records hold prompt + resultText, so without this they'd
+   * accumulate for the daemon's lifetime (security review #296 PR 3).
+   */
+  private evictOldTerminal(): void {
+    let overBy = this.jobs.size - this.config.maxRetained;
+    if (overBy <= 0) return;
+    // Map preserves insertion order → iterating yields oldest-first.
+    for (const [id, rec] of this.jobs) {
+      if (overBy <= 0) break;
+      if (TERMINAL.has(rec.status)) {
+        this.jobs.delete(id);
+        overBy--;
+      }
+    }
   }
 
   status(jobId: string): JobView | null {
@@ -273,6 +326,7 @@ export class AgentJobRunner implements AgentJobHandler {
     if (rec.endedAt === undefined) rec.endedAt = this.deps.now();
     this.runningCount = Math.max(0, this.runningCount - 1);
     this.deliver(rec);
+    this.evictOldTerminal();
     this.maybeStart();
   }
 

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -53,7 +53,28 @@ import type {
   PermissionResponse,
 } from "./types";
 import { CHANNEL_DRIVEN_ORIGINS } from "./types";
-import type { AgentJobHandler } from "./agent-jobs";
+import type { AgentJobHandler, JobView } from "./agent-jobs";
+
+/**
+ * Map a `JobView` to the snake_case shape agents see over the tools (#296 PR 3
+ * Codex review). The `dispatch_job` contract and `job_status`/`list_jobs`/
+ * `cancel_job` all speak `job_id`, so the wire representation must too — the
+ * runner's internal camelCase (`jobId`, `createdAt`, …) never leaks to agents.
+ */
+function toWireJobView(v: JobView): Record<string, unknown> {
+  return {
+    job_id: v.jobId,
+    agent: v.agent,
+    dispatcher: v.dispatcher,
+    status: v.status,
+    created_at: v.createdAt,
+    ...(v.startedAt !== undefined ? { started_at: v.startedAt } : {}),
+    ...(v.endedAt !== undefined ? { ended_at: v.endedAt } : {}),
+    ...(v.exitCode !== undefined ? { exit_code: v.exitCode } : {}),
+    ...(v.resultText !== undefined ? { result_text: v.resultText } : {}),
+    ...(v.error !== undefined ? { error: v.error } : {}),
+  };
+}
 import { evaluate, type PolicyDecision, type ToolRequestContext } from "../policy/engine";
 
 /** Escape XML text content (`&`, `<`, `>`) so a `</channel>` in user text
@@ -1303,16 +1324,25 @@ export class BusCoreImpl implements BusCore {
             ...(typeof payload.model === "string" ? { model: payload.model } : {}),
             ...(typeof payload.timeoutMs === "number" ? { timeoutMs: payload.timeoutMs } : {}),
           });
-          this.sendJobResult(agentId, msg.req_id, { ok: true, result });
+          // Present the id as snake_case `job_id` to match the tool contract and
+          // the follow-up tools (Codex review); pass `{ error }` through as-is.
+          const wire = "jobId" in result ? { job_id: result.jobId, status: result.status } : result;
+          this.sendJobResult(agentId, msg.req_id, { ok: true, result: wire });
           return;
         }
         case "status": {
           const result = handler.status(typeof payload.job_id === "string" ? payload.job_id : "");
-          this.sendJobResult(agentId, msg.req_id, { ok: true, result });
+          this.sendJobResult(agentId, msg.req_id, {
+            ok: true,
+            result: result ? toWireJobView(result) : null,
+          });
           return;
         }
         case "list": {
-          this.sendJobResult(agentId, msg.req_id, { ok: true, result: handler.list() });
+          this.sendJobResult(agentId, msg.req_id, {
+            ok: true,
+            result: handler.list().map(toWireJobView),
+          });
           return;
         }
         case "cancel": {

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -45,12 +45,15 @@ import type {
   BusEvent,
   BusEventTopic,
   BusOrigin,
+  IpcJobRequest,
+  IpcJobResult,
   IpcMessage,
   IpcPrompt,
   PermissionRequest,
   PermissionResponse,
 } from "./types";
 import { CHANNEL_DRIVEN_ORIGINS } from "./types";
+import type { AgentJobHandler } from "./agent-jobs";
 import { evaluate, type PolicyDecision, type ToolRequestContext } from "../policy/engine";
 
 /** Escape XML text content (`&`, `<`, `>`) so a `</channel>` in user text
@@ -160,6 +163,16 @@ export interface BusCoreOptions {
    * usable without the wiring (and in tests).
    */
   onMcpSendFailed?: (agentId: string, ctx: { reason: string }) => void;
+  /**
+   * Agent-job handler (issue #296 PR 3). Set by the daemon so inbound
+   * `job_request` IPC (from an agent's `dispatch_job`/`job_status`/`list_jobs`/
+   * `cancel_job` tool) routes to the daemon-resident `AgentJobRunner`. Omitted
+   * in tests / when agent jobs are disabled — a `job_request` then gets a clean
+   * "not enabled" error rather than a hang. Also settable post-hoc via
+   * `setJobHandler` (the runner needs `sendPrompt`, so it's constructed AFTER
+   * the bus — same late-binding pattern as `slashCommandHandler`).
+   */
+  jobHandler?: AgentJobHandler;
 }
 
 /* ───────────────────────────────────────────────────────────────────── */
@@ -178,6 +191,14 @@ export interface BusCore {
    */
   setSlashCommandHandler(handler: SlashCommandHandler | null): void;
   setStreamPromptHandler(handler: StreamPromptHandler | null): void;
+  /**
+   * Install or replace the agent-job handler (#296 PR 3). The daemon wires
+   * this once the `AgentJobRunner` is constructed (which needs `sendPrompt`,
+   * so it can't be a constructor-only option). Pass `null` to detach on
+   * teardown. When unset, inbound `job_request` IPC is answered with a clean
+   * "agent jobs not enabled" error.
+   */
+  setJobHandler(handler: AgentJobHandler | null): void;
   /**
    * Install or replace the #222 reconciliation signal handler. Wired by the
    * bus runtime once the Session Manager is available. Pass `null` to detach
@@ -212,6 +233,10 @@ export class BusCoreImpl implements BusCore {
   private readonly eventLogAppend: EventLogAppendFn;
   private slashCommandHandler: SlashCommandHandler | null;
   private streamPromptHandler: StreamPromptHandler | null;
+  // Settable post-hoc (like streamPromptHandler): the AgentJobRunner needs
+  // `sendPrompt` for result delivery, so the daemon constructs it after the
+  // bus and wires it via setJobHandler (#296 PR 3).
+  private jobHandler: AgentJobHandler | null;
   private readonly onError: (err: unknown, ctx?: Record<string, unknown>) => void;
   private readonly evaluatePolicy: (ctx: ToolRequestContext) => PolicyDecision;
   // Settable post-hoc (like streamPromptHandler): the bus is constructed
@@ -385,6 +410,7 @@ export class BusCoreImpl implements BusCore {
     this.eventLogAppend = opts.eventLogAppend ?? eventLogAppend;
     this.slashCommandHandler = opts.slashCommandHandler ?? null;
     this.streamPromptHandler = opts.streamPromptHandler ?? null;
+    this.jobHandler = opts.jobHandler ?? null;
     this.onError = opts.onError ?? ((err, ctx) => console.error("[bus]", err, ctx));
     this.evaluatePolicy = opts.evaluatePolicy ?? evaluate;
     if (opts.onMcpSendFailed) this.onMcpSendFailed = opts.onMcpSendFailed;
@@ -873,6 +899,10 @@ export class BusCoreImpl implements BusCore {
     this.streamPromptHandler = handler;
   }
 
+  setJobHandler(handler: AgentJobHandler | null): void {
+    this.jobHandler = handler;
+  }
+
   setMcpSendFailedHandler(
     handler: ((agentId: string, ctx: { reason: string }) => void) | null,
   ): void {
@@ -1240,9 +1270,93 @@ export class BusCoreImpl implements BusCore {
   }
 
   /**
+   * Handle an inbound agent-job control request (#296 PR 3). `agentId` is the
+   * DISPATCHER — the agent whose socket carried the request; we stamp it as the
+   * job's dispatcher rather than trusting any client-supplied value, so results
+   * route back to the caller and one agent can't dispatch as another. Always
+   * sends exactly one `job_result` (a missing handler / bad op / thrown error
+   * becomes `ok:false` — never a silent drop that would hang the caller).
+   */
+  private handleJobRequest(agentId: string, msg: IpcJobRequest): void {
+    const handler = this.jobHandler;
+    if (!handler) {
+      this.sendJobResult(agentId, msg.req_id, {
+        ok: false,
+        error: "agent jobs are not enabled on this daemon",
+      });
+      return;
+    }
+    const payload = (msg.payload ?? {}) as {
+      agent?: unknown;
+      prompt?: unknown;
+      model?: unknown;
+      timeoutMs?: unknown;
+      job_id?: unknown;
+    };
+    try {
+      switch (msg.op) {
+        case "dispatch": {
+          const result = handler.dispatch({
+            agent: typeof payload.agent === "string" ? payload.agent : "",
+            prompt: typeof payload.prompt === "string" ? payload.prompt : "",
+            dispatcher: agentId,
+            ...(typeof payload.model === "string" ? { model: payload.model } : {}),
+            ...(typeof payload.timeoutMs === "number" ? { timeoutMs: payload.timeoutMs } : {}),
+          });
+          this.sendJobResult(agentId, msg.req_id, { ok: true, result });
+          return;
+        }
+        case "status": {
+          const result = handler.status(typeof payload.job_id === "string" ? payload.job_id : "");
+          this.sendJobResult(agentId, msg.req_id, { ok: true, result });
+          return;
+        }
+        case "list": {
+          this.sendJobResult(agentId, msg.req_id, { ok: true, result: handler.list() });
+          return;
+        }
+        case "cancel": {
+          const result = handler.cancel(typeof payload.job_id === "string" ? payload.job_id : "");
+          this.sendJobResult(agentId, msg.req_id, { ok: true, result });
+          return;
+        }
+        default:
+          this.sendJobResult(agentId, msg.req_id, {
+            ok: false,
+            error: `unknown job op: ${String(msg.op)}`,
+          });
+          return;
+      }
+    } catch (err) {
+      this.onError(err, { ctx: "job_request", op: msg.op, agent_id: agentId });
+      this.sendJobResult(agentId, msg.req_id, {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /** Send a correlated `job_result` back to the dispatching agent (#296 PR 3). */
+  private sendJobResult(
+    agentId: string,
+    reqId: string,
+    r: { ok: boolean; result?: unknown; error?: string },
+  ): void {
+    if (!this.ipcServer) return;
+    const msg: IpcJobResult = {
+      type: "job_result",
+      req_id: reqId,
+      ok: r.ok,
+      ...(r.result !== undefined ? { result: r.result } : {}),
+      ...(r.error !== undefined ? { error: r.error } : {}),
+    };
+    this.ipcServer.send(agentId, msg);
+  }
+
+  /**
    * Route messages received from the Bus MCP into the right ingest path.
    * Per spec §5.4, the Bus core handles `reply`, `ask`, `cancel`,
-   * `request_human`, and `permission_request` inbound from MCP.
+   * `request_human`, `job_request`, and `permission_request` inbound from MCP.
    */
   private handleIpcMessage(agentId: string, msg: IpcMessage): void {
     switch (msg.type) {
@@ -1324,6 +1438,13 @@ export class BusCoreImpl implements BusCore {
         });
         break;
       }
+      case "job_request":
+        // #296 PR 3: an agent's dispatch_job/job_status/list_jobs/cancel_job
+        // tool routes here over IPC. The AgentJobRunner lives in the daemon
+        // (only it spawns/tracks the headless `claude -p` job processes); we
+        // run the op and send back a correlated `job_result`.
+        this.handleJobRequest(agentId, msg);
+        break;
       case "permission_request": {
         // Same origin-propagation fix as request_human above: the
         // request_id-bearing payload now also carries the originating

--- a/src/bus/mcp-server.ts
+++ b/src/bus/mcp-server.ts
@@ -51,6 +51,8 @@ import {
   type IpcAskAnswer,
   type IpcCancel,
   type IpcHello,
+  type IpcJobRequest,
+  type IpcJobResult,
   type IpcMessage,
   type IpcPermissionRequest,
   type IpcPermissionResponse,
@@ -279,6 +281,26 @@ const RequestHumanArgsSchema = z.object({
   question: z.string(),
 });
 
+const DispatchJobArgsSchema = z.object({
+  agent: z.string(),
+  prompt: z.string(),
+  model: z.string().optional(),
+  timeoutMs: z.number().optional(),
+});
+
+const JobIdArgsSchema = z.object({
+  job_id: z.string(),
+});
+
+/**
+ * Bound on how long a job-control call waits for Bus core's `IpcJobResult`.
+ * All four ops resolve SYNCHRONOUSLY in the daemon runner, so a reply is
+ * effectively immediate; this only fires if the daemon died or dropped the
+ * frame. Bounded (not open-ended like `request_human`) precisely because the
+ * whole point of the primitive is that a job call can NEVER wedge the turn.
+ */
+const JOB_REQUEST_TIMEOUT_MS = 30_000;
+
 /* ───────────────────────────────────────────────────────────────────── */
 /* BusMcpServer — wiring logic, transport-agnostic                       */
 /* ───────────────────────────────────────────────────────────────────── */
@@ -385,6 +407,14 @@ export class BusMcpServer {
 
   private readonly pendingAnswers = new Map<string, PendingAnswer>();
 
+  /**
+   * Pending job-control calls keyed by `req_id`. Each of the four job tools
+   * mints a `req_id`, registers its resolver here, sends an `IpcJobRequest`,
+   * and awaits — the correlated `IpcJobResult` from Bus core resolves it.
+   * Mirrors {@link pendingAnswers} for the `request_human` round-trip.
+   */
+  private readonly pendingJobRequests = new Map<string, (result: IpcJobResult) => void>();
+
   constructor(opts: BusMcpServerOptions) {
     this.agentId = opts.agentId;
     this.ipc = opts.ipc;
@@ -440,6 +470,14 @@ export class BusMcpServer {
           return this.handleCancel(rawArgs);
         case "request_human":
           return this.handleRequestHuman(rawArgs);
+        case "dispatch_job":
+          return this.handleDispatchJob(rawArgs);
+        case "job_status":
+          return this.handleJobStatus(rawArgs);
+        case "list_jobs":
+          return this.handleListJobs();
+        case "cancel_job":
+          return this.handleCancelJob(rawArgs);
         default:
           return {
             content: [{ type: "text", text: `Unknown tool: ${name}` }],
@@ -522,6 +560,9 @@ export class BusMcpServer {
         case "permission_response":
           this.deliverPermissionResponse(msg);
           return;
+        case "job_result":
+          this.deliverJobResult(msg);
+          return;
         // Bus core never sends these to the plugin in normal operation;
         // log and ignore for forward-compat.
         default:
@@ -598,6 +639,13 @@ export class BusMcpServer {
       .catch((err: unknown) => {
         process.stderr.write(`Bus MCP: permission notification failed: ${String(err)}\n`);
       });
+  }
+
+  private deliverJobResult(msg: IpcJobResult): void {
+    const resolve = this.pendingJobRequests.get(msg.req_id);
+    if (!resolve) return; // unknown / already-settled (timeout raced) — drop.
+    this.pendingJobRequests.delete(msg.req_id);
+    resolve(msg);
   }
 
   /* ── Tool handlers ──────────────────────────────────────────────── */
@@ -689,6 +737,90 @@ export class BusMcpServer {
     return {
       content: [{ type: "text", text: answer }],
     };
+  }
+
+  /* ── Agent-job tool handlers (issue #296 PR 3) ──────────────────── */
+
+  /**
+   * Route one job-control op to Bus core and await the correlated result.
+   * The `AgentJobRunner` lives in the daemon, so these tools can't touch it
+   * directly — they mint a `req_id`, register a resolver, send the
+   * `IpcJobRequest`, and await the matching `IpcJobResult`. A timeout guards
+   * against a dead daemon so a job call can never wedge the caller's turn.
+   */
+  private jobRequest(
+    op: IpcJobRequest["op"],
+    payload: Record<string, unknown>,
+  ): Promise<IpcJobResult> {
+    const reqId = randomUUID();
+    return new Promise<IpcJobResult>((resolve) => {
+      const timer = setTimeout(() => {
+        this.pendingJobRequests.delete(reqId);
+        resolve({
+          type: "job_result",
+          req_id: reqId,
+          ok: false,
+          error: "job request timed out — no response from Bus core",
+        });
+      }, JOB_REQUEST_TIMEOUT_MS);
+      // Don't let a stray timer keep the process alive if everything else is done.
+      timer.unref?.();
+      this.pendingJobRequests.set(reqId, (result) => {
+        clearTimeout(timer);
+        resolve(result);
+      });
+      const ipcMsg: IpcJobRequest = {
+        type: "job_request",
+        agent_id: this.agentId,
+        req_id: reqId,
+        op,
+        payload,
+      };
+      this.ipc.send(ipcMsg);
+    });
+  }
+
+  /** Serialise an `IpcJobResult` back to the calling agent as the tool result. */
+  private jobResultContent(res: IpcJobResult) {
+    if (!res.ok) {
+      return {
+        content: [
+          { type: "text", text: JSON.stringify({ error: res.error ?? "job request failed" }) },
+        ],
+        isError: true,
+      };
+    }
+    return {
+      content: [{ type: "text", text: JSON.stringify(res.result ?? null) }],
+    };
+  }
+
+  private async handleDispatchJob(raw: unknown) {
+    const args = DispatchJobArgsSchema.parse(raw ?? {});
+    const res = await this.jobRequest("dispatch", {
+      agent: args.agent,
+      prompt: args.prompt,
+      ...(args.model !== undefined ? { model: args.model } : {}),
+      ...(args.timeoutMs !== undefined ? { timeoutMs: args.timeoutMs } : {}),
+    });
+    return this.jobResultContent(res);
+  }
+
+  private async handleJobStatus(raw: unknown) {
+    const args = JobIdArgsSchema.parse(raw ?? {});
+    const res = await this.jobRequest("status", { job_id: args.job_id });
+    return this.jobResultContent(res);
+  }
+
+  private async handleListJobs() {
+    const res = await this.jobRequest("list", {});
+    return this.jobResultContent(res);
+  }
+
+  private async handleCancelJob(raw: unknown) {
+    const args = JobIdArgsSchema.parse(raw ?? {});
+    const res = await this.jobRequest("cancel", { job_id: args.job_id });
+    return this.jobResultContent(res);
   }
 }
 

--- a/src/bus/mcp-server.ts
+++ b/src/bus/mcp-server.ts
@@ -282,9 +282,11 @@ const RequestHumanArgsSchema = z.object({
 });
 
 const DispatchJobArgsSchema = z.object({
-  agent: z.string(),
-  prompt: z.string(),
-  model: z.string().optional(),
+  // Bounds are early client-side feedback; Bus core's AgentJobRunner re-enforces
+  // the configured caps authoritatively (security review #296 PR 3).
+  agent: z.string().max(128),
+  prompt: z.string().max(100_000),
+  model: z.string().max(64).optional(),
   timeoutMs: z.number().optional(),
 });
 

--- a/src/bus/mcp-tools.ts
+++ b/src/bus/mcp-tools.ts
@@ -82,4 +82,53 @@ export const BUS_MCP_TOOLS = [
       required: ["question"],
     },
   },
+  {
+    name: "dispatch_job",
+    description:
+      "Dispatch a background job to another agent (e.g. run `reg`/`suzy` on a long " +
+      "research/draft task). Fire-and-return: returns a `job_id` IMMEDIATELY and the " +
+      "job runs headless in its own process — never blocks your turn. The result is " +
+      "delivered back to you when it finishes, and is queryable via `job_status`. Use " +
+      "this instead of shelling out to `claude -p` yourself.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        agent: { type: "string", description: "Name of the agent to run the job." },
+        prompt: { type: "string", description: "The task for that agent." },
+        model: { type: "string", description: "Optional model override." },
+        timeoutMs: { type: "number", description: "Optional per-job wall-clock (capped)." },
+      },
+      required: ["agent", "prompt"],
+    },
+  },
+  {
+    name: "job_status",
+    description: "Get the status + result of a dispatched job by its `job_id`.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        job_id: { type: "string" },
+      },
+      required: ["job_id"],
+    },
+  },
+  {
+    name: "list_jobs",
+    description: "List all agent jobs and their statuses (queued/running/done/failed/…).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "cancel_job",
+    description: "Cancel a queued or running job by its `job_id` (kills the process).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        job_id: { type: "string" },
+      },
+      required: ["job_id"],
+    },
+  },
 ] as const;

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -34,7 +34,12 @@ import { join } from "node:path";
 import { randomUUID } from "node:crypto";
 import type { AgentConfig, BusOrigin } from "./types";
 import { BusCoreImpl, type BusCore } from "./core";
-import { AgentJobRunner, DEFAULT_AGENT_JOB_CONFIG, type AgentJobConfig } from "./agent-jobs";
+import {
+  AgentJobRunner,
+  DEFAULT_AGENT_JOB_CONFIG,
+  type AgentJobConfig,
+  type JobView,
+} from "./agent-jobs";
 import { runAgentJobHeadless } from "../runner";
 import { agentExists } from "../agents";
 import { SessionManager } from "./session-manager";
@@ -297,6 +302,69 @@ export function createRotateAgent(deps: RotateAgentDeps): (agentId: string) => P
 }
 
 /**
+ * Deliver a finished agent job back to its DISPATCHER (decision 1a) as a
+ * system-origin prompt, so it can act on / report the result — the loop the
+ * `/tmp` fire-scripts faked by tailing a log.
+ *
+ * Codex review (#296 PR 3): `bus.sendPrompt` overwrites the agent's single-slot
+ * prompt-origin bookkeeping. If we delivered while the dispatcher was mid-turn
+ * on a channel prompt (Discord/Web/…), its later `reply(final)` would be
+ * attributed to this `origin:"cron"` and misrouted/dropped. So we deliver
+ * immediately only when the dispatcher is idle; if it's mid-turn we defer to its
+ * next `response.turn_end`. Best-effort either way — the result is always
+ * queryable via `job_status`, so if the dispatcher never turns again we simply
+ * don't push (no clobber, no loss).
+ */
+export function deliverAgentJobResult(
+  bus: Pick<BusCore, "sendPrompt" | "isAgentTurnActive" | "subscribe">,
+  job: JobView,
+  logger: Pick<Console, "warn">,
+): void {
+  const detail = job.error ? `Error: ${job.error}` : (job.resultText ?? "(job produced no output)");
+  const send = (): void => {
+    void bus
+      .sendPrompt({
+        agent_id: job.dispatcher,
+        origin: "cron",
+        origin_id: `agent-job:${job.jobId}`,
+        user_id: "system",
+        text:
+          `Agent job ${job.jobId} (agent "${job.agent}") finished with status ` +
+          `"${job.status}".\n\n${detail}`,
+        metadata: {
+          kind: "agent_job_result",
+          job_id: job.jobId,
+          job_agent: job.agent,
+          job_status: job.status,
+        },
+      })
+      .catch((err) =>
+        logger.warn(`[bus-runtime] agent-job result delivery for ${job.jobId} failed`, err),
+      );
+  };
+
+  if (!bus.isAgentTurnActive(job.dispatcher)) {
+    send();
+    return;
+  }
+  // Mid-turn: defer to the dispatcher's next turn end so we never clobber the
+  // live prompt-origin. One-shot subscription.
+  let delivered = false;
+  const sub = bus.subscribe({ agent_id: job.dispatcher, topics: ["response.turn_end"] }, () => {
+    if (delivered) return;
+    delivered = true;
+    sub.close();
+    send();
+  });
+  // Race guard: the turn may have ended between the check and the subscribe.
+  if (!delivered && !bus.isAgentTurnActive(job.dispatcher)) {
+    delivered = true;
+    sub.close();
+    send();
+  }
+}
+
+/**
  * Mount the Bus runtime stack and return a teardown handle.
  *
  * Idempotency: each call returns a fresh handle. Callers must invoke
@@ -373,36 +441,7 @@ export async function mountBusRuntime(
     const jobRunner = new AgentJobRunner(agentJobConfig, {
       runAgentJob: (input) => runAgentJobHeadless(input),
       isKnownAgent: agentExists,
-      deliverResult: (job) => {
-        // Decision 1a: deliver the finished job back to the DISPATCHER as a
-        // system-origin prompt so it can act on / report the result — closing
-        // the loop the fire-scripts faked by tailing a log. `origin:"cron"`
-        // (a real, non-channel BusOrigin with `user_id:"system"`, mirroring the
-        // scheduler) keeps it off any user surface; the dispatcher decides how
-        // to surface it. Best-effort — the runner already guards this call.
-        const detail = job.error
-          ? `Error: ${job.error}`
-          : (job.resultText ?? "(job produced no output)");
-        void bus
-          .sendPrompt({
-            agent_id: job.dispatcher,
-            origin: "cron",
-            origin_id: `agent-job:${job.jobId}`,
-            user_id: "system",
-            text:
-              `Agent job ${job.jobId} (agent "${job.agent}") finished with status ` +
-              `"${job.status}".\n\n${detail}`,
-            metadata: {
-              kind: "agent_job_result",
-              job_id: job.jobId,
-              job_agent: job.agent,
-              job_status: job.status,
-            },
-          })
-          .catch((err) =>
-            logger.warn(`[bus-runtime] agent-job result delivery for ${job.jobId} failed`, err),
-          );
-      },
+      deliverResult: (job) => deliverAgentJobResult(bus, job, logger),
       now: Date.now,
       genId: () => randomUUID(),
     });

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -31,8 +31,12 @@
 
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { randomUUID } from "node:crypto";
 import type { AgentConfig, BusOrigin } from "./types";
 import { BusCoreImpl, type BusCore } from "./core";
+import { AgentJobRunner, DEFAULT_AGENT_JOB_CONFIG, type AgentJobConfig } from "./agent-jobs";
+import { runAgentJobHeadless } from "../runner";
+import { agentExists } from "../agents";
 import { SessionManager } from "./session-manager";
 import { wireSlashCommands } from "./wiring";
 import { createMcpReconciler } from "./mcp-reconciler";
@@ -352,6 +356,58 @@ export async function mountBusRuntime(
       }),
     );
 
+    // #296 PR 3 — agent-job primitive. Gives agents a supported `dispatch_job`
+    // instead of hand-rolling `/tmp` fire-scripts + `claude -p` + `nohup … &`
+    // (the shape that wedged the daemon for ~11h in #295). The runner lives
+    // HERE in the daemon (only it can spawn/track processes); `dispatch_job`
+    // etc. route over IPC to `handleJobRequest`. Fire-and-return, capped
+    // concurrency, hard timeout cap, dispatcher-validated agent — a job can
+    // never block the caller's turn or spawn an unknown agent. Wired BEFORE
+    // agent spawn so a just-spawned agent's first dispatch is never dropped.
+    let agentJobConfig: AgentJobConfig;
+    try {
+      agentJobConfig = getSettings().agentJobs;
+    } catch {
+      agentJobConfig = DEFAULT_AGENT_JOB_CONFIG; // settings not loaded (early boot / tests)
+    }
+    const jobRunner = new AgentJobRunner(agentJobConfig, {
+      runAgentJob: (input) => runAgentJobHeadless(input),
+      isKnownAgent: agentExists,
+      deliverResult: (job) => {
+        // Decision 1a: deliver the finished job back to the DISPATCHER as a
+        // system-origin prompt so it can act on / report the result — closing
+        // the loop the fire-scripts faked by tailing a log. `origin:"cron"`
+        // (a real, non-channel BusOrigin with `user_id:"system"`, mirroring the
+        // scheduler) keeps it off any user surface; the dispatcher decides how
+        // to surface it. Best-effort — the runner already guards this call.
+        const detail = job.error
+          ? `Error: ${job.error}`
+          : (job.resultText ?? "(job produced no output)");
+        void bus
+          .sendPrompt({
+            agent_id: job.dispatcher,
+            origin: "cron",
+            origin_id: `agent-job:${job.jobId}`,
+            user_id: "system",
+            text:
+              `Agent job ${job.jobId} (agent "${job.agent}") finished with status ` +
+              `"${job.status}".\n\n${detail}`,
+            metadata: {
+              kind: "agent_job_result",
+              job_id: job.jobId,
+              job_agent: job.agent,
+              job_status: job.status,
+            },
+          })
+          .catch((err) =>
+            logger.warn(`[bus-runtime] agent-job result delivery for ${job.jobId} failed`, err),
+          );
+      },
+      now: Date.now,
+      genId: () => randomUUID(),
+    });
+    bus.setJobHandler(jobRunner);
+
     // #227 restart-based session rotation. The bus PTY is spawned once at boot
     // and kept alive, so the session JSONL grows unbounded and per-prompt
     // latency creeps up (#213). When the per-agent message/age threshold trips,
@@ -580,7 +636,16 @@ export async function mountBusRuntime(
       async stop() {
         if (stopped) return;
         stopped = true;
-        // Stall watchdog first: cancel its sweep timer + bus subscription and
+        // Agent-job runner: cancel in-flight jobs + clear the queue so no
+        // headless `claude -p` outlives the daemon, and detach the handler so
+        // a late `job_request` gets a clean "not enabled" error (#296 PR 3).
+        try {
+          jobRunner.stop();
+          bus.setJobHandler(null);
+        } catch (err) {
+          logger.error("[bus-runtime] jobRunner.stop() failed", err);
+        }
+        // Stall watchdog next: cancel its sweep timer + bus subscription and
         // await any in-flight kill so it can't respawn a session mid-teardown.
         await stallWatchdog.stop();
         // Adapters first: stop inbound traffic so nothing new hits the

--- a/src/bus/types.ts
+++ b/src/bus/types.ts
@@ -213,6 +213,8 @@ export type IpcMessage =
   | IpcAskAnswer
   | IpcCancel
   | IpcRequestHuman
+  | IpcJobRequest
+  | IpcJobResult
   | IpcPermissionRequest
   | IpcPermissionResponse
   | IpcError;
@@ -286,6 +288,45 @@ export interface IpcRequestHuman {
    */
   ask_id: string;
   question: string;
+}
+
+/**
+ * Agent-job control request — Bus MCP server → Bus core (issue #296 PR 3).
+ *
+ * The `AgentJobRunner` lives in the DAEMON (only it can spawn/track the
+ * headless `claude -p` job processes), while the four job tools
+ * (`dispatch_job` / `job_status` / `list_jobs` / `cancel_job`) are invoked in
+ * the per-agent MCP SUBPROCESS. So the MCP server routes each call over the
+ * socket as this one generic envelope and awaits the correlated
+ * {@link IpcJobResult}. Mirrors the `request_human` round-trip.
+ *
+ * `agent_id` is the DISPATCHER — the agent whose socket carried the request;
+ * Bus core stamps it as the job's dispatcher (never trusting a client-supplied
+ * value) so results route back to the caller. `op` selects the runner method;
+ * `payload` carries the tool args (validated by the runner, not here).
+ */
+export interface IpcJobRequest {
+  type: "job_request";
+  agent_id: string;
+  /** Correlation id the matching `IpcJobResult` must echo. */
+  req_id: string;
+  op: "dispatch" | "status" | "list" | "cancel";
+  payload: Record<string, unknown>;
+}
+
+/**
+ * Agent-job control result — Bus core → Bus MCP server, correlated by `req_id`.
+ * `ok:false` carries `error`; `ok:true` carries the op-specific `result`
+ * (dispatch → `{jobId,status}|{error}`, status → `JobView|null`,
+ * list → `JobView[]`, cancel → `{ok,error?}`) which the MCP server serialises
+ * straight back to the calling agent as the tool result.
+ */
+export interface IpcJobResult {
+  type: "job_result";
+  req_id: string;
+  ok: boolean;
+  result?: unknown;
+  error?: string;
 }
 
 export interface IpcPermissionRequest {

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,6 +8,11 @@ import {
   parseStallWatchdogConfig,
   type StallWatchdogConfig,
 } from "./bus/stall-watchdog";
+import {
+  DEFAULT_AGENT_JOB_CONFIG,
+  parseAgentJobConfig,
+  type AgentJobConfig,
+} from "./bus/agent-jobs";
 import { parsePlugins, type PluginEntry } from "./plugins";
 import { parseMemorySearchSettings, type MemorySearchSettings } from "./memory";
 
@@ -234,6 +239,7 @@ const DEFAULT_SETTINGS: Settings = {
   // Clone so a future in-place edit of settings.stallWatchdog can't mutate the
   // shared exported default.
   stallWatchdog: structuredClone(DEFAULT_STALL_CONFIG),
+  agentJobs: structuredClone(DEFAULT_AGENT_JOB_CONFIG),
   governance: { watchdog: {} },
   session: { autoRotate: false, maxMessages: 50, maxAgeHours: 24, summaryPath: "" },
   // Default runtime: `bus` (Sprint 5.4 flip after Hetzner staging soak ended
@@ -689,6 +695,8 @@ export interface Settings {
   mcp: McpConfig;
   watchdog: WatchdogSettings;
   stallWatchdog: StallWatchdogConfig;
+  /** Agent-job primitive config (#296 PR 3): concurrency cap + per-job timeouts. */
+  agentJobs: AgentJobConfig;
   governance: GovernanceConfig;
   plugins: Record<string, PluginEntry>;
   session: SessionConfig;
@@ -1101,6 +1109,7 @@ function parseSettings(raw: Record<string, any>, discordUserIds?: string[]): Set
     mcp: parseMcpConfig(raw.mcp, raw.web?.enabled),
     watchdog: parseWatchdogConfig(raw.watchdog),
     stallWatchdog: parseStallWatchdogConfig(raw.stallWatchdog),
+    agentJobs: parseAgentJobConfig(raw.agentJobs),
     governance: parseGovernanceConfig(raw.governance),
     plugins: parsePlugins(raw.plugins),
     memorySearch: parseMemorySearchSettings(raw.memorySearch),

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -744,6 +744,7 @@ export async function runClaudeOnce(
   baseEnv: Record<string, string>,
   timeoutMs: number = DEFAULT_SESSION_TIMEOUT_MS,
   cwd?: string,
+  signal?: AbortSignal,
 ): Promise<{ rawStdout: string; stderr: string; exitCode: number }> {
   const args = [...baseArgs];
   const normalizedModel = model.trim().toLowerCase();
@@ -765,6 +766,13 @@ export async function runClaudeOnce(
       timeoutMs,
     );
   });
+  // Cancellation (e.g. a job cancelled via the AgentJobRunner): abort like a
+  // timeout so the catch below kills the process and returns.
+  const abortPromise = new Promise<never>((_, reject) => {
+    if (!signal) return;
+    if (signal.aborted) reject(new Error("aborted"));
+    else signal.addEventListener("abort", () => reject(new Error("aborted")), { once: true });
+  });
 
   try {
     const [rawStdout, stderr] = (await Promise.race([
@@ -773,6 +781,7 @@ export async function runClaudeOnce(
         collectStream(proc.stderr as ReadableStream<Uint8Array>, MAX_OUTPUT_BYTES),
       ]),
       timeoutPromise,
+      abortPromise,
     ])) as [string, string];
 
     if (timeoutId) clearTimeout(timeoutId);
@@ -806,6 +815,40 @@ export async function runClaudeOnce(
       exitCode: 124,
     };
   }
+}
+
+/**
+ * Run a named agent as a one-shot headless job (for the bus AgentJobRunner). Loads
+ * the agent's persona (IDENTITY/SOUL/CLAUDE.md), runs `claude -p <prompt>` in the
+ * agent's dir with plain-text output, and returns the final text. Honours the
+ * AbortSignal (cancel → kill) and the timeout via `runClaudeOnce`. This is the
+ * supported replacement for the hand-rolled `/tmp` fire-scripts that caused #295.
+ */
+export async function runAgentJobHeadless(input: {
+  agent: string;
+  prompt: string;
+  model?: string;
+  timeoutMs: number;
+  signal: AbortSignal;
+}): Promise<{ exitCode: number; resultText?: string; error?: string; timedOut?: boolean }> {
+  const settings = getSettings();
+  const ctx = await loadAgent(input.agent);
+  const persona = await loadAgentPrompts(input.agent);
+  const args = [CLAUDE_EXECUTABLE, "-p", input.prompt, ...buildSecurityArgs(settings.security)];
+  if (persona) args.push("--append-system-prompt", persona);
+  const model = input.model?.trim() || settings.model;
+  const { rawStdout, stderr, exitCode } = await runClaudeOnce(
+    args,
+    model,
+    settings.api,
+    cleanSpawnEnv(),
+    input.timeoutMs,
+    ctx.dir,
+    input.signal,
+  );
+  if (exitCode === 124) return { exitCode, timedOut: true, error: stderr || "timed out" };
+  if (exitCode !== 0) return { exitCode, error: stderr || `claude exited ${exitCode}` };
+  return { exitCode, resultText: rawStdout.trim() };
 }
 
 // Runs claude with --output-format stream-json --verbose, reading NDJSON events as they

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -66,6 +66,7 @@ import {
   indexSessionsBackground,
 } from "./memory";
 import { loadAgent } from "./agents";
+import { validateModelString } from "./jobs";
 import { selectModel } from "./model-router";
 import { recordResult, abortReason, clearSession, startSession } from "./watchdog";
 import { getPluginManager, type EventContext } from "./plugins";
@@ -832,6 +833,10 @@ export async function runAgentJobHeadless(input: {
   signal: AbortSignal;
 }): Promise<{ exitCode: number; resultText?: string; error?: string; timedOut?: boolean }> {
   const settings = getSettings();
+  // Security review (#296 PR 3): validate the caller-supplied model against the
+  // allow-list before spawning — reject an attacker-picked tier rather than
+  // silently falling back. Throws → the job is marked failed (never spawns).
+  validateModelString(input.model, "agent job");
   const ctx = await loadAgent(input.agent);
   const persona = await loadAgentPrompts(input.agent);
   const args = [CLAUDE_EXECUTABLE, "-p", input.prompt, ...buildSecurityArgs(settings.security)];


### PR DESCRIPTION
## PR 3/3 of #296 — first-class agent-job primitive (root-smell fix)

Epic **#296** is the 3-PR fix for the #295 daemon outage (an agent hand-rolled a `/tmp` fire-script that `Bun.spawn(["claude","-p",…])` + `nohup … &`, holding the Bash tool's pipe and wedging the session for ~11h).

- **PR 1 — stall watchdog (recovery):** merged (#297, #300).
- **PR 2 — Bash-exec guard (prevention):** merged (#302).
- **PR 3 — agent-job primitive (this PR):** removes the *need* to improvise jobs at all.

### What it does

Gives agents a supported `dispatch_job` tool so one agent can fire a long background job to another named agent (`reg`/`suzy` research/draft runs), get a `job_id` back **immediately**, and have the result delivered back when it finishes — instead of shelling out to `claude -p` by hand.

- `dispatch_job({ agent, prompt, model?, timeoutMs? })` → `{ job_id, status }` immediately (fire-and-return; never blocks the caller's turn — that awaiting is exactly what wedged #295).
- `job_status` / `list_jobs` / `cancel_job` for observability + control.
- The finished job's result is delivered back to the **dispatching** agent (via the bus) and stays queryable.

### Architecture (why it's wired this way)

The `AgentJobRunner` lives in the **daemon** — only it can spawn/track the headless `claude -p` job processes. The four tools run in the per-agent **MCP subprocess**, which reaches the daemon over the existing unix socket. So each tool call routes over IPC as one correlated request/response (`IpcJobRequest`/`IpcJobResult`), mirroring the existing `request_human` round-trip. Fire-and-return, in-memory registry (no cross-restart persistence — matches the scheduler + restart-rotation model).

### Security posture

The daemon spawns agent processes in response to an IPC message, so this went through a dedicated security review. Confirmed sound and hardened:

- **No dispatcher spoofing** — the job's `dispatcher` is stamped from the socket-authenticated `agent_id`, never a client-supplied value.
- **No shell injection** — `Bun.spawn(args, …)` uses an args array (no shell); prompt/model are separate argv elements; the executable is fixed.
- **Sandbox escape closed (HIGH, fixed)** — `agentExists` now requires the kebab-case name charset before the `existsSync` check, so `agent:"../../etc"` can't spawn `claude -p` with cwd outside `agents/`.
- **Model allow-listed** — caller model validated (`validateModelString`) before spawn; no silent tier escalation.
- **Bounded** — caller-uninfluenceable concurrency cap + hard timeout cap; queue-depth cap + prompt-length cap + oldest-terminal record eviction (a looping `dispatch_job` can't OOM the daemon).
- **No turn-wedge** — the MCP round-trip is bounded by a 30 s timeout, and the daemon always sends exactly one `job_result`.

### Test plan

- `src/bus/__tests__/agent-jobs.test.ts` — registry transitions, fire-and-return, concurrency/queue caps, prompt-length cap, retention eviction, cancel/stop.
- `src/bus/__tests__/agent-jobs-ipc.test.ts` — real-UDS socket round-trip: dispatch/status/list/cancel, result delivery, unknown-agent + not-enabled paths.
- `src/__tests__/agents.test.ts` — `agentExists` path-traversal rejection.
- Full bus suite green.

Refs #296, #295.

https://claude.ai/code/session_01RJZianxrwQWLhYGmALm7L9
