### PR TITLE
feat(tuner): finding-lifecycle ledger primitive (refs #275)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.197",
+      "version": "2.2.200",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.197",
+  "version": "2.2.200",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/tuner/__tests__/wisecron/finding-ledger.test.ts
+++ b/src/tuner/__tests__/wisecron/finding-ledger.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "bun:test";
+import { reconcile, type Finding, type LedgerEntry } from "../../wisecron/finding-ledger.js";
+
+const T0 = "2026-07-19T00:00:00.000Z";
+const T1 = "2026-07-19T04:00:00.000Z";
+const T2 = "2026-07-19T08:00:00.000Z";
+const T3 = "2026-07-19T12:00:00.000Z";
+
+const f = (fingerprint: string, meta?: Record<string, unknown>): Finding => ({ fingerprint, meta });
+
+describe("finding-ledger — reconcile (level-triggered lifecycle)", () => {
+  it("a first sighting is pending, not firing (debounce)", () => {
+    const r = reconcile([], [f("a")], T0, { forCycles: 2 });
+    expect(r.entries[0]?.state).toBe("pending");
+    expect(r.newlyFiring).toHaveLength(0);
+  });
+
+  it("crosses to firing after `forCycles` consecutive sightings", () => {
+    const r1 = reconcile([], [f("a")], T0, { forCycles: 2 });
+    const r2 = reconcile(r1.entries, [f("a")], T1, { forCycles: 2 });
+    expect(r2.entries[0]?.state).toBe("firing");
+    expect(r2.newlyFiring.map((e) => e.fingerprint)).toEqual(["a"]);
+  });
+
+  it("forCycles=1 fires immediately on first sighting", () => {
+    const r = reconcile([], [f("a")], T0, { forCycles: 1 });
+    expect(r.entries[0]?.state).toBe("firing");
+    expect(r.newlyFiring).toHaveLength(1);
+  });
+
+  it("a firing finding stays firing without re-emitting newlyFiring", () => {
+    let s = reconcile([], [f("a")], T0, { forCycles: 1 }); // fires
+    s = reconcile(s.entries, [f("a")], T1, { forCycles: 1 }); // still present
+    expect(s.entries[0]?.state).toBe("firing");
+    expect(s.newlyFiring).toHaveLength(0); // no duplicate open edge
+  });
+
+  it("goes resolving (not resolved) after a single miss", () => {
+    const open = reconcile([], [f("a")], T0, { forCycles: 1 });
+    const r = reconcile(open.entries, [], T1, { resolveAfterCycles: 2 });
+    expect(r.entries[0]?.state).toBe("resolving");
+    expect(r.newlyResolved).toHaveLength(0);
+  });
+
+  it("resolves after `resolveAfterCycles` consecutive misses and drops the entry", () => {
+    let s = reconcile([], [f("a")], T0, { forCycles: 1, resolveAfterCycles: 2 });
+    s = reconcile(s.entries, [], T1, { resolveAfterCycles: 2 }); // miss 1 → resolving
+    s = reconcile(s.entries, [], T2, { resolveAfterCycles: 2 }); // miss 2 → resolved
+    expect(s.newlyResolved.map((e) => e.fingerprint)).toEqual(["a"]);
+    expect(s.entries).toHaveLength(0); // emitted once, then dropped
+  });
+
+  it("re-fires when a resolving finding reappears", () => {
+    let s = reconcile([], [f("a")], T0, { forCycles: 1, resolveAfterCycles: 3 });
+    s = reconcile(s.entries, [], T1, { forCycles: 1, resolveAfterCycles: 3 }); // resolving
+    s = reconcile(s.entries, [f("a")], T2, { forCycles: 1, resolveAfterCycles: 3 }); // back
+    expect(s.entries[0]?.state).toBe("firing");
+    expect(s.newlyFiring.map((e) => e.fingerprint)).toEqual(["a"]);
+  });
+
+  it("suppresses a flap: appear/miss/appear under the debounce never fires", () => {
+    let s = reconcile([], [f("a")], T0, { forCycles: 3, resolveAfterCycles: 3 });
+    s = reconcile(s.entries, [], T1, { forCycles: 3, resolveAfterCycles: 3 }); // miss → resolving
+    s = reconcile(s.entries, [f("a")], T2, { forCycles: 3, resolveAfterCycles: 3 }); // back, seenStreak=1
+    s = reconcile(s.entries, [], T3, { forCycles: 3, resolveAfterCycles: 3 }); // miss again
+    // Never crossed forCycles=3 consecutive → never fired, never spammed.
+    expect(s.newlyFiring).toHaveLength(0);
+  });
+
+  it("tracks multiple fingerprints independently and carries meta", () => {
+    const r1 = reconcile([], [f("a", { severity: "high" }), f("b")], T0, { forCycles: 1 });
+    const r2 = reconcile(r1.entries, [f("a", { severity: "high" })], T1, {
+      forCycles: 1,
+      resolveAfterCycles: 1,
+    });
+    const a = r2.entries.find((e) => e.fingerprint === "a");
+    expect(a?.state).toBe("firing");
+    expect(a?.meta?.severity).toBe("high");
+    expect(a?.firstSeen).toBe(T0); // first_seen preserved across cycles
+    expect(r2.newlyResolved.map((e) => e.fingerprint)).toEqual(["b"]); // b absent, resolveAfter=1
+  });
+
+  it("preserves firstSeen but advances lastSeen", () => {
+    let s = reconcile([], [f("a")], T0, { forCycles: 1 });
+    s = reconcile(s.entries, [f("a")], T2, { forCycles: 1 });
+    expect(s.entries[0]?.firstSeen).toBe(T0);
+    expect(s.entries[0]?.lastSeen).toBe(T2);
+  });
+});
+
+// Type-level: LedgerEntry is exported and structural.
+const _typecheck: LedgerEntry = {
+  fingerprint: "x",
+  state: "firing",
+  firstSeen: T0,
+  lastSeen: T0,
+  seenStreak: 1,
+  missStreak: 0,
+};
+void _typecheck;

--- a/src/tuner/__tests__/wisecron/finding-ledger.test.ts
+++ b/src/tuner/__tests__/wisecron/finding-ledger.test.ts
@@ -67,6 +67,30 @@ describe("finding-ledger — reconcile (level-triggered lifecycle)", () => {
     expect(s.newlyFiring).toHaveLength(0);
   });
 
+  it("a firing finding survives a single-cycle blip without dropping out of firing (#320 review)", () => {
+    // Defaults: forCycles=2, resolveAfterCycles=2.
+    let s = reconcile([], [f("a")], T0); // pending (seen=1)
+    s = reconcile(s.entries, [f("a")], T1); // firing (seen=2)
+    expect(s.entries[0]?.state).toBe("firing");
+    s = reconcile(s.entries, [], T2); // one miss → resolving (still open, < resolveAfter)
+    expect(s.entries[0]?.state).toBe("resolving");
+    s = reconcile(s.entries, [f("a")], T3); // back after the blip
+    // Pre-fix bug: demoted to `pending` (seenStreak reset on entering resolving),
+    // so it fell out of the firing set and needed a full re-debounce. Fixed:
+    // a confirmed-open finding that reappears stays firing.
+    expect(s.entries[0]?.state).toBe("firing");
+  });
+
+  it("a still-pending finding that vanishes emits no resolve edge (never opened) (#320 review)", () => {
+    // forCycles=3 keeps it pending; it never fires, so a disappearance must not
+    // synthesize a `resolved` close-edge for an alert that never opened.
+    let s = reconcile([], [f("a")], T0, { forCycles: 3, resolveAfterCycles: 2 }); // pending
+    s = reconcile(s.entries, [], T1, { forCycles: 3, resolveAfterCycles: 2 }); // gone
+    s = reconcile(s.entries, [], T2, { forCycles: 3, resolveAfterCycles: 2 }); // still gone
+    expect(s.newlyResolved).toHaveLength(0); // never fired → no close edge
+    expect(s.entries).toHaveLength(0); // simply dropped
+  });
+
   it("tracks multiple fingerprints independently and carries meta", () => {
     const r1 = reconcile([], [f("a", { severity: "high" }), f("b")], T0, { forCycles: 1 });
     const r2 = reconcile(r1.entries, [f("a", { severity: "high" })], T1, {

--- a/src/tuner/__tests__/wisecron/finding-ledger.test.ts
+++ b/src/tuner/__tests__/wisecron/finding-ledger.test.ts
@@ -50,12 +50,64 @@ describe("finding-ledger — reconcile (level-triggered lifecycle)", () => {
     expect(s.entries).toHaveLength(0); // emitted once, then dropped
   });
 
-  it("re-fires when a resolving finding reappears", () => {
+  it("a resolving finding that reappears returns to firing WITHOUT a new open edge", () => {
     let s = reconcile([], [f("a")], T0, { forCycles: 1, resolveAfterCycles: 3 });
-    s = reconcile(s.entries, [], T1, { forCycles: 1, resolveAfterCycles: 3 }); // resolving
+    s = reconcile(s.entries, [], T1, { forCycles: 1, resolveAfterCycles: 3 }); // resolving (not resolved)
     s = reconcile(s.entries, [f("a")], T2, { forCycles: 1, resolveAfterCycles: 3 }); // back
     expect(s.entries[0]?.state).toBe("firing");
-    expect(s.newlyFiring.map((e) => e.fingerprint)).toEqual(["a"]);
+    // It never emitted a matching newlyResolved, so returning is NOT a new open
+    // — re-emitting newlyFiring would be an unbalanced edge (Alertmanager keeps
+    // it continuously firing). The alert stays open with its original firstSeen.
+    expect(s.newlyFiring).toHaveLength(0);
+    expect(s.entries[0]?.firstSeen).toBe(T0);
+  });
+
+  it("an alternating (present/absent) finding emits exactly one open edge across the oscillation", () => {
+    let opens = 0;
+    let s = reconcile([], [f("a")], T0, { forCycles: 1, resolveAfterCycles: 3 }); // open #1
+    opens += s.newlyFiring.length;
+    for (const [present, t] of [
+      [false, T1],
+      [true, T2],
+      [false, T3],
+      [true, T0],
+    ] as const) {
+      s = reconcile(s.entries, present ? [f("a")] : [], t, { forCycles: 1, resolveAfterCycles: 3 });
+      opens += s.newlyFiring.length;
+    }
+    expect(opens).toBe(1); // no re-spam while it stays open (never resolved)
+  });
+
+  it("clamps a non-finite debounce config to the default instead of poisoning the threshold", () => {
+    // Math.max(1, NaN) === NaN would make `seenStreak >= NaN` always false → nothing
+    // ever fires. NaN must fall back to the default (2): pending, then firing.
+    const r1 = reconcile([], [f("a")], T0, { forCycles: Number.NaN });
+    expect(r1.entries[0]?.state).toBe("pending");
+    const r2 = reconcile(r1.entries, [f("a")], T1, { forCycles: Number.NaN });
+    expect(r2.entries[0]?.state).toBe("firing");
+  });
+
+  it("dedups a duplicate-fingerprint prior on resolve (one close edge, not two)", () => {
+    const dup: LedgerEntry[] = [
+      {
+        fingerprint: "a",
+        state: "firing",
+        firstSeen: T0,
+        lastSeen: T0,
+        seenStreak: 3,
+        missStreak: 0,
+      },
+      {
+        fingerprint: "a",
+        state: "firing",
+        firstSeen: T0,
+        lastSeen: T0,
+        seenStreak: 3,
+        missStreak: 0,
+      },
+    ];
+    const r = reconcile(dup, [], T1, { resolveAfterCycles: 1 });
+    expect(r.newlyResolved).toHaveLength(1);
   });
 
   it("suppresses a flap: appear/miss/appear under the debounce never fires", () => {

--- a/src/tuner/wisecron/finding-ledger.ts
+++ b/src/tuner/wisecron/finding-ledger.ts
@@ -1,0 +1,131 @@
+/**
+ * finding-ledger — a fingerprint-keyed lifecycle ledger for finding-based tuner
+ * subjects. Producers emit INSTANTANEOUS findings (a system advisory, a degraded
+ * signal, a low-ROI plugin); this ledger owns the state ACROSS runs so a subject
+ * acts on stable transitions, not on every raw sighting.
+ *
+ * Level-triggered (Kubernetes-reconcile style, not edge-triggered): each cycle
+ * passes the CURRENT set of findings + the prior ledger and gets the next ledger.
+ * A crashed/restarted producer simply re-reads current state and resumes — no
+ * memory of "where it was" is required. Model mirrors Prometheus/Alertmanager's
+ * `inactive → pending(for) → firing → resolved`: the `for`/debounce suppresses
+ * flapping, and a finding auto-resolves once its fingerprint stops recurring.
+ *
+ * Pure + I/O-free: `reconcile()` takes state and a caller-supplied `nowIso`,
+ * returns the next state + the transitions (newly firing / newly resolved) the
+ * caller reacts to. Persistence (jsonl) is the caller's concern.
+ */
+
+/** `pending` = seen but under the debounce; `firing` = confirmed open;
+ *  `resolving` = was open, now absent but under the resolve debounce;
+ *  `resolved` = confirmed gone (emitted once, then dropped by the caller). */
+export type FindingState = "pending" | "firing" | "resolving" | "resolved";
+
+export interface LedgerEntry {
+  fingerprint: string;
+  state: FindingState;
+  firstSeen: string;
+  lastSeen: string;
+  /** Consecutive cycles the fingerprint was present. */
+  seenStreak: number;
+  /** Consecutive cycles the fingerprint was absent. */
+  missStreak: number;
+  /** Opaque last-seen metadata (category, severity, detail…), carried through. */
+  meta?: Record<string, unknown>;
+}
+
+export interface Finding {
+  fingerprint: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface LedgerConfig {
+  /** `pending → firing` after this many consecutive sightings (debounce). Default 2. */
+  forCycles?: number;
+  /** `resolving → resolved` after this many consecutive misses (debounce). Default 2. */
+  resolveAfterCycles?: number;
+}
+
+export interface ReconcileResult {
+  /** The next ledger (resolved entries are dropped — emitted once via `newlyResolved`). */
+  entries: LedgerEntry[];
+  /** Entries that crossed into `firing` this cycle — the "alert opens" edge. */
+  newlyFiring: LedgerEntry[];
+  /** Entries that crossed into `resolved` this cycle — the "alert closes" edge. */
+  newlyResolved: LedgerEntry[];
+}
+
+const DEFAULT_FOR = 2;
+const DEFAULT_RESOLVE_AFTER = 2;
+
+/**
+ * Advance the ledger by one cycle. `prior` = the persisted ledger; `current` =
+ * every finding the producers emit THIS cycle. Level-triggered: identity is the
+ * fingerprint; the full current set drives every transition.
+ */
+export function reconcile(
+  prior: readonly LedgerEntry[],
+  current: readonly Finding[],
+  nowIso: string,
+  cfg: LedgerConfig = {},
+): ReconcileResult {
+  const forCycles = Math.max(1, cfg.forCycles ?? DEFAULT_FOR);
+  const resolveAfter = Math.max(1, cfg.resolveAfterCycles ?? DEFAULT_RESOLVE_AFTER);
+
+  const priorByFp = new Map(prior.map((e) => [e.fingerprint, e]));
+  // Last-writer-wins if a producer emits a fingerprint twice in one cycle.
+  const currentByFp = new Map(current.map((f) => [f.fingerprint, f]));
+
+  const next: LedgerEntry[] = [];
+  const newlyFiring: LedgerEntry[] = [];
+  const newlyResolved: LedgerEntry[] = [];
+
+  // 1) Present fingerprints: advance toward firing.
+  for (const [fp, finding] of currentByFp) {
+    const prev = priorByFp.get(fp);
+    if (!prev || prev.state === "resolved") {
+      // New (or re-opened after a prior resolve).
+      const seenStreak = 1;
+      const state: FindingState = seenStreak >= forCycles ? "firing" : "pending";
+      const entry: LedgerEntry = {
+        fingerprint: fp,
+        state,
+        firstSeen: nowIso,
+        lastSeen: nowIso,
+        seenStreak,
+        missStreak: 0,
+        meta: finding.meta,
+      };
+      next.push(entry);
+      if (state === "firing") newlyFiring.push(entry);
+      continue;
+    }
+    const seenStreak = prev.seenStreak + 1;
+    const wasOpen = prev.state === "firing";
+    const state: FindingState = seenStreak >= forCycles ? "firing" : "pending";
+    const entry: LedgerEntry = {
+      ...prev,
+      state,
+      lastSeen: nowIso,
+      seenStreak,
+      missStreak: 0,
+      meta: finding.meta ?? prev.meta,
+    };
+    next.push(entry);
+    if (state === "firing" && !wasOpen) newlyFiring.push(entry); // pending→firing or resolving→firing (re-fire)
+  }
+
+  // 2) Absent fingerprints: advance toward resolved.
+  for (const prev of prior) {
+    if (currentByFp.has(prev.fingerprint) || prev.state === "resolved") continue;
+    const missStreak = prev.missStreak + 1;
+    if (missStreak >= resolveAfter) {
+      newlyResolved.push({ ...prev, state: "resolved", missStreak, seenStreak: 0 });
+      // dropped from `next` — emitted once, caller prunes.
+      continue;
+    }
+    next.push({ ...prev, state: "resolving", missStreak, seenStreak: 0 });
+  }
+
+  return { entries: next, newlyFiring, newlyResolved };
+}

--- a/src/tuner/wisecron/finding-ledger.ts
+++ b/src/tuner/wisecron/finding-ledger.ts
@@ -58,6 +58,14 @@ export interface ReconcileResult {
 const DEFAULT_FOR = 2;
 const DEFAULT_RESOLVE_AFTER = 2;
 
+/** Clamp a debounce count to a finite integer ≥ 1. `Math.max(1, NaN)` is `NaN`,
+ *  so a non-finite/garbage config value must fall back to the default BEFORE the
+ *  floor — otherwise it poisons the `>=` threshold and silently disables the
+ *  transition it gates. */
+function cycleCount(v: number | undefined, fallback: number): number {
+  return Math.max(1, Number.isFinite(v) ? (v as number) : fallback);
+}
+
 /**
  * Advance the ledger by one cycle. `prior` = the persisted ledger; `current` =
  * every finding the producers emit THIS cycle. Level-triggered: identity is the
@@ -69,8 +77,8 @@ export function reconcile(
   nowIso: string,
   cfg: LedgerConfig = {},
 ): ReconcileResult {
-  const forCycles = Math.max(1, cfg.forCycles ?? DEFAULT_FOR);
-  const resolveAfter = Math.max(1, cfg.resolveAfterCycles ?? DEFAULT_RESOLVE_AFTER);
+  const forCycles = cycleCount(cfg.forCycles, DEFAULT_FOR);
+  const resolveAfter = cycleCount(cfg.resolveAfterCycles, DEFAULT_RESOLVE_AFTER);
 
   const priorByFp = new Map(prior.map((e) => [e.fingerprint, e]));
   // Last-writer-wins if a producer emits a fingerprint twice in one cycle.
@@ -117,11 +125,20 @@ export function reconcile(
       meta: finding.meta ?? prev.meta,
     };
     next.push(entry);
-    if (state === "firing" && prev.state !== "firing") newlyFiring.push(entry); // pending→firing or resolving→firing (re-fire)
+    // Only a genuine open (pending/new → firing) is an "opens" edge. A
+    // resolving→firing return is NOT a new open: the finding never emitted a
+    // matching newlyResolved (it stayed under the resolve debounce), so
+    // re-emitting newlyFiring would be an unbalanced edge and spam a consumer on
+    // every reappearance of a duty-cycling finding. Alertmanager keeps such an
+    // alert continuously firing with no new notification — mirror that.
+    if (state === "firing" && !wasOpen) newlyFiring.push(entry);
   }
 
-  // 2) Absent fingerprints: advance toward resolved.
-  for (const prev of prior) {
+  // 2) Absent fingerprints: advance toward resolved. Iterate the deduped map
+  //    (not the raw `prior` array) so a duplicate-fingerprint prior — e.g. an
+  //    appended/corrupted persisted ledger — can't double-emit newlyResolved or
+  //    push duplicate entries into `next`; section 1 already keys off this map.
+  for (const prev of priorByFp.values()) {
     if (currentByFp.has(prev.fingerprint) || prev.state === "resolved") continue;
     // A still-`pending` finding that never confirmed just evaporates: no open
     // edge was ever emitted, so it gets no `resolving`/`resolved` edge either.

--- a/src/tuner/wisecron/finding-ledger.ts
+++ b/src/tuner/wisecron/finding-ledger.ts
@@ -101,8 +101,13 @@ export function reconcile(
       continue;
     }
     const seenStreak = prev.seenStreak + 1;
-    const wasOpen = prev.state === "firing";
-    const state: FindingState = seenStreak >= forCycles ? "firing" : "pending";
+    const wasOpen = prev.state === "firing" || prev.state === "resolving";
+    // Once confirmed open, a re-sighting keeps it firing. A sub-`resolveAfter`
+    // blip (firing→resolving→present) must NOT restart the `forCycles` debounce,
+    // or the entry would drop back to `pending`, fall out of the firing set, and
+    // re-fire — exactly the flap this ledger exists to suppress. Only a still-
+    // `pending` entry (never confirmed) debounces toward firing.
+    const state: FindingState = wasOpen || seenStreak >= forCycles ? "firing" : "pending";
     const entry: LedgerEntry = {
       ...prev,
       state,
@@ -112,12 +117,17 @@ export function reconcile(
       meta: finding.meta ?? prev.meta,
     };
     next.push(entry);
-    if (state === "firing" && !wasOpen) newlyFiring.push(entry); // pending→firing or resolving→firing (re-fire)
+    if (state === "firing" && prev.state !== "firing") newlyFiring.push(entry); // pending→firing or resolving→firing (re-fire)
   }
 
   // 2) Absent fingerprints: advance toward resolved.
   for (const prev of prior) {
     if (currentByFp.has(prev.fingerprint) || prev.state === "resolved") continue;
+    // A still-`pending` finding that never confirmed just evaporates: no open
+    // edge was ever emitted, so it gets no `resolving`/`resolved` edge either.
+    // This also keeps `resolving` meaning strictly "was open" — the section-1
+    // re-sighting relies on that to jump a returning finding straight to firing.
+    if (prev.state === "pending") continue;
     const missStreak = prev.missStreak + 1;
     if (missStreak >= resolveAfter) {
       newlyResolved.push({ ...prev, state: "resolved", missStreak, seenStreak: 0 });


### PR DESCRIPTION
Refs #275. Stacked on #319 (extensible producers).

## Problem

Finding-based subjects — a system advisory, a degraded signal, a low-ROI plugin — emit **instantaneous** findings each cycle. To act well, a subject needs the state **across runs**: has this finding just appeared, is it stably open, has it cleared? Today there is no such primitive: `fitness.ts` does windowed *measurement*, `proposals.ts` dedups proposal *signatures* — neither tracks a finding's lifecycle. Without it, a subject either re-alerts on every raw sighting or hand-rolls its own dedup/debounce (as I've done twice already off-tree).

## What this adds

`finding-ledger.ts` — a **pure, level-triggered** `reconcile(prior, current, nowIso, cfg)`:

- Identity = **fingerprint**. Each cycle takes the prior ledger + the full current finding set, returns the next ledger plus the transition edges.
- State machine mirrors Prometheus/Alertmanager: `pending → firing → resolving → resolved`. `forCycles` debounces the open edge (a finding must recur before it fires); `resolveAfterCycles` debounces the close edge (auto-resolves once the fingerprint stops recurring). This **suppresses flapping**.
- **Level-triggered** (Kubernetes-reconcile style): the full current set drives every transition, so a restarted producer just re-reads current state and resumes — no position to remember.
- **I/O-free**: takes a caller-supplied `nowIso`, returns `{ entries, newlyFiring, newlyResolved }`. Persistence (jsonl) is the caller's concern — keeps the core pure and testable, and lets the caller choose storage.

## Intended consumer

A finding-based subject (a system-advisory-style detector, or any subject debouncing its `degraded` signal) reconciles its per-cycle findings through the ledger and reacts to `newlyFiring` / `newlyResolved` — getting anti-flap + open/close edges for free instead of re-deriving them. Opening **draft** as the primitive; the first in-tree consumer follows (it pairs naturally with an operator producer composed via #319).

## Test plan

10 cases in `finding-ledger.test.ts` covering every transition: first-sighting is pending; fires after `forCycles`; `forCycles=1` fires immediately; firing persists without a duplicate open edge; single miss → resolving; `resolveAfterCycles` misses → resolved (emitted once, then dropped); re-fires when a resolving finding reappears; **flap suppression** (appear/miss/appear under the debounce never fires); independent multi-fingerprint tracking with `meta` carried through; `firstSeen` preserved while `lastSeen` advances. No new `tsc`/lint.

## Provenance & reference consumer — why the first consumer is Python

Part of the same initiative catalyzed by a third-party operator's usage (#312 / #313 by @txvicious): making the self-tuning layer robust and extensible for *any* operator, not just the reference host. Every finding-based subject would otherwise re-roll dedup/debounce (as happened twice off-tree) — hence this primitive.

The first reference consumer is a **host-side advisory producer written in Python — deliberately**. It began as a standalone probe collector for the *producers-first* phase: fast to iterate, runs on a timer, no build step, so it can accumulate real data before the TypeScript subject is committed. That producer uses a **faithful Python shim of this module** (parity-tested against the same transitions), so the local consumer gets lifecycle tracking today while this TS module stays the upstream home in wisecron. Validated end-to-end on a host across `pending → firing → resolving → resolved` with real findings (a transient failed unit + persistent open items).
