### PR TITLE
feat(bus): durable schedule_task tool + block native session-scoped cron (closes #342)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.212",
+      "version": "2.2.213",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.212",
+  "version": "2.2.213",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/runner.test.ts
+++ b/src/__tests__/runner.test.ts
@@ -502,3 +502,65 @@ describe("withCleanProcessEnv (oat01 exception wiring)", () => {
     }
   });
 });
+
+/* ───────────────────────────────────────────────────────────────────── */
+/* buildSecurityArgs — native scheduling-tool block on headless paths     */
+/* (#342: dispatch_job / any `claude -p` must not reach native cron)      */
+/* ───────────────────────────────────────────────────────────────────── */
+
+describe("buildSecurityArgs — native scheduling-tool block", () => {
+  const NATIVE = ["CronCreate", "CronDelete", "CronList", "ScheduleWakeup"];
+
+  function disallowedOf(args: string[]): string[] {
+    const i = args.indexOf("--disallowedTools");
+    return i >= 0 ? args[i + 1].split(",") : [];
+  }
+
+  it("blocks the four native tools at the default 'moderate' level", () => {
+    const args = runnerMod.buildSecurityArgs({
+      level: "moderate",
+      allowedTools: [],
+      disallowedTools: [],
+    });
+    const blocked = disallowedOf(args);
+    for (const t of NATIVE) expect(blocked).toContain(t);
+  });
+
+  it("keeps the strict denials AND adds the native tools at 'strict'", () => {
+    const args = runnerMod.buildSecurityArgs({
+      level: "strict",
+      allowedTools: [],
+      disallowedTools: [],
+    });
+    const blocked = disallowedOf(args);
+    for (const t of [...NATIVE, "Bash", "WebSearch", "WebFetch"]) {
+      expect(blocked).toContain(t);
+    }
+  });
+
+  it("merges operator-configured disallowedTools with the native block (single flag)", () => {
+    const args = runnerMod.buildSecurityArgs({
+      level: "moderate",
+      allowedTools: [],
+      disallowedTools: ["SomeCustomTool"],
+    });
+    // Exactly one --disallowedTools flag, containing both.
+    expect(args.filter((a) => a === "--disallowedTools")).toHaveLength(1);
+    const blocked = disallowedOf(args);
+    expect(blocked).toContain("SomeCustomTool");
+    for (const t of NATIVE) expect(blocked).toContain(t);
+  });
+
+  it("locked mode uses the --tools allow-list (native cron already excluded)", () => {
+    const args = runnerMod.buildSecurityArgs({
+      level: "locked",
+      allowedTools: [],
+      disallowedTools: [],
+    });
+    const toolsIdx = args.indexOf("--tools");
+    expect(toolsIdx).toBeGreaterThanOrEqual(0);
+    expect(args[toolsIdx + 1]).toBe("Read,Grep,Glob,Write");
+    // The allow-list already excludes CronCreate; no --disallowedTools needed.
+    for (const t of NATIVE) expect(args[toolsIdx + 1].split(",")).not.toContain(t);
+  });
+});

