### PR TITLE
fix(pty): recover idle-footer word boundaries from CHA moves (2.1.220) — unblocks reg/suzy/publisher jobs

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.215",
+      "version": "2.2.216",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.215",
+  "version": "2.2.216",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/src/__tests__/pty-output-parser.test.ts
+++ b/src/__tests__/pty-output-parser.test.ts
@@ -443,6 +443,35 @@ describe("pty-output-parser — sentinel flow (synthetic)", () => {
     expect(qEvs[0]!.type).toBe("quiet");
   });
 
+  test("issue #344: idle footer positioned by CHA (claude 2.1.220) opens the gate and fires quiet — regression for the reg/suzy/publisher pty-supervisor hang", () => {
+    const enc = new TextEncoder();
+    const parser = createParser({ quietWindowMs: 100 });
+    const uuid = "uuid-344-cha";
+    const sentinelBytes = encodeSentinel(buildSentinel(uuid));
+
+    const now = 1000;
+    startTurn(parser, uuid, sentinelBytes, now);
+
+    // claude 2.1.220 lays out the REPL footer with CHA (Cursor Horizontal
+    // Absolute, `\x1B[<col>G`) rather than CUF — the exact bytes captured from
+    // the production PTY: "(shift+tab\x1B[39Gto\x1B[42Gcycle)". Before the CHA
+    // pre-pass, stripAnsi erased the moves and glued the words into
+    // "(shift+tabtocycle)", so hasIdleReplFooter's "tab to cycle" match never
+    // fired → quiet withheld → sentinel never written → turn hung to timeout.
+    feed(
+      parser,
+      enc.encode(
+        "✻ ok\x1b[28G(shift+tab\x1b[39Gto\x1b[42Gcycle)\x1b[49G·\x1b[51G←\x1b[53Gfor\x1b[57Gagents",
+      ),
+      now,
+    );
+    expect(parser.sawActivityIndicatorThisTurn).toBe(true);
+
+    const qEvs = tick(parser, now + 200);
+    expect(qEvs.length).toBe(1);
+    expect(qEvs[0]!.type).toBe("quiet");
+  });
+
   test("issue #316: bare 'to cycle' in response prose (not the footer) does NOT trip the gate", () => {
     const enc = new TextEncoder();
     const parser = createParser({ quietWindowMs: 100 });
@@ -710,6 +739,18 @@ describe("stripAnsi", () => {
     const out = stripAnsi("a\x1b[9999Cb");
     // 128-space cap from CUF_MAX_SPACES.
     expect(out).toBe(`a${" ".repeat(128)}b`);
+  });
+
+  // Regression for #344: claude 2.1.220 positions the REPL footer words by
+  // absolute column via CHA (`\x1B[<n>G`) instead of CUF. Without the CHA
+  // pre-pass the words glued together ("(shift+tabtocycle)") and the
+  // idle-footer gate never matched, hanging every pty-supervisor turn.
+  test("recovers word boundaries from CHA sequences (claude 2.1.220 footer)", () => {
+    expect(stripAnsi("(shift+tab\x1b[39Gto\x1b[42Gcycle)")).toBe("(shift+tab to cycle)");
+  });
+
+  test("converts \\x1B[G (no count) to a single space", () => {
+    expect(stripAnsi("foo\x1b[Gbar")).toBe("foo bar");
   });
 });
 

--- a/src/runner/pty-output-parser.ts
+++ b/src/runner/pty-output-parser.ts
@@ -533,24 +533,39 @@ const CUF_MAX_SPACES = 128;
  * Handled:
  *   - `\x1B[<n>C`  → CUF (Cursor Forward n columns) — emit min(n, CAP) spaces.
  *   - `\x1B[C`     → CUF with default 1 — emit one space.
+ *   - `\x1B[<n>G`  → CHA (Cursor Horizontal Absolute) — emit a SINGLE space.
+ *     claude 2.1.220 lays out the idle REPL footer by absolute column
+ *     (`(shift+tab\x1B[39Gto\x1B[42Gcycle)`) instead of CUF. Without expanding
+ *     it, `stripAnsi` erases the moves and glues the words into
+ *     `(shift+tabtocycle)`, so `hasIdleReplFooter`'s "tab to cycle" match never
+ *     fires — `tick` withholds `quiet`, the sentinel is never written, and the
+ *     pty-supervisor turn hangs to its full timeout (the reg/suzy/publisher
+ *     job failures). A single space can't reproduce the exact column gap (that
+ *     needs running-column tracking) but it preserves the WORD BOUNDARY, which
+ *     is all the footer gate and word-recovery consumers actually need.
  *
  * Not handled (deliberately):
- *   - `\x1B[<n>G`  → CHA (absolute column) — needs current column tracking
- *     to compute the right padding; out of scope for a band-aid. Operators
- *     hitting this case should validate on the Bus runtime (Sprint 5) which
- *     reads JSONL instead of PTY rendering.
  *   - `\x1B[<n>D`  → CUB (Cursor Back) — only matters for redraws, not
  *     for first-pass word-boundary recovery.
  *   - `\x1B[<r>;<c>H` → CUP (Cursor Position) — full terminal-emulation
