### PR TITLE
feat(bus): deliver stall-watchdog operator alerts to chat (closes #301)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.193",
+      "version": "2.2.194",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.193",
+  "version": "2.2.194",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,9 @@ jobs:
       # shared process) and infra-dependent tests (DB/queue CI doesn't provide).
       # Folding those in would make CI permanently red. Tracked for cleanup — see
       # the issue linked in the PR — after which these paths widen toward full.
+      # `src/adapters` added #301: the adapter suites are clean (252 pass) and
+      # they are where outbound routing and turn-semantics risk actually lives.
+      # Without them the adapter half of a delivery change never runs in CI —
+      # and there is no typecheck step to back it up.
       - name: Run tests (clean suites)
-        run: bun test src/bus src/tuner src/observability src/skills-tuner src/plugins/eval-framework src/__tests__/governance
+        run: bun test src/bus src/adapters src/tuner src/observability src/skills-tuner src/plugins/eval-framework src/__tests__/governance

--- a/src/adapters/discord/__tests__/discord-outbound.test.ts
+++ b/src/adapters/discord/__tests__/discord-outbound.test.ts
@@ -463,4 +463,102 @@ describe("DiscordAdapter — multi-agent fan-out", () => {
     expect(byCh.get("ch-2")).toBe("for ops");
     expect(byCh.get("th-1")).toBe("for ops");
   });
+  /* #301 — out-of-band operator alerts (stall watchdog). */
+
+  it("renders a system.operator_alert to the agent's primary channel", async () => {
+    adapter = await startAdapter(h, {
+      routing: {
+        channels: { "ch-2": "ops" },
+        threads: { "th-1": "ops" },
+        dmAgentId: "global",
+        primaryChannelByAgent: { ops: "ch-2" },
+      },
+    });
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "",
+      topic: "system.operator_alert",
+      payload: {
+        level: "critical",
+        text: "stall-watchdog: looked ALIVE",
+        source: "stall-watchdog",
+      },
+    });
+    // Narrowed to the operator's primary channel, not fanned out to th-1.
+    expect(h.rest.sent.map((m) => m.channelId)).toEqual(["ch-2"]);
+    expect(h.rest.sent[0]?.text).toContain("looked ALIVE");
+  });
+
+  it("never routes an alert for agent A to a channel owned only by agent B", async () => {
+    adapter = await startAdapter(h, {
+      routing: { channels: { "ch-1": "triage", "ch-2": "ops" }, dmAgentId: "global" },
+    });
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "",
+      topic: "system.operator_alert",
+      payload: { level: "warn", text: "ops alert", source: "stall-watchdog" },
+    });
+    expect(h.rest.sent.map((m) => m.channelId)).toEqual(["ch-2"]);
+  });
+
+  it("posts an alert to ONE channel even when the agent owns several and no primary is set", async () => {
+    // #151's fan-out containment is opt-in: without a primaryChannelByAgent
+    // entry, targetChannels degrades to every channel AND thread mapped to
+    // the agent. Tolerable for a periodic heartbeat; an alert storm for a
+    // stall alert, whose guards bound per session, not per channel.
+    adapter = await startAdapter(h, {
+      routing: {
+        channels: { "ch-1": "ops", "ch-2": "ops" },
+        threads: { "th-1": "ops" },
+        dmAgentId: "global",
+        // deliberately NO primaryChannelByAgent — the documented default
+      },
+    });
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "",
+      topic: "system.operator_alert",
+      payload: { level: "critical", text: "wedged", source: "stall-watchdog" },
+    });
+
+    // A reply would fan out to all three; an alert must not.
+    expect(h.rest.sent).toHaveLength(1);
+  });
+
+  it("still fans a normal reply out to every routed channel (alert narrowing is alert-only)", async () => {
+    adapter = await startAdapter(h, {
+      routing: {
+        channels: { "ch-1": "ops", "ch-2": "ops" },
+        threads: { "th-1": "ops" },
+        dmAgentId: "global",
+      },
+    });
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "s",
+      topic: "response.text",
+      payload: { text: "a normal reply" },
+    });
+
+    expect(h.rest.sent.map((m) => m.channelId).sort()).toEqual(["ch-1", "ch-2", "th-1"]);
+  });
+
+  it("drops an alert with no text rather than posting an empty message", async () => {
+    adapter = await startAdapter(h, {
+      routing: { channels: { "ch-2": "ops" }, dmAgentId: "global" },
+    });
+    h.bus.emit({
+      ts: Date.now(),
+      agent_id: "ops",
+      session_id: "",
+      topic: "system.operator_alert",
+      payload: { level: "warn", source: "stall-watchdog" },
+    });
+    expect(h.rest.sent).toHaveLength(0);
+  });
 });