--- a/src/bus/__tests__/schedule-ops.test.ts
+++ b/src/bus/__tests__/schedule-ops.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Tests for schedule-ops.ts — the durable scheduled-task writer backing the
+ * `schedule_task` / `list_scheduled_tasks` / `delete_scheduled_task` bus tools
+ * (#342).
+ *
+ * The load-bearing test is the round-trip: a task written by `scheduleTask`
+ * must be re-parsed by `loadJobs()` with a NON-NULL `schedule`. That is the
+ * exact failure mode of the incident — a hand-written `reminder-*.md` missing
+ * its `schedule:` field parsed to null and silently never scheduled.
+ *
+ * Run with: bun test src/bus/__tests__/schedule-ops.test.ts
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import { existsSync } from "node:fs";
+import { rm, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+import { scheduleTask, listScheduledTasks, deleteScheduledTask } from "../schedule-ops";
+import { loadJobs } from "../../jobs";
+import { getJobsDir, getAgentsDir } from "../../config";
+import { BUS_MCP_TOOLS } from "../mcp-tools";
+
+const createdFlat: string[] = [];
+const createdAgents: string[] = [];
+
+function uniq(suffix: string): string {
+  return `tst-sched-${suffix}-${Date.now().toString(36)}${Math.floor(Math.random() * 1000)}`;
+}
+
+afterEach(async () => {
+  for (const f of createdFlat.splice(0)) await rm(f, { force: true });
+  for (const a of createdAgents.splice(0)) {
+    await rm(join(getAgentsDir(), a), { recursive: true, force: true });
+  }
+});
+
+describe("scheduleTask — write target", () => {
+  it("writes to the flat jobs dir for a caller with no scaffolded agent dir (the default/global session)", async () => {
+    const label = uniq("flat");
+    const flatPath = join(getJobsDir(), `${label}.md`);
+    createdFlat.push(flatPath);
+
+    const summary = await scheduleTask({
+      agentId: "default",
+      label,
+      cron: "0 8 24 7 *",
+      prompt: "Send a Discord reminder to the user: call the GP for Ginna.",
+    });
+
+    expect(summary.scope).toBe("shared");
+    expect(existsSync(flatPath)).toBe(true);
+  });
+
+  it("writes agent-scoped when the caller has a scaffolded agents/<id>/ dir", async () => {
+    const agent = uniq("agent");
+    await mkdir(join(getAgentsDir(), agent), { recursive: true });
+    createdAgents.push(agent);
+
+    const summary = await scheduleTask({
+      agentId: agent,
+      label: "morning-check",
+      cron: "0 7 * * *",
+      prompt: "Do the morning check.",
+      recurring: true,
+    });
+
+    expect(summary.scope).toBe("agent");
+    expect(existsSync(join(getAgentsDir(), agent, "jobs", "morning-check.md"))).toBe(true);
+  });
+});
+
+describe("scheduleTask — round-trip (the incident guard)", () => {
+  it("produces a file loadJobs() re-parses with a non-null schedule", async () => {
+    const label = uniq("roundtrip");
+    createdFlat.push(join(getJobsDir(), `${label}.md`));
+
+    await scheduleTask({
+      agentId: "default",
+      label,
+      cron: "30 8 * * 1",
+      prompt: "Weekly Monday 08:30 reminder.",
+      recurring: true,
+    });
+
+    const jobs = await loadJobs();
+    const job = jobs.find((j) => (j.label ?? j.name) === label);
+    expect(job).toBeDefined();
+    // The exact bug: schedule must NOT be null/empty, else it never schedules.
+    expect(job!.schedule).toBe("30 8 * * 1");
+    expect(job!.recurring).toBe(true);
+  });
+
+  it("defaults recurring to false (one-off ad-hoc reminders)", async () => {
+    const label = uniq("oneoff");
+    createdFlat.push(join(getJobsDir(), `${label}.md`));
+
+    const summary = await scheduleTask({
+      agentId: "default",
+      label,
+      cron: "0 9 25 12 *",
+      prompt: "One-off.",
+    });
+
+    expect(summary.recurring).toBe(false);
+    const job = (await loadJobs()).find((j) => (j.label ?? j.name) === label);
+    expect(job!.recurring).toBe(false);
+  });
+});
+
+describe("scheduleTask — validation", () => {
+  it("rejects path-traversal labels", async () => {
+    for (const bad of ["../etc/passwd", "foo/bar", "..", "a\\b"]) {
+      await expect(
+        scheduleTask({ agentId: "default", label: bad, cron: "0 8 * * *", prompt: "x" }),
+      ).rejects.toThrow(/label/i);
+    }
+  });
+
+  it("rejects an invalid cron expression", async () => {
+    await expect(
+      scheduleTask({ agentId: "default", label: uniq("badcron"), cron: "not a cron", prompt: "x" }),
+    ).rejects.toThrow(/cron/i);
+    // 6 fields (too many) must also be rejected.
+    await expect(
+      scheduleTask({
+        agentId: "default",
+        label: uniq("badcron2"),
+        cron: "0 8 * * * *",
+        prompt: "x",
+      }),
+    ).rejects.toThrow();
+  });
+
+  it("rejects an empty prompt", async () => {
+    await expect(
+      scheduleTask({
+        agentId: "default",
+        label: uniq("noprompt"),
+        cron: "0 8 * * *",
+        prompt: "  ",
+      }),
+    ).rejects.toThrow(/prompt/i);
+  });
+
+  it("rejects a duplicate label instead of silently overwriting", async () => {
+    const label = uniq("dup");
+    createdFlat.push(join(getJobsDir(), `${label}.md`));
+    await scheduleTask({ agentId: "default", label, cron: "0 8 * * *", prompt: "first" });
+    await expect(
+      scheduleTask({ agentId: "default", label, cron: "0 9 * * *", prompt: "second" }),
+    ).rejects.toThrow(/already exists/i);
+  });
+
+  it("rejects a model value crafted to inject a forged frontmatter field", async () => {
+    // A newline in `model` must not smuggle in e.g. `agent: reg` and reroute
+    // the job — `validateModelString` rejects anything outside the model set.
+    const label = uniq("modelinject");
+    await expect(
+      scheduleTask({
+        agentId: "default",
+        label,
+        cron: "0 8 * * *",
+        prompt: "x",
+        model: "sonnet\nagent: reg",
+      }),
+    ).rejects.toThrow(/model/i);
+    // Nothing should have been written.
+    expect(existsSync(join(getJobsDir(), `${label}.md`))).toBe(false);
+  });
+
+  it("rejects a cron with an internal newline (passes 5-field check but corrupts the file)", async () => {
+    // "0\n8 * * *" splits to 5 valid fields (\s matches \n) but would render an
+    // unparseable `schedule:` — the newline guard rejects it outright.
+    const label = uniq("cronnewline");
+    await expect(
+      scheduleTask({ agentId: "default", label, cron: "0\n8 * * *", prompt: "x" }),
+    ).rejects.toThrow(/newline/i);
+    expect(existsSync(join(getJobsDir(), `${label}.md`))).toBe(false);
+  });
+});
+
+describe("listScheduledTasks / deleteScheduledTask", () => {
+  it("lists then deletes a task for the default caller", async () => {
+    const label = uniq("managed");
+    createdFlat.push(join(getJobsDir(), `${label}.md`));
+    await scheduleTask({ agentId: "default", label, cron: "0 8 * * *", prompt: "managed task" });
+
+    const listed = await listScheduledTasks("default");
+    expect(listed.some((t) => t.label === label)).toBe(true);
+
+    await deleteScheduledTask("default", label);
+    expect(existsSync(join(getJobsDir(), `${label}.md`))).toBe(false);
+  });
+
+  it("throws when deleting a task that does not exist", async () => {
+    await expect(deleteScheduledTask("default", uniq("ghost"))).rejects.toThrow(
+      /no scheduled task/i,
+    );
+  });
+
+  it("rejects path-traversal labels on delete", async () => {
+    await expect(deleteScheduledTask("default", "../../secret")).rejects.toThrow(/label/i);
+  });
+});
+
+describe("schedule_task tool schema — structural guard", () => {
+  it("advertises cron, label and prompt as required so the MCP layer rejects a missing schedule", () => {
+    const tool = BUS_MCP_TOOLS.find((t) => t.name === "schedule_task");
+    expect(tool).toBeDefined();
+    const required = (tool as { inputSchema: { required?: string[] } }).inputSchema.required ?? [];
+    expect(required).toContain("cron");
+    expect(required).toContain("label");
+    expect(required).toContain("prompt");
+  });
+
+  it("steers away from native cron tools in its description", () => {
+    const tool = BUS_MCP_TOOLS.find((t) => t.name === "schedule_task");
+    expect(tool!.description).toMatch(/CronCreate|ScheduleWakeup/);
+  });
+});

--- a/src/bus/__tests__/session-manager.test.ts
+++ b/src/bus/__tests__/session-manager.test.ts
@@ -28,6 +28,7 @@ import { join } from "node:path";
 import { encodeCwdForProjectsDir } from "../jsonl-line-types";
 import type { ReceiptRecord } from "../receipt";
 import {
+  buildClaudeArgs,
   defaultSupervisionFor,
   resolveAgentCwd,
   SessionManager,
@@ -55,6 +56,29 @@ describe("defaultSupervisionFor", () => {
     const nonChannel: BusOrigin[] = ["cron", "heartbeat", "cli", "rest"];
     for (const origin of nonChannel) {
       expect(defaultSupervisionFor(origin)).toBe("process-stream-json");
+    }
+  });
+});
+
+/* ───────────────────────────────────────────────────────────────────── */
+/* buildClaudeArgs — native scheduling-tool block (#342)                 */
+/* ───────────────────────────────────────────────────────────────────── */
+
+describe("buildClaudeArgs — native scheduling-tool block", () => {
+  it("blocks CronCreate/CronDelete/CronList/ScheduleWakeup on every spawned bus agent", () => {
+    const agent: AgentConfig = {
+      id: "default",
+      cwd: "/tmp",
+      session_id: "11111111-2222-3333-4444-555555555555",
+    };
+    const args = buildClaudeArgs(agent, "pty-stdin");
+    const idx = args.indexOf("--disallowedTools");
+    expect(idx).toBeGreaterThanOrEqual(0);
+    const value = args[idx + 1];
+    // Comma-joined, matching the neighbouring --allowedTools convention.
+    const blocked = value.split(",");
+    for (const tool of ["CronCreate", "CronDelete", "CronList", "ScheduleWakeup"]) {
+      expect(blocked).toContain(tool);
     }
   });
 });

--- a/src/bus/core.ts
+++ b/src/bus/core.ts
@@ -76,6 +76,12 @@ function toWireJobView(v: JobView): Record<string, unknown> {
   };
 }
 import { evaluate, type PolicyDecision, type ToolRequestContext } from "../policy/engine";
