### PR TITLE
feat(slack): render system.operator_alert (refs #325)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.197",
+      "version": "2.2.202",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.197",
+  "version": "2.2.202",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/adapters/slack/__tests__/slack.test.ts
+++ b/src/adapters/slack/__tests__/slack.test.ts
@@ -969,7 +969,9 @@ describe("SlackAdapter — stop() cleanup", () => {
       routing: { channels: { C100: "triage", C200: "research" } },
     });
     // Two agents × three topics = six subscriptions.
-    expect(bus.state().subscriberCount).toBe(6);
+    // 2 agents x 4 subscriptions (response.text, permission_request,
+    // request_human, operator_alert #325).
+    expect(bus.state().subscriberCount).toBe(8);
     await adapter.stop();
     adapter = null;
     expect(bus.state().subscriberCount).toBe(0);
@@ -1737,5 +1739,51 @@ describe("SlackAdapter — tailer echo suppression (#217)", () => {
     await waitFor(() => api.sent.length > 0);
     expect(api.sent).toHaveLength(1);
     expect(api.sent[0]?.text).toBe("recovered");
+  });
+
+  it("delivers system.operator_alert as a standalone message (#325)", async () => {
+    adapter = await startAdapter();
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "system.operator_alert",
+      payload: { text: "stall watchdog: possible false-positive kill" },
+    });
+    await waitFor(() => api.sent.length > 0);
+    expect(api.sent[0]?.channel).toBe("C100");
+    expect(api.sent[0]?.text).toContain("stall watchdog");
+  });
+
+  it("bounds system.operator_alert to the primary channel, not a fan-out (#325)", async () => {
+    adapter = await startAdapter({
+      routing: {
+        channels: { C100: "triage", C200: "triage" },
+        primaryChannelByAgent: { triage: "C200" },
+      },
+    });
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "system.operator_alert",
+      payload: { text: "one alert" },
+    });
+    await waitFor(() => api.sent.length > 0);
+    expect(api.sent).toHaveLength(1);
+    expect(api.sent[0]?.channel).toBe("C200");
+  });
+
+  it("drops an empty system.operator_alert (#325)", async () => {
+    adapter = await startAdapter();
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "system.operator_alert",
+      payload: { text: "" },
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(api.sent).toHaveLength(0);
   });
 });

--- a/src/adapters/slack/__tests__/slack.test.ts
+++ b/src/adapters/slack/__tests__/slack.test.ts
@@ -1786,4 +1786,18 @@ describe("SlackAdapter — tailer echo suppression (#217)", () => {
     await new Promise((r) => setTimeout(r, 20));
     expect(api.sent).toHaveLength(0);
   });
+
+  it("converts markdown bold to Slack mrkdwn in operator_alert (#325)", async () => {
+    adapter = await startAdapter();
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "system.operator_alert",
+      payload: { text: "\u{1F6E1}\uFE0F **stall-watchdog** flagged a kill" },
+    });
+    await waitFor(() => api.sent.length > 0);
+    expect(api.sent[0]?.text).toContain("*stall-watchdog*");
+    expect(api.sent[0]?.text).not.toContain("**");
+  });
 });