--- a/src/adapters/discord/index.ts
+++ b/src/adapters/discord/index.ts
@@ -158,7 +158,14 @@ export class DiscordAdapter {
       const sub = this.bus.subscribe(
         {
           agent_id: agentId,
-          topics: ["response.text", "channel.permission_request", "system.request_human"],
+          topics: [
+            "response.text",
+            "channel.permission_request",
+            "system.request_human",
+            // #301: out-of-band operator alerts (stall watchdog). A dedicated
+            // topic, not `response.text`, so it carries no turn semantics.
+            "system.operator_alert",
+          ],
         },
         (event) => this.handleBusEvent(agentId, event),
       );
@@ -539,6 +546,30 @@ export class DiscordAdapter {
       for (const channelId of targetChannels) {
         void this.safeSendMessage(channelId, prompt, components);
       }
+      return;
+    }
+
+    // #301: an out-of-band operator alert (e.g. the stall watchdog flagging a
+    // kill that looked like a false positive). Rendered as a standalone
+    // message — it is NOT a reply, so it must not touch turn state, edit a
+    // live message, or register a pending ask.
+    if (event.topic === "system.operator_alert") {
+      const payload = event.payload as { text?: string };
+      const text = typeof payload.text === "string" ? payload.text : "";
+      if (!text) return;
+      // Deliberately ONE channel, unlike the reply fan-out below.
+      // `targetChannels` is already `[primaryChannel]` when the operator set
+      // one; without an entry it degrades to `channelsForAgent`, i.e. every
+      // channel AND thread mapped to the agent (#151's opt-in containment —
+      // see the comment above). For a periodic heartbeat that is merely
+      // noisy; for a stall alert it is an alert storm into places like
+      // `daily-digest-*`, and the watchdog's guards bound alerts per SESSION,
+      // not per channel. Taking the first also matches Telegram's
+      // single-target semantics, so one logical alert has the same blast
+      // radius on both surfaces.
+      const alertChannel = targetChannels[0];
+      if (!alertChannel) return;
+      void this.safeSendMessage(alertChannel, text);
       return;
     }
 

--- a/src/adapters/telegram/__tests__/telegram.test.ts
+++ b/src/adapters/telegram/__tests__/telegram.test.ts
@@ -1260,6 +1260,228 @@ describe("TelegramAdapter — request_human flow", () => {
 });
 
 /* ────────────────────────────────────────────────────────────────────── */
+/* #301 — out-of-band operator alerts                                       */
+/* ────────────────────────────────────────────────────────────────────── */
+
+describe("TelegramAdapter — system.operator_alert (#301)", () => {
+  /** Drive one inbound prompt so the agent has a live chat + turn. */
+  async function feedInbound(): Promise<void> {
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 50,
+          from: { id: 42 },
+          chat: { id: 100, type: "private" },
+          text: "hello",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length > 0);
+  }
+
+  it("delivers the alert as a NEW message", async () => {
+    adapter = await startAdapter();
+    await feedInbound();
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "",
+      topic: "system.operator_alert",
+      payload: {
+        level: "critical",
+        text: "stall-watchdog: looked ALIVE",
+        source: "stall-watchdog",
+      },
+    });
+
+    await waitFor(() => api.sendMessages.length === 1);
+    expect(api.sendMessages[0]?.chat_id).toBe(100);
+    expect(api.sendMessages[0]?.text).toContain("looked ALIVE");
+  });
+
+  it("does NOT overwrite the agent's live reply message", async () => {
+    // The bug this guards: routing the alert through `handleResponseText`
+    // would take the edit-in-place branch and replace the in-flight reply of
+    // the very agent the watchdog is reporting on.
+    adapter = await startAdapter();
+    await feedInbound();
+
+    // Open a live turn.
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "response.text",
+      payload: { text: "working", intent: "progress" },
+    });
+    await waitFor(() => api.sendMessages.length === 1);
+    const editsBefore = api.editMessages.length;
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "",
+      topic: "system.operator_alert",
+      payload: { level: "critical", text: "watchdog alert", source: "stall-watchdog" },
+    });
+
+    // Fresh send, and the live turn message is untouched.
+    await waitFor(() => api.sendMessages.length === 2);
+    expect(api.editMessages.length).toBe(editsBefore);
+    expect(api.sendMessages[1]?.text).toContain("watchdog alert");
+  });
+
+  it("drops an alert with no text rather than posting an empty message", async () => {
+    adapter = await startAdapter();
+    await feedInbound();
+    const before = api.sendMessages.length;
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "",
+      topic: "system.operator_alert",
+      payload: { level: "warn", source: "stall-watchdog" },
+    });
+
+    await new Promise((r) => setTimeout(r, 30));
+    expect(api.sendMessages.length).toBe(before);
+  });
+
+  it("converts the markdown prefix to HTML rather than sending literal asterisks", async () => {
+    adapter = await startAdapter();
+    await feedInbound();
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "",
+      topic: "system.operator_alert",
+      payload: {
+        level: "critical",
+        text: "**stall-watchdog** looked ALIVE",
+        source: "stall-watchdog",
+      },
+    });
+
+    await waitFor(() => api.sendMessages.length === 1);
+    const sent = api.sendMessages[0];
+    expect(sent?.parse_mode).toBe("HTML");
+    expect(sent?.text).toContain("<b>stall-watchdog</b>");
+    expect(sent?.text).not.toContain("**");
+  });
+
+  it("WARNS instead of dropping silently when the agent has no known chat", async () => {
+    // Send-only deployments (telegram.receiveEnabled:false, #260) never
+    // populate lastChatPerAgent, so an agent with no static routing.chats
+    // entry lands here. An alert that reaches neither chat nor a greppable
+    // log line would defeat the point of #301.
+    const warnings: string[] = [];
+    // `global` is subscribed (defaultAgentId) but has NO routing.chats entry,
+    // so targetForAgent falls through to null once lastChatPerAgent is empty.
+    adapter = await startAdapter({
+      routing: { chats: { "100": "triage" }, defaultAgentId: "global" },
+      receiveEnabled: false,
+      logger: { ...SILENT_LOGGER, warn: (m: string) => warnings.push(m) },
+    });
+    // NOTE: deliberately no feedInbound() — lastChatPerAgent stays empty.
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "global",
+      session_id: "",
+      topic: "system.operator_alert",
+      payload: { level: "critical", text: "alert for an unrouted agent", source: "stall-watchdog" },
+    });
+
+    await waitFor(() => warnings.length > 0);
+    expect(warnings.some((w) => w.includes("operator_alert"))).toBe(true);
+    expect(warnings.some((w) => w.includes("global"))).toBe(true);
+    expect(api.sendMessages).toHaveLength(0);
+  });
+
+  it("forwards message_thread_id so a forum alert lands in the watched topic", async () => {
+    adapter = await startAdapter();
+    // Inbound from a forum topic → lastChatPerAgent carries the thread id.
+    api.enqueueUpdates([
+      {
+        message: {
+          message_id: 51,
+          from: { id: 42 },
+          chat: { id: 100, type: "supergroup" },
+          message_thread_id: 5,
+          text: "hello",
+        },
+      },
+    ]);
+    await waitFor(() => bus.prompts.length > 0);
+    const before = api.sendMessages.length;
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "",
+      topic: "system.operator_alert",
+      payload: { level: "critical", text: "forum alert", source: "stall-watchdog" },
+    });
+
+    await waitFor(() => api.sendMessages.length === before + 1);
+    // Without this the alert posts to General, not the topic being watched.
+    expect(api.sendMessages[before]?.message_thread_id).toBe(5);
+  });
+
+  it("falls back to plain text when the HTML send 400s on malformed markup", async () => {
+    // sendHtml's documented caller contract. The alert interpolates an
+    // arbitrary err.message, so a parse 400 must degrade to unformatted
+    // text rather than vanish — dropping it would defeat #301.
+    adapter = await startAdapter();
+    await feedInbound();
+    const before = api.sendMessages.length;
+
+    let firstCall = true;
+    const realSend = api.sendMessage.bind(api);
+    api.sendMessage = async (params) => {
+      if (firstCall && params.parse_mode === "HTML") {
+        firstCall = false;
+        throw new Error("Telegram API 400: can't parse entities: unmatched tag");
+      }
+      return realSend(params);
+    };
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "",
+      topic: "system.operator_alert",
+      payload: { level: "critical", text: "**alert** with bad markup", source: "stall-watchdog" },
+    });
+
+    await waitFor(() => api.sendMessages.length === before + 1);
+    const sent = api.sendMessages[before];
+    // Delivered, and as plain text (no parse_mode) rather than dropped.
+    expect(sent?.parse_mode).toBeUndefined();
+    expect(sent?.text).toContain("alert");
+  });
+
+  it("still delivers via the static routing.chats fallback with no inbound message", async () => {
+    adapter = await startAdapter({ routing: { chats: { "100": "triage" } } });
+    // No feedInbound() — must resolve the target from routing.chats alone.
+
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "",
+      topic: "system.operator_alert",
+      payload: { level: "warn", text: "static-route alert", source: "stall-watchdog" },
+    });
+
+    await waitFor(() => api.sendMessages.length === 1);
+    expect(api.sendMessages[0]?.chat_id).toBe(100);
+  });
+});
+
+/* ────────────────────────────────────────────────────────────────────── */
 /* stop() cleanup                                                           */
 /* ────────────────────────────────────────────────────────────────────── */
 
