### PR TITLE
feat(telemetry): extensible host-telemetry producers + open stream namespace (refs #275)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.197",
+      "version": "2.2.199",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.197",
+  "version": "2.2.199",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/skills-tuner/core/fitness.ts
+++ b/src/skills-tuner/core/fitness.ts
@@ -14,6 +14,7 @@
 
 import type { TunableSubject } from "./interfaces.js";
 import type {
+  KnownTelemetryStream,
   Metric,
   TelemetryCapability,
   TelemetryProvider,
@@ -163,7 +164,7 @@ export function activateFitness(
  */
 export async function deriveCapabilitiesFromHealthChecks(
   subjects: readonly TunableSubject[],
-  subjectStream: Partial<Record<string, TelemetryStream>>,
+  subjectStream: Partial<Record<string, KnownTelemetryStream>>,
   schemaVersion = TELEMETRY_CONTRACT_VERSION,
 ): Promise<TelemetryCapability[]> {
   const caps: TelemetryCapability[] = [];

--- a/src/skills-tuner/core/telemetry.ts
+++ b/src/skills-tuner/core/telemetry.ts
@@ -49,7 +49,18 @@ export const TELEMETRY_STREAMS = [
   "memory_signal",
 ] as const;
 
-export type TelemetryStream = (typeof TELEMETRY_STREAMS)[number];
+/** The built-in streams this repo ships producers for. */
+export type KnownTelemetryStream = (typeof TELEMETRY_STREAMS)[number];
+/**
+ * A telemetry stream name. One of the built-in {@link KnownTelemetryStream}s,
+ * OR any operator-defined string — so a host-composed producer (see
+ * `buildHostTelemetryProvider`'s `extraProducers`) can advertise its own
+ * signal without editing this enum. The `& {}` preserves literal autocomplete
+ * for the known streams while widening to `string`. Custom producers SHOULD
+ * namespace their streams (e.g. `custom.<name>`) to avoid colliding with a
+ * future built-in.
+ */
+export type TelemetryStream = KnownTelemetryStream | (string & {});
 
 /**
  * The whole contract surface is versioned per host release for certification.

--- a/src/tuner/__tests__/wisecron/host-telemetry-provider.test.ts
+++ b/src/tuner/__tests__/wisecron/host-telemetry-provider.test.ts
@@ -741,3 +741,64 @@ describe("SessionJsonlTelemetryProducer", () => {
     expect(mem.every((s) => s.labels!.file.includes("mémoire"))).toBe(true);
   });
 });
+
+describe("buildHostTelemetryProvider — extraProducers (operator extension point)", () => {
+  // A minimal operator-supplied producer advertising its OWN (custom-namespaced)
+  // stream — the third-party instrumentation path this PR unlocks.
+  class CustomDemoProducer implements TelemetryProvider {
+    contractVersion(): string {
+      return "1.0.0";
+    }
+    capabilities() {
+      return [
+        { stream: "custom.demo" as TelemetryStream, schemaVersion: "1.0.0", available: true },
+      ];
+    }
+    async query(stream: TelemetryStream, _range: DateRange): Promise<MetricSample[]> {
+      if (stream !== "custom.demo") return [];
+      return [{ ts: new Date(NOW_MS), value: 42, labels: { source: "demo" } }];
+    }
+  }
+
+  it("composes an operator producer advertising a CUSTOM stream", async () => {
+    const provider = buildHostTelemetryProvider({ extraProducers: [new CustomDemoProducer()] });
+    const demo = provider.capabilities().find((c) => c.stream === "custom.demo");
+    expect(demo?.available).toBe(true);
+    const samples = await provider.query("custom.demo" as TelemetryStream, RANGE);
+    expect(samples).toHaveLength(1);
+    expect(samples[0]?.value).toBe(42);
+  });
+
+  it("still advertises every built-in stream (no regression)", () => {
+    const provider = buildHostTelemetryProvider({ extraProducers: [new CustomDemoProducer()] });
+    const streams = new Set(provider.capabilities().map((c) => c.stream));
+    for (const s of TELEMETRY_STREAMS) expect(streams.has(s)).toBe(true);
+  });
+
+  it("an available operator producer upgrades a built-in stream that shipped unavailable", async () => {
+    class UpgradeProducer implements TelemetryProvider {
+      contractVersion(): string {
+        return "1.0.0";
+      }
+      capabilities() {
+        return [
+          { stream: "memory_signal" as TelemetryStream, schemaVersion: "1.0.0", available: true },
+        ];
+      }
+      async query(): Promise<MetricSample[]> {
+        return [];
+      }
+    }
+    // Without `memorySignalHistoryPath` the built-in memory_signal ships unavailable;
+    // the operator producer (composed last) upgrades it via the available-wins merge.
+    const provider = buildHostTelemetryProvider({ extraProducers: [new UpgradeProducer()] });
+    const cap = provider.capabilities().find((c) => c.stream === "memory_signal");
+    expect(cap?.available).toBe(true);
+  });
+
+  it("omitting extraProducers is a no-op (back-compat)", () => {
+    const before = buildHostTelemetryProvider({}).capabilities().length;
+    const after = buildHostTelemetryProvider({ extraProducers: [] }).capabilities().length;
+    expect(after).toBe(before);
+  });
+});

--- a/src/tuner/__tests__/wisecron/host-telemetry-provider.test.ts
+++ b/src/tuner/__tests__/wisecron/host-telemetry-provider.test.ts
@@ -802,3 +802,110 @@ describe("buildHostTelemetryProvider — extraProducers (operator extension poin
     expect(after).toBe(before);
   });
 });
+
+describe("CompositeTelemetryProvider — double-served stream guard (#319 review)", () => {
+  // A producer that owns exactly one stream at a fixed availability, optionally
+  // returning one sample for it — lets us stage the contested-available case
+  // deterministically (no built-in probe/fs flakiness).
+  class FixedProducer implements TelemetryProvider {
+    constructor(
+      private readonly stream: string,
+      private readonly available: boolean,
+      private readonly sample?: MetricSample,
+    ) {}
+    contractVersion(): string {
+      return "1.0.0";
+    }
+    capabilities() {
+      return [
+        {
+          stream: this.stream as TelemetryStream,
+          schemaVersion: "1.0.0",
+          available: this.available,
+        },
+      ];
+    }
+    async query(stream: TelemetryStream): Promise<MetricSample[]> {
+      return stream === this.stream && this.sample ? [this.sample] : [];
+    }
+  }
+
+  function captureWarn<T>(fn: () => T): { result: T; warnings: string[] } {
+    const warnings: string[] = [];
+    const orig = console.warn;
+    console.warn = (msg?: unknown) => {
+      warnings.push(String(msg));
+    };
+    try {
+      return { result: fn(), warnings };
+    } finally {
+      console.warn = orig;
+    }
+  }
+
+  it("two producers serving the same stream available → one capability, warns once, query still doubles", async () => {
+    const composite = new CompositeTelemetryProvider([
+      new FixedProducer("tool_call", true, { ts: new Date(NOW_MS), value: 1 }),
+      new FixedProducer("tool_call", true, { ts: new Date(NOW_MS), value: 2 }),
+    ]);
+
+    const { result: caps, warnings } = captureWarn(() => {
+      const first = composite.capabilities();
+      composite.capabilities(); // second call must NOT re-warn (once per instance)
+      return first;
+    });
+
+    // The manifest keeps ONE entry (the first producer); the second is hidden.
+    expect(caps.filter((c) => c.stream === "tool_call")).toHaveLength(1);
+    // Guard fired exactly once despite two capabilities() calls.
+    expect(warnings.filter((w) => w.includes("tool_call"))).toHaveLength(1);
+
+    // But query() concatenates — the guard warns, it does NOT dedupe. This pins
+    // the double-count so a future "silent dedupe" refactor is a conscious choice.
+    const samples = await composite.query("tool_call" as TelemetryStream, RANGE);
+    expect(samples).toHaveLength(2);
+  });
+
+  it("upgrading an UNAVAILABLE built-in does not trip the guard", () => {
+    class UpgradeProducer implements TelemetryProvider {
+      contractVersion(): string {
+        return "1.0.0";
+      }
+      capabilities() {
+        return [
+          { stream: "memory_signal" as TelemetryStream, schemaVersion: "1.0.0", available: true },
+        ];
+      }
+      async query(): Promise<MetricSample[]> {
+        return [];
+      }
+    }
+    // No memorySignalHistoryPath → the built-in memory_signal ships unavailable,
+    // so the operator producer legitimately upgrades it — not a conflict.
+    const { result: provider, warnings } = captureWarn(() =>
+      buildHostTelemetryProvider({ extraProducers: [new UpgradeProducer()] }),
+    );
+    const cap = provider.capabilities().find((c) => c.stream === "memory_signal");
+    expect(cap?.available).toBe(true);
+    expect(warnings.filter((w) => w.includes("memory_signal"))).toHaveLength(0);
+  });
+
+  it("a disjoint custom stream never leaks into a built-in stream's query()", async () => {
+    class CustomProducer implements TelemetryProvider {
+      contractVersion(): string {
+        return "1.0.0";
+      }
+      capabilities() {
+        return [
+          { stream: "custom.demo" as TelemetryStream, schemaVersion: "1.0.0", available: true },
+        ];
+      }
+      async query(stream: TelemetryStream): Promise<MetricSample[]> {
+        return stream === "custom.demo" ? [{ ts: new Date(NOW_MS), value: 7 }] : [];
+      }
+    }
+    const provider = buildHostTelemetryProvider({ extraProducers: [new CustomProducer()] });
+    const toolCall = await provider.query("tool_call" as TelemetryStream, RANGE);
+    expect(toolCall.every((s) => s.value !== 7)).toBe(true);
+  });
+});

--- a/src/tuner/__tests__/wisecron/telemetry-mcp.test.ts
+++ b/src/tuner/__tests__/wisecron/telemetry-mcp.test.ts
@@ -103,6 +103,44 @@ describe("registerHostTelemetryTools + bridgeToolCaller (in-process)", () => {
     expect(host.queries[0]?.stream).toBe("cron_run");
   });
 
+  it("round-trips a custom (extraProducer) stream through the served MCP surface", async () => {
+    // A host whose only stream is operator-defined (`custom.<name>`) — the
+    // extraProducers path. Regression guard: QueryArgsSchema once validated
+    // `stream` against the closed TELEMETRY_STREAMS enum, so a custom stream was
+    // advertised available via telemetry__capabilities but rejected at query
+    // time, and McpTelemetryProvider.query silently degraded to [].
+    class CustomHost implements TelemetryProvider {
+      contractVersion(): string {
+        return TELEMETRY_CONTRACT_VERSION;
+      }
+      capabilities(): TelemetryCapability[] {
+        return [
+          {
+            stream: "custom.demo" as TelemetryStream,
+            schemaVersion: TELEMETRY_CONTRACT_VERSION,
+            available: true,
+          },
+        ];
+      }
+      async query(stream: TelemetryStream): Promise<MetricSample[]> {
+        return stream === "custom.demo" ? [{ ts: IN, value: 42, labels: { source: "demo" } }] : [];
+      }
+    }
+    const bridge = new PluginMcpBridge(join(tmpDir, "audit.jsonl"));
+    registerHostTelemetryTools(bridge, { provider: new CustomHost() });
+    const provider = new McpTelemetryProvider(bridgeToolCaller(bridge));
+    await provider.connect();
+
+    // Advertised available over the wire...
+    const cap = provider.capabilities().find((c) => c.stream === "custom.demo");
+    expect(cap?.available).toBe(true);
+    // ...AND actually queryable over the wire (not silently empty).
+    const samples = await provider.query("custom.demo" as TelemetryStream, RANGE);
+    expect(samples).toHaveLength(1);
+    expect(samples[0]?.value).toBe(42);
+    expect(samples[0]?.labels).toEqual({ source: "demo" });
+  });
+
   it("re-registration replaces the prior tools (idempotent surface)", () => {
     const bridge = new PluginMcpBridge(join(tmpDir, "audit.jsonl"));
     registerHostTelemetryTools(bridge, { provider: new StubHostProvider() });

--- a/src/tuner/wisecron/host-telemetry-provider.ts
+++ b/src/tuner/wisecron/host-telemetry-provider.ts
@@ -945,6 +945,10 @@ export class TemplateFeedbackTelemetryProducer implements TelemetryProvider {
 export class CompositeTelemetryProvider implements TelemetryProvider, ViewManifestSource {
   constructor(private readonly providers: TelemetryProvider[]) {}
 
+  /** Streams already flagged as double-served, so the guard warns once per
+   *  stream per instance instead of every `capabilities()` call. */
+  private readonly warnedStreamConflicts = new Set<string>();
+
   contractVersion(): string {
     return TELEMETRY_CONTRACT_VERSION;
   }
@@ -958,6 +962,18 @@ export class CompositeTelemetryProvider implements TelemetryProvider, ViewManife
       // First writer wins; an available producer upgrades a prior unavailable.
       if (!cur) best.set(c.stream, c);
       else if (!cur.available && c.available) best.set(c.stream, c);
+      else if (cur.available && c.available && !this.warnedStreamConflicts.has(c.stream)) {
+        // Two producers both serve this stream `available`. The merge keeps the
+        // first (this manifest hides the second), but `query()` concatenates
+        // every producer — so the second's samples silently double-count.
+        // Producers MUST own disjoint streams; see `extraProducers`' contract.
+        this.warnedStreamConflicts.add(c.stream);
+        console.warn(
+          `[telemetry] stream "${c.stream}" is served \`available\` by more than one ` +
+            `producer — query() will double-count it. Producers must own disjoint streams ` +
+            `(an extraProducer may only upgrade an \`unavailable\` built-in).`,
+        );
+      }
     }
     for (const s of TELEMETRY_STREAMS) {
       if (!best.has(s)) {
@@ -1045,10 +1061,20 @@ export interface HostTelemetryConfig {
   /**
    * Operator-supplied producers composed alongside the built-ins — the
    * extension point for a host to add its own telemetry source (or a custom
-   * stream) without editing this function. Each is merged into the composite
-   * exactly like a built-in: its `capabilities()` win the per-stream merge
-   * when available, and its `query()` results are concatenated. Custom streams
-   * SHOULD be namespaced (`custom.<name>`).
+   * stream) without editing this function. Composed LAST.
+   *
+   * Contract — each producer MUST own streams DISJOINT from every `available`
+   * built-in stream:
+   * - `capabilities()` merge is first-available-wins, so an extraProducer only
+   *   ever UPGRADES a built-in that shipped `unavailable`; it can NOT override a
+   *   built-in that is already `available` (that built-in was listed first).
+   * - `query()` CONCATENATES every producer, so if an extraProducer claims a
+   *   stream a built-in already serves `available`, its samples double-count
+   *   (the capability manifest hides it, but the data still flows). This is
+   *   operator misconfiguration — `buildHostTelemetryProvider` warns on it.
+   *
+   * Custom streams SHOULD be namespaced (`custom.<name>`) to stay disjoint from
+   * current and future built-ins.
    */
   extraProducers?: TelemetryProvider[];
 }

--- a/src/tuner/wisecron/host-telemetry-provider.ts
+++ b/src/tuner/wisecron/host-telemetry-provider.ts
@@ -1042,6 +1042,15 @@ export interface HostTelemetryConfig {
    * specialized page and falls back to the universal page like any plugin.
    */
   tunerView?: TunerViewSources;
+  /**
+   * Operator-supplied producers composed alongside the built-ins — the
+   * extension point for a host to add its own telemetry source (or a custom
+   * stream) without editing this function. Each is merged into the composite
+   * exactly like a built-in: its `capabilities()` win the per-stream merge
+   * when available, and its `query()` results are concatenated. Custom streams
+   * SHOULD be namespaced (`custom.<name>`).
+   */
+  extraProducers?: TelemetryProvider[];
 }
 
 /**
@@ -1094,5 +1103,8 @@ export function buildHostTelemetryProvider(
   if (cfg.tunerView) {
     providers.push(new TunerViewProvider(cfg.tunerView));
   }
+  // Operator-supplied producers last, so an explicit host source can upgrade
+  // a built-in stream that shipped unavailable (the merge is available-wins).
+  if (cfg.extraProducers?.length) providers.push(...cfg.extraProducers);
   return new CompositeTelemetryProvider(providers);
 }

--- a/src/tuner/wisecron/index.ts
+++ b/src/tuner/wisecron/index.ts
@@ -12,7 +12,7 @@
 import type { Registry } from "../../skills-tuner/core/registry.js";
 import type { LLMClient } from "../../skills-tuner/core/llm.js";
 import type { TunableSubject } from "../../skills-tuner/core/interfaces.js";
-import type { TelemetryProvider, TelemetryStream } from "../../skills-tuner/core/telemetry.js";
+import type { KnownTelemetryStream, TelemetryProvider } from "../../skills-tuner/core/telemetry.js";
 import { AuditLog } from "../../skills-tuner/core/audit-log.js";
 import { activateFitness } from "../../skills-tuner/core/fitness.js";
 import {
@@ -60,7 +60,7 @@ export interface WisecronContext {
  * Honours per-subject `enabled` flags in settings.subjects.
  */
 /** Maps each producer-dependent subject to the telemetry stream it consumes. */
-const SUBJECT_STREAM: Partial<Record<string, TelemetryStream>> = {
+const SUBJECT_STREAM: Partial<Record<string, KnownTelemetryStream>> = {
   cron: "cron_run",
   hook: "hook_exec",
   mcp_plugin: "tool_call",

--- a/src/tuner/wisecron/telemetry-mcp.ts
+++ b/src/tuner/wisecron/telemetry-mcp.ts
@@ -32,7 +32,6 @@ import {
   type TelemetryProvider,
   type TelemetryStream,
   TELEMETRY_CONTRACT_VERSION,
-  TELEMETRY_STREAMS,
 } from "../../skills-tuner/core/telemetry.js";
 
 // ── Wire contract ────────────────────────────────────────────────────────────
@@ -64,7 +63,14 @@ interface QueryResult {
 }
 
 const QueryArgsSchema = z.object({
-  stream: z.enum(TELEMETRY_STREAMS),
+  // Not `z.enum(TELEMETRY_STREAMS)`: `buildHostTelemetryProvider`'s
+  // `extraProducers` can advertise operator-defined (`custom.<name>`) streams
+  // via `telemetry__capabilities`, so the served query surface must accept them
+  // too — otherwise a stream reported `available` here would reject at query
+  // time and `McpTelemetryProvider.query` would silently degrade to `[]`
+  // (available-but-always-empty). Bounded length since this is socket-exposed;
+  // unknown streams simply return no samples (each producer owns its own).
+  stream: z.string().min(1).max(128),
   start: z.string(),
   end: z.string(),
   filters: z.record(z.string(), z.string()).optional(),


### PR DESCRIPTION
Refs #275.

## Problem

`buildHostTelemetryProvider()` composes a **hardcoded** list of producers, and `TelemetryStream` is a **closed** union of the built-in stream names. Together these mean an operator cannot compose their own telemetry source — or declare their own signal — without editing core / forking. The producer *interface* (`TelemetryProvider`) and the composite are already there; the missing piece is an extension point.

## What this does

- **`HostTelemetryConfig.extraProducers?: TelemetryProvider[]`** — operator-supplied producers, composed alongside the built-ins. Merged exactly like a built-in: `capabilities()` win the per-stream merge when available, `query()` results are concatenated. Composed **last**, so an explicit host source can upgrade a built-in stream that shipped unavailable (the merge is available-wins).
- **Widen `TelemetryStream`** to `KnownTelemetryStream | (string & {})` — a stream name is one of the built-ins **or** any operator-defined string, so a composed producer can advertise its own signal (custom producers SHOULD namespace, e.g. `custom.<name>`). The `& {}` preserves literal autocomplete for the known streams. `KnownTelemetryStream` is exported for code that still wants the closed set.

Backward-compatible: `extraProducers` is optional (omitting it is a no-op), and every existing call site / stream literal stays valid.

## Why

The extension point third-party operators need to instrument their own signals — and, in turn, to tune their own subjects — on the same rails as the built-ins, without a fork. Complements the consumer-side host-telemetry surface already shipped.

## Test plan

New cases in `host-telemetry-provider.test.ts`:
- an operator producer advertising a **custom** stream (`custom.demo`) is composed → shows up available in `capabilities()` and returns samples via `query()`;
- **no regression**: every built-in stream is still advertised;
- an available operator producer **upgrades** a built-in stream that shipped unavailable (available-wins merge);
- omitting `extraProducers` is a **no-op** (back-compat).

Full `src/tuner` + `src/skills-tuner` suites green (453 pass, 0 fail). The widening adds **no** new `tsc` errors (repo-wide count unchanged) and no lint errors — verified the two `switch (stream)` sites keep a safe default.

## Provenance

This extension point was surfaced by a third-party operator running the tuner (issues #312 / #313 by @txvicious): a downstream user instrumenting and culling their own plugins hit the wall that a host can't add its own telemetry source — or declare its own signal — without editing core. Crediting that report; it's the concrete "operator can't extend without forking" case this PR removes.