--- a/src/adapters/slack/__tests__/slack.test.ts
+++ b/src/adapters/slack/__tests__/slack.test.ts
@@ -29,7 +29,12 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { randomUUID, createHmac } from "node:crypto";
-import { SlackAdapter, buildPermissionBlocks, PERMISSION_ACTION_ID_REGEX } from "../index";
+import {
+  SlackAdapter,
+  buildPermissionBlocks,
+  PERMISSION_ACTION_ID_REGEX,
+  mdToSlackMrkdwn,
+} from "../index";
 import type { BusCore, SendPromptRequest } from "../../../bus/core";
 import type {
   Subscription,
@@ -1799,5 +1804,77 @@ describe("SlackAdapter — tailer echo suppression (#217)", () => {
     await waitFor(() => api.sent.length > 0);
     expect(api.sent[0]?.text).toContain("*stall-watchdog*");
     expect(api.sent[0]?.text).not.toContain("**");
+  });
+
+  it("drops a payload-less system.operator_alert without an unhandled rejection (#325)", async () => {
+    // The subscription callback is fire-and-forget (`void handleOperatorAlert`),
+    // so a throw on a payload-less event surfaces as an UNHANDLED rejection, not
+    // via api.sent. Capture it directly — a passing api.sent assertion alone
+    // would not distinguish the pre-fix crash.
+    const rejections: unknown[] = [];
+    const onRej = (e: unknown) => rejections.push(e);
+    process.on("unhandledRejection", onRej);
+    try {
+      adapter = await startAdapter();
+      bus.emit({
+        ts: Date.now(),
+        agent_id: "triage",
+        session_id: "s1",
+        topic: "system.operator_alert",
+      } as unknown as BusEvent);
+      // A well-formed alert AFTER it must still deliver (handler survived).
+      bus.emit({
+        ts: Date.now(),
+        agent_id: "triage",
+        session_id: "s1",
+        topic: "system.operator_alert",
+        payload: { text: "still alive" },
+      });
+      await waitFor(() => api.sent.length > 0);
+      await new Promise((r) => setTimeout(r, 20)); // let any pending rejection settle
+      expect(rejections).toHaveLength(0);
+      expect(api.sent).toHaveLength(1);
+      expect(api.sent[0]?.text).toBe("still alive");
+    } finally {
+      process.off("unhandledRejection", onRej);
+    }
+  });
+
+  it("drops a system.operator_alert whose payload has no text field (#325)", async () => {
+    adapter = await startAdapter();
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "system.operator_alert",
+      payload: { other: 1 } as unknown as { text?: string },
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(api.sent).toHaveLength(0);
+  });
+
+  it("skips a tailer-origin system.operator_alert (echo guard, #325)", async () => {
+    adapter = await startAdapter();
+    bus.emit({
+      ts: Date.now(),
+      agent_id: "triage",
+      session_id: "s1",
+      topic: "system.operator_alert",
+      payload: { text: "echo", _meta: { source: TAILER_EVENT_SOURCE } },
+    });
+    await new Promise((r) => setTimeout(r, 20));
+    expect(api.sent).toHaveLength(0);
+  });
+});
+
+describe("mdToSlackMrkdwn — Markdown → Slack mrkdwn (#325)", () => {
+  it("converts bold, strikethrough, links and headers; leaves compatible markup", () => {
+    expect(mdToSlackMrkdwn("**b** and __b2__")).toBe("*b* and *b2*");
+    expect(mdToSlackMrkdwn("~~gone~~")).toBe("~gone~");
+    expect(mdToSlackMrkdwn("see [docs](https://x.io/y)")).toBe("see <https://x.io/y|docs>");
+    expect(mdToSlackMrkdwn("# Title")).toBe("*Title*");
+    // multi-line bold converts (dotAll); code/italic pass through unchanged.
+    expect(mdToSlackMrkdwn("**two\nlines**")).toBe("*two\nlines*");
+    expect(mdToSlackMrkdwn("`code` and _i_")).toBe("`code` and _i_");
   });
 });

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -602,8 +602,32 @@ export class SlackAdapter {
         { agent_id: agentId, topics: ["system.request_human"] },
         (event) => void this.handleRequestHuman(agentId, event),
       ),
+      this.bus.subscribe(
+        { agent_id: agentId, topics: ["system.operator_alert"] },
+        (event) => void this.handleOperatorAlert(agentId, event),
+      ),
     ];
     this.subscriptions.set(agentId, subs);