@@ -1268,8 +1490,9 @@ describe("TelegramAdapter — stop()", () => {
     adapter = await startAdapter({
       routing: { chats: { "100": "triage", "200": "research" } },
     });
-    // Two agents × four topics (text, edit_text, permission, request_human) = eight.
-    expect(bus.state().subscriberCount).toBe(8);
+    // Two agents × five topics (text, edit_text, permission, request_human,
+    // operator_alert — the last added by #301) = ten.
+    expect(bus.state().subscriberCount).toBe(10);
     await adapter.stop();
     adapter = null;
     expect(bus.state().subscriberCount).toBe(0);

--- a/src/adapters/telegram/index.ts
+++ b/src/adapters/telegram/index.ts
@@ -488,8 +488,69 @@ export class TelegramAdapter {
         { agent_id: agentId, topics: ["system.request_human"] },
         (event) => void this.handleRequestHuman(agentId, event),
       ),
+      // #301: out-of-band operator alerts. Deliberately its own topic and its
+      // own handler — routing it through `handleResponseText` would apply turn
+      // semantics to a non-reply (close the receipt as `turn_observed` and
+      // edit the alert over the agent's live reply message).
+      this.bus.subscribe(
+        { agent_id: agentId, topics: ["system.operator_alert"] },
+        (event) => void this.handleOperatorAlert(agentId, event),
+      ),
     );
     this.subscriptions.set(agentId, subs);
+  }
+
+  /**
+   * #301 — deliver an out-of-band operator alert as a NEW message.
+   *
+   * Contrast with `handleResponseText`: this deliberately does not
+   * `armReceiptTimeout`, `stopSpinner`, `closeTelegramReceipt`, or edit
+   * `lastBotMessage`. An alert is not turn output, so applying turn semantics
+   * to it would corrupt the receipt of — and overwrite the visible reply of —
+   * the very turn the watchdog is reporting on.
+   */
+  private async handleOperatorAlert(agentId: string, event: BusEvent): Promise<void> {
+    if (!eventBelongsToTelegram(event)) return;
+    const payload = event.payload as { text?: string };
+    const text = typeof payload.text === "string" ? payload.text : "";
+    if (!text) return;
+    const target = this.targetForAgent(agentId);
+    if (!target) {
+      // Never drop an operator alert silently. In send-only mode
+      // (`telegram.receiveEnabled: false`, #260) `lastChatPerAgent` is never
+      // populated, so an agent reachable only via `defaultAgentId` lands
+      // here — and an alert that reaches neither chat nor a greppable log
+      // line defeats the point of #301. Matches the sibling handlers.
+      this.logger.warn(`[telegram-adapter] no target chat for operator_alert on agent ${agentId}`);
+      return;
+    }
+    // Via sendHtml, not safeSendMessage: the alert text carries markdown
+    // (the `**stall-watchdog**` prefix), which Telegram renders as literal
+    // asterisks without the markdown→HTML conversion. sendHtml is a pure
+    // send wrapper and touches no turn state.
+    //
+    // `message_thread_id` is forwarded like every other send in this file:
+    // without it a forum-group alert lands in General instead of the topic
+    // the operator actually watches (and General is often closed, which then
+    // 400s).
+    //
+    // The plain-text fallback is sendHtml's documented caller contract (see
+    // its JSDoc). The alert interpolates an arbitrary `err.message` from
+    // SessionManager.restart, making it the least predictable input to
+    // markdownToTelegramHtml in this file — so a malformed-markup 400 must
+    // degrade to unformatted text, not vanish. Dropping it here would
+    // contradict the no-silent-drop rule enforced just above.
+    const send = { chat_id: target.chat_id, text, message_thread_id: target.message_thread_id };
+    await this.safe("sendMessage", async () => {
+      try {
+        return await this.sendHtml(send);
+      } catch (err) {
+        // Only a malformed-HTML 400 warrants raw text; anything else (429,
+        // network, benign 400) rethrows to `safe`, which logs it.
+        if (!isTelegramHtmlParseError(err)) throw err;
+        return await this.api.sendMessage(send);
+      }
+    });
   }
 
   private async handleResponseText(agentId: string, event: BusEvent): Promise<void> {

--- a/src/bus/__tests__/session-manager.test.ts
+++ b/src/bus/__tests__/session-manager.test.ts
@@ -745,7 +745,20 @@ describe("session-id collision rotation", () => {
         `echo "Error: Session ID 99999999-9999-9999-9999-999999999bad is already in use."; exit 1`,
       ],
       busSocketPath: "/tmp/test-bus-rotate.sock",
-      sessionCollisionDetectMs: 300,
+      // 2000ms, not 300ms. An UPPER BOUND, not a fixed wait, FOR A STAND-IN
+      // THAT EXITS WITHIN IT — the sibling at the top of this describe keeps
+      // 500ms deliberately, because its retry stand-in `sleep 60`s and so
+      // burns the whole window; do not "fix the inconsistency" by raising it.
+      // `detectSessionIdCollision` resolves as soon as `proc.onExit` fires,
+      // so a fast stand-in still finishes in ~ms and the suite pays nothing.
+      // Observed: at 300ms these tests flaked under the CPU contention of
+      // concurrently running test files; at 2000ms they passed 10/10 in
+      // isolation and across repeated full-suite runs.
+      // NOT claimed: that the window is the only race here. The detector
+      // also depends on the marker chunk arriving before `onExit`
+      // (session-manager.ts:421-435), which no window size fixes. If these
+      // flake again, suspect that ordering rather than raising the bound.
+      sessionCollisionDetectMs: 2000,
       persistRotatedSessionId: async () => {},
       logger: { warn: () => {}, info: () => {}, error: () => {} },
     });
