### PR TITLE
fix(bus): expand CHA cursor moves so boot-dialog matching survives 2.1.220 (follow-up to #345)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
       "name": "claudeclaw-plus",
       "source": "./",
       "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw.",
-      "version": "2.2.216",
+      "version": "2.2.217",
       "keywords": [
         "cron",
         "heartbeat",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
   "name": "claudeclaw-plus",
-  "version": "2.2.216",
+  "version": "2.2.217",
   "description": "ClaudeClaw+ — governance, orchestration, persistent memory, and hardened web UI for Claude Code daemons. Sister project to moazbuilds/claudeclaw."
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,5 +67,13 @@ jobs:
       # they are where outbound routing and turn-semantics risk actually lives.
       # Without them the adapter half of a delivery change never runs in CI —
       # and there is no typecheck step to back it up.
+      #
+      # `src/__tests__/pty-boot-dialog.test.ts` added here: the boot-dialog
+      # watcher guards agents getting past claude's startup confirmation
+      # dialogs. Its exclusion is why a stale-fixture failure — and a real
+      # CHA-rendering drift bug in the watcher's ANSI stripper (the bus-path
+      # analogue of the #345 pty-supervisor footer hang) — slipped past CI.
+      # Fast (~0.5s), pure fake-PTY, no infra; verified 0 fail in the shared
+      # process (1443 pass across the clean suites) and stable across repeat runs.
       - name: Run tests (clean suites)
-        run: bun test src/bus src/adapters src/tuner src/observability src/skills-tuner src/plugins/eval-framework src/__tests__/governance src/__tests__/mcp-multiplexer-integration.test.ts src/__tests__/event-processor.test.ts
+        run: bun test src/bus src/adapters src/tuner src/observability src/skills-tuner src/plugins/eval-framework src/__tests__/governance src/__tests__/mcp-multiplexer-integration.test.ts src/__tests__/event-processor.test.ts src/__tests__/pty-boot-dialog.test.ts

--- a/src/__tests__/pty-boot-dialog.test.ts
+++ b/src/__tests__/pty-boot-dialog.test.ts
@@ -46,9 +46,27 @@ describe("PtyAgentProcess boot-dialog watcher (issue #193)", () => {
   test("answers the dev-channels dialog with a bare Enter (its default is accept)", () => {
     const { pty, writes, emit } = makeFakePty();
     new PtyAgentProcess("main", pty);
+    // The real dialog carries the "Enter to confirm" affordance below the
+    // selected ("❯") option — the generic-confirm branch keys on it.
     emit(
       "WARNING: Loading development channels\n" +
-        "❯ 1. I am using this for local development\n  2. Exit",
+        "❯ 1. I am using this for local development\n  2. Exit\n" +
+        "Enter to confirm · Esc to cancel",
+    );
+    expect(writes).toEqual(["\r"]);
+  });
+
+  test("answers a CHA-rendered dev-channels dialog (claude 2.1.220 absolute-column layout; regression for the #345 drift class)", () => {
+    const { pty, writes, emit } = makeFakePty();
+    new PtyAgentProcess("main", pty);
+    // claude 2.1.220 positions words by absolute column (CHA, `\x1B[<col>G`).
+    // Before stripAnsiEscapes expanded CHA to spaces, "Enter\x1B[..Gto\x1B[..Gconfirm"
+    // collapsed to "Entertoconfirm" and the includes("Enter to confirm") gate
+    // never fired — the dialog went unanswered and the agent hung at boot.
+    emit(
+      "WARNING: Loading development channels\n" +
+        "❯ 1. I am using this for local development\n  2. Exit\n" +
+        "Enter\x1b[39Gto\x1b[42Gconfirm\x1b[49G· Esc to cancel",
     );
     expect(writes).toEqual(["\r"]);
   });

--- a/src/bus/session-agent-process.ts
+++ b/src/bus/session-agent-process.ts
@@ -22,17 +22,28 @@ import type { ChildProcess } from "node:child_process";
 // process-stream-json, tmux) must not require the native PTY dep just to
 // construct an AgentProcess (Codex P1 on PR #149).
 import { sanitizePtyPromptText } from "../runner/pty-prompt-sanitizer";
+// `pty-output-parser` is a pure module (no bun-pty), so reusing its
+// cursor-move→space expander does NOT pull the native PTY dep into the bus
+// module — same rationale as importing the sanitiser above.
+import { expandCursorForwardToSpaces } from "../runner/pty-output-parser";
 import type { SupervisionMode } from "./types";
 
 /** Strip ANSI OSC/CSI escape sequences so dialog matching survives the
  *  cursor-positioning escapes the CLI interleaves into rendered text. Without
  *  this, a raw substring like "development channels" silently stops matching
- *  after a CLI build renders it as "development\x1b[32Gchannels". Mirrors the
- *  stripper in `runner/pty-process.ts` (kept local to avoid importing the PTY
- *  runner into the bus module). */
+ *  after a CLI build renders it as "development\x1b[32Gchannels".
+ *
+ *  CRITICALLY, cursor-move escapes are first EXPANDED to word-boundary spaces
+ *  (`expandCursorForwardToSpaces`: CUF `\x1B[<n>C` #119, CHA `\x1B[<n>G` #345),
+ *  not merely deleted. claude 2.1.220 lays out dialog affordances by absolute
+ *  column ("Enter\x1B[39Gto\x1B[42Gconfirm"), so deleting the escape alone would
+ *  glue the words ("Entertoconfirm") and break the literal `includes("Enter to
+ *  confirm")` / `includes("Yes, I accept")` dialog gates — leaving a spawned
+ *  agent stuck at the boot dialog. This is the bus-path analogue of the #345
+ *  pty-supervisor footer hang. */
 function stripAnsiEscapes(text: string): string {
   return (
-    text
+    expandCursorForwardToSpaces(text)
       // biome-ignore lint/suspicious/noControlCharactersInRegex: OSC escape sequences require control bytes.
       .replace(/\x1b\][^\x07\x1b]*(?:\x07|\x1b\\)/g, "")
       // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI CSI escape stripper.


### PR DESCRIPTION
Follow-up to #345. Fixes the **bus-path analogue** of the same CLI-drift class, plus the stale test and the CI gap that let both slip through.

## Root cause

The boot-dialog watcher (`PtyAgentProcess`, issue #193) answers claude's startup confirmation dialogs by matching the rendered text — e.g. `buf.includes("Enter to confirm")`, `buf.includes("Yes, I accept")`. It first runs the text through a local `stripAnsiEscapes`.

That stripper **deleted** cursor-move escapes without restoring the word-boundary space they represent. Claude **2.1.220** lays out dialog affordances by absolute column (**CHA**, `ESC[<n>G`), so:

```
"Enter\x1b[39Gto\x1b[42Gconfirm"  →  stripAnsiEscapes  →  "Entertoconfirm"
```

`includes("Enter to confirm")` → **false**. A freshly spawned agent could hang unanswered at the boot dialog. (Verified with the watcher's exact stripper.) The `/tab\s*to\s*cycle/` footer checks survived only because `\s*` tolerates the glue — which is why the daemon limped along rather than dying outright.

This is exactly #345's bug (`hasIdleReplFooter` "tab to cycle" collapsing to "tabtocycle") on a different code path.

## The fix

Reuse the now-CUF+CHA-aware `expandCursorForwardToSpaces` (a **pure** module — no bun-pty, same import rationale as the sanitiser already in this file) as a pre-pass in `stripAnsiEscapes`. Cursor moves become word-boundary spaces before stripping, so every literal dialog/footer match survives the CLI's cursor-positioned rendering. One import + one pre-pass.

## Also in this PR

- **Stale test fixed.** The dev-channels test fed `"…❯ 1. I am using this…\n  2. Exit"` — **without** the `Enter to confirm` affordance the real dialog carries and the generic-confirm branch requires. It asserted a `"\r"` the watcher (correctly) never sent. Fixed the fixture to match the real dialog.
- **CHA regression test** — a CHA-rendered dev-channels dialog now gets answered.
- **CI gap closed.** `test.yml` didn't run `pty-boot-dialog.test.ts` (root `src/__tests__/` is excluded for pre-existing pollution) — that's *why* this failure and the CHA drift were invisible to #345's CI. Added it after verifying **0 fail in the shared process (1443 pass across 94 files)** and 5/5 stable across repeat runs. (My source fix was already CI-gated via `src/bus` → `session-agent-process.test.ts`; this adds the integration coverage.)

## Test plan

- `pty-boot-dialog.test.ts`: **5 pass / 0 fail**, stable ×3 (includes the setTimeout-based bypass test and the new CHA test).
- `session-agent-process.test.ts` (exercises the changed `stripAnsiEscapes`): green.
- `pty-process.test.ts`, `pty-output-parser.test.ts`: green (47/47 each).
- Pre-fix baseline on clean main: exactly 1 fail (the stale test) → 0 with this change.
- `bun run lint`: exit 0.

## SDC status

- ✅ tests-written · ✅ tests-passing (scoped) · ✅ security-reviewed (inline; pure helper, linear regex, allowlist + destructive-default protection unchanged)
- ⏳ pr-review — this PR, awaiting Terrence's sign-off.

Version 2.2.217 (plugin + marketplace). Not merged — awaiting review + explicit go.