- *     territory; same JSONL-replacement rationale as CHA.
+ *     territory; validate on the Bus runtime (JSONL) instead.
  */
 export function expandCursorForwardToSpaces(text: string): string {
-  // biome-ignore lint/suspicious/noControlCharactersInRegex: CUF is an ANSI CSI sequence.
-  return text.replace(/\x1b\[(\d*)C/g, (_match, digits: string) => {
-    const n = digits.length === 0 ? 1 : parseInt(digits, 10);
-    if (!Number.isFinite(n) || n <= 0) return " ";
-    return " ".repeat(Math.min(n, CUF_MAX_SPACES));
-  });
+  return (
+    text
+      // CUF (Cursor Forward, `\x1B[<n>C`) → min(n, CAP) spaces. Issue #119.
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: CUF is an ANSI CSI sequence.
+      .replace(/\x1b\[(\d*)C/g, (_match, digits: string) => {
+        const n = digits.length === 0 ? 1 : parseInt(digits, 10);
+        if (!Number.isFinite(n) || n <= 0) return " ";
+        return " ".repeat(Math.min(n, CUF_MAX_SPACES));
+      })
+      // CHA (Cursor Horizontal Absolute, `\x1B[<n>G`) → a single word-boundary
+      // space. claude 2.1.220 positions footer words by absolute column; see
+      // the docstring for why one space (not exact padding) is sufficient.
+      // biome-ignore lint/suspicious/noControlCharactersInRegex: CHA is an ANSI CSI sequence.
+      .replace(/\x1b\[\d*G/g, " ")
+  );
 }
 
 /**


### PR DESCRIPTION
## What

Fixes the pty-supervisor turn-completion hang that broke **every scheduled agent job** (reg / suzy / publisher) and `claudeclaw fire` on the server — turns ran to their full timeout (`PTY turn timed out … max retries exhausted`, empty output, `turnCount: 0`).

## Root cause (byte-level)

The pty-supervisor completes a turn when the parser emits `quiet`. Since #316/#317, `tick()` only emits `quiet` once `hasIdleReplFooter()` sees the idle-REPL footer text **"tab to cycle"** in the output tail.

Claude **2.1.220** changed how it paints that footer — it now positions each word with **CHA** (Cursor Horizontal Absolute, `ESC[<col>G`) instead of **CUF** (`ESC[<n>C`). Captured from the production PTY:

```
…\x1b[28G(shift+tab\x1b[39Gto\x1b[42Gcycle)\x1b[49G·\x1b[51G←\x1b[53Gfor\x1b[57Gagents
```

`expandCursorForwardToSpaces` only expanded **CUF**, so `stripAnsi` erased the CHA moves and glued the words into `(shift+tabtocycle)`. `"tab to cycle"` never matched → `quiet` never fired → the sentinel was never written → **the turn hung to its full timeout.**

Why only some paths broke:
- **pty-supervisor** (fire + scheduled jobs) — uses the footer gate → **hung**.
- **bus agents** (Telegram/Discord) — use JSONL detection, no footer gate → unaffected.
- **headless `claude -p`** (`runAgentJobHeadless`) — no interactive TUI footer → unaffected (the known workaround).

Diagnosed by instrumenting the real pty-supervisor spawn on the server (env-gated debug, reverted) and capturing the raw footer bytes: `shift` and `cycle` each appeared once, `to cycle` **zero** times — the words were CHA-separated, not space-separated.

## The fix

Expand **CHA** (`ESC[<n>G`) to a single **word-boundary space** in `expandCursorForwardToSpaces`. A single space can't reproduce the exact absolute-column gap (that needs running-column tracking) but it preserves the word boundary — all the footer gate and word-recovery consumers actually need. One added `.replace()` plus the docstring update (the CHA case was previously listed as "not handled — out of scope").

## Test plan

- **Integration (reproduces the incident):** feed the exact production CHA footer bytes through `feed()` + `tick()` → the activity gate opens and `quiet` fires. This test fails on `main` (RED) and passes with the fix (GREEN).
- **Unit:** `stripAnsi("(shift+tab\x1b[39Gto\x1b[42Gcycle)")` → `"(shift+tab to cycle)"`; `ESC[G` (no count) → single space.
- Full `pty-output-parser.test.ts`: **47 pass / 0 fail** — `extractResponseText`, the golden fixture, and the CUF tests all still pass (CHA→space doesn't harm response extraction).
- `bun run lint`: exit 0.

Two pre-existing failures in `pty-boot-dialog.test.ts` (the #193 boot-dialog watcher, bus path, its own `stripAnsiEscapes`) are **unrelated** — they fail on clean `main` too, and look like the *same* class of 2.1.220 CLI footer drift on a different path. Flagged for a separate follow-up.

## SDC status

- ✅ tests-written · ✅ tests-passing (scoped to `pty-output-parser.test.ts`) · ✅ security-reviewed (inline; linear regex, no ReDoS, whitespace-only normalization, gate not weakened)
- ⏳ pr-review — this PR, awaiting Terrence's sign-off.

Version bumped to 2.2.216 (plugin + marketplace). Not merged — awaiting review + explicit go.