@@ -764,7 +777,20 @@ describe("session-id collision rotation", () => {
       commandOverride: "/bin/sh",
       argsOverride: ["-c", "echo unrelated boot error; exit 1"],
       busSocketPath: "/tmp/test-bus-rotate.sock",
-      sessionCollisionDetectMs: 300,
+      // 2000ms, not 300ms. An UPPER BOUND, not a fixed wait, FOR A STAND-IN
+      // THAT EXITS WITHIN IT — the sibling at the top of this describe keeps
+      // 500ms deliberately, because its retry stand-in `sleep 60`s and so
+      // burns the whole window; do not "fix the inconsistency" by raising it.
+      // `detectSessionIdCollision` resolves as soon as `proc.onExit` fires,
+      // so a fast stand-in still finishes in ~ms and the suite pays nothing.
+      // Observed: at 300ms these tests flaked under the CPU contention of
+      // concurrently running test files; at 2000ms they passed 10/10 in
+      // isolation and across repeated full-suite runs.
+      // NOT claimed: that the window is the only race here. The detector
+      // also depends on the marker chunk arriving before `onExit`
+      // (session-manager.ts:421-435), which no window size fixes. If these
+      // flake again, suspect that ordering rather than raising the bound.
+      sessionCollisionDetectMs: 2000,
       persistRotatedSessionId: async (agentId, sessionId) => {
         persisted.push({ agentId, sessionId });
       },
@@ -790,7 +816,20 @@ describe("session-id collision rotation", () => {
       // inside the detection window.
       argsOverride: ["-c", "echo non-collision crash; exit 1"],
       busSocketPath: "/tmp/test-bus-rotate.sock",
-      sessionCollisionDetectMs: 300,
+      // 2000ms, not 300ms. An UPPER BOUND, not a fixed wait, FOR A STAND-IN
+      // THAT EXITS WITHIN IT — the sibling at the top of this describe keeps
+      // 500ms deliberately, because its retry stand-in `sleep 60`s and so
+      // burns the whole window; do not "fix the inconsistency" by raising it.
+      // `detectSessionIdCollision` resolves as soon as `proc.onExit` fires,
+      // so a fast stand-in still finishes in ~ms and the suite pays nothing.
+      // Observed: at 300ms these tests flaked under the CPU contention of
+      // concurrently running test files; at 2000ms they passed 10/10 in
+      // isolation and across repeated full-suite runs.
+      // NOT claimed: that the window is the only race here. The detector
+      // also depends on the marker chunk arriving before `onExit`
+      // (session-manager.ts:421-435), which no window size fixes. If these
+      // flake again, suspect that ordering rather than raising the bound.
+      sessionCollisionDetectMs: 2000,
       logger: { warn: () => {}, info: () => {}, error: () => {} },
     });
     const agent = mkAgent({ id: "rot-race", session_id: STALE });

--- a/src/bus/__tests__/stall-alert-delivery.test.ts
+++ b/src/bus/__tests__/stall-alert-delivery.test.ts
@@ -1,0 +1,299 @@
+/**
+ * #301 — the stall watchdog's operator-alert path.
+ *
+ * Acceptance from the issue:
+ *  - a `suspected_false_positive` kill delivers its flag + ceiling suggestion
+ *    to the operator's chat surface, in addition to the log + audit;
+ *  - delivery is best-effort — a delivery error never affects recovery.
+ */
+
+import { describe, it, expect } from "bun:test";
+import type { BusEvent } from "../types";
+import {
+  createStallAlertNotifier,
+  STALL_ALERT_PREFIX,
+  OPERATOR_ALERT_TOPIC,
+  MAX_ALERT_CHARS,
+  type StallAlertBus,
+  type StallAlertLogger,
+} from "../stall-alert-delivery";
+import { StallWatchdog, DEFAULT_STALL_CONFIG, type StallWatchdogDeps } from "../stall-watchdog";
+
+/** Length of the cap suffix appended by clampForChat, in code points. */
+const SUFFIX_LEN = Array.from("… (rest in the daemon log)").length;
+
+function harness(opts?: { busThrows?: boolean }) {
+  const published: BusEvent[] = [];
+  const logs: Array<{ level: "warn" | "error"; args: unknown[] }> = [];
+
+  const bus: StallAlertBus = {
+    ingestSessionEvent: (e) => {
+      if (opts?.busThrows) throw new Error("bus is down");
+      published.push(e);
+    },
+  };
+  const logger: StallAlertLogger = {
+    warn: (...args) => logs.push({ level: "warn", args }),
+    error: (...args) => logs.push({ level: "error", args }),
+  };
+
+  const notify = createStallAlertNotifier({ bus, logger, now: () => 1_700_000_000_000 });
+  return { notify, published, logs };
+}
+
+describe("stall alert delivery (#301)", () => {
+  it("delivers the alert on the dedicated operator-alert topic", () => {
+    const { notify, published } = harness();
+    notify("critical", "Stall-killed reg but it looked ALIVE", "reg");
+
+    expect(published).toHaveLength(1);
+    const e = published[0];
+    expect(e?.topic).toBe(OPERATOR_ALERT_TOPIC);
+    expect(e?.agent_id).toBe("reg");
+    expect((e?.payload as { text: string }).text).toContain("looked ALIVE");
+  });
+
+  it("labels the alert so it is not mistaken for the agent's own reply", () => {
+    const { notify, published } = harness();
+    notify("critical", "raise stallWatchdog.ceilings.bash.killSeconds", "reg");
+
+    const text = (published[0]?.payload as { text: string }).text;
+    expect(text.startsWith(STALL_ALERT_PREFIX)).toBe(true);
+  });
+
+  it("sets NO origin so Discord routes via primaryChannelByAgent, not a reply channel", () => {
+    // An origin would either be dropped (foreign channel-driven) or routed
+    // back to a source channel. The operator-alert path needs neither.
+    const { notify, published } = harness();
+    notify("warn", "outstanding 400s", "suzy");
+
+    const payload = published[0]?.payload as { origin?: string; origin_id?: string };
+    expect(payload.origin).toBeUndefined();
+    expect(payload.origin_id).toBeUndefined();
+  });
+
+  it("still logs both levels, on the durable path, as before", () => {
+    const { notify, logs } = harness();
+    notify("critical", "critical msg", "reg");
+    notify("warn", "warn msg", "reg");
+
+    expect(logs.find((l) => l.level === "error")?.args).toContain("critical msg");
+    expect(logs.find((l) => l.level === "warn")?.args).toContain("warn msg");
+  });
+
+  it("logs BEFORE attempting delivery, so a bus failure cannot lose the alert", () => {
+    const { notify, logs } = harness({ busThrows: true });
+    notify("critical", "the alert text", "reg");
+
+    // The original alert is still in the log even though delivery threw.
+    expect(logs.some((l) => l.args.includes("the alert text"))).toBe(true);
+  });
+
+  it("swallows a delivery failure — never throws at the caller (recovery path)", () => {
+    const { notify, logs } = harness({ busThrows: true });
+
+    expect(() => notify("critical", "alert", "reg")).not.toThrow();
+    // and it surfaces the delivery failure itself
+    expect(logs.some((l) => l.args.some((a) => String(a).includes("delivery failed")))).toBe(true);
+  });
+
+  it("skips delivery when there is no agent to route to", () => {
+    const { notify, published, logs } = harness();
+    notify("critical", "no agent", "");
+
+    expect(published).toHaveLength(0);
+    expect(logs).toHaveLength(1); // still logged
+  });
+
+  it("NEVER publishes a reply topic — a reply carries turn semantics", () => {
+    // Regression guard. `response.text` would make Telegram close the open
+    // receipt as `turn_observed` and edit the alert OVER the agent's live
+    // reply message, and would make the web UI bridge splice the alert into
+    // an in-flight /api/chat response.
+    const { notify, published } = harness();
+    notify("critical", "c", "reg");
+    notify("warn", "w", "reg");
+
+    // Assert delivery actually happened FIRST: `.every()` on an empty array
+    // is vacuously true, so without this the guard would still pass if the
+    // notifier stopped publishing altogether.
+    expect(published).toHaveLength(2);
+    const replyTopics = ["response.text", "response.edit_text", "response.turn_end"];
+    expect(published.every((e) => !replyTopics.includes(e.topic))).toBe(true);
+  });
+
+  it("carries the level so a surface can style by severity", () => {
+    const { notify, published } = harness();
+    notify("warn", "w", "reg");
+    notify("critical", "c", "reg");
+
+    expect((published[0]?.payload as { level: string }).level).toBe("warn");
+    expect((published[1]?.payload as { level: string }).level).toBe("critical");
+  });
+
+  it("truncates the chat copy but logs the full text", () => {
+    // The chat surface is a less trusted sink than the daemon log: an
+    // interpolated err.message can carry absolute host paths or a session id.
+    const { notify, published, logs } = harness();
+    const huge = `restart failed: ${"/very/long/host/path".repeat(200)}`;
+    notify("critical", huge, "reg");
+
+    const delivered = (published[0]?.payload as { text: string }).text;
+    // Assert it lands AT the cap, not merely "shorter than input" — the
+    // loose form would pass a cap that let 3000 chars through.
+    const body = delivered.slice(STALL_ALERT_PREFIX.length + 1);
+    expect(Array.from(body).length).toBeLessThanOrEqual(MAX_ALERT_CHARS + SUFFIX_LEN);
+    expect(delivered).toContain("rest in the daemon log");
+    // full text still reached the log
+    expect(logs.some((l) => l.args.includes(huge))).toBe(true);
+  });
+
+  it("passes a short message through UNcapped, with no suffix", () => {
+    const { notify, published } = harness();
+    notify("warn", "short and sweet", "reg");
+
+    const text = (published[0]?.payload as { text: string }).text;
+    expect(text).toBe(`${STALL_ALERT_PREFIX} short and sweet`);
+    expect(text).not.toContain("rest in the daemon log");
+  });
+
+  it("caps by code POINT, so all-astral text is not measured in one unit and cut in another", () => {
+    // 400 emoji = 800 UTF-16 units but only 400 code points. Measuring the
+    // guard in units while slicing in points made this trip the cap and then
+    // remove nothing — claiming content was dropped when none was, and
+    // delivering ~2x the intended cap.
+    const { notify, published } = harness();
+    const astral = "😀".repeat(400);
+    notify("critical", astral, "reg");
+
+    const text = (published[0]?.payload as { text: string }).text;
+    expect(text).not.toContain("rest in the daemon log");
+    expect(text).toBe(`${STALL_ALERT_PREFIX} ${astral}`);
+  });
+
+  it("never splits a surrogate pair when capping the chat copy", () => {
+    // An interpolated err.message can carry an emoji. Cutting by UTF-16 code
+    // unit at exactly the boundary would emit a lone surrogate.
+    const { notify, published } = harness();
+    // Pad so the cap lands mid-emoji, then fill past it with astral chars.
+    const msg = `${"a".repeat(599)}${"😀".repeat(50)}`;
+    notify("critical", msg, "reg");
+
+    const text = (published[0]?.payload as { text: string }).text;
+    // No unpaired surrogate anywhere in the delivered text.
+    expect(
+      /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?<![\uD800-\uDBFF])[\uDC00-\uDFFF]/.test(text),
+    ).toBe(false);
+  });
+
+  it("does not throw even when the logger itself throws", () => {
+    const boom: StallAlertLogger = {
+      warn: () => {
+        throw new Error("logger down");
+      },
+      error: () => {
+        throw new Error("logger down");
+      },
+    };
+    const notify = createStallAlertNotifier({
+      bus: {
+        ingestSessionEvent: () => {
+          throw new Error("bus down");
+        },
+      },
+      logger: boom,
+    });
+
+    expect(() => notify("critical", "alert", "reg")).not.toThrow();
+  });
+});
+
+/* ── End-to-end through the watchdog itself ───────────────────────────────── */
+
+function watchdogDeps(notify: StallWatchdogDeps["notify"]): StallWatchdogDeps {
+  return {
+    subscribe: () => () => {},
+    restart: async () => {},
+    captureForensic: async () => ({ cpuAdvancing: true, outputRecencyMs: 500 }),
+    recordKill: async () => ({
+      classification: "suspected_false_positive",
+      suggestedKillSeconds: 1800,
+    }),
+    notify,
+    now: () => 0,
+  };
+}
+
+function toolUse(ts: number): BusEvent {
+  return {
+    ts,
+    agent_id: "reg",
+    session_id: "s1",
+    topic: "response.tool_use",
+    payload: { id: "b1", name: "Bash" },
+  };
+}
+
+describe("stall watchdog → operator alert, end to end (#301)", () => {
+  it("a suspected_false_positive kill reaches the operator surface with the ceiling suggestion", async () => {
+    const published: BusEvent[] = [];
+    const logs: Array<{ level: "warn" | "error"; args: unknown[] }> = [];
+    const notify = createStallAlertNotifier({
+      bus: { ingestSessionEvent: (e) => published.push(e) },
+      logger: {
+        warn: (...args) => logs.push({ level: "warn", args }),
+        error: (...args) => logs.push({ level: "error", args }),
+      },
+    });
+
+    const wd = new StallWatchdog(DEFAULT_STALL_CONFIG, watchdogDeps(notify));
+    wd.ingest(toolUse(0));
+    await wd.sweep(950_000);
+
+    const alert = published.find((e) =>
+      (e.payload as { text: string }).text.includes("looked ALIVE"),
+    );
+    expect(alert).toBeDefined();
+    expect(alert?.agent_id).toBe("reg");
+
+    const text = (alert?.payload as { text: string }).text;
+    expect(text).toContain("stallWatchdog.ceilings.bash.killSeconds");
+    expect(text).toContain("1800");
+  });
+
+  it("passes the stalled agent id through so the alert routes to that agent's channel", async () => {
+    const seen: string[] = [];
+    const wd = new StallWatchdog(
+      DEFAULT_STALL_CONFIG,
+      watchdogDeps((_l, _m, agentId) => seen.push(agentId)),
+    );
+    wd.ingest(toolUse(0));
+    await wd.sweep(950_000);
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.every((a) => a === "reg")).toBe(true);
+  });
+
+  it("a failing delivery does not prevent the restart (recovery is unaffected)", async () => {
+    let restarts = 0;
+    const deps = watchdogDeps(
+      createStallAlertNotifier({
+        bus: {
+          ingestSessionEvent: () => {
+            throw new Error("bus is down");
+          },
+        },
+        logger: { warn: () => {}, error: () => {} },
+      }),
+    );
+    deps.restart = async () => {
+      restarts++;
+    };
+
+    const wd = new StallWatchdog(DEFAULT_STALL_CONFIG, deps);
+    wd.ingest(toolUse(0));
+    await wd.sweep(950_000);
+
+    expect(restarts).toBe(1);
+  });
+});