+  }
+
+  private async handleOperatorAlert(agentId: string, event: BusEvent): Promise<void> {
+    if (!eventBelongsToSlack(event)) return;
+    const payload = event.payload as { text?: string };
+    const text = typeof payload.text === "string" ? payload.text : "";
+    if (!text) return;
+    // #325/#301: a standalone out-of-band operator alert (e.g. the stall
+    // watchdog). It is NOT a reply — it must not touch turn state or register
+    // a pending ask, so it deliberately does NOT go through handleResponseText.
+    // Bound to ONE channel (the primary when set), mirroring Discord/Telegram:
+    // the fan-out fallback maps every channel AND thread for the agent, which
+    // is an alert storm for a stall alert, not a heartbeat.
+    const alertChannel =
+      this.primaryChannelByAgent?.[agentId] ?? this.resolveTargetChannels(agentId, null)[0];
+    if (!alertChannel) {
+      this.logger.warn(`[slack-adapter] no target channel for operator_alert on agent ${agentId}`);
+      return;
+    }
+    await this.safePostMessage({ channel: alertChannel, text });
   }
 
   private async handleResponseText(agentId: string, event: BusEvent): Promise<void> {

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -627,7 +627,12 @@ export class SlackAdapter {
       this.logger.warn(`[slack-adapter] no target channel for operator_alert on agent ${agentId}`);
       return;
     }
-    await this.safePostMessage({ channel: alertChannel, text });
+    // The alert text uses markdown bold (**x**), but Slack mrkdwn bold is a
+    // SINGLE asterisk, so **x** would render with literal asterisks. Convert it
+    // (the sibling adapters handle their own markup: Discord ** is native,
+    // Telegram converts to HTML). #325.
+    const mrkdwn = text.replace(/\*\*(.+?)\*\*/g, "*$1*");
+    await this.safePostMessage({ channel: alertChannel, text: mrkdwn });
   }
 
   private async handleResponseText(agentId: string, event: BusEvent): Promise<void> {

--- a/src/adapters/slack/index.ts
+++ b/src/adapters/slack/index.ts
@@ -76,6 +76,21 @@ function eventBelongsToSlack(event: BusEvent): boolean {
 }
 
 /**
+ * Minimal Markdown → Slack `mrkdwn` conversion for out-of-band alert text.
+ * Slack mrkdwn is NOT Markdown: bold is a single `*`, strikethrough a single
+ * `~`, links are `<url|text>`, and there are no `#` headers. This covers the
+ * constructs an operator-alert producer realistically emits; `_italic_` and
+ * `` `code` `` already render the same in both, so they pass through untouched.
+ */
+export function mdToSlackMrkdwn(md: string): string {
+  return md
+    .replace(/(\*\*|__)([\s\S]+?)\1/g, "*$2*") // **bold** / __bold__ → *bold*
+    .replace(/~~([\s\S]+?)~~/g, "~$1~") // ~~strike~~ → ~strike~
+    .replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, "<$2|$1>") // [t](url) → <url|t>
+    .replace(/^#{1,6}[ \t]+(.+)$/gm, "*$1*"); // # Header → *Header* (no headers in mrkdwn)
+}
+
+/**
  * Cap on the `seenEventIds` LRU. Slack retries every ~1s up to 3 times,
  * so a 5k entry cap covers >1h of traffic at 1 event/sec — far beyond
  * the retry window — while bounding memory to ~5k strings (~200kB).
@@ -612,8 +627,15 @@ export class SlackAdapter {
 
   private async handleOperatorAlert(agentId: string, event: BusEvent): Promise<void> {
     if (!eventBelongsToSlack(event)) return;
-    const payload = event.payload as { text?: string };
-    const text = typeof payload.text === "string" ? payload.text : "";
+    // Consistency with handleResponseText: never re-deliver the JSONL tailer's
+    // observability echo. operator_alert is in-process today (no tailer echo),
+    // so this is a defensive no-op that keeps the guard uniform across handlers.
+    if (isTailerOriginEvent(event)) return;
+    // Defensive: `payload?.text` — a payload-less event must be dropped, not
+    // crash (the callback is fire-and-forget `void`, so a throw here is an
+    // unhandled rejection). Mirrors handleResponseText.
+    const payload = event.payload as { text?: string } | undefined;
+    const text = typeof payload?.text === "string" ? payload.text : "";
     if (!text) return;
     // #325/#301: a standalone out-of-band operator alert (e.g. the stall
     // watchdog). It is NOT a reply — it must not touch turn state or register
@@ -621,18 +643,25 @@ export class SlackAdapter {
     // Bound to ONE channel (the primary when set), mirroring Discord/Telegram:
     // the fan-out fallback maps every channel AND thread for the agent, which
     // is an alert storm for a stall alert, not a heartbeat.
-    const alertChannel =
-      this.primaryChannelByAgent?.[agentId] ?? this.resolveTargetChannels(agentId, null)[0];
+    // resolveTargetChannels already collapses to [primary] when set, so no
+    // separate primaryChannelByAgent lookup is needed here.
+    const targets = this.resolveTargetChannels(agentId, null);
+    const alertChannel = targets[0];
     if (!alertChannel) {
       this.logger.warn(`[slack-adapter] no target channel for operator_alert on agent ${agentId}`);
       return;
     }
-    // The alert text uses markdown bold (**x**), but Slack mrkdwn bold is a
-    // SINGLE asterisk, so **x** would render with literal asterisks. Convert it
-    // (the sibling adapters handle their own markup: Discord ** is native,
-    // Telegram converts to HTML). #325.
-    const mrkdwn = text.replace(/\*\*(.+?)\*\*/g, "*$1*");
-    await this.safePostMessage({ channel: alertChannel, text: mrkdwn });
+    // No primary set AND >1 candidate → the [0] pick is arbitrary (config key
+    // order). Surface it so the operator can pin a channel instead of an alert
+    // silently landing somewhere they don't watch.
+    if (targets.length > 1) {
+      this.logger.warn(
+        `[slack-adapter] operator_alert for agent ${agentId} has ${targets.length} candidate ` +
+          `channels and no primaryChannelByAgent; delivering to ${alertChannel}. Set ` +
+          `routing.primaryChannelByAgent.${agentId} to target a specific channel.`,
+      );
+    }
+    await this.safePostMessage({ channel: alertChannel, text: mdToSlackMrkdwn(text) });
   }
 
   private async handleResponseText(agentId: string, event: BusEvent): Promise<void> {


### PR DESCRIPTION
Refs #325.

## Problem

#321 added `system.operator_alert` (the daemon's "alert the operator on their surface" primitive) and wired it into Discord and Telegram. Slack was left out: it subscribes to `response.text`, `channel.permission_request`, and `system.request_human`, but not `system.operator_alert`. An operator whose primary surface is Slack therefore still saw stall-watchdog alerts only in `journalctl` / `stall-kills.jsonl` — the log-only situation #301 set out to fix.

## What this does

Adds the `system.operator_alert` subscription and a `handleOperatorAlert` handler that mirrors Discord, carrying over both constraints from #321:

1. **Not routed through the reply path.** The alert carries no turn semantics, so it does not go through `handleResponseText` — it must not close a turn receipt or register a pending ask. Standalone `chat.postMessage`.
2. **Blast radius bounded to one channel.** It targets the agent's primary channel when set (`primaryChannelByAgent`), else the first resolved channel — never the fan-out that maps every channel *and thread* to the agent. Fine for a heartbeat; an alert storm for a stall alert. Matches Discord's and Telegram's single-target semantics, so one logical alert has the same reach on every surface.

## Scope

This is the Slack half of #325. The **web UI** half is deliberately left for a follow-up: as the issue notes, an alert there isn't chat output and likely belongs in a notifications surface rather than spliced into `webui-bridge`'s conversation stream — a small design call worth its own PR.

## Test plan

Three new cases in `slack.test.ts`: the alert is delivered as a standalone message; it is bounded to the primary channel (not fanned out); an empty alert is dropped. Updated the subscription-count assertion (3→4 topics per agent). Full `src/adapters/slack` suite green (74 pass, 0 fail); no new `tsc`/lint.
