### PR TITLE
ci: run bun test on the clean module suites

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.179",
+      "version": "2.2.180",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.179",
+  "version": "2.2.180",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,15 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      # Scoped to the actively-developed module suites, which pass cleanly.
-      # The root `src/__tests__/` suite is intentionally excluded for now: it
-      # has ~41 pre-existing failures that are a mix of cross-test pollution
-      # (tests that pass in isolation but not in the shared process) and
-      # infra-dependent tests (DB/queue that CI doesn't provide). Folding it in
-      # would make CI permanently red. Tracked for cleanup — see the issue
-      # linked in the PR — after which these paths can be widened toward the
-      # full `bun test`.
-      - name: Run tests (clean module suites)
-        run: bun test src/bus src/tuner src/observability src/skills-tuner src/governance
+      # Scoped to the suites that pass cleanly. `bun test` treats these as path
+      # patterns, so each must point at a dir that actually holds *.test.ts:
+      # the module dirs (src/bus, src/tuner, src/observability, src/skills-tuner)
+      # plus the governance tests — which live under src/__tests__/governance,
+      # NOT src/governance (that dir has no tests). The rest of the root
+      # `src/__tests__/` suite is intentionally excluded for now: ~41 pre-existing
+      # failures, a mix of cross-test pollution (pass in isolation, fail in the
+      # shared process) and infra-dependent tests (DB/queue CI doesn't provide).
+      # Folding those in would make CI permanently red. Tracked for cleanup — see
+      # the issue linked in the PR — after which these paths widen toward full.
+      - name: Run tests (clean suites)
+        run: bun test src/bus src/tuner src/observability src/skills-tuner src/__tests__/governance

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    name: Bun test (module suites)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Scoped to the actively-developed module suites, which pass cleanly.
+      # The root `src/__tests__/` suite is intentionally excluded for now: it
+      # has ~41 pre-existing failures that are a mix of cross-test pollution
+      # (tests that pass in isolation but not in the shared process) and
+      # infra-dependent tests (DB/queue that CI doesn't provide). Folding it in
+      # would make CI permanently red. Tracked for cleanup — see the issue
+      # linked in the PR — after which these paths can be widened toward the
+      # full `bun test`.
+      - name: Run tests (clean module suites)
+        run: bun test src/bus src/tuner src/observability src/skills-tuner src/governance


### PR DESCRIPTION
## What

Adds a **`Test`** GitHub Actions job (`.github/workflows/test.yml`) that runs `bun test` on the module suites — `src/bus`, `src/tuner`, `src/observability`, `src/skills-tuner`, `src/governance` (~700 tests).

## Why

Until now CI ran **no unit tests** — the "Bun Smoke Test" only does a build/parse/type-check. That's how PR #290's 3 hanging `collectObservations` tests showed green. This wires the tests into CI so that class of regression is caught.

## Scope (deliberately not the full suite yet)

A full `bun test` on main is **2518 pass / 41 fail**, and all 41 failures are in root `src/__tests__/` — a mix of cross-test pollution (pass in isolation, fail in the shared process) and infra-dependent tests (DB/queue not in CI). Folding those in would make CI permanently red. The scoped module suites are pollution-free and green (700/0, ~2 min).

Cleanup of `src/__tests__/` and widening the scope toward the full suite is tracked in #304.

Refs #304.