--- a/src/bus/runtime-mount.ts
+++ b/src/bus/runtime-mount.ts
@@ -53,6 +53,7 @@ import { peekSession } from "../sessions";
 import { generateSummary } from "../rotation";
 import { getSettings } from "../config";
 import { StallWatchdog, DEFAULT_STALL_CONFIG, type StallWatchdogConfig } from "./stall-watchdog";
+import { createStallAlertNotifier } from "./stall-alert-delivery";
 import { probeProcessTreeCpu, classifyKill, appendStallKillAudit } from "./stall-forensics";
 
 export interface BusRuntimeHandle {
@@ -609,10 +610,11 @@ export async function mountBusRuntime(
         });
         return outcome;
       },
-      notify: (level, message) => {
-        if (level === "critical") logger.error("[stall-watchdog]", message);
-        else logger.warn("[stall-watchdog]", message);
-      },
+      // #301: log AND deliver to the operator's chat surface. A wrong kill
+      // (suspected_false_positive) is the case the operator most needs to see
+      // — it means a ceiling is too tight — and it previously reached only
+      // journalctl + stall-kills.jsonl.
+      notify: createStallAlertNotifier({ bus, logger }),
       now: () => Date.now(),
     });
     stallWatchdog.start();

--- a/src/bus/stall-alert-delivery.ts
+++ b/src/bus/stall-alert-delivery.ts
@@ -1,0 +1,183 @@
+/**
+ * Operator-alert delivery for the stall watchdog (#301).
+ *
+ * The watchdog's `notify` was log-only: a `suspected_false_positive` kill —
+ * the case the operator most needs to see, because it means a ceiling is set
+ * too tight and legitimate work is being killed — only reached `journalctl`
+ * and `.claude/claudeclaw/stall-kills.jsonl`. Noticing it required reading
+ * server logs.
+ *
+ * There is no `sendToOperator` primitive in the daemon; outbound chat is a
+ * publish/subscribe fan-out (adapters subscribe to bus topics and translate
+ * them). This module adds that missing primitive as a dedicated topic,
+ * `system.operator_alert`, which the Discord and Telegram adapters render as
+ * a standalone message.
+ *
+ * **Why a dedicated topic and NOT `response.text`.** Reusing the reply topic
+ * looks simpler and is wrong: `response.text` *is* the agent's turn output, so
+ * adapters apply turn semantics to it. On Telegram, a non-progress
+ * `response.text` closes the open receipt as `turn_observed` and — when a turn
+ * is live — is EDITED IN PLACE over the agent's current reply message
+ * (`adapters/telegram/index.ts` `handleResponseText`). An out-of-band watchdog
+ * alert would therefore destroy the in-flight reply of the very agent it is
+ * reporting on, and corrupt that turn's receipt. The web UI bridge
+ * (`bus/webui-bridge.ts`) also accumulates `response.text` into whatever
+ * `/api/chat` response is in flight. A separate topic avoids all of this by
+ * construction: nothing that consumes turn state subscribes to it.
+ *
+ * Three further choices:
+ *
+ * 1. **`ingestSessionEvent`, not `ingestReply`.** `ingestReply` maps only
+ *    reply intents onto reply topics and stamps the agent's stale
+ *    `lastPromptOrigin` onto the payload. `ingestSessionEvent` publishes the
+ *    event verbatim, and for a `system.*` topic it hits none of the
+ *    delivery-gate branches (`session.init`, `bus.events.replay_done`,
+ *    `prompt`, `response.turn_end`), so it has no side effects on turn state.
+ *
+ * 2. **No `origin`.** This means BOTH adapters deliver the alert: Discord's
+ *    filter passes an absent origin, and Telegram's `eventBelongsToTelegram`
+ *    returns true for `origin === undefined`. So where both are mounted for an
+ *    agent, one alert reaches one Discord channel and one Telegram chat.
+ *    That is intended — an operator alert should reach the operator wherever
+ *    they are watching — but it is fan-out across surfaces, not a single
+ *    destination.
+ *
+ *    The two surfaces resolve their single target differently:
+ *      - Discord prefers `primaryChannelByAgent` (the operator-designated
+ *        channel), else the agent's first routed channel. The alert handler
+ *        deliberately takes ONE channel rather than the reply fan-out.
+ *      - Telegram has NO `primaryChannelByAgent` equivalent. `targetForAgent`
+ *        returns the chat that last messaged the agent, else the first chat
+ *        mapped to it — a conversational chat, not an operator-designated one.
+ *
+ * 3. **No rate limiting here.** The warn call sites are behind the per-tool
+ *    `warned` latch and the restart-failure site behind `killing` +
+ *    `restartFailedAt`/`restartFailureCooldownMs`. The two post-kill sites
+ *    (false-positive and genuine-wedge) are NOT behind those — they fire after
+ *    a successful restart, by which point `killing` is released and the
+ *    session state holding the latch is deleted. What bounds them is
+ *    one-alert-per-kill plus `SessionManager`'s own `MAX_RESTARTS_PER_WINDOW`
+ *    limiter — a real guard, but downstream and in another file. The
+ *    conclusion still holds (a limiter here would be redundant); the bound
+ *    just isn't local.
+ */
+
+import type { BusEvent } from "./types";
+
+/** The bus surface this needs — narrowed so tests don't build a whole BusCore. */
+export interface StallAlertBus {
+  ingestSessionEvent(e: BusEvent): void;
+}
+
+/** Log sink, matching the daemon logger's shape. */
+export interface StallAlertLogger {
+  warn(...args: unknown[]): void;
+  error(...args: unknown[]): void;
+}
+
+/** Prefix so an alert is never mistaken for the agent's own reply. */
+export const STALL_ALERT_PREFIX = "🛡️ **stall-watchdog**";
+
+/**
+ * Dedicated operator-alert topic. Matches the `system.${string}` arm of
+ * `BusEventTopic`, so no type change is needed. Deliberately NOT a reply
+ * topic — see the module header.
+ */
+export const OPERATOR_ALERT_TOPIC = "system.operator_alert" as const;
+
+/** Payload shape adapters render. `level` lets a surface style by severity. */
+export interface OperatorAlertPayload {
+  level: "warn" | "critical";
+  text: string;
+  source: string;
+}
+
+/**
+ * Cap the chat copy of an alert. The daemon log keeps the full text.
+ *
+ * This is VOLUME control, not a disclosure control. It bounds how much a
+ * pathological `err.message` can dump into a chat channel; it does not
+ * redact, and it cannot: the leak-y throws in `SessionManager.restart` (an
+ * absolute socket path, a session id) are ~100-140 chars and so pass through
+ * the cap untouched. If those need withholding from chat, that is redaction
+ * at the message-construction site, not a length limit here.
+ */
+export const MAX_ALERT_CHARS = 600;
+
+function clampForChat(message: string): string {
+  // Count and slice in the SAME unit — code points, not UTF-16 code units.
+  // Measuring in one and cutting in the other means an all-emoji message
+  // trips the guard (2 units each) while the slice removes nothing, so we
+  // would claim content was dropped when none was, and deliver ~2x the cap.
+  const chars = Array.from(message);
+  if (chars.length <= MAX_ALERT_CHARS) return message;
+  // Slicing by code point also avoids cutting a surrogate pair in half,
+  // which would emit a lone surrogate that renders as a replacement glyph.
+  return `${chars.slice(0, MAX_ALERT_CHARS).join("")}… (rest in the daemon log)`;
+}
+
+export interface StallAlertNotifierOpts {
+  bus: StallAlertBus;
+  logger: StallAlertLogger;
+  /** Injectable clock so tests get deterministic timestamps. */
+  now?: () => number;
+}
+
+/**
+ * Build the watchdog's `notify` dep: log as before, and additionally deliver
+ * to the operator's chat surface.
+ *
+ * Delivery is strictly best-effort — a throw from the bus is swallowed and
+ * logged, never propagated, because `notify` is called on the recovery path
+ * (including from the restart-failure catch block) and must not be able to
+ * interrupt it.
+ */
+export function createStallAlertNotifier(
+  opts: StallAlertNotifierOpts,
+): (level: "warn" | "critical", message: string, agentId: string) => void {
+  const { bus, logger, now = () => Date.now() } = opts;
+
+  return (level, message, agentId) => {
+    // 1. Log first — the durable path, with the FULL message. If delivery
+    //    below explodes, the operator still has journalctl + stall-kills.jsonl.
+    //    Deliberately outside the try below so ordering is guaranteed.
+    try {
+      if (level === "critical") logger.error("[stall-watchdog]", message);
+      else logger.warn("[stall-watchdog]", message);
+    } catch {
+      /* a throwing logger must not break recovery either */
+    }
+
+    // 2. Deliver to the operator's surface. Best-effort, never throws:
+    //    notify() is called from the restart-failure catch block, so an
+    //    escape here would reject the sweep and surface as an unhandled
+    //    rejection.
+    if (!agentId) return;
+    try {
+      const payload: OperatorAlertPayload = {
+        level,
+        text: `${STALL_ALERT_PREFIX} ${clampForChat(message)}`,
+        source: "stall-watchdog",
+        // No `origin` / `origin_id`: routes via primaryChannelByAgent.
+      };
+      bus.ingestSessionEvent({
+        ts: now(),
+        agent_id: agentId,
+        session_id: "",
+        topic: OPERATOR_ALERT_TOPIC,
+        payload,
+      });
+    } catch (err) {
+      try {
+        logger.error(
+          "[stall-watchdog]",
+          `operator-alert delivery failed (recovery unaffected): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      } catch {
+        /* nothing left to do — never rethrow onto the recovery path */
+      }
+    }
+  };
+}

--- a/src/bus/stall-watchdog.ts
+++ b/src/bus/stall-watchdog.ts
@@ -268,8 +268,21 @@ export interface StallWatchdogDeps {
     ceiling: ToolCeiling;
     snapshot: ForensicSnapshot;
   }): Promise<StallKillOutcome>;
-  /** Surface a warn / false-positive flag to the operator (Discord/critical log). */
-  notify(level: "warn" | "critical", message: string): void;
+  /**
+   * Surface a warn / false-positive flag to the operator: the daemon log plus
+   * whichever chat surfaces are mounted (Discord and/or Telegram, via #301's
+   * `system.operator_alert` topic).
+   *
+   * `agentId` is the stalled agent the alert is ABOUT. The wiring uses it to
+   * route the alert to that agent's operator channel (#301) — a bus alert has
+   * no inbound origin to reply to, so routing has to be keyed on the agent.
+   *
+   * Implementations MUST be best-effort: a delivery failure must never
+   * interrupt recovery. Callers do NOT rate-limit here — every call site is
+   * already behind an existing guard (the per-tool `warned` latch, the
+   * `killing` set, or the `restartFailedAt` cooldown).
+   */
+  notify(level: "warn" | "critical", message: string, agentId: string): void;
   /** Clock seam (tests inject a deterministic clock). */
   now(): number;
 }
@@ -351,6 +364,7 @@ export class StallWatchdog {
             `Session ${s.agentId} has had \`${decision.tool}\` outstanding for ` +
               `${Math.round(decision.outstandingMs / 1000)}s (warn ${decision.ceiling.warnSeconds}s / ` +
               `kill ${decision.ceiling.killSeconds}s).`,
+            s.agentId,
           );
         }
         continue;
@@ -367,6 +381,7 @@ export class StallWatchdog {
             `Session ${s.agentId} \`${decision.tool}\` outstanding ` +
               `${Math.round(decision.outstandingMs / 1000)}s — past kill ceiling ` +
               `(${decision.ceiling.killSeconds}s) but stallWatchdog.action=warn, NOT restarting.`,
+            s.agentId,
           );
         }
         continue;
@@ -429,6 +444,7 @@ export class StallWatchdog {
         "critical",
         `Stall-kill of ${s.agentId} FAILED to restart: ${err instanceof Error ? err.message : String(err)}. ` +
           `Backing off ${Math.round(this.config.restartFailureCooldownMs / 1000)}s before retry.`,
+        s.agentId,
       );
       return;
     }
@@ -461,12 +477,14 @@ export class StallWatchdog {
           `(cpuAdvancing=${snapshot.cpuAdvancing}, outputRecencyMs=${snapshot.outputRecencyMs}). ` +
           `If this tool legitimately runs that long, raise \`stallWatchdog.ceilings.${cls}.killSeconds\`` +
           (outcome.suggestedKillSeconds ? ` (suggest ~${outcome.suggestedKillSeconds}s).` : `.`),
+        s.agentId,
       );
     } else {
       this.deps.notify(
         "warn",
         `Stall-killed ${s.agentId} on \`${decision.tool}\` after ` +
           `${Math.round(decision.outstandingMs / 1000)}s (genuine wedge — session respawned).`,
+        s.agentId,
       );
     }
   }