+import {
+  deleteScheduledTask,
+  listScheduledTasks,
+  scheduleTask,
+  type ScheduleTaskInput,
+} from "./schedule-ops";
 
 /** Escape XML text content (`&`, `<`, `>`) so a `</channel>` in user text
  *  can't close the wrapper element early and inject sibling markup. */
@@ -1438,6 +1444,14 @@ export class BusCoreImpl implements BusCore {
    * becomes `ok:false` — never a silent drop that would hang the caller).
    */
   private handleJobRequest(agentId: string, msg: IpcJobRequest): void {
+    // Durable scheduled-task ops are independent of the AgentJobRunner — they
+    // only write/read file-backed cron jobs in the daemon's cwd, so they must
+    // NOT be gated on `this.jobHandler` (which guards the headless dispatch
+    // runner). Route them before that gate.
+    if (msg.op === "schedule" || msg.op === "list_scheduled" || msg.op === "unschedule") {
+      void this.handleScheduleRequest(agentId, msg);
+      return;
+    }
     const handler = this.jobHandler;
     if (!handler) {
       this.sendJobResult(agentId, msg.req_id, {
@@ -1498,6 +1512,54 @@ export class BusCoreImpl implements BusCore {
       }
     } catch (err) {
       this.onError(err, { ctx: "job_request", op: msg.op, agent_id: agentId });
+      this.sendJobResult(agentId, msg.req_id, {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  /**
+   * Handle the durable scheduled-task ops (`schedule` / `list_scheduled` /
+   * `unschedule`) inline in the daemon. Writing the job file here — not in the
+   * agent's MCP subprocess — is deliberate: the daemon's cwd is the project
+   * root, so `schedule-ops.ts` resolves the same jobs dir that `loadJobs()`
+   * scans and the 30s hot-reload picks up. Errors (bad cron, bad label,
+   * duplicate) are returned as `ok:false` so the agent sees a clear message
+   * rather than a silent miss.
+   */
+  private async handleScheduleRequest(agentId: string, msg: IpcJobRequest): Promise<void> {
+    const p = (msg.payload ?? {}) as {
+      label?: unknown;
+      cron?: unknown;
+      prompt?: unknown;
+      recurring?: unknown;
+      model?: unknown;
+    };
+    try {
+      if (msg.op === "schedule") {
+        const input: ScheduleTaskInput = {
+          agentId,
+          label: typeof p.label === "string" ? p.label : "",
+          cron: typeof p.cron === "string" ? p.cron : "",
+          prompt: typeof p.prompt === "string" ? p.prompt : "",
+          ...(typeof p.recurring === "boolean" ? { recurring: p.recurring } : {}),
+          ...(typeof p.model === "string" ? { model: p.model } : {}),
+        };
+        const summary = await scheduleTask(input);
+        this.sendJobResult(agentId, msg.req_id, { ok: true, result: summary });
+        return;
+      }
+      if (msg.op === "list_scheduled") {
+        const tasks = await listScheduledTasks(agentId);
+        this.sendJobResult(agentId, msg.req_id, { ok: true, result: tasks });
+        return;
+      }
+      // unschedule
+      await deleteScheduledTask(agentId, typeof p.label === "string" ? p.label : "");
+      this.sendJobResult(agentId, msg.req_id, { ok: true, result: { deleted: true } });
+    } catch (err) {
+      this.onError(err, { ctx: "schedule_request", op: msg.op, agent_id: agentId });
       this.sendJobResult(agentId, msg.req_id, {
         ok: false,
         error: err instanceof Error ? err.message : String(err),

--- a/src/bus/mcp-server.ts
+++ b/src/bus/mcp-server.ts
@@ -294,6 +294,18 @@ const JobIdArgsSchema = z.object({
   job_id: z.string(),
 });
 
+const ScheduleTaskArgsSchema = z.object({
+  label: z.string().max(128),
+  cron: z.string().max(128),
+  prompt: z.string().max(100_000),
+  recurring: z.boolean().optional(),
+  model: z.string().max(64).optional(),
+});
+
+const DeleteScheduledTaskArgsSchema = z.object({
+  label: z.string().max(128),
+});
+
 /**
  * Bound on how long a job-control call waits for Bus core's `IpcJobResult`.
  * All four ops resolve SYNCHRONOUSLY in the daemon runner, so a reply is
@@ -480,6 +492,12 @@ export class BusMcpServer {
           return this.handleListJobs();
         case "cancel_job":
           return this.handleCancelJob(rawArgs);
+        case "schedule_task":
+          return this.handleScheduleTask(rawArgs);
+        case "list_scheduled_tasks":
+          return this.handleListScheduledTasks();
+        case "delete_scheduled_task":
+          return this.handleDeleteScheduledTask(rawArgs);
         default:
           return {
             content: [{ type: "text", text: `Unknown tool: ${name}` }],
@@ -822,6 +840,31 @@ export class BusMcpServer {
   private async handleCancelJob(raw: unknown) {
     const args = JobIdArgsSchema.parse(raw ?? {});
     const res = await this.jobRequest("cancel", { job_id: args.job_id });
+    return this.jobResultContent(res);
+  }
+
+  /* ── Durable scheduled-task tool handlers (#342) ────────────────── */
+
+  private async handleScheduleTask(raw: unknown) {
+    const args = ScheduleTaskArgsSchema.parse(raw ?? {});
+    const res = await this.jobRequest("schedule", {
+      label: args.label,
+      cron: args.cron,
+      prompt: args.prompt,
+      ...(args.recurring !== undefined ? { recurring: args.recurring } : {}),
+      ...(args.model !== undefined ? { model: args.model } : {}),
+    });
+    return this.jobResultContent(res);
+  }
+
+  private async handleListScheduledTasks() {
+    const res = await this.jobRequest("list_scheduled", {});
+    return this.jobResultContent(res);
+  }
+
+  private async handleDeleteScheduledTask(raw: unknown) {
+    const args = DeleteScheduledTaskArgsSchema.parse(raw ?? {});
+    const res = await this.jobRequest("unschedule", { label: args.label });
     return this.jobResultContent(res);
   }
 }

--- a/src/bus/mcp-tools.ts
+++ b/src/bus/mcp-tools.ts
@@ -131,4 +131,76 @@ export const BUS_MCP_TOOLS = [
       required: ["job_id"],
     },
   },
+  {
+    name: "schedule_task",
+    description:
+      "Schedule a task to run later, on a cron schedule. Use this for ANY " +
+      "time-based request — a one-off reminder ('remind me at 8am tomorrow'), " +
+      "an ad-hoc future task, or a recurring job. This is the ONLY correct way " +
+      "to schedule: do NOT use native `CronCreate`/`ScheduleWakeup` tools even " +
+      "if they appear available — those are tied to this live session and " +
+      "silently fail to fire once the session rotates (they will NOT survive " +
+      "until tomorrow morning). Tasks scheduled here are durable across " +
+      "restarts and session boundaries.\n\n" +
+      "The `prompt` runs LATER in a fresh session with no memory of this " +
+      "conversation, so it must be self-contained — say what to do AND where " +
+      'to deliver it, e.g. "Send a Discord reminder to the user in channel ' +
+      '<id>: 📞 Call the GP for Ginna."\n\n' +
+      "`cron` is a standard 5-field expression (minute hour day-of-month month " +
+      "day-of-week) interpreted in the daemon's local timezone. Finest " +
+      "granularity is one minute, and there is up to ~30s of pickup latency, " +
+      "so this can't do sub-minute timing. Set `recurring: true` for a " +
+      "repeating job; it defaults to false (fires once, then disables itself).",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        label: {
+          type: "string",
+          description: "Short kebab-case name (becomes the job filename), e.g. `reminder-call-gp`.",
+        },
+        cron: {
+          type: "string",
+          description: "5-field cron expression, e.g. `0 8 24 7 *` for 08:00 on 24 July.",
+        },
+        prompt: {
+          type: "string",
+          description:
+            "Self-contained instruction to run when it fires, including the delivery target.",
+        },
+        recurring: {
+          type: "boolean",
+          description:
+            "Repeat on every match (true) vs fire once then self-disable (false, default).",
+        },
+        model: {
+          type: "string",
+          description: "Optional model override (opus/sonnet/haiku/glm).",
+        },
+      },
+      required: ["label", "cron", "prompt"],
+    },
+  },
+  {
+    name: "list_scheduled_tasks",
+    description:
+      "List your durable scheduled tasks (label, cron, recurring). Distinct " +
+      "from `list_jobs`, which lists in-flight background dispatches.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {},
+    },
+  },
+  {
+    name: "delete_scheduled_task",
+    description:
+      "Delete one durable scheduled task by its `label` (e.g. to cancel a " +
+      "reminder). Use `list_scheduled_tasks` to see labels.",
+    inputSchema: {
+      type: "object" as const,
+      properties: {
+        label: { type: "string" },
+      },
+      required: ["label"],
+    },
+  },
 ] as const;

--- a/src/bus/schedule-ops.ts
+++ b/src/bus/schedule-ops.ts
@@ -29,7 +29,7 @@
  */
 
 import { existsSync } from "node:fs";
-import { mkdir, unlink } from "node:fs/promises";
+import { mkdir, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { getAgentsDir, getJobsDir } from "../config";
 import { validateJobLabel } from "../agents";
@@ -121,12 +121,20 @@ export async function scheduleTask(input: ScheduleTaskInput): Promise<ScheduledT
   const { dir, scope } = resolveTarget(input.agentId);
   await mkdir(dir, { recursive: true });
   const path = join(dir, `${input.label}.md`);
-  if (existsSync(path)) {
-    throw new Error(
-      `a scheduled task named "${input.label}" already exists — delete it first or choose another label`,
-    );
+  // Exclusive create ("wx") IS the duplicate check — atomic, so two concurrent
+  // schedule_task calls with the same label can't both pass a separate
+  // existsSync() and race to overwrite one another. EEXIST maps to the friendly
+  // "already exists" error; any other error propagates.
+  try {
+    await writeFile(path, renderTaskFile(input), { flag: "wx" });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "EEXIST") {
+      throw new Error(
+        `a scheduled task named "${input.label}" already exists — delete it first or choose another label`,
+      );
+    }
+    throw err;
   }
-  await Bun.write(path, renderTaskFile(input));
   return { label: input.label, cron: input.cron, recurring: input.recurring === true, scope };
 }
 

--- a/src/bus/schedule-ops.ts
+++ b/src/bus/schedule-ops.ts
@@ -1,0 +1,166 @@
+/**
+ * Durable scheduled-task operations for the bus runtime.
+ *
+ * These back the `schedule_task` / `list_scheduled_tasks` /
+ * `delete_scheduled_task` bus MCP tools. They run in the DAEMON process
+ * (routed there over IPC by `core.ts:handleJobRequest`), never in the agent's
+ * MCP-server process — the daemon's cwd is the project root, so the job files
+ * land where `loadJobs()` actually scans and the 30s hot-reload picks them up.
+ *
+ * Why this exists at all: the #342 incident had the agent reach for Claude
+ * Code's native `CronCreate`, whose wakeup is session-scoped and silently died
+ * before the overnight reminder fired. ClaudeClaw+'s file-backed jobs are
+ * durable across session/restart boundaries; this module is the validated
+ * writer for them, so the agent can no longer produce a broken job file by
+ * hand (the other half of that incident: a `reminder-*.md` missing its
+ * required `schedule:` field, silently never scheduled).
+ *
+ * Write target mirrors the existing on-disk convention:
+ *   - a named agent (a scaffolded `agents/<id>/` dir exists) → its own
+ *     `agents/<id>/jobs/` dir, where `loadJobs()` tags `job.agent = <id>` from
+ *     the directory (authoritative) and the scheduler routes the fire back to
+ *     that same agent.
+ *   - the default/global session (no `agents/default/` scaffold) → the flat
+ *     `getJobsDir()`, exactly where its `reminder-*.md` files already live. A
+ *     flat job carries no `agent:` field, so the scheduler routes it to
+ *     `defaultAgentId` — which is that same global session.
+ * This keeps the round-trip correct for either caller without a magic
+ * "is this the default agent" string check.
+ */
+
+import { existsSync } from "node:fs";
+import { mkdir, unlink } from "node:fs/promises";
+import { join } from "node:path";
+import { getAgentsDir, getJobsDir } from "../config";
+import { validateJobLabel } from "../agents";
+import { loadJobs, validateModelString } from "../jobs";
+import { validateCronExpression } from "./scheduler";
+
+export interface ScheduleTaskInput {
+  /** The calling agent's id (from `CCAW_AGENT_ID` / the IPC frame). */
+  agentId: string;
+  /** kebab-case job label; becomes the `.md` filename. */
+  label: string;
+  /** 5-field cron expression (`minute hour day-of-month month day-of-week`). */
+  cron: string;
+  /** Instruction to run when the task fires (delivered as a fresh session prompt). */
+  prompt: string;
+  /** Repeat on every cron match (`true`) vs fire once then self-disable (`false`, default). */
+  recurring?: boolean;
+  /** Optional per-job model override (opus/sonnet/haiku/glm). */
+  model?: string;
+}
+
+export interface ScheduledTaskSummary {
+  label: string;
+  cron: string;
+  recurring: boolean;
+  /** `"agent"` = written under `agents/<id>/jobs/`; `"shared"` = flat jobs dir. */
+  scope: "agent" | "shared";
+}
+
+function resolveTarget(agentId: string): { dir: string; scope: "agent" | "shared" } {
+  const agentDir = join(getAgentsDir(), agentId);
+  if (existsSync(agentDir)) return { dir: join(agentDir, "jobs"), scope: "agent" };
+  return { dir: getJobsDir(), scope: "shared" };
+}
+
+function renderTaskFile(input: ScheduleTaskInput): string {
+  const lines = [
+    "---",
+    `label: ${input.label}`,
+    `schedule: ${input.cron}`,
+    `recurring: ${input.recurring === true}`,
+    "enabled: true",
+    ...(input.model && input.model.trim() !== "" ? [`model: ${input.model.trim()}`] : []),
+    "---",
+    "",
+    input.prompt.trim(),
+    "",
+  ];
+  return lines.join("\n");
+}
+
+/**
+ * Create a durable scheduled task. Throws (never silently no-ops) on an
+ * invalid label, invalid cron, empty prompt, or a duplicate label — the
+ * caller surfaces the thrown message to the agent as an error tool result.
+ */
+export async function scheduleTask(input: ScheduleTaskInput): Promise<ScheduledTaskSummary> {
+  const lv = validateJobLabel(input.label);
+  if (!lv.valid) {
+    throw new Error(`invalid label "${input.label}": ${lv.error}`);
+  }
+  if (!input.prompt || input.prompt.trim() === "") {
+    throw new Error(
+      "prompt is required — say what to do when the task fires, and where to deliver it",
+    );
+  }
+  // `model` is the only other value written into the frontmatter, and unlike
+  // `label`/`cron` it is otherwise free text. Validate it against the allowed
+  // model set (throws on anything else) so a crafted value containing a newline
+  // cannot inject a forged frontmatter field (e.g. `agent:` to reroute the job).
+  validateModelString(input.model, "schedule_task model");
+  // Throws on malformed cron (wrong field count / out-of-range / junk chars).
+  validateCronExpression(input.cron);
+  // Belt-and-braces: every value interpolated into the frontmatter is checked
+  // here for newlines regardless of the field-specific validators above, so a
+  // newline can never smuggle in a forged field (`agent:`, `enabled:`) or
+  // silently corrupt the block (a `\n` in `cron` passes the 5-field check —
+  // `\s` matches newlines — but would render an unparseable `schedule:`).
+  for (const [field, value] of [
+    ["label", input.label],
+    ["cron", input.cron],
+    ["model", input.model ?? ""],
+  ] as const) {
+    if (/[\r\n]/.test(value)) {
+      throw new Error(`${field} must not contain newlines`);
+    }
+  }
+
+  const { dir, scope } = resolveTarget(input.agentId);
+  await mkdir(dir, { recursive: true });
+  const path = join(dir, `${input.label}.md`);
+  if (existsSync(path)) {
+    throw new Error(
+      `a scheduled task named "${input.label}" already exists — delete it first or choose another label`,
+    );
+  }
+  await Bun.write(path, renderTaskFile(input));
+  return { label: input.label, cron: input.cron, recurring: input.recurring === true, scope };
+}
+
+/**
+ * List the caller's scheduled tasks. Reuses `loadJobs()` (the canonical
+ * parser) and filters to the caller's scope: a named agent sees its own
+ * `agents/<id>/jobs/`; the default/global session sees the flat (un-agented)
+ * jobs.
+ */
+export async function listScheduledTasks(agentId: string): Promise<ScheduledTaskSummary[]> {
+  const { scope } = resolveTarget(agentId);
+  const jobs = await loadJobs();
+  const mine = jobs.filter((j) => (scope === "agent" ? j.agent === agentId : !j.agent));
+  return mine.map((j) => ({
+    label: j.label ?? j.name,
+    cron: j.schedule,
+    recurring: j.recurring,
+    scope,
+  }));
+}
+
+/**
+ * Delete one scheduled task by label from the caller's scope. Throws if the
+ * label is invalid or no such task exists.
+ */
+export async function deleteScheduledTask(agentId: string, label: string): Promise<void> {
+  const lv = validateJobLabel(label);
+  if (!lv.valid) {
+    throw new Error(`invalid label "${label}": ${lv.error}`);
+  }
+  const { dir } = resolveTarget(agentId);
+  const path = join(dir, `${label}.md`);
+  if (!existsSync(path)) {
+    throw new Error(`no scheduled task named "${label}"`);
+  }
+  await unlink(path);
+}

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -33,6 +33,7 @@ import { realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { NATIVE_SCHEDULING_TOOLS_BLOCKLIST } from "../config";
 import { cleanSpawnEnv, withCleanProcessEnv } from "../runner";
 import {
   deleteConfigForPty,
@@ -359,30 +360,6 @@ const PLUS_BUS_TOOL_NAMES = [
   "mcp__plugin_claudeclaw-plus_plus-bus__ask",
   "mcp__plugin_claudeclaw-plus_plus-bus__cancel",
   "mcp__plugin_claudeclaw-plus_plus-bus__request_human",
-];
-
-/**
- * Claude Code's native scheduling tools, blocked unconditionally on every
- * bus agent via `--disallowedTools`.
- *
- * These are session-scoped: a wakeup they register is delivered only if the
- * exact underlying Claude session that created it is still live at fire time.
- * Under the bus runtime, sessions rotate and churn independently of the
- * daemon, so a reminder scheduled for hours later silently never fires (the
- * #342 "call the GP for Ginna at 8am" incident). ClaudeClaw+'s own
- * file-backed job scheduler (`schedule_job` bus tool → `agents/<id>/jobs/`)
- * is durable across session boundaries and is the only correct path here, so
- * the native tools are removed rather than left as a tempting wrong door.
- *
- * This is a hardcoded floor, not operator-configurable: the tools are broken
- * by architecture under bus, not merely a security preference, and hardcoding
- * means the block takes effect on deploy with no settings.json edit.
- */
-const NATIVE_SCHEDULING_TOOLS_BLOCKLIST = [
-  "CronCreate",
-  "CronDelete",
-  "CronList",
-  "ScheduleWakeup",
 ];
 
 /**

--- a/src/bus/session-manager.ts
+++ b/src/bus/session-manager.ts
@@ -362,6 +362,30 @@ const PLUS_BUS_TOOL_NAMES = [
 ];
 
 /**
+ * Claude Code's native scheduling tools, blocked unconditionally on every
+ * bus agent via `--disallowedTools`.
+ *
+ * These are session-scoped: a wakeup they register is delivered only if the
+ * exact underlying Claude session that created it is still live at fire time.
+ * Under the bus runtime, sessions rotate and churn independently of the
+ * daemon, so a reminder scheduled for hours later silently never fires (the
+ * #342 "call the GP for Ginna at 8am" incident). ClaudeClaw+'s own
+ * file-backed job scheduler (`schedule_job` bus tool → `agents/<id>/jobs/`)
+ * is durable across session boundaries and is the only correct path here, so
+ * the native tools are removed rather than left as a tempting wrong door.
+ *
+ * This is a hardcoded floor, not operator-configurable: the tools are broken
+ * by architecture under bus, not merely a security preference, and hardcoding
+ * means the block takes effect on deploy with no settings.json edit.
+ */
+const NATIVE_SCHEDULING_TOOLS_BLOCKLIST = [
+  "CronCreate",
+  "CronDelete",
+  "CronList",
+  "ScheduleWakeup",
+];
+
+/**
  * Resolve the absolute path to the ClaudeClaw+ plugin root — the
  * directory containing `.claude-plugin/plugin.json` and `.mcp.json`.
  * Computed from `session-manager.ts`'s own location: this file lives
@@ -481,6 +505,12 @@ export function buildClaudeArgs(agent: AgentConfig, mode: SupervisionMode): stri
   }
   args.push("--plugin-dir", resolveClaudeclawPluginRoot());
   args.push("--allowedTools", PLUS_BUS_TOOL_NAMES.join(","));
+  // Block Claude Code's native session-scoped scheduling tools so the agent
+  // is funnelled to the durable `schedule_job` bus tool instead. See the
+  // NATIVE_SCHEDULING_TOOLS_BLOCKLIST comment for why (the #342 lost-reminder
+  // incident). Comma-joined to match `--allowedTools` above and the value
+  // `claude` parses for `--disallowedTools`.
+  args.push("--disallowedTools", NATIVE_SCHEDULING_TOOLS_BLOCKLIST.join(","));
   args.push(
     "--dangerously-load-development-channels",
     `plugin:${CLAUDECLAW_PLUGIN_NAME}@${PLUGIN_MARKETPLACE_TAG}`,

--- a/src/bus/types.ts
+++ b/src/bus/types.ts
@@ -326,13 +326,20 @@ export interface IpcRequestHuman {
  * Bus core stamps it as the job's dispatcher (never trusting a client-supplied
  * value) so results route back to the caller. `op` selects the runner method;
  * `payload` carries the tool args (validated by the runner, not here).
+ *
+ * The `schedule` / `list_scheduled` / `unschedule` ops back the durable
+ * scheduled-task tools (`schedule_task` etc.). Unlike the four AgentJobRunner
+ * ops they don't touch the runner at all — Bus core handles them directly via
+ * `schedule-ops.ts`, writing file-backed cron jobs in the daemon's cwd so the
+ * hot-reload loop schedules them. They're on this same envelope to reuse the
+ * correlated round-trip plumbing.
  */
 export interface IpcJobRequest {
   type: "job_request";
   agent_id: string;
   /** Correlation id the matching `IpcJobResult` must echo. */
   req_id: string;
-  op: "dispatch" | "status" | "list" | "cancel";
+  op: "dispatch" | "status" | "list" | "cancel" | "schedule" | "list_scheduled" | "unschedule";
   payload: Record<string, unknown>;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -46,6 +46,29 @@ export const DEFAULT_SESSION_TIMEOUT_MS = 120 * 60 * 1000;
 
 export const DEFAULT_IMAGE_OUTPUT_ROOT = join(HEARTBEAT_DIR, "outbox", "discord");
 
+/**
+ * Claude Code's native scheduling tools, blocked on every claude process the
+ * daemon spawns — both the interactive bus PTY session (`buildClaudeArgs`) and
+ * every headless `claude -p` path (`buildSecurityArgs`, e.g. the `dispatch_job`
+ * subagent runner).
+ *
+ * Their wakeups are tied to the specific session that registered them. Under
+ * the bus runtime a session rotates/churns independently of the daemon, and a
+ * headless dispatch is a one-shot process that exits immediately — so a
+ * wakeup scheduled through these tools silently never fires (issue #342, the
+ * lost "call the GP for Ginna at 8am" reminder). ClaudeClaw+'s own file-backed
+ * scheduler (`schedule_task`) is durable across those boundaries and is the
+ * only correct path, so the native tools are removed rather than left as a
+ * tempting wrong door. Hardcoded, not operator-configurable: they're broken by
+ * architecture here, not a security preference.
+ */
+export const NATIVE_SCHEDULING_TOOLS_BLOCKLIST = [
+  "CronCreate",
+  "CronDelete",
+  "CronList",
+  "ScheduleWakeup",
+] as const;
+
 export function getJobsDir(): string {
   if (cached?.jobsDir) {
     return isAbsolute(cached.jobsDir) ? cached.jobsDir : join(process.cwd(), cached.jobsDir);

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -27,6 +27,7 @@ import {
 import {
   getSettings,
   DEFAULT_SESSION_TIMEOUT_MS,
+  NATIVE_SCHEDULING_TOOLS_BLOCKLIST,
   type ModelConfig,
   type SecurityConfig,
   type AgenticMode,
@@ -1351,28 +1352,36 @@ export function buildSecurityArgs(security: SecurityConfig): string[] {
       ? ["--dangerously-skip-permissions"]
       : ["--permission-mode", permissionMode];
 
-  switch (security.level) {
-    case "locked":
-      // Include Write tool so memory persistence works even in locked mode
-      args.push("--tools", "Read,Grep,Glob,Write");
-      break;
-    case "strict":
-      args.push("--disallowedTools", "Bash,WebSearch,WebFetch");
-      break;
-    case "moderate":
-      // all tools available, scoped to project dir via system prompt
-      break;
-    case "unrestricted":
-      // all tools, no directory restriction
-      break;
+  // Native scheduling tools (CronCreate/…) are broken in every daemon-spawned
+  // claude process — a headless `claude -p` is a one-shot that exits before any
+  // wakeup could fire (#342). Block them everywhere buildSecurityArgs is used,
+  // merged into a single `--disallowedTools` alongside the level's own denials
+  // and any operator config, so multiple `--disallowedTools` flags can't fight.
+  const disallowed = new Set<string>(NATIVE_SCHEDULING_TOOLS_BLOCKLIST);
+
+  if (security.level === "locked") {
+    // Include Write tool so memory persistence works even in locked mode. This
+    // is an allow-LIST (`--tools`): everything else, native cron included, is
+    // already unavailable, so no `--disallowedTools` is needed here.
+    args.push("--tools", "Read,Grep,Glob,Write");
+    if (security.allowedTools.length > 0) {
+      args.push("--allowedTools", security.allowedTools.join(" "));
+    }
+    return args;
   }
+
+  if (security.level === "strict") {
+    disallowed.add("Bash");
+    disallowed.add("WebSearch");
+    disallowed.add("WebFetch");
+  }
+  // "moderate" / "unrestricted": all tools available except the merged denials.
+  for (const tool of security.disallowedTools) disallowed.add(tool);
 
   if (security.allowedTools.length > 0) {
     args.push("--allowedTools", security.allowedTools.join(" "));
   }
-  if (security.disallowedTools.length > 0) {
-    args.push("--disallowedTools", security.disallowedTools.join(" "));
-  }
+  args.push("--disallowedTools", [...disallowed].join(","));
 
   return args;
 }


### PR DESCRIPTION
## Problem (closes #342)

An overnight "remind me to call the GP for Ginna at 8am tomorrow" never fired. Root cause: the agent used Claude Code's **native `CronCreate`**, whose wakeup is tied to the live session — under the bus runtime, sessions rotate/churn independently of the daemon, so the wakeup silently died before fire time. A second, older reminder file was also broken (missing its `schedule:` field), so it never scheduled at all.

The ask wasn't to fix those files — it was to make the agent **always** use ClaudeClaw+'s own durable cron for any task, one-off or recurring.

## The change (three parts, wired for `runtime: bus`)

**A — block the broken door.** Every bus agent now spawns with `--disallowedTools CronCreate,CronDelete,CronList,ScheduleWakeup` (`src/bus/session-manager.ts`). These are architecturally broken under bus, not a preference, so it's an unconditional hardcoded floor — **takes effect on deploy, no server settings.json edit needed.**

**B — add a durable door.** New `schedule_task` / `list_scheduled_tasks` / `delete_scheduled_task` bus MCP tools (`src/bus/mcp-tools.ts`, handlers in `src/bus/mcp-server.ts`) backed by a new `src/bus/schedule-ops.ts`. They write file-backed cron jobs that survive restarts/session boundaries. `cron` is **required** in the tool schema, so the missing-`schedule:` bug class is structurally impossible through this path.

Writes are routed **over IPC to the daemon** (via `src/bus/core.ts`), not done in the MCP subprocess — the subprocess has the wrong cwd, so a direct write would land where `loadJobs()` never scans. This mirrors the existing `dispatch_job` pattern. The 30s hot-reload picks the job up with no restart. Default/global session → flat jobs dir (where its reminders already live); named agent → its own `agents/<id>/jobs/`.

**C — steer.** `schedule_task`'s description tells the agent to use it for any scheduling and never the native cron tools.

## Security review

An independent security pass found a **frontmatter-injection via the `model` field** (a newline could forge an `agent:` reroute or `enabled: false`). Fixed: `model` is validated against the allowed set, plus a belt-and-braces newline guard rejects newlines in every value written to frontmatter (also closes a `cron` internal-newline self-DoS). `label` (path-traversal), `prompt` (body-only), and `agentId` (daemon-stamped, not client-supplied) were confirmed safe.

**Deferred (LOW, follow-up):** no per-scope cap on job count — a runaway persona could bloat the jobs dir. Duplicate labels already throw; prompt is capped at 100KB.

## Tests

15 new tests in `src/bus/__tests__/schedule-ops.test.ts` — the load-bearing one is the **round-trip guard**: a task written by `scheduleTask` must re-parse via `loadJobs()` with a non-null `schedule` (directly reproduces the incident bug). Plus flat-vs-agent target, path-traversal / invalid-cron / empty-prompt / duplicate / model-injection / cron-newline rejection, list/delete, and a schema required-field guard. `session-manager.test.ts` gains a test that `buildClaudeArgs` emits the four blocked tools.

## Review status — please read

**Stage-8 code review has NOT run.** The repo's CI `Claude Code Review` workflow is `disabled_manually`, and `/code-review:code-review` is user-triggered so it couldn't be run automatically. This PR was opened with `ALLOW_PR_PUBLISH=1`, deferring the stage-8 review to a maintainer running the skill or re-enabling CI. Tests, lint, and security review are complete. **Do not merge without the code review.**
