### PR TITLE
fix(runner): gate turn completion on the idle REPL footer (closes #316)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.192",
+      "version": "2.2.193",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.192",
+  "version": "2.2.193",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/pty-output-parser.test.ts
+++ b/src/__tests__/pty-output-parser.test.ts
@@ -71,7 +71,10 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
     // one of claude's spinner glyphs. Markers (`●`/`⏺`) are
     // deliberately NOT in the gate (Codex P1 on PR #124) because they
     // appear in the TUI status box + scrollback redraws.
-    feed(parser, new TextEncoder().encode("✻ a"), now);
+    // The response must also leave claude back at the idle REPL prompt — its
+    // footer's "to cycle" hint is what tells the parser the turn is genuinely
+    // done (issue #316); without it, quiet is correctly withheld.
+    feed(parser, new TextEncoder().encode("✻ a\nshift+tab to cycle"), now);
     expect(parser.sawByteSinceTurnStart).toBe(true);
 
     // Within the quiet window after that byte → still no quiet.
@@ -101,10 +104,11 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
     expect(startEv).toEqual({ type: "turn-start", offset: parser.totalBytes });
     expect(parser.state).toBe("accumulating");
 
-    // Response trickles in — include `✻` (spinner) so the
-    // activity-indicator gate is satisfied alongside the byte-seen gate.
+    // Response trickles in — include `✻` (spinner) so the activity-indicator
+    // gate is satisfied, and the idle REPL footer ("to cycle") so the
+    // turn-done gate (issue #316) is satisfied alongside the byte-seen gate.
     now += 10;
-    expect(feed(parser, enc.encode("✻ ack"), now)).toEqual([]);
+    expect(feed(parser, enc.encode("✻ ack\nshift+tab to cycle"), now)).toEqual([]);
     expect(parser.state).toBe("accumulating");
 
     // tick fires before the quiet window elapses → no event.
@@ -142,9 +146,10 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
 
     let now = 1000;
     startTurn(parser, uuid, sentinelBytes, now);
-    // Include `✻` so the activity-indicator gate is satisfied — the
-    // debounce test isn't about gating, but quiet can't fire without it.
-    feed(parser, enc.encode("✻ first chunk"), now);
+    // Include `✻` (activity gate) and the idle footer "to cycle" (turn-done
+    // gate, issue #316) — the debounce test isn't about gating, but quiet
+    // can't fire without both being satisfied.
+    feed(parser, enc.encode("✻ first chunk\nshift+tab to cycle"), now);
 
     // Quiet window elapses → quiet fires.
     now += 200;
@@ -372,11 +377,126 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
     now += 200;
     expect(tick(parser, now)).toEqual([]);
 
-    // Spinner appears → gate opens.
-    feed(parser, enc.encode("✻ thinking"), now);
+    // Spinner appears (activity gate opens), then claude returns to the idle
+    // prompt (footer "to cycle" — turn-done gate, issue #316).
+    feed(parser, enc.encode("✻ thinking\nshift+tab to cycle"), now);
     expect(parser.sawActivityIndicatorThisTurn).toBe(true);
 
     // Quiet window elapses → quiet now fires.
+    const qEvs = tick(parser, now + 200);
+    expect(qEvs.length).toBe(1);
+    expect(qEvs[0]!.type).toBe("quiet");
+  });
+
+  test("issue #316: mid-turn quiet during a tool wait (spinner, no idle footer) does NOT fire; quiet fires once the idle footer returns", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-316-toolwait";
+    const sentinelBytes = encodeSentinel(buildSentinel(uuid));
+
+    let now = 1000;
+    startTurn(parser, uuid, sentinelBytes, now);
+
+    // Claude starts generating (spinner → activity gate opens), calls a tool,
+    // and the stream goes quiet WHILE the tool runs. The bottom-of-screen
+    // footer shows the running/interrupt state — NOT the idle "to cycle" hint.
+    feed(parser, enc.encode("✻ Running bash… esc to interrupt"), now);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(true);
+
+    // Quiet window elapses mid-turn. Pre-#316 this fired `quiet` and completed
+    // the turn prematurely (losing the rest of the work); post-#316 the missing
+    // idle footer withholds it.
+    now += 200;
+    expect(tick(parser, now)).toEqual([]);
+    // Still withheld after many quiet windows while the tool is running.
+    now += 5000;
+    expect(tick(parser, now)).toEqual([]);
+
+    // Tool finishes, claude produces the rest of the answer and returns to the
+    // idle prompt — the footer's "to cycle" hint reappears.
+    feed(parser, enc.encode("done.\nshift+tab to cycle"), now);
+
+    // NOW quiet fires — the turn is genuinely complete.
+    const qEvs = tick(parser, now + 200);
+    expect(qEvs.length).toBe(1);
+    expect(qEvs[0]!.type).toBe("quiet");
+  });
+
+  test("issue #316: idle footer is detected even when CUF sequences render the inter-word space", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-316-cuf";
+    const sentinelBytes = encodeSentinel(buildSentinel(uuid));
+
+    let now = 1000;
+    startTurn(parser, uuid, sentinelBytes, now);
+
+    // claude 2.1.89+ renders inter-word spaces as CUF (cursor-forward)
+    // sequences, so the footer arrives as "to\x1b[1Ccycle" (no literal space)
+    // wrapped in colour codes. The parser must expand CUF back to spaces and
+    // strip ANSI before matching, or the gate would never open.
+    feed(parser, enc.encode("✻ ok\x1b[38;5;244mshift+tab\x1b[1Cto\x1b[1Ccycle"), now);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(true);
+
+    const qEvs = tick(parser, now + 200);
+    expect(qEvs.length).toBe(1);
+    expect(qEvs[0]!.type).toBe("quiet");
+  });
+
+  test("issue #316: bare 'to cycle' in response prose (not the footer) does NOT trip the gate", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-316-prose";
+    const sentinelBytes = encodeSentinel(buildSentinel(uuid));
+
+    let now = 1000;
+    startTurn(parser, uuid, sentinelBytes, now);
+
+    // Response body legitimately contains the words "to cycle" (explaining a
+    // loop) — but claude is mid-turn, about to call a tool, and the idle
+    // footer's anchored "tab to cycle" hint is NOT present. Matching the bare
+    // "to cycle" here would falsely satisfy the gate and let a subsequent
+    // tool-wait quiet complete the turn early — the exact bug #316 fixes.
+    feed(parser, enc.encode("✻ Here's a loop to cycle through the frames:"), now);
+    expect(parser.sawByteSinceTurnStart).toBe(true);
+    expect(parser.sawActivityIndicatorThisTurn).toBe(true);
+
+    // Quiet window elapses mid-turn → NO quiet (anchored marker absent).
+    now += 200;
+    expect(tick(parser, now)).toEqual([]);
+    now += 5000;
+    expect(tick(parser, now)).toEqual([]);
+
+    // Turn finishes → real footer "shift+tab to cycle" (contains "tab to
+    // cycle") → quiet fires.
+    feed(parser, enc.encode(" done.\nshift+tab to cycle"), now);
+    const qEvs = tick(parser, now + 200);
+    expect(qEvs.length).toBe(1);
+    expect(qEvs[0]!.type).toBe("quiet");
+  });
+
+  test("issue #316: a stale footer marker is evicted from footerTail once >2048 bytes accumulate", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-316-evict";
+    const sentinelBytes = encodeSentinel(buildSentinel(uuid));
+
+    let now = 1000;
+    startTurn(parser, uuid, sentinelBytes, now);
+
+    // A stale footer paints early in the turn (e.g. a resumed-session
+    // scrollback replay), then the turn keeps generating well past the
+    // 2048-byte footerTail cap — the stale marker must be evicted so it cannot
+    // satisfy the gate during a later mid-turn tool-wait quiet.
+    feed(parser, enc.encode("✻ shift+tab to cycle"), now); // stale marker + spinner
+    feed(parser, enc.encode("x".repeat(3000)), now); // push it out of the 2048-byte tail
+    expect(parser.sawActivityIndicatorThisTurn).toBe(true);
+
+    now += 200;
+    expect(tick(parser, now)).toEqual([]); // marker evicted → no quiet
+
+    // Real footer returns at turn end → quiet fires.
+    feed(parser, enc.encode("\nshift+tab to cycle"), now);
     const qEvs = tick(parser, now + 200);
     expect(qEvs.length).toBe(1);
     expect(qEvs[0]!.type).toBe("quiet");

--- a/src/__tests__/pty-process.test.ts
+++ b/src/__tests__/pty-process.test.ts
@@ -379,6 +379,10 @@ describe("PtyProcess — runTurn sentinel-echo (clean boundary)", () => {
   // status-box row and in resumed scrollback. Real claude emits
   // spinners while generating; `/bin/cat` doesn't, so we slip one
   // into the prompt and let cat echo it back to satisfy the gate.
+  // The prompts ALSO carry the idle REPL footer "to cycle" (issue #316):
+  // the parser only treats quiet as turn-completion once claude has returned
+  // to the idle prompt. `/bin/cat` echoes it back, standing in for the footer
+  // real claude paints when a turn finishes.
 
   test("cat echoes the sentinel back → cleanBoundary=true", async () => {
     const proc = await spawnPty(
@@ -389,7 +393,7 @@ describe("PtyProcess — runTurn sentinel-echo (clean boundary)", () => {
         sentinelMaxWaitMs: 5000,
       }),
     );
-    const result = await proc.runTurn("✻ hello world", { timeoutMs: 5000 });
+    const result = await proc.runTurn("✻ hello world shift+tab to cycle", { timeoutMs: 5000 });
     expect(result.cleanBoundary).toBe(true);
     // cat echoes the prompt; the response should contain it.
     expect(result.text.toLowerCase()).toContain("hello world");
@@ -407,7 +411,7 @@ describe("PtyProcess — runTurn sentinel-echo (clean boundary)", () => {
         sentinelMaxWaitMs: 5000,
       }),
     );
-    const longPrompt = `✻ ${"x".repeat(500)}`;
+    const longPrompt = `✻ ${"x".repeat(500)} shift+tab to cycle`;
     const result = await proc.runTurn(longPrompt, { timeoutMs: 5000 });
     expect(result.cleanBoundary).toBe(true);
     expect(result.text).toContain("x".repeat(20));
@@ -424,7 +428,7 @@ describe("PtyProcess — runTurn sentinel-echo (clean boundary)", () => {
       }),
     );
     let chunkBytes = 0;
-    const result = await proc.runTurn("✻ streaming-test-payload", {
+    const result = await proc.runTurn("✻ streaming-test-payload shift+tab to cycle", {
       timeoutMs: 5000,
       onChunk: (s) => {
         chunkBytes += s.length;
@@ -455,7 +459,7 @@ describe("PtyProcess — runTurn sentinel max-wait fallback", () => {
     const proc = await spawnPty(
       baseOpts({
         _commandOverride: "/bin/sh",
-        _argsOverride: ["-c", "stty -echo; printf '\\xe2\\x9c\\xbb'; sleep 5"],
+        _argsOverride: ["-c", "stty -echo; printf '\\xe2\\x9c\\xbb shift+tab to cycle'; sleep 5"],
         quietWindowMs: 50,
         sentinelMaxWaitMs: 250,
       }),
@@ -488,7 +492,7 @@ describe("PtyProcess — runTurn sentinel max-wait fallback", () => {
         _commandOverride: "/bin/sh",
         _argsOverride: [
           "-c",
-          "echo BANNER_BANNER_BANNER_PRETURN; stty -echo; printf '\\xe2\\x9c\\xbb response-bytes-during-turn'; sleep 5",
+          "echo BANNER_BANNER_BANNER_PRETURN; stty -echo; printf '\\xe2\\x9c\\xbb response-bytes-during-turn shift+tab to cycle'; sleep 5",
         ],
         quietWindowMs: 100,
         sentinelMaxWaitMs: 400,
@@ -545,7 +549,7 @@ describe("PtyProcess — sentinel UUID override hook", () => {
         _sentinelUuidOverride: () => "pinned-uuid-1234",
       }),
     );
-    const result = await proc.runTurn("✻ hi", { timeoutMs: 5000 });
+    const result = await proc.runTurn("✻ hi shift+tab to cycle", { timeoutMs: 5000 });
     expect(result.cleanBoundary).toBe(true);
     await proc.dispose();
   });
@@ -566,7 +570,7 @@ describe("PtyProcess — concurrency", () => {
     // per Codex P1 on PR #124); without it the first turn never
     // completes and the test times out instead of exercising the
     // concurrency rejection.
-    const t1 = proc.runTurn("✻ first", { timeoutMs: 5000 });
+    const t1 = proc.runTurn("✻ first shift+tab to cycle", { timeoutMs: 5000 });
     let err: unknown;
     try {
       await proc.runTurn("✻ second", { timeoutMs: 5000 });

--- a/src/runner/pty-output-parser.ts
+++ b/src/runner/pty-output-parser.ts
@@ -64,6 +64,16 @@
 /** Quiet window before the supervisor writes the sentinel. Default 500ms. */
 export const DEFAULT_QUIET_WINDOW_MS = 500;
 
+/** Rolling raw-output tail size (bytes) kept for idle-REPL-footer detection.
+ *  Large enough to always contain the current bottom-of-screen footer paint,
+ *  small enough to stay cheap. Issue #316. */
+const FOOTER_TAIL_MAX = 2048;
+
+/** Lenient decoder for the footer tail. The tail can start mid-UTF-8-char, so
+ *  fatal:false lets partial leading bytes decode to replacement chars without
+ *  throwing — fine for a substring match. */
+const _footerDecoder = new TextDecoder("utf-8", { fatal: false });
+
 /** State of the parser. */
 export type ParserState = "idle" | "accumulating" | "awaiting-sentinel" | "complete";
 
@@ -138,6 +148,13 @@ export interface Parser {
   pending: Uint8Array;
   /** Stream offset that the first byte of `pending` represents. */
   pendingBaseOffset: number;
+  /** Rolling tail of recent raw output bytes (ANSI-laden), capped at
+   *  `FOOTER_TAIL_MAX`. Used by `tick` to detect claude's idle REPL footer
+   *  ("to cycle"), which only reappears when the turn is genuinely done — NOT
+   *  during a mid-turn tool/sub-agent wait (which also goes quiet). Gating
+   *  `quiet` on it stops a mid-turn quiet from completing the turn early.
+   *  Issue #316. */
+  footerTail: Uint8Array;
 }
 
 /** Create a fresh parser instance (in `idle` state). */
@@ -157,6 +174,7 @@ export function createParser(opts?: { quietWindowMs?: number }): Parser {
     activityScanCarry: new Uint8Array(0),
     pending: new Uint8Array(0),
     pendingBaseOffset: 0,
+    footerTail: new Uint8Array(0),
   };
 }
 
@@ -187,6 +205,10 @@ export function startTurn(
   parser.activityScanCarry = new Uint8Array(0);
   parser.pending = new Uint8Array(0);
   parser.pendingBaseOffset = parser.totalBytes;
+  // Empty the footer tail so the idle-footer detection reflects THIS turn's
+  // completion, not a stale "to cycle" left in the buffer from the pre-turn
+  // idle prompt. Issue #316.
+  parser.footerTail = new Uint8Array(0);
   return { type: "turn-start", offset: parser.turnStartOffset };
 }
 
@@ -211,6 +233,15 @@ export function feed(parser: Parser, chunk: Uint8Array, now: number): ParserEven
     // Activity-indicator scan — strengthens issue #87's gate so the
     // sentinel isn't written when the only bytes seen are TUI redraws.
     scanForActivityIndicator(parser, chunk);
+    // Issue #316: keep a rolling tail of raw output so `tick` can detect the
+    // idle REPL footer that only reappears when the turn is truly done, and
+    // NOT during a mid-turn tool/sub-agent wait (which also goes quiet).
+    const footerCombined =
+      parser.footerTail.length === 0 ? chunk : concatBytes(parser.footerTail, chunk);
+    parser.footerTail =
+      footerCombined.length > FOOTER_TAIL_MAX
+        ? footerCombined.slice(footerCombined.length - FOOTER_TAIL_MAX)
+        : footerCombined;
   }
 
   // We only scan for the sentinel after the supervisor has actually written
@@ -253,6 +284,32 @@ export function feed(parser: Parser, chunk: Uint8Array, now: number): ParserEven
 }
 
 /**
+ * True when the parser's recent output tail shows claude's idle REPL footer —
+ * the mode-cycler hint that only paints when claude is idle at the prompt (turn
+ * genuinely done), and is ABSENT while a turn is in progress, including mid-turn
+ * tool/sub-agent waits (which paint an interrupt/running footer). Gating `quiet`
+ * on this stops a mid-turn quiet from being mistaken for turn completion (#316).
+ *
+ * Matches **"tab to cycle"**, the version-stable core of the hint ("shift+tab to
+ * cycle" in older CLIs, "tab to cycle permission modes" in 2.1.168+). It is
+ * DELIBERATELY not the bare "to cycle": `footerTail` holds ALL recent output
+ * (response prose, tool output, echoed file contents), so a bare "to cycle"
+ * substring could appear in legitimate turn content ("a loop to cycle through …")
+ * and falsely satisfy the gate mid-turn — reintroducing the very bug this fixes.
+ * "tab to cycle" mirrors the stricter marker `session-agent-process` uses in its
+ * boot-dialog matcher for exactly this prose-safety reason.
+ *
+ * CUF cursor-forward sequences (which render inter-word spaces on claude 2.1.89+)
+ * are expanded back to spaces BEFORE stripping ANSI, so a footer rendered as
+ * "tab\x1b[1Cto\x1b[1Ccycle" still matches.
+ */
+function hasIdleReplFooter(parser: Parser): boolean {
+  if (parser.footerTail.length === 0) return false;
+  const text = stripAnsi(expandCursorForwardToSpaces(_footerDecoder.decode(parser.footerTail)));
+  return text.toLowerCase().includes("tab to cycle");
+}
+
+/**
  * Tick the parser's quiet timer. The supervisor should call this on a regular
  * interval (e.g. every 50ms). When the parser is in `accumulating` state and
  * `now - lastByteAt >= quietWindowMs`, emits a single `quiet` event so the
@@ -283,6 +340,13 @@ export function tick(parser: Parser, now: number): ParserEvent[] {
   // supervisor's `sentinelMaxWaitMs` (default 30s) fails the turn
   // visibly — better than returning garbage.
   if (!parser.sawActivityIndicatorThisTurn) return [];
+  // Issue #316: a mid-turn tool call / sub-agent wait ALSO makes the stream go
+  // quiet, but claude has not returned to its idle prompt — its footer shows
+  // the running/interrupt state, not the mode-cycler "to cycle" hint. Only
+  // treat quiet as turn-completion once the idle REPL footer is showing, so a
+  // mid-turn tool-wait quiet no longer completes the turn prematurely. The
+  // outer turn timeout remains the backstop if a future CLI renames the hint.
+  if (!hasIdleReplFooter(parser)) return [];
   if (now - parser.lastByteAt < parser.quietWindowMs) return [];
   parser.quietEmitted = true;
   return [{ type: "quiet", offset: parser.totalBytes }];
@@ -315,6 +379,7 @@ export function resetTurn(parser: Parser): void {
   parser.activityScanCarry = new Uint8Array(0);
   parser.pending = new Uint8Array(0);
   parser.pendingBaseOffset = parser.totalBytes;
+  parser.footerTail = new Uint8Array(0);
 }
 
 /**


### PR DESCRIPTION
Closes #316.

## Problem
The PTY runner's turn-completion detection treated any 500ms stream-quiet (after a spinner glyph was seen) as "turn done". But multi-step **tool / sub-agent** turns legitimately go quiet mid-turn while a tool runs, so the detector fired `quiet` mid-turn and completed the turn **prematurely** (losing the rest of the work) — and for the daemon's long agent jobs it desynced into the outer turn timeout. ~91% of scheduled jobs (reg/suzy/publisher) were timing out; the publisher published nothing for ~2 months.

Reproduced with an instrumented parser + the real `run()` path (opus, MCP): a 4-step Bash task was severed at step 2 by a quiet during a `sleep` tool-wait.

## Fix
Gate `quiet` on claude's idle REPL footer being present in the recent output, matching the anchored, version-stable, **prose-safe** core `tab to cycle` (`shift+tab to cycle` in older CLIs, `tab to cycle permission modes` in 2.1.168+). That hint only paints when claude is idle at the prompt — never during a tool/sub-agent wait — so a mid-turn quiet no longer completes the turn. Mirrors the bus adapter's footer-marker approach and its prose-safe matcher; reuses the parser's existing `expandCursorForwardToSpaces` + `stripAnsi` so CUF/ANSI-interspersed footers still match. The outer turn timeout remains the backstop if a future CLI renames the hint.

## Tests
154 PTY tests green. New/updated coverage: mid-turn tool-wait suppression, CUF-tolerant footer matching, the **prose false-positive regression** (bare `to cycle` in response text must NOT trip the gate — the hole caught in review), and the 2048-byte `footerTail` eviction boundary. Existing quiet tests were updated to emit the footer (same pattern they already use for the `✻` spinner).

## Review
- **Security** (everything-claude-code:security-reviewer) — CLEAN, no CRITICAL/HIGH. Buffer bounded (2048B), no crash/ReDoS on adversarial bytes, outer-timeout backstop verified against `pty-process.ts`.
- **Code review** (feature-dev:code-reviewer) — found a CRITICAL unanchored-substring match (bare `to cycle` would false-positive on response prose / tool output). **Fixed** by anchoring to `tab to cycle` + the regression test above.

## Known tradeoff / follow-up
`tab to cycle` is now a hard prerequisite for clean turn completion. If a future CLI renames the footer, turns slow-fail via the outer timeout (retryable) rather than hang. Suggested follow-up: a CI golden-fixture assertion on the footer string so a CLI bump fails a test instead of silently degrading in production.
