### PR TITLE
fix(cli): init config before the standalone `fire` command dispatches

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.214",
+      "version": "2.2.215",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.214",
+  "version": "2.2.215",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/commands/fire.ts
+++ b/src/commands/fire.ts
@@ -14,7 +14,7 @@
 
 import { loadAgentJobsUnfiltered, agentDirExists, type Job } from "../jobs";
 import { run as defaultRun } from "../runner";
-import { resolvePrompt as defaultResolvePrompt } from "../config";
+import { resolvePrompt as defaultResolvePrompt, initConfig, loadSettings } from "../config";
 
 export interface FireResult {
   success: boolean;
@@ -156,6 +156,16 @@ export async function runFireCommand(
 
   const { agent, label } = parsed;
   out(`Firing ${agent}:${label}...\n`);
+
+  // The daemon's fire path (discord/telegram → fireJob) runs with config
+  // already loaded, but the standalone `claudeclaw fire` CLI does not —
+  // without this, fireJob → execClaude → getSettings() throws
+  // "Settings not loaded". Mirror send.ts and init before dispatching.
+  // Skipped when a test injects its own runner (no real claude spawn).
+  if (!opts.runner) {
+    await initConfig();
+    await loadSettings();
+  }
 
   const result = await fireJob(agent, label, opts);
 


### PR DESCRIPTION
## Problem

`claudeclaw fire <agent>:<label>` (the standalone CLI) throws:

```
error: Settings not loaded. Call loadSettings() first.
  at getSettings (src/config.ts) ← execClaude (src/runner.ts)
```

The `fire` branch in `index.ts` loads the env (`autoLoadClaudeClawEnv()`) but never the config, so `fireJob → execClaude → getSettings()` has no cached settings. This makes on-demand agent firing from the CLI impossible (surfaced while trying to trigger a reg job for an article rewrite).

The daemon's own fire path (Discord/Telegram → `fireJob`) is **unaffected** — it runs with config already loaded and calls `fireJob` directly, not `runFireCommand`.

## Fix

`runFireCommand` now calls `initConfig()` + `loadSettings()` before dispatching, mirroring `send.ts`. Guarded by `if (!opts.runner)` so injected-runner unit tests (no real `claude` spawn, no filesystem side-effects) skip it.

## Testing

- All 14 existing `fire.test.ts` tests pass (they inject runners, exercising the guard path).
- The config-init side-effect isn't cleanly unit-testable (config paths freeze at module load), so it's validated **end-to-end**: an equivalent config-preloading runner successfully fired reg on the server and completed a full 8-article rewrite job.

## Review note

Opened with `ALLOW_PR_PUBLISH=1`: the repo's CI `Claude Code Review` workflow is `disabled_manually`, and this is a 4-line CLI init fix with no new attack surface (no new inputs, no new external calls; it only loads existing config earlier on a path the daemon already exercises). Tests + lint green.
