### PR TITLE
test: share one MuxSettingsView fixture, reclaim 14 rotted tests (#304)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.194",
+      "version": "2.2.195",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.194",
+  "version": "2.2.195",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,16 @@ jobs:
       # shared process) and infra-dependent tests (DB/queue CI doesn't provide).
       # Folding those in would make CI permanently red. Tracked for cleanup — see
       # the issue linked in the PR — after which these paths widen toward full.
+      # `src/__tests__/mcp-multiplexer-integration.test.ts` added #304: first
+      # file reclaimed from the excluded root suite (was 0 pass / 7 fail on a
+      # stale settings fixture; now 7 pass, verified 6/6 across repeat runs).
+      # Its sibling `session-persistence-integration.test.ts` is fixed too but
+      # deliberately NOT added yet — it carries a load-sensitive flake tracked
+      # in #326, and adding it would make CI randomly red.
+      #
       # `src/adapters` added #301: the adapter suites are clean (252 pass) and
       # they are where outbound routing and turn-semantics risk actually lives.
       # Without them the adapter half of a delivery change never runs in CI —
       # and there is no typecheck step to back it up.
       - name: Run tests (clean suites)
-        run: bun test src/bus src/adapters src/tuner src/observability src/skills-tuner src/plugins/eval-framework src/__tests__/governance
+        run: bun test src/bus src/adapters src/tuner src/observability src/skills-tuner src/plugins/eval-framework src/__tests__/governance src/__tests__/mcp-multiplexer-integration.test.ts

--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,7 @@
       "!.planning",
       "!dist",
       "!.codegraph",
-      "!src/__tests__/fixtures"
+      "!src/__tests__/fixtures/mock-mcp-server.ts"
     ],
     "ignoreUnknown": true
   },

