### PR TITLE
fix(event-processor): record the dedupe key the event was selected with (#304)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.195",
+      "version": "2.2.196",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.195",
+  "version": "2.2.196",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,10 @@ jobs:
       # shared process) and infra-dependent tests (DB/queue CI doesn't provide).
       # Folding those in would make CI permanently red. Tracked for cleanup — see
       # the issue linked in the PR — after which these paths widen toward full.
+      # `src/__tests__/event-processor.test.ts` added #304 cluster 2: was
+      # 4 pass / 9 fail on a source-side ReferenceError; now 14 pass, stable
+      # 8/8 across repeat runs.
+      #
       # `src/__tests__/mcp-multiplexer-integration.test.ts` added #304: first
       # file reclaimed from the excluded root suite (was 0 pass / 7 fail on a
       # stale settings fixture; now 7 pass, verified 6/6 across repeat runs).
@@ -42,4 +46,4 @@ jobs:
       # Without them the adapter half of a delivery change never runs in CI —
       # and there is no typecheck step to back it up.
       - name: Run tests (clean suites)
-        run: bun test src/bus src/adapters src/tuner src/observability src/skills-tuner src/plugins/eval-framework src/__tests__/governance src/__tests__/mcp-multiplexer-integration.test.ts
+        run: bun test src/bus src/adapters src/tuner src/observability src/skills-tuner src/plugins/eval-framework src/__tests__/governance src/__tests__/mcp-multiplexer-integration.test.ts src/__tests__/event-processor.test.ts

--- a/src/__tests__/event-processor.test.ts
+++ b/src/__tests__/event-processor.test.ts
@@ -12,6 +12,7 @@ import {
   initProcessor,
   processNext,
   processPending,
+  processPersistedEvent,
   getPendingCount,
   getLastProcessedSeq,
   getDedupeStats,
@@ -122,6 +123,67 @@ describe("Event Processor", () => {
 
     expect(processCount).toBe(1);
     expect(hasDedupeKey(dedupeKey)).toBe(true);
+  });
+
+  it("dedupes correctly even when the handler mutates the event it was given", async () => {
+    // Regression guard for the key/event pairing. The dedupe key is computed
+    // when an event is SELECTED (and tested against `isDuplicate`), but
+    // `onEvent` receives the record by reference and runs before the key is
+    // recorded. Recomputing the key after the handler instead of carrying it
+    // forward would record the event under a key that was never checked — so
+    // an identical event would not be recognised as a duplicate.
+    //
+    // Asserted via the observable consequence (processed once, not twice)
+    // rather than the key value, because `getDedupeKey` is module-private and
+    // recomputing it here would just recreate the fixture drift #304 is about.
+    let processCount = 0;
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async (event) => {
+        processCount++;
+        // A handler mutating the record it was handed. Nothing in
+        // `ProcessorConfig["onEvent"]` forbids this.
+        (event.payload as Record<string, unknown>).mutatedByHandler = true;
+        return { success: true };
+      },
+    });
+
+    // Two identical events, no upstream dedupeKey -> same canonical key.
+    const payload = { original: "value" };
+    await append(createTestEntry({ payload: { ...payload }, dedupeKey: "" }));
+    await append(createTestEntry({ payload: { ...payload }, dedupeKey: "" }));
+
+    await processPending();
+
+    expect(processCount).toBe(1);
+  });
+
+  it("processPersistedEvent also records the key the event was selected with", async () => {
+    // The sibling of the bug fixed above. `processPersistedEvent` captures
+    // `const dedupeKey = getDedupeKey(event)` BEFORE calling `onEvent` and
+    // reuses it afterwards — already correct, but nothing guarded it, so a
+    // refactor to recompute after the handler would silently reintroduce the
+    // identical defect on a path the daemon actually uses (start.ts ->
+    // initGatewayProcessor -> getGatewayProcessor -> processPersistedEvent).
+    let processCount = 0;
+    await initProcessor({
+      retentionDays: 7,
+      onEvent: async (event) => {
+        processCount++;
+        (event.payload as Record<string, unknown>).mutatedByHandler = true;
+        return { success: true };
+      },
+    });
+
+    const payload = { sibling: "value" };
+    const first = await append(createTestEntry({ payload: { ...payload }, dedupeKey: "" }));
+    await append(createTestEntry({ payload: { ...payload }, dedupeKey: "" }));
+
+    // Process the first by id, then let the queue pick up the second.
+    await processPersistedEvent(first.id);
+    await processPending();
+
+    expect(processCount).toBe(1);
   });
 
   it("should handle event failure with retry", async () => {

--- a/src/event-processor.ts
+++ b/src/event-processor.ts
@@ -251,8 +251,13 @@ export async function processNext(): Promise<boolean> {
   isProcessing = true;
 
   try {
-    // Find next pending event
+    // Find next pending event, capturing the dedupe key it was selected with.
+    // The key must travel with the event: `onEvent` below receives the record
+    // by reference, so recomputing the key after the handler has run would
+    // depend on no handler ever mutating it. Carrying it forward makes the
+    // recorded key provably the same one `isDuplicate` tested.
     let nextEvent: EventRecord | null = null;
+    let nextDedupeKey: string | null = null;
 
     for await (const event of readFrom(lastProcessedSeq + 1)) {
       // Skip non-pending events and internal events (like status updates)
@@ -267,6 +272,7 @@ export async function processNext(): Promise<boolean> {
         continue;
       }
       nextEvent = event;
+      nextDedupeKey = eventDedupeKey;
       break;
     }
 
@@ -296,8 +302,21 @@ export async function processNext(): Promise<boolean> {
         status: "done",
       });
 
-      // Record for deduplication
-      await recordProcessed(nextEvent, dedupeKey);
+      // Record for deduplication under the key this event was selected with.
+      //
+      // Throws rather than falling back to `getDedupeKey(nextEvent)`: that
+      // fallback IS the defect this fixes (recomputing after the handler may
+      // have mutated the record), so an invariant violation must fail loudly
+      // instead of silently recording under a key that was never checked.
+      // Unreachable as written — `nextEvent` and `nextDedupeKey` are assigned
+      // together immediately before the `break`, and the `!nextEvent` guard is
+      // the only way past the loop — but TS cannot narrow one from the other.
+      if (nextDedupeKey === null) {
+        throw new Error(
+          `[processor] internal: no dedupe key captured for event ${nextEvent.id} (seq ${nextEvent.seq})`,
+        );
+      }
+      await recordProcessed(nextEvent, nextDedupeKey);
 
       lastProcessedSeq = nextEvent.seq;
       console.log(`[processor] Successfully processed event ${nextEvent.id}`);


### PR DESCRIPTION
Cluster 2 of #304. Fixes 9 of the 27 remaining failures in the excluded root suite and adds the file to the CI test scope.

**Unlike cluster 1, this is a source bug, not test rot.** The tests were correct the whole time and were correctly reporting a real defect in `src/event-processor.ts`. See the correction posted to #304 — my own scope comment there misattributed this to the test file, and the remaining clusters need a third category alongside "pollution" and "test rot": *source bugs that only the excluded tests were catching*.

## The bug

`processNext()` referenced an undeclared variable:

```
ReferenceError: dedupeKey is not defined
  at processNext (src/event-processor.ts:300:49)
```

Introduced by `8cbd850` ("apply all security and correctness fixes from PR review", 5 Apr), which moved the duplicate check into the `for await` loop. Its diff removed:

```
-    const dedupeKey = getDedupeKey(nextEvent);
-    if (isDuplicate(dedupeKey)) {
```

replacing it with a block-scoped `eventDedupeKey` inside the loop — while leaving `recordProcessed(nextEvent, dedupeKey)` ~24 lines below, outside the edited hunk, pointing at the variable it had just deleted.

A clean oversight, not an unfinished semantics change: `recordProcessed`'s signature was untouched, and the correct sibling was left alone. It was committed directly to main, so there was no review thread that could have caught it. It survived 3.5 months because nothing ran it.

## Never live, and why that matters

`processNext` has never had a production caller. Its only in-module caller, `processPending`, is also test-only; the daemon reaches this module by a different entry point entirely (`start.ts` → `initGatewayProcessor` → `getGatewayProcessor` → `processPersistedEvent`).

So the throw was only ever test-visible. That legitimately raises "delete instead of fix". Fixed rather than deleted because `processPending` is exported public API, the file header documents the serial path as deliberate Phase 1 design, and deleting drops the only coverage of the in-loop dedupe-skip — semantics the live gateway path shares.

## Carry the key forward, don't recompute

The first fix recomputed at the point of use: `recordProcessed(nextEvent, getDedupeKey(nextEvent))`. `getDedupeKey` is pure, so that looks equivalent.

It isn't. `onEvent` receives the record **by reference** and runs between selection and recording:

```ts
onEvent: (event: EventRecord) => Promise<ProcessingResult>;
```

Nothing in that contract forbids a handler mutating the event. If one does, the recomputed key differs from the one `isDuplicate` tested, so the event is recorded under a key that was never checked — and an identical event is not recognised as a duplicate.

So the key is captured alongside `nextEvent` at selection and carried forward. This restores the pre-`8cbd850` invariant (one key, computed once, used for both check and record) *under* that commit's new structure rather than reverting it.

**The sibling already did this.** `processPersistedEvent` computes `const dedupeKey` before `onEvent` and reuses it after — so this restores consistency between the two rather than inventing a convention.

The call site **throws** on a null key rather than falling back to a recompute: that fallback *is* the defect, so an invariant violation must fail loudly instead of silently recording under an unchecked key. Unreachable as written — verified by a probe showing the branch is taken 0 times across the suite — but TypeScript cannot narrow one variable from the other.

## The tests were the interesting part

Mutation testing found the first fix was **unverified**: removing the carry-forward left the suite at 13 pass / 0 fail, because no existing handler mutates its event, making recompute and carry-forward indistinguishable.

Two guards added, both mutation-verified:

- **`processNext`** — a handler that mutates, asserting the observable consequence (processed once, not twice). Asserted behaviourally rather than on the key value because `getDedupeKey` is module-private, and recomputing it in the test would recreate exactly the fixture drift cluster 1 removed. Note this guards the *naive alternative fix*, not the original ReferenceError — the stronger property.
- **`processPersistedEvent`** — the sibling was correct but had **zero** coverage: mutating it broke no tests at all, across the event-processor, gateway and escalation-wiring suites. It is the path the daemon actually uses, so the live path was the unguarded one.

Each guard fails only itself under its own mutation.

## CI scope

Adds `src/__tests__/event-processor.test.ts`: 15 pass, stable across repeat runs, contributing zero failures to the widened line.

**Honest note on that line:** it is already non-deterministically red by ~2 tests, independent of this change. Repeated full-scope runs each failed a *different* pre-existing test (`session-id collision rotation` in two variants, `BusCore IPC #252`), all of which pass in isolation and none of which this branch touches. Four such load-sensitive tests are now recorded on #326. The `tests-passing` gate was therefore scoped to the paths this PR touches, per the project's TEST_ARGS guidance, rather than re-run until green.

## Disclosed, not fixed here

Two tests this PR turns from red to green assert nothing at all — `should handle permanent failure` and `should handle processor errors gracefully` both have zero `expect()` calls and pass merely by not throwing. `should handle event failure with retry` asserts only that the handler ran, never that the status became `retry_scheduled`. No test in the file asserts event status after processing, so the whole failure/retry/DLQ branch executes unasserted. That is assertion drift — #304 cluster 4 — flagged rather than folded in so the clusters stay separable.

Latent, outside this PR's claims: `generateDedupeKey` normalizes only *top-level* payload keys, so semantically identical payloads with differently-ordered nested keys hash differently.

A typecheck step (#324) would have caught `dedupeKey is not defined` in April.

## Verification

```
event-processor   4 pass /  9 fail  ->  15 pass / 0 fail
guard 1 mutated  14 pass /  1 fail  (only its own test)
guard 2 mutated  14 pass /  1 fail  (only its own test)
bun run lint     exit 0
```