### PR DESCRIPTION
Closes #301.

## Problem

The stall watchdog's `notify` was log-only. A `suspected_false_positive` kill — the case the operator most needs to see, because it means a ceiling is too tight and legitimate work is being killed — reached only `journalctl` and `stall-kills.jsonl`. Noticing one required reading server logs.

## The missing primitive

There is no `sendToOperator` in the daemon; outbound chat is a publish/subscribe fan-out. This adds that primitive as a dedicated topic, `system.operator_alert` (already valid under the `system.${string}` arm of `BusEventTopic`, so no type change), rendered by the Discord and Telegram adapters as a standalone message.

## Why not reuse `response.text`

That was the first cut and it is actively destructive. `response.text` *is* the agent's turn output, so adapters apply turn semantics to it. On Telegram a non-progress `response.text` closes the open receipt as `turn_observed` and, when a turn is live, is **edited in place** over `lastBotMessage` — so an out-of-band alert would have overwritten the in-flight reply of the very agent the watchdog is reporting on, on the recovery path. The web UI bridge also accumulates `response.text` into any in-flight `/api/chat` response.

A separate topic avoids all of it by construction: nothing that consumes turn state subscribes to it. Guarded by a regression test asserting no reply topic is ever published, and a Telegram test asserting a live turn's message is not edited — both verified to fail against the original implementation.