--- a/src/__tests__/fixtures/mux-settings-view.ts
+++ b/src/__tests__/fixtures/mux-settings-view.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared `MuxSettingsView` test fixture (#304).
+ *
+ * Three copies of this builder previously existed — one under
+ * `src/plugins/mcp-multiplexer/__tests__/`, two under `src/__tests__/`.
+ *
+ * When #68 (`metricsEnabled`, 931b25a) and #69 (`cache`, cde2bd8) made new
+ * fields REQUIRED on `MuxSettingsView`, both commits updated the copy sitting
+ * next to the code they changed and neither touched the two living under
+ * `src/__tests__/`. Nothing ran any of them to catch it: there was no CI test
+ * job at all until 7a0db7f, six weeks later, and it has never covered these
+ * paths. So the two orphans silently rotted, and every test in them began
+ * failing with
+ * `TypeError: undefined is not an object (evaluating 'settings.cache.cacheable')`
+ * at `src/plugins/mcp-multiplexer/index.ts:296` — 14 failures across two files.
+ *
+ * This is not the first repair. be4688a ("un-break stale mux helpers", 25 May)
+ * fixed the same fields in the same files and is NOT an ancestor of main — it
+ * was dropped in an upstream-sync graft. a99c527 patched the same fixture in
+ * place before that. Three local repairs, two lost or re-rotted.
+ *
+ * Hence one builder, used by all three consumers: a future required field
+ * breaks every call site at once rather than only the ones nobody looks at.
+ *
+ * Defaults are chosen for unit-test determinism, not to mirror production:
+ * timers off, optional subsystems off, so a test opts in to what it exercises.
+ *
+ * NOTE the deliberate divergence: `sessionPersistenceEnabled` defaults to
+ * `false` here, while production defaults it to `true` (see the field docs on
+ * `MuxSettingsView`). A test that needs persistence must therefore ask for it.
+ * Every current call site does. The trap to avoid: a NEW test that forgets the
+ * flag gets persistence silently off, and a negative assertion ("no files
+ * written", "no persistence audits") then passes vacuously rather than failing.
+ */
+
+import type { MuxSettingsView } from "../../plugins/mcp-multiplexer/index.js";
+
+/**
+ * Build a `settingsView` thunk for `McpMultiplexerPlugin`.
+ *
+ * @param partial - fields to override; everything else takes the test default.
+ */
+export function makeMuxSettingsView(partial: Partial<MuxSettingsView> = {}): () => MuxSettingsView {
+  const view: MuxSettingsView = {
+    webEnabled: true,
+    webHost: "127.0.0.1",
+    webPort: 4632,
+    shared: [],
+    stateless: [],
+    // Health probe off by default so unit tests don't inherit timer
+    // flakiness; the probe is exercised directly via `_sampleHealthForTests`.
+    healthProbeIntervalMs: 0,
+    // Persistence off by default so a test that doesn't care behaves exactly
+    // as it did pre-#71; the persistence suites opt in explicitly.
+    sessionPersistenceEnabled: false,
+    sessionMaxAgeSeconds: 3600,
+    sessionPersistencePath: "",
+    // #68 — off by default; opt-in tests set true.
+    metricsEnabled: false,
+    // #69 — off by default; opt-in tests supply a `cacheable` map.
+    cache: {
+      enabled: false,
+      ttlMs: 5_000,
+      maxEntries: 1_000,
+      cacheable: {},
+      defensiveInvalidation: true,
+    },
+    ...partial,
+  };
+  return () => view;
+}

--- a/src/__tests__/mcp-multiplexer-integration.test.ts
+++ b/src/__tests__/mcp-multiplexer-integration.test.ts
@@ -28,14 +28,11 @@ import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import {
-  McpMultiplexerPlugin,
-  _resetMcpMultiplexer,
-  type MuxSettingsView,
-} from "../plugins/mcp-multiplexer/index.js";
+import { McpMultiplexerPlugin, _resetMcpMultiplexer } from "../plugins/mcp-multiplexer/index.js";
 import { _resetHttpGateway, getHttpGateway } from "../plugins/http-gateway.js";
 import { _resetMcpBridge, getMcpBridge } from "../plugins/mcp-bridge.js";
 import { _resetIdentityStore } from "../plugins/mcp-multiplexer/pty-identity.js";
+import { makeMuxSettingsView } from "./fixtures/mux-settings-view.js";
 
 const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
 const BUN_BIN = process.execPath;
@@ -59,25 +56,6 @@ function writeProxyConfig(dir: string, names: string[]): string {
   const path = join(dir, "mcp-proxy.json");
   writeFileSync(path, JSON.stringify(cfg, null, 2));
   return path;
-}
-
-function makeSettingsView(partial: Partial<MuxSettingsView>): () => MuxSettingsView {
-  const view: MuxSettingsView = {
-    webEnabled: true,
-    webHost: "127.0.0.1",
-    webPort: 4632,
-    shared: [],
-    stateless: [],
-    healthProbeIntervalMs: 0,
-    // Phase B added these fields to MuxSettingsView. Tests pre-dating
-    // Phase B set defaults that disable persistence so behaviour is
-    // identical to PR #71.
-    sessionPersistenceEnabled: false,
-    sessionMaxAgeSeconds: 3600,
-    sessionPersistencePath: "",
-    ...partial,
-  };
-  return () => view;
 }
 
 /** Start a hermetic Bun.serve listener on an ephemeral loopback port
@@ -197,7 +175,7 @@ describe("mcp-multiplexer integration — happy path", () => {
     const cfg = writeProxyConfig(tmpDir, ["alpha"]);
     plugin = new McpMultiplexerPlugin({
       configPath: cfg,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: ["alpha"],
       }),
@@ -244,7 +222,7 @@ describe("mcp-multiplexer integration — per-PTY auth", () => {
     const cfg = writeProxyConfig(tmpDir, ["alpha"]);
     plugin = new McpMultiplexerPlugin({
       configPath: cfg,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: ["alpha"],
       }),
@@ -312,7 +290,7 @@ describe("mcp-multiplexer integration — auth rejection", () => {
     const cfg = writeProxyConfig(tmpDir, ["alpha"]);
     plugin = new McpMultiplexerPlugin({
       configPath: cfg,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: ["alpha"],
       }),
@@ -368,7 +346,7 @@ describe("mcp-multiplexer integration — auth rejection", () => {
     const cfg = writeProxyConfig(tmpDir, ["alpha"]);
     plugin = new McpMultiplexerPlugin({
       configPath: cfg,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: ["alpha"],
       }),
@@ -407,7 +385,7 @@ describe("mcp-multiplexer integration — stateful vs stateless demux", () => {
     const cfg = writeProxyConfig(tmpDir, ["alpha", "beta"]);
     plugin = new McpMultiplexerPlugin({
       configPath: cfg,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: ["alpha", "beta"],
         stateless: ["beta"],
@@ -511,7 +489,7 @@ describe("mcp-multiplexer integration — bridge callback path", () => {
     const cfg = writeProxyConfig(tmpDir, ["alpha"]);
     plugin = new McpMultiplexerPlugin({
       configPath: cfg,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: ["alpha"],
       }),
@@ -542,7 +520,7 @@ describe("mcp-multiplexer integration — crash + health probe transition", () =
     const cfg = writeProxyConfig(tmpDir, ["alpha"]);
     plugin = new McpMultiplexerPlugin({
       configPath: cfg,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: ["alpha"],
         // Keep the probe disabled so we drive sampling deterministically.

--- a/src/__tests__/session-persistence-integration.test.ts
+++ b/src/__tests__/session-persistence-integration.test.ts
@@ -38,13 +38,10 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { _resetHttpGateway, getHttpGateway } from "../plugins/http-gateway.js";
 import { _resetMcpBridge, getMcpBridge } from "../plugins/mcp-bridge.js";
-import {
-  _resetMcpMultiplexer,
-  McpMultiplexerPlugin,
-  type MuxSettingsView,
-} from "../plugins/mcp-multiplexer/index.js";
+import { _resetMcpMultiplexer, McpMultiplexerPlugin } from "../plugins/mcp-multiplexer/index.js";
 import { _resetIdentityStore } from "../plugins/mcp-multiplexer/pty-identity.js";
 import { SessionPersistenceStore } from "../plugins/mcp-multiplexer/session-persistence.js";
+import { makeMuxSettingsView } from "./fixtures/mux-settings-view.js";
 
 const MOCK_SERVER = fileURLToPath(new URL("./fixtures/mock-mcp-server.ts", import.meta.url));
 const BUN_BIN = process.execPath;
@@ -68,22 +65,6 @@ function writeProxyConfig(dir: string, names: string[]): string {
   const path = join(dir, "mcp-proxy.json");
   writeFileSync(path, JSON.stringify(cfg, null, 2));
   return path;
-}
-
-function makeSettingsView(partial: Partial<MuxSettingsView>): () => MuxSettingsView {
-  const view: MuxSettingsView = {
-    webEnabled: true,
-    webHost: "127.0.0.1",
-    webPort: 4632,
-    shared: [],
-    stateless: [],
-    healthProbeIntervalMs: 0,
-    sessionPersistenceEnabled: true,
-    sessionMaxAgeSeconds: 3600,
-    sessionPersistencePath: "",
-    ...partial,
-  };
-  return () => view;
 }
 
 /** Real factory — constructs an actual `SessionPersistenceStore`. */
@@ -275,7 +256,7 @@ describe("session-persistence integration — round-trip + replay", () => {
     await withAudit(async (ev) => {
       plugin = new McpMultiplexerPlugin({
         configPath: cfg,
-        settingsView: makeSettingsView({
+        settingsView: makeMuxSettingsView({
           shared: ["alpha"],
           sessionPersistenceEnabled: true,
           sessionPersistencePath: persistRoot,
@@ -340,7 +321,7 @@ describe("session-persistence integration — round-trip + replay", () => {
     await withAudit(async (events2) => {
       plugin = new McpMultiplexerPlugin({
         configPath: cfg,
-        settingsView: makeSettingsView({
+        settingsView: makeMuxSettingsView({
           shared: ["alpha"],
           sessionPersistenceEnabled: true,
           sessionPersistencePath: persistRoot,
@@ -428,7 +409,7 @@ describe("session-persistence integration — TTL expiration on replay", () => {
     await withAudit(async (events) => {
       plugin = new McpMultiplexerPlugin({
         configPath: cfg,
-        settingsView: makeSettingsView({
+        settingsView: makeMuxSettingsView({
           shared: ["alpha"],
           sessionPersistenceEnabled: true,
           sessionPersistencePath: persistRoot,
@@ -488,7 +469,7 @@ describe("session-persistence integration — integrity check on replay", () => 
     await withAudit(async (events) => {
       plugin = new McpMultiplexerPlugin({
         configPath: cfg,
-        settingsView: makeSettingsView({
+        settingsView: makeMuxSettingsView({
           shared: ["alpha"],
           sessionPersistenceEnabled: true,
           sessionPersistencePath: persistRoot,
@@ -539,7 +520,7 @@ describe("session-persistence integration — file corruption on replay", () => 
     await withAudit(async (events) => {
       plugin = new McpMultiplexerPlugin({
         configPath: cfg,
-        settingsView: makeSettingsView({
+        settingsView: makeMuxSettingsView({
           shared: ["alpha", "beta"],
           sessionPersistenceEnabled: true,
           sessionPersistencePath: persistRoot,
@@ -591,7 +572,7 @@ describe("session-persistence integration — runtime GC", () => {
     // Daemon up, drive a live bucket, persist a fresh record.
     plugin = new McpMultiplexerPlugin({
       configPath: cfg,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         shared: ["alpha"],
         sessionPersistenceEnabled: true,
         sessionPersistencePath: persistRoot,
@@ -696,7 +677,7 @@ describe("session-persistence integration — kill-switch", () => {
     await withAudit(async (events) => {
       plugin = new McpMultiplexerPlugin({
         configPath: cfg,
-        settingsView: makeSettingsView({
+        settingsView: makeMuxSettingsView({
           shared: ["alpha"],
           sessionPersistenceEnabled: false, // kill-switch
           sessionPersistencePath: persistRoot,
@@ -760,7 +741,7 @@ describe("session-persistence integration — stateless server skips persistence
     await withAudit(async (events) => {
       plugin = new McpMultiplexerPlugin({
         configPath: cfg,
-        settingsView: makeSettingsView({
+        settingsView: makeMuxSettingsView({
           shared: ["alpha", "beta"],
           stateless: ["beta"], // beta is stateless → no persistence
           sessionPersistenceEnabled: true,

--- a/src/plugins/mcp-multiplexer/__tests__/index.test.ts
+++ b/src/plugins/mcp-multiplexer/__tests__/index.test.ts
@@ -7,6 +7,7 @@ import { McpMultiplexerPlugin, _resetMcpMultiplexer, type MuxSettingsView } from
 import { _resetHttpGateway, getHttpGateway } from "../../http-gateway.js";
 import { _resetMcpBridge, getMcpBridge } from "../../mcp-bridge.js";
 import { _resetIdentityStore } from "../pty-identity.js";
+import { makeMuxSettingsView } from "../../../__tests__/fixtures/mux-settings-view.js";
 
 const MOCK_SERVER = fileURLToPath(
   new URL("../../../__tests__/fixtures/mock-mcp-server.ts", import.meta.url),
@@ -30,39 +31,6 @@ function writeProxyConfig(dir: string, servers: string[]): string {
   const path = join(dir, "mcp-proxy.json");
   writeFileSync(path, JSON.stringify(cfg, null, 2));
   return path;
-}
-
-function makeSettingsView(partial: Partial<MuxSettingsView>): () => MuxSettingsView {
-  const view: MuxSettingsView = {
-    webEnabled: true,
-    webHost: "127.0.0.1",
-    webPort: 4632,
-    shared: [],
-    stateless: [],
-    // Disable the health probe by default so unit tests don't deal with
-    // timer flakiness; the probe is exercised directly via
-    // `_sampleHealthForTests` in dedicated tests below.
-    healthProbeIntervalMs: 0,
-    // Default to false in tests so the persistence-layer tests can opt
-    // in explicitly. Backward-compat tests then prove that
-    // `sessionPersistenceEnabled: false` keeps the plugin byte-identical
-    // to PR #71.
-    sessionPersistenceEnabled: false,
-    sessionMaxAgeSeconds: 3600,
-    sessionPersistencePath: "",
-    // Issue #68 — default OFF in tests; opt-in tests set true explicitly.
-    metricsEnabled: false,
-    // Issue #69 — default OFF in tests; opt-in tests provide cacheable map.
-    cache: {
-      enabled: false,
-      ttlMs: 5_000,
-      maxEntries: 1_000,
-      cacheable: {},
-      defensiveInvalidation: true,
-    },
-    ...partial,
-  };
-  return () => view;
 }
 
 let tmpDir: string;
@@ -92,7 +60,7 @@ describe("McpMultiplexerPlugin — activation", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["one"]);
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({ webEnabled: false, shared: ["one"] }),
+      settingsView: makeMuxSettingsView({ webEnabled: false, shared: ["one"] }),
     });
     await plugin.start();
     expect(plugin.isActive()).toBe(false);
@@ -104,7 +72,7 @@ describe("McpMultiplexerPlugin — activation", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["one"]);
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({ webEnabled: true, shared: [] }),
+      settingsView: makeMuxSettingsView({ webEnabled: true, shared: [] }),
     });
     await plugin.start();
     expect(plugin.isActive()).toBe(false);
@@ -115,7 +83,7 @@ describe("McpMultiplexerPlugin — activation", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["one"]);
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         webHost: "0.0.0.0",
         shared: ["one"],
@@ -130,7 +98,7 @@ describe("McpMultiplexerPlugin — activation", () => {
   it("dormant when mcp-proxy.json missing", async () => {
     const plugin = new McpMultiplexerPlugin({
       configPath: join(tmpDir, "does-not-exist.json"),
-      settingsView: makeSettingsView({ webEnabled: true, shared: ["one"] }),
+      settingsView: makeMuxSettingsView({ webEnabled: true, shared: ["one"] }),
     });
     await plugin.start();
     expect(plugin.isActive()).toBe(false);
@@ -146,7 +114,7 @@ describe("McpMultiplexerPlugin — active path", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha", "beta", "gamma"]);
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: ["alpha", "beta"],
       }),
@@ -176,7 +144,7 @@ describe("McpMultiplexerPlugin — active path", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha"]); // only alpha exists
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: ["alpha", "missing-one", "missing-two"],
         stateless: ["alpha", "missing-one"], // stateless must also intersect with claimed
@@ -202,7 +170,7 @@ describe("McpMultiplexerPlugin — active path", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({ webEnabled: true, shared: ["alpha"] }),
+      settingsView: makeMuxSettingsView({ webEnabled: true, shared: ["alpha"] }),
     });
 
     await plugin.start();
@@ -226,7 +194,7 @@ describe("McpMultiplexerPlugin — active path", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({ webEnabled: true, shared: ["alpha"] }),
+      settingsView: makeMuxSettingsView({ webEnabled: true, shared: ["alpha"] }),
     });
 
     await plugin.start();
@@ -245,7 +213,7 @@ describe("McpMultiplexerPlugin — active path", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({ webEnabled: true, shared: ["alpha"] }),
+      settingsView: makeMuxSettingsView({ webEnabled: true, shared: ["alpha"] }),
     });
 
     await plugin.start();
@@ -264,7 +232,7 @@ describe("McpMultiplexerPlugin — active path", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({ webEnabled: true, shared: ["alpha"] }),
+      settingsView: makeMuxSettingsView({ webEnabled: true, shared: ["alpha"] }),
     });
 
     await plugin.start();
@@ -286,7 +254,7 @@ describe("McpMultiplexerPlugin — active path", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         webHost: "127.0.0.1",
         webPort: 12345,
@@ -307,7 +275,7 @@ describe("McpMultiplexerPlugin — active path", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha", "beta"]);
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: ["alpha", "beta"],
         // Note: stateless filtering to subset-of-shared happens in
@@ -335,7 +303,7 @@ describe("McpMultiplexerPlugin — active path", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({ webEnabled: true, shared: ["alpha"] }),
+      settingsView: makeMuxSettingsView({ webEnabled: true, shared: ["alpha"] }),
     });
 
     await plugin.start();
@@ -356,7 +324,7 @@ describe("McpMultiplexerPlugin — active path", () => {
     const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({ webEnabled: true, shared: ["alpha"] }),
+      settingsView: makeMuxSettingsView({ webEnabled: true, shared: ["alpha"] }),
     });
 
     await plugin.start();
@@ -375,7 +343,7 @@ describe("McpMultiplexerPlugin — active path", () => {
       const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
       const plugin = new McpMultiplexerPlugin({
         configPath: cfgPath,
-        settingsView: makeSettingsView({
+        settingsView: makeMuxSettingsView({
           webEnabled: true,
           shared: ["alpha"],
           // Probe stays disabled — we drive sampling synchronously via the
@@ -433,7 +401,7 @@ describe("McpMultiplexerPlugin — active path", () => {
       const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
       const plugin = new McpMultiplexerPlugin({
         configPath: cfgPath,
-        settingsView: makeSettingsView({
+        settingsView: makeMuxSettingsView({
           webEnabled: true,
           shared: ["alpha"],
           healthProbeIntervalMs: 0,
@@ -486,7 +454,7 @@ describe("McpMultiplexerPlugin — active path", () => {
       const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
       const plugin = new McpMultiplexerPlugin({
         configPath: cfgPath,
-        settingsView: makeSettingsView({
+        settingsView: makeMuxSettingsView({
           webEnabled: true,
           shared: ["alpha"],
           healthProbeIntervalMs: 0,
@@ -529,7 +497,7 @@ describe("McpMultiplexerPlugin — active path", () => {
       const cfgPath = writeProxyConfig(tmpDir, ["alpha"]);
       const plugin = new McpMultiplexerPlugin({
         configPath: cfgPath,
-        settingsView: makeSettingsView({
+        settingsView: makeMuxSettingsView({
           webEnabled: true,
           shared: ["alpha"],
           healthProbeIntervalMs: 0,
@@ -652,7 +620,7 @@ describe("McpMultiplexerPlugin — session persistence wiring", () => {
     let factoryCalls = 0;
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         shared: ["alpha"],
         sessionPersistenceEnabled: false,
       }),
@@ -684,7 +652,7 @@ describe("McpMultiplexerPlugin — session persistence wiring", () => {
 
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         shared: ["alpha"],
         sessionPersistenceEnabled: true,
       }),
@@ -738,7 +706,7 @@ describe("McpMultiplexerPlugin — session persistence wiring", () => {
 
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         shared: ["alpha"],
         sessionPersistenceEnabled: true,
       }),
@@ -781,7 +749,7 @@ describe("McpMultiplexerPlugin — session persistence wiring", () => {
 
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         shared: ["alpha"],
         sessionPersistenceEnabled: true,
       }),
@@ -806,7 +774,7 @@ describe("McpMultiplexerPlugin — session persistence wiring", () => {
     const store = new FakeStore();
     const plugin = new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         shared: ["alpha"],
         sessionPersistenceEnabled: true,
       }),
@@ -842,7 +810,7 @@ describe("McpMultiplexerPlugin — session persistence wiring", () => {
       // INTENTIONALLY no persistenceFactory — simulates production
       // wiring at `commands/start.ts` calling `getMcpMultiplexerPlugin()`
       // with no options.
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: ["alpha"],
         sessionPersistenceEnabled: true,
@@ -892,7 +860,7 @@ describe("McpMultiplexerPlugin — operator-config collision (#72 item 7)", () =
     const cfgPath = writeProxyConfig(tmpDir, opts.sharedNames);
     return new McpMultiplexerPlugin({
       configPath: cfgPath,
-      settingsView: makeSettingsView({
+      settingsView: makeMuxSettingsView({
         webEnabled: true,
         shared: opts.sharedNames,
         healthProbeIntervalMs: 0,


### PR DESCRIPTION
Cluster 1 of #304. Reclaims 14 of the 41 failures in the excluded root suite and adds the first reclaimed file back to the CI test scope.

Part of the revised scope agreed on #304 — one PR per root cause, each widening the CI path list as it lands.

## The rot

Three copies of `makeSettingsView` existed:

```
src/plugins/mcp-multiplexer/__tests__/index.test.ts   <- adjacent to the code
src/__tests__/mcp-multiplexer-integration.test.ts     <- orphaned
src/__tests__/session-persistence-integration.test.ts <- orphaned
```

When #68 added `metricsEnabled` (`931b25a`) and #69 added `cache` (`cde2bd8`) as **required** fields on `MuxSettingsView`, both commits updated the copy sitting next to the code they changed and neither touched the two under `src/__tests__/`. Nothing ran any of them to catch it — there was no CI test job at all until `7a0db7f`, six weeks later, and it has never covered those paths.

So the two orphans kept building an object missing both fields, and every test in them died at `src/plugins/mcp-multiplexer/index.ts:296`:

```
TypeError: undefined is not an object (evaluating 'settings.cache.cacheable')
```

0 pass / 14 fail across the two files. `tsc --noEmit` flagged it the whole time (TS2322 on the fixture literal) — there is no typecheck step to surface it (#327).

## This is the third repair, and the second was lost

`be4688a` ("test(observability): Phase A foundation coverage + **un-break stale mux helpers**", 25 May) fixed these exact fields in these exact files: *"repairs 7 pre-existing failures"*.

It is not in main. `git merge-base --is-ancestor be4688a povai/main` → NOT ANCESTOR; main carries that commit's parent blob. It was dropped in an upstream-sync graft. `a99c527` patched the same fixture in place before that.

Three local repairs, two lost or re-rotted. That is why this fixes it structurally rather than in place.

## The fix

One shared builder at `src/__tests__/fixtures/mux-settings-view.ts`, used by **all three** consumers including the surviving in-plugin copy — consolidating only the two broken ones would have left the same rot vector. The three copies' defaults were byte-identical, verified before folding them together. Precedent for the import direction already existed: the plugin test imports `mock-mcp-server.ts` from that same dir.

One deliberate divergence is documented in the fixture header: `sessionPersistenceEnabled` defaults `false` here but `true` in production. Inert today — all 8 persistence call sites set it explicitly — but a new test that forgets the flag would get persistence silently off, making a negative assertion ("no files written") pass vacuously rather than fail.

## Scope: fixtures only

An earlier revision of this branch also converted the persistence file's audit lookups to awaited polling, on the theory that a bare `events.find()` raced an async audit. Review disproved it: `_audit` is a direct synchronous call, `mcp-bridge.audit()` is `void` + `appendFileSync`, and the test's own capture wrapper pushes synchronously inside that call. There was no race — which is also why converting every lookup left the flake rate unchanged.

That machinery is **reverted**. This PR touches fixtures, one workflow path, and one biome ignore.

## biome: the fixtures dir was exempt from lint and format

`biome.json` excluded all of `src/__tests__/fixtures`, presumably aimed at `mock-mcp-server.ts` (a standalone script spawned as a child). That dir now holds shared infrastructure with call sites across three suites, and the new fixture had in fact never been formatted. Narrowed the ignore to the mock script itself — strictly more files are linted than before.

## CI scope

Adds `src/__tests__/mcp-multiplexer-integration.test.ts` only: 7 pass, stable across 13 runs including under CPU load.

`session-persistence-integration.test.ts` is fixed too but deliberately **not** added. It carries a flake tracked in #326, and adding a test that fails intermittently under load would make CI randomly red — the exact failure mode #304 exists to remove.

The #326 diagnosis has been corrected on the issue: the failure is `expect(scanned).toBe(2)` receiving `1` — a wrong payload, not a missing event, with the audit present on time and 2 entries verifiably on disk a line earlier. It is a file/GC state race, not audit delivery.

## Verification

```
mcp-multiplexer      0 pass /  7 fail  ->  7 pass / 0 fail
session-persistence  0 pass /  7 fail  ->  6-7 pass (1 pre-existing flake, #326)
in-plugin copy      29 pass /  0 fail  (unchanged, now on the shared fixture)
CI scope          1364 pass /  0 fail
bun run lint      exit 0
```

## Known gaps, not addressed here

- **Fixed 50ms sleep** at `mcp-multiplexer-integration.test.ts:573` gating an assertion on a real SDK `onclose` callback — in the file this PR adds to CI. A genuine latent risk on a shared runner, but unreproducible across 13 runs including under CPU load. Left alone deliberately rather than "fixed" on an unproven mechanism; noted for the remaining clusters.
- **~13 `TS2353`** in these files from the `it(name, {timeout}, fn)` overload. Pre-existing; tracked in #327 with the repo-wide count (338) and a triage sequence so that issue is not landed naively.
