### PR TITLE
fix(bus): split StallDecision so handleKill is type-checked (closes #324)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.197",
+      "version": "2.2.203",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.197",
+  "version": "2.2.203",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/bus/stall-watchdog.ts
+++ b/src/bus/stall-watchdog.ts
@@ -195,15 +195,21 @@ export function newSessionState(
   return { agentId, sessionId, outstanding: new Map(), lastActivityAt: now };
 }
 
+/** The shared shape of an actionable stall (everything but the verb). */
+type StallSignal = {
+  tool: string;
+  toolUseId: string;
+  outstandingMs: number;
+  ceiling: ToolCeiling;
+};
+
+// `warn` and `kill` are DISTINCT members (not a combined `"warn" | "kill"`),
+// so `Extract<StallDecision, { action: "kill" }>` resolves to the kill member
+// instead of `never` and `handleKill`'s body is actually type-checked (#324).
 export type StallDecision =
   | { action: "none" }
-  | {
-      action: "warn" | "kill";
-      tool: string;
-      toolUseId: string;
-      outstandingMs: number;
-      ceiling: ToolCeiling;
-    };
+  | ({ action: "warn" } & StallSignal)
+  | ({ action: "kill" } & StallSignal);
 
 const rank = (a: StallDecision["action"]): number => (a === "kill" ? 2 : a === "warn" ? 1 : 0);
 
@@ -233,7 +239,16 @@ export function evaluateStall(
       rank(action) > rank(worst.action) ||
       (rank(action) === rank(worst.action) && age > worstAge)
     ) {
-      worst = { action, tool: t.name, toolUseId: t.id, outstandingMs: age, ceiling: c };
+      // `action` is narrowed to "warn" | "kill" here (the "none" case
+      // continued above). Build with a LITERAL action so the object is
+      // assignable to the split union.
+      const signal: StallSignal = {
+        tool: t.name,
+        toolUseId: t.id,
+        outstandingMs: age,
+        ceiling: c,
+      };
+      worst = action === "kill" ? { action: "kill", ...signal } : { action: "warn", ...signal };
       worstAge = age;
     }
   }

--- a/src/bus/stall-watchdog.ts
+++ b/src/bus/stall-watchdog.ts
@@ -203,13 +203,19 @@ type StallSignal = {
   ceiling: ToolCeiling;
 };
 
-// `warn` and `kill` are DISTINCT members (not a combined `"warn" | "kill"`),
-// so `Extract<StallDecision, { action: "kill" }>` resolves to the kill member
-// instead of `never` and `handleKill`'s body is actually type-checked (#324).
-export type StallDecision =
-  | { action: "none" }
-  | ({ action: "warn" } & StallSignal)
-  | ({ action: "kill" } & StallSignal);
+/**
+ * A decision to kill — its own named member so `handleKill` can type its
+ * parameter directly on it (#324). Deliberately NOT
+ * `Extract<StallDecision, { action: "kill" }>`: that construct silently
+ * resolves to `never` if the union is ever recombined into one
+ * `{ action: "warn" | "kill" }` member — and since every access on `never`
+ * compiles, handleKill's body would go un-type-checked again with no signal.
+ */
+type KillDecision = { action: "kill" } & StallSignal;
+
+// `warn` and `kill` are DISTINCT members (not a combined `"warn" | "kill"`), so
+// each carries a single literal discriminant the consumers can narrow on.
+export type StallDecision = { action: "none" } | ({ action: "warn" } & StallSignal) | KillDecision;
 
 const rank = (a: StallDecision["action"]): number => (a === "kill" ? 2 : a === "warn" ? 1 : 0);
 
@@ -428,7 +434,7 @@ export class StallWatchdog {
   /** capture forensic → restart → classify+audit → flag false positives. */
   private async handleKill(
     s: SessionStallState,
-    decision: Extract<StallDecision, { action: "kill" }>,
+    decision: KillDecision,
     now: number,
   ): Promise<void> {
     let snapshot: ForensicSnapshot = { cpuAdvancing: null, outputRecencyMs: null };


### PR DESCRIPTION
Closes #324.

## Problem

`StallDecision` carried `warn` and `kill` in a single combined member:

```ts
| { action: "warn" | "kill"; tool: string; toolUseId: string; outstandingMs: number; ceiling: ToolCeiling }
```

`handleKill` takes `Extract<StallDecision, { action: "kill" }>`. Because `"warn" | "kill"` is not assignable to `"kill"`, the `Extract` matched nothing and the parameter resolved to `never` — so every property access inside `handleKill` was unchecked. Concretely: #321 made `notify`'s `agentId` argument required and added it at three call sites inside `handleKill`; in an un-type-checked function a missed argument wouldn't be caught at build time (it would surface at runtime as `agentId === undefined` hitting the notifier's guard — a silently swallowed alert).

## Fix

Split `warn` and `kill` into distinct members over a shared `StallSignal` shape. `Extract<StallDecision, { action: "kill" }>` now resolves to the kill member and `handleKill`'s body is genuinely type-checked. Construction in `sweep()` stays type-safe by building each member with a **literal** action (the object is otherwise not assignable to the split union).

## Verification

- Repo-wide `tsc --noEmit` drops from **452 to 441 errors** — the 11 removed are exactly this file's, which go to **0**.
- Full `src/bus` suite green (503 pass, 0 fail).
- No new lint.

## Out of scope

The issue suggests pairing this with a `typecheck` script + CI step. That's worth doing but can't go green yet — 441 pre-existing repo-wide errors remain (tracked in #327). Adding the CI gate belongs in that cleanup, not here.