## Routing

No `origin` on the payload, which means **both** adapters deliver: Discord's filter passes an absent origin and Telegram's `eventBelongsToTelegram` returns true for it. So where both are mounted, one alert reaches one Discord channel and one Telegram chat — intended, but fan-out across surfaces rather than a single destination.

The two surfaces resolve their single target differently. Discord prefers `primaryChannelByAgent` (the operator-designated channel), else the agent's first routed channel. Telegram has **no** `primaryChannelByAgent` equivalent — `targetForAgent` returns the chat that last messaged the agent, else the first chat mapped to it, i.e. a conversational chat rather than an operator-designated one. Telegram's handler sends a fresh message and touches no turn state.

## Hardening

- Chat copy capped at 600 code points; the daemon log keeps the full text. This is **volume** control, not a disclosure control — the known leaky throws in `SessionManager.restart` (an absolute socket path, a session id) are ~140 chars and pass under the cap untouched; withholding those would need redaction at the message-construction site. The cap counts **and** slices in code points — measuring in UTF-16 units while slicing in code points made all-emoji text trip the cap, remove nothing, and deliver ~2x the cap.
- Delivery is best-effort and cannot throw. `notify` is called from the restart-failure catch block, so an escape would reject the sweep as an unhandled rejection. A throwing logger is guarded too, and log-before-publish ordering is explicit and tested.
- A malformed-markup 400 on Telegram degrades to plain text rather than vanishing — `sendHtml`'s documented caller contract.
- `message_thread_id` is forwarded like every other send in the file, so a forum-group alert lands in the watched topic rather than General.
- A no-target alert warns instead of returning silently. In send-only mode (`telegram.receiveEnabled: false`, #260) `lastChatPerAgent` never populates, so an agent reachable only via `defaultAgentId` previously produced an alert reaching neither chat nor a greppable log line.
- No new rate limiting. The warn sites are behind the per-tool `warned` latch and the restart-failure site behind `killing` + the cooldown. The two post-kill sites are **not** — they fire after a successful restart, once `killing` is released and the latch-holding state deleted; what bounds them is one-alert-per-kill plus `SessionManager`'s `MAX_RESTARTS_PER_WINDOW`. A local limiter would still be redundant, but the bound is downstream.

`notify` gained an `agentId` parameter (all five call sites already had `s.agentId` in hand) because routing is agent-keyed.

## Test plan

- 20 unit tests for the delivery helper, 5 Discord outbound, 8 Telegram.
- Every fix is mutation-tested: each guard was verified to fail against its own broken version, and only that one.
- `bun test` at the new CI scope (now including `src/adapters`): 1357 pass, 0 fail. Full-repo `bun run lint` clean.

## Drive-by

Three tests in `session-manager.test.ts` used a 300ms `sessionCollisionDetectMs`. That value is an upper bound — the detector resolves on `proc.onExit` — but it was tight enough that CPU contention from concurrently running test files flaked them once this PR's tests were added. Raised to 2000ms; costs nothing in the happy path, and they pass 10/10 in isolation. The comment deliberately does not claim the window is the only race: the detector also depends on the marker chunk arriving before `onExit`, which no window size fixes.

## Discord alert blast radius

The alert handler takes **one** channel, unlike the reply fan-out beside it. `primaryChannelByAgent` containment (#151) is opt-in, so without an entry `targetChannels` degrades to every channel *and thread* mapped to the agent. Noisy for a periodic heartbeat; an alert storm into places like `daily-digest-*` for a stall alert, whose guards bound per session, not per channel. Taking the first also matches Telegram's single-target semantics, so one logical alert has the same blast radius on both surfaces. A companion test asserts normal replies still fan out — the narrowing is alert-only.

## CI coverage

`src/adapters` is added to the CI test step (carried over from #300 note 5). Without it the adapter half of a delivery change — routing, thread ids, the parse-error fallback, turn-state isolation — never ran in CI, and there is no typecheck step to back it up. 1357 pass at the new scope.

## Known gaps, not addressed here

- Slack and the web UI do not render `system.operator_alert`. Not a regression — neither surfaced these alerts before — but incomplete if either is the primary operator surface.
- **Pre-existing:** the shared `warned` latch in `stall-watchdog.ts` means the critical "past kill ceiling" alert can never fire in `action: "warn"` mode, because the soft warn latches the flag first. This caps what #301 delivers in warn-only mode and deserves its own issue.
- **Pre-existing, repo-wide:** no `allowed_mentions` on Discord sends, so an `@everyone` in any agent text pings.
- **Pre-existing:** `handleKill`'s `Extract<..., {action: "kill"}>` resolves to `never` (deferred from #300 note 1), so that function is not type-checked. All five `notify` call sites were verified by hand.